### PR TITLE
Feature/che 302 modify country picker behaviour

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		13582A4CA50EBFD03D887D86DC604D3E /* SuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEF8FF844432087B298E2A3C44338EA /* SuccessViewController.swift */; };
 		1409DA75C26BA70F7B65C5F0CD21D2BF /* FormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0600C978273FB44B737CB432A614001 /* FormView.swift */; };
 		15525A3126022C5200E180F3 /* PrimerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15525A3026022C5200E180F3 /* PrimerDelegate.swift */; };
+		15525ABC2603448400E180F3 /* UIButtonExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15525ABB2603448400E180F3 /* UIButtonExtension.swift */; };
 		15770F5F589FAFE38D56518B76888DE9 /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624F4E1D623540ED76B50D9BE131BF3F /* CountryCode.swift */; };
 		16D94678DE1920B6E17527281F9CB23A /* ApplePay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2002F8927F12A15A280FF35F453CC095 /* ApplePay.swift */; };
 		16E347ECB734C4F5128F4BD779A20F59 /* CardFormViewController+CardScannerViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D3137BF546015A824F63FAF3C11B6C8 /* CardFormViewController+CardScannerViewControllerDelegate.swift */; };
@@ -83,7 +84,6 @@
 		95C8DAC16162EA4D1782ACB8CB440C90 /* PrimerSDK-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DF84E6A07CD8CF79199939E7454BB615 /* PrimerSDK-dummy.m */; };
 		98C2BC28355140BA21355CE876774A31 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */; };
 		995659215CAD9C1F069778B7E05D47E0 /* PrimerSDK-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C9D6EF83807CF3A1F5C9CE698CA88650 /* PrimerSDK-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9F50C087556306C29DB4796C323DE214 /* UIButtonExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105FAFDEA00556F653679E56004F5188 /* UIButtonExtension.swift */; };
 		A4A1AE5442B11F0EE787F1D3AC6C24E7 /* Primer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E214B403D06E835E9E6ED60A38AB01BB /* Primer.swift */; };
 		A5FD0F95B6C7F48D8B919FF0B0E4039A /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812634B7DFD24E38665FAB2D7F3DE47B /* Endpoint.swift */; };
 		A8AF02267FB518CBEAEC004CC32CBD9D /* CardFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D3066DEC0F3A69A66B1FD1F83BFC08B /* CardFormViewModel.swift */; };
@@ -149,8 +149,8 @@
 		0768349103D6F57CAD6122D7812F0770 /* VaultService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultService.swift; sourceTree = "<group>"; };
 		0C85C006C0CFC12B346503CB5D186245 /* FormViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormViewModel.swift; sourceTree = "<group>"; };
 		0D34D1F6EDC8908CA2C71CBDCE0E31D2 /* Validation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
-		105FAFDEA00556F653679E56004F5188 /* UIButtonExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIButtonExtension.swift; sourceTree = "<group>"; };
 		15525A3026022C5200E180F3 /* PrimerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PrimerDelegate.swift; path = ../Core/Delegates/PrimerDelegate.swift; sourceTree = "<group>"; };
+		15525ABB2603448400E180F3 /* UIButtonExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButtonExtension.swift; sourceTree = "<group>"; };
 		19B3B6840DCBFC688F7293043B2A93B1 /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		1B4A7277390D022C0A1659F78E7F2FD8 /* PrimerSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerSDK.debug.xcconfig; sourceTree = "<group>"; };
 		1DF93C73A4D016FD80163AA9B721436B /* ApplePayViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePayViewModel.swift; sourceTree = "<group>"; };
@@ -349,6 +349,7 @@
 				15525A3026022C5200E180F3 /* PrimerDelegate.swift */,
 				1E646282DAAF8499270F90F85C23DF88 /* DateExtension.swift */,
 				2C57B99EBCBACF0F47BCAE30E5F77BB6 /* StringExtension.swift */,
+				15525ABB2603448400E180F3 /* UIButtonExtension.swift */,
 			);
 			name = Extensions;
 			path = PrimerSDK/Classes/Extensions;
@@ -612,7 +613,6 @@
 			isa = PBXGroup;
 			children = (
 				7EC854A62B1E648F04BCE25D57A5730B /* PresentationController.swift */,
-				105FAFDEA00556F653679E56004F5188 /* UIButtonExtension.swift */,
 				24181EEB4DE660F307D03BB898C78790 /* UITableViewCellExtensions.swift */,
 				DE647A0588C1EAF7385DE54EAD658EE8 /* UITextFieldExtensions.swift */,
 				DCF623CC014B43724E2C234C4B123C65 /* UIViewControllerExtensions.swift */,
@@ -1047,6 +1047,7 @@
 				15770F5F589FAFE38D56518B76888DE9 /* CountryCode.swift in Sources */,
 				912AB4A1231ECFFEC75B5A62B1D4FBF2 /* Currency.swift in Sources */,
 				D97A5F7353AF2AAFC92479F489F26C6B /* DateExtension.swift in Sources */,
+				15525ABC2603448400E180F3 /* UIButtonExtension.swift in Sources */,
 				F1AE0292BECC18378113FB5B519429BB /* DependencyInjection.swift in Sources */,
 				03A9743A4BE36F4470E139FAB75D1113 /* DirectCheckoutViewModel.swift in Sources */,
 				E3DB2BE658C9EB0AB1A1FDC5722482F7 /* DirectDebitMandate.swift in Sources */,
@@ -1107,7 +1108,6 @@
 				13582A4CA50EBFD03D887D86DC604D3E /* SuccessViewController.swift in Sources */,
 				03F85F796460BBC5065AF2D3296AFC19 /* TokenizationService.swift in Sources */,
 				89013A0EC9C47491565E5ECE8790A2CA /* TransitioningDelegate.swift in Sources */,
-				9F50C087556306C29DB4796C323DE214 /* UIButtonExtension.swift in Sources */,
 				92746FD45662E6C394EEA18DEC9EC1BB /* UITableViewCellExtensions.swift in Sources */,
 				DACCD16E8C384D3622805D5472755EF7 /* UITextFieldExtensions.swift in Sources */,
 				C1F7632F63AA5790B277D74424EB2B2A /* UIViewControllerExtensions.swift in Sources */,

--- a/PrimerSDK/Classes/Core/UI/Views/Form/FormView.swift
+++ b/PrimerSDK/Classes/Core/UI/Views/Form/FormView.swift
@@ -21,6 +21,8 @@ class FormView: UIView {
     
     @Dependency private(set) var theme: PrimerThemeProtocol
     
+    // MARK: - PROPERTIES
+    
     let navBar = UINavigationBar()
     let title = UILabel()
     let link = UILabel()
@@ -38,6 +40,14 @@ class FormView: UIView {
     
     weak var delegate: FormViewDelegate?
     
+    // MARK: - LIFE-CYCLE
+    
+    deinit {
+        log(logLevel: .debug, message: "🧨 destroyed: \(self.self)")
+    }
+    
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -50,11 +60,7 @@ class FormView: UIView {
         
     }
     
-    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-    
-    deinit {
-        log(logLevel: .debug, message: "🧨 destroyed: \(self.self)")
-    }
+    // MARK: - VIEW CONFIGURATION
     
     func render() {
         if (textFields.isEmpty) {
@@ -101,32 +107,7 @@ class FormView: UIView {
             }
         }
     }
-}
-
-// MARK: Picker
-extension FormView: UIPickerViewDataSource, UIPickerViewDelegate {
-    func numberOfComponents(in pickerView: UIPickerView) -> Int {
-        return 1
-    }
     
-    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return countries.count
-    }
-    
-    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        return countries[row].country
-    }
-    
-    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        let textFieldColumn: Int = pickerView.tag % 10
-        let textFieldRow: Int = (pickerView.tag - textFieldColumn) / 10
-        textFields[textFieldRow][textFieldColumn].text = countries[row].rawValue
-//        textFields[textFieldRow][textFieldColumn].resignFirstResponder()
-    }
-}
-
-// MARK: Configuration
-extension FormView {
     private func configureNavbar() {
         guard let delegate = delegate else { return }
         
@@ -167,22 +148,6 @@ extension FormView {
         navBar.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
     }
     
-    @objc
-    private func back() {
-        delegate?.back()
-    }
-    
-    @objc
-    func toolbarCancelButtonTapped(_ sender: UIBarButtonItem) {
-        countryPickerTextField?.text = nil
-        countryPickerTextField?.resignFirstResponder()
-    }
-    
-    @objc
-    func toolbarSubmitButtonTapped(_ sender: UIBarButtonItem) {
-        countryPickerTextField?.resignFirstResponder()
-    }
-    
     private func configureTitle() {
         guard let delegate = delegate else { return }
         if (theme.layout.showMainTitle) {
@@ -193,7 +158,6 @@ extension FormView {
         title.textColor = theme.colorTheme.text1
     }
     
-    // Textfield
     private func configureTextField(_ model: FormTextFieldType, column: Int, row: Int, index: Int) -> Int {
         guard let delegate = delegate else { return 0 }
         let textField = PrimerTextField()
@@ -286,61 +250,6 @@ extension FormView {
         return index + 1
     }
     
-    @objc private func onTextFieldEditingDidEnd(_ sender: UITextField) {
-        validateTextField(sender)
-        validateForm()
-    }
-    
-    @objc private func onTextFieldEditingChanged(_ sender: UITextField) {
-        guard let delegate = delegate else { return }
-        guard let text = sender.text?.withoutWhiteSpace else { return }
-        let column: Int = sender.tag % 10
-        let row: Int = (sender.tag - column) / 10
-        let mask = delegate.formType.textFields[row][column].mask
-        
-        if (mask.exists) {
-            sender.text = mask?.apply(on: text.uppercased())
-        }
-        
-        validateTextField(sender, markError: false)
-        validateForm()
-    }
-    
-    private func validateTextField(_ sender: UITextField, markError: Bool = true, showValidity: Bool = true) {
-        guard let delegate = delegate else { return }
-        guard let textField = sender as? PrimerTextField else { return }
-        
-        if textField.validationIsOptional {
-            textField.renderSubViews(validationState: .default)
-            return
-        }
-        
-        guard let text = textField.text?.withoutWhiteSpace else { return }
-        
-        let column: Int = textField.tag % 10
-        let row: Int = (textField.tag - column) / 10
-        
-        if (delegate.formType.textFields.count > row) {
-            let validation = delegate.formType.textFields[row][column].validate(text)
-            validatedFields[row][column] = validation.0
-            
-            let mask = delegate.formType.textFields[row][column].mask
-            sender.text = mask?.apply(on: text.uppercased()) ?? sender.text
-            
-            if (validation.0) {
-                textField.renderSubViews(validationState: showValidity ? .valid : .default)
-            } else {
-                textField.renderSubViews(validationState: markError ? .invalid : .default)
-                textField.errorMessage.text = markError ? validation.1 : ""
-            }
-        }
-    }
-    
-    private func validateForm() {
-        let isAllValid = validatedFields.allSatisfy({ row in return row.allSatisfy { return $0 == true } })
-        button.toggleValidity(isAllValid, validColor: theme.colorTheme.tint1, defaultColor: theme.colorTheme.disabled1)
-    }
-    
     private func configureLink() {
         guard let delegate = delegate else { return }
         link.text = delegate.formType.subtitle
@@ -350,10 +259,6 @@ extension FormView {
         let tapRecogniser = UITapGestureRecognizer(target: self, action: #selector(onLinkTap))
         link.isUserInteractionEnabled = true
         link.addGestureRecognizer(tapRecogniser)
-    }
-    
-    @objc private func onLinkTap(_ sender: UITapGestureRecognizer?) {
-        delegate?.openLink()
     }
     
     private func configureButton() {
@@ -376,26 +281,6 @@ extension FormView {
         default:
             break
         }
-    }
-    
-    @objc private func onButtonPressed(_ button: UIButton) {
-        textFields.forEach { row in
-            row.forEach {
-                guard let textField = $0 as? PrimerTextField else { return }
-                let column: Int = textField.tag % 10
-                let row: Int = (textField.tag - column) / 10
-                guard let type = delegate?.formType.textFields[row][column] else { return }
-                delegate?.submit(textField.text, type: type)
-            }
-        }
-        guard let delegate = delegate else { return }
-        switch delegate.formType {
-        case .cardForm:
-            button.setBusy(theme: theme)
-        default:
-            break
-        }
-        delegate.onSubmit()
     }
     
     private func configureScannerButton() {
@@ -429,24 +314,7 @@ extension FormView {
         iconView.widthAnchor.constraint(equalToConstant: iconView.intrinsicContentSize.width * 0.75).isActive = true
     }
     
-    @objc private func showScanner() {
-        delegate?.onBottomLinkTapped()
-    }
-}
-
-// MARK: Anchoring
-extension FormView {
-//    func anchorNavbar() {
-//        navBar.translatesAutoresizingMaskIntoConstraints = false
-//
-//        if #available(iOS 13.0, *) {
-//            navBar.topAnchor.constraint(equalTo: topAnchor, constant: 6).isActive = true
-//        } else {
-//            navBar.topAnchor.constraint(equalTo: topAnchor, constant: 18).isActive = true
-//        }
-//
-//        navBar.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
-//    }
+    // MARK: Anchoring
     
     func anchorContentView() {
         contentView.translatesAutoresizingMaskIntoConstraints = false
@@ -532,22 +400,147 @@ extension FormView {
         }
         
     }
-}
-
-extension String {
-    var isValidAccountNumber: Bool {
-        print(!self.isEmpty)
-        return !self.isEmpty
+    
+//    func anchorNavbar() {
+//        navBar.translatesAutoresizingMaskIntoConstraints = false
+//
+//        if #available(iOS 13.0, *) {
+//            navBar.topAnchor.constraint(equalTo: topAnchor, constant: 6).isActive = true
+//        } else {
+//            navBar.topAnchor.constraint(equalTo: topAnchor, constant: 18).isActive = true
+//        }
+//
+//        navBar.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
+//    }
+    
+    // MARK: - ACTIONS
+    
+    @objc
+    private func back() {
+        delegate?.back()
     }
+    
+    @objc
+    private func onTextFieldEditingDidEnd(_ sender: UITextField) {
+        validateTextField(sender)
+        validateForm()
+    }
+    
+    @objc
+    private func onTextFieldEditingChanged(_ sender: UITextField) {
+        guard let delegate = delegate else { return }
+        guard let text = sender.text?.withoutWhiteSpace else { return }
+        let column: Int = sender.tag % 10
+        let row: Int = (sender.tag - column) / 10
+        let mask = delegate.formType.textFields[row][column].mask
+        
+        if (mask.exists) {
+            sender.text = mask?.apply(on: text.uppercased())
+        }
+        
+        validateTextField(sender, markError: false)
+        validateForm()
+    }
+    
+    @objc
+    private func onLinkTap(_ sender: UITapGestureRecognizer?) {
+        delegate?.openLink()
+    }
+    
+    @objc
+    func toolbarCancelButtonTapped(_ sender: UIBarButtonItem) {
+        countryPickerTextField?.text = nil
+        countryPickerTextField?.resignFirstResponder()
+    }
+    
+    @objc
+    func toolbarSubmitButtonTapped(_ sender: UIBarButtonItem) {
+        countryPickerTextField?.resignFirstResponder()
+    }
+    
+    private func validateTextField(_ sender: UITextField, markError: Bool = true, showValidity: Bool = true) {
+        guard let delegate = delegate else { return }
+        guard let textField = sender as? PrimerTextField else { return }
+        
+        if textField.validationIsOptional {
+            textField.renderSubViews(validationState: .default)
+            return
+        }
+        
+        guard let text = textField.text?.withoutWhiteSpace else { return }
+        
+        let column: Int = textField.tag % 10
+        let row: Int = (textField.tag - column) / 10
+        
+        if (delegate.formType.textFields.count > row) {
+            let validation = delegate.formType.textFields[row][column].validate(text)
+            validatedFields[row][column] = validation.0
+            
+            let mask = delegate.formType.textFields[row][column].mask
+            sender.text = mask?.apply(on: text.uppercased()) ?? sender.text
+            
+            if (validation.0) {
+                textField.renderSubViews(validationState: showValidity ? .valid : .default)
+            } else {
+                textField.renderSubViews(validationState: markError ? .invalid : .default)
+                textField.errorMessage.text = markError ? validation.1 : ""
+            }
+        }
+    }
+    
+    private func validateForm() {
+        let isAllValid = validatedFields.allSatisfy({ row in return row.allSatisfy { return $0 == true } })
+        button.toggleValidity(isAllValid, validColor: theme.colorTheme.tint1, defaultColor: theme.colorTheme.disabled1)
+    }
+    
+    
+    
+    @objc private func onButtonPressed(_ button: UIButton) {
+        textFields.forEach { row in
+            row.forEach {
+                guard let textField = $0 as? PrimerTextField else { return }
+                let column: Int = textField.tag % 10
+                let row: Int = (textField.tag - column) / 10
+                guard let type = delegate?.formType.textFields[row][column] else { return }
+                delegate?.submit(textField.text, type: type)
+            }
+        }
+        guard let delegate = delegate else { return }
+        switch delegate.formType {
+        case .cardForm:
+            button.setBusy(theme: theme)
+        default:
+            break
+        }
+        delegate.onSubmit()
+    }
+    
+    @objc
+    private func showScanner() {
+        delegate?.onBottomLinkTapped()
+    }
+    
 }
 
-extension UIButton {
-    func setBusy(theme: PrimerThemeProtocol) {
-        let indicator = UIActivityIndicatorView()
-        self.setTitle("", for: .normal)
-        self.addSubview(indicator)
-        indicator.pin(to: self)
-        indicator.color = theme.colorTheme.text2
-        indicator.startAnimating()
+// MARK: - PICKER VIEW DELEGATE & DATA SOURCE
+
+extension FormView: UIPickerViewDataSource, UIPickerViewDelegate {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return countries.count
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return countries[row].country
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        let textFieldColumn: Int = pickerView.tag % 10
+        let textFieldRow: Int = (pickerView.tag - textFieldColumn) / 10
+        textFields[textFieldRow][textFieldColumn].text = countries[row].rawValue
+//        textFields[textFieldRow][textFieldColumn].resignFirstResponder()
     }
 }

--- a/PrimerSDK/Classes/Core/UI/Views/Form/FormView.swift
+++ b/PrimerSDK/Classes/Core/UI/Views/Form/FormView.swift
@@ -29,6 +29,7 @@ class FormView: UIView {
     let contentView = UIScrollView()
     
     var textFields: [[UITextField]] = []
+    var countryPickerTextField: PrimerTextField?
     var validatedFields: [[Bool]] = []
     
     let countries = CountryCode.all
@@ -120,7 +121,7 @@ extension FormView: UIPickerViewDataSource, UIPickerViewDelegate {
         let textFieldColumn: Int = pickerView.tag % 10
         let textFieldRow: Int = (pickerView.tag - textFieldColumn) / 10
         textFields[textFieldRow][textFieldColumn].text = countries[row].rawValue
-        textFields[textFieldRow][textFieldColumn].resignFirstResponder()
+//        textFields[textFieldRow][textFieldColumn].resignFirstResponder()
     }
 }
 
@@ -166,8 +167,20 @@ extension FormView {
         navBar.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
     }
     
-    @objc private func back() {
+    @objc
+    private func back() {
         delegate?.back()
+    }
+    
+    @objc
+    func toolbarCancelButtonTapped(_ sender: UIBarButtonItem) {
+        countryPickerTextField?.text = nil
+        countryPickerTextField?.resignFirstResponder()
+    }
+    
+    @objc
+    func toolbarSubmitButtonTapped(_ sender: UIBarButtonItem) {
+        countryPickerTextField?.resignFirstResponder()
     }
     
     private func configureTitle() {
@@ -205,19 +218,33 @@ extension FormView {
         // accessbility identifier
         
         switch model {
-        case .cardholderName: textField.accessibilityIdentifier = "nameField"
-        case .cardNumber: textField.accessibilityIdentifier = "cardField"
-        case .expiryDate: textField.accessibilityIdentifier = "expiryField"
-        case .cvc: textField.accessibilityIdentifier = "cvcField"
-        case .addressLine1: textField.accessibilityIdentifier = "addressLine1Field"
-        case .addressLine2: textField.accessibilityIdentifier = "addressLine2Field"
-        case .firstName: textField.accessibilityIdentifier = "firstNameField"
-        case .lastName: textField.accessibilityIdentifier = "lastNameField"
-        case .city: textField.accessibilityIdentifier = "cityField"
-        case .country: textField.accessibilityIdentifier = "countryField"
-        case .postalCode: textField.accessibilityIdentifier = "postalCodeField"
-        case .email: textField.accessibilityIdentifier = "emailField"
-        case .iban: textField.accessibilityIdentifier = "ibanField"
+        case .cardholderName:
+            textField.accessibilityIdentifier = "nameField"
+        case .cardNumber:
+            textField.accessibilityIdentifier = "cardField"
+        case .expiryDate:
+            textField.accessibilityIdentifier = "expiryField"
+        case .cvc:
+            textField.accessibilityIdentifier = "cvcField"
+        case .addressLine1:
+            textField.accessibilityIdentifier = "addressLine1Field"
+        case .addressLine2:
+            textField.accessibilityIdentifier = "addressLine2Field"
+        case .firstName:
+            textField.accessibilityIdentifier = "firstNameField"
+        case .lastName:
+            textField.accessibilityIdentifier = "lastNameField"
+        case .city:
+            textField.accessibilityIdentifier = "cityField"
+        case .country:
+            textField.accessibilityIdentifier = "countryField"
+            countryPickerTextField = textField
+        case .postalCode:
+            textField.accessibilityIdentifier = "postalCodeField"
+        case .email:
+            textField.accessibilityIdentifier = "emailField"
+        case .iban:
+            textField.accessibilityIdentifier = "ibanField"
         default:
             break
         }
@@ -232,7 +259,16 @@ extension FormView {
             countryPickerView.tag = textField.tag
             countryPickerView.delegate = self
             countryPickerView.dataSource = self
-        default: break
+            
+            let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 44))
+            let cancelBarButton = UIBarButtonItem(title: "Cancel", style: .plain, target: self, action: #selector(toolbarCancelButtonTapped(_:)))
+            let flexWidth = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+            let submitButton = UIBarButtonItem(title: "Submit", style: .done, target: self, action: #selector(toolbarSubmitButtonTapped(_:)))
+            toolbar.items = [cancelBarButton, flexWidth, submitButton]
+            textField.inputAccessoryView = toolbar
+            
+        default:
+            break
         }
         
         textField.text = delegate.formType.textFields[row][column].initialValue

--- a/PrimerSDK/Classes/Extensions/StringExtension.swift
+++ b/PrimerSDK/Classes/Extensions/StringExtension.swift
@@ -98,5 +98,10 @@ extension String {
         return mutableAttString
     }
     
+    var isValidAccountNumber: Bool {
+        print(!self.isEmpty)
+        return !self.isEmpty
+    }
+    
 }
 

--- a/PrimerSDK/Classes/Extensions/UIButtonExtension.swift
+++ b/PrimerSDK/Classes/Extensions/UIButtonExtension.swift
@@ -1,6 +1,23 @@
+//
+//  UIButtonExtension.swift
+//  PrimerSDK
+//
+//  Created by Evangelos Pittas on 18/3/21.
+//
+
 import UIKit
 
 extension UIButton {
+    
+    func setBusy(theme: PrimerThemeProtocol) {
+        let indicator = UIActivityIndicatorView()
+        self.setTitle("", for: .normal)
+        self.addSubview(indicator)
+        indicator.pin(to: self)
+        indicator.color = theme.colorTheme.text2
+        indicator.startAnimating()
+    }
+    
     func showSpinner(_ color: UIColor = .white) {
         self.isUserInteractionEnabled = false
         self.setTitle("", for: .normal)
@@ -24,4 +41,5 @@ extension UIButton {
         self.backgroundColor = isValid ? validColor : defaultColor
         self.isEnabled = isValid
     }
+    
 }


### PR DESCRIPTION
CHE-302

# What this PR does

Adds toolbar with cancel & submit button on country picker.

# Notable decisions & other stuff

Restructured `FormView`

Please check if this is the desired behaviour.

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
