### PR TITLE
Move paths back into the API. Having them as part of the Service stru…

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Payment Services/DirectDebitService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/DirectDebitService.swift
@@ -62,7 +62,6 @@ struct DirectDebitCreateMandateRequest: Codable {
     let id: String
     let userDetails: UserDetails
     let bankDetails: BankDetails
-    var path: String = "/gocardless/mandates"
 }
 
 struct UserDetails: Codable {

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/KlarnaService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/KlarnaService.swift
@@ -26,7 +26,6 @@ struct KlarnaCreatePaymentSessionAPIRequest: Codable {
     let totalAmount: Int
     let localeData: LocaleData
     let orderItems: [OrderItem]
-    var path: String = "/klarna/payment-sessions"
 }
 
 struct KlarnaSessionCategory: Codable {
@@ -47,7 +46,6 @@ struct KlarnaCreatePaymentSessionAPIResponse: Codable {
 struct KlarnaFinalizePaymentSessionRequest: Codable {
     let paymentMethodConfigId: String
     let sessionId: String
-    var path: String = "/klarna/payment-sessions/finalize"
 }
 
 struct KlarnaSessionOrderLines: Codable {

--- a/Sources/PrimerSDK/Classes/Data Models/PayPal.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PayPal.swift
@@ -19,7 +19,6 @@ struct PayPalCreateOrderRequest: Codable {
     var locale: CountryCode? = nil
     let returnUrl: String
     let cancelUrl: String
-    var path: String = "/paypal/orders/create"
 }
 
 struct PayPalCreateOrderResponse: Codable {
@@ -31,7 +30,6 @@ struct PayPalCreateBillingAgreementRequest: Codable {
     let paymentMethodConfigId: String
     let returnUrl: String
     let cancelUrl: String
-    var path: String = "/paypal/billing-agreements/create-agreement"
 }
 
 struct PayPalCreateBillingAgreementResponse: Codable {
@@ -53,7 +51,6 @@ struct PayPalOrderLink: Decodable {
 
 struct PayPalConfirmBillingAgreementRequest: Encodable {
     let paymentMethodConfigId, tokenId: String
-    var path: String = "/paypal/billing-agreements/confirm-agreement"
 }
 
 struct PayPalConfirmBillingAgreementResponse: Codable {

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethodTokenizationRequest.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethodTokenizationRequest.swift
@@ -8,7 +8,6 @@ struct PaymentMethodTokenizationRequest: Encodable {
     let tokenType: TokenType?
     let paymentFlow: PaymentFlow?
     let customerId: String?
-    var path: String = "/payment-instruments"
     
     init(paymentInstrument: PaymentInstrument, state: AppStateProtocol) {
         self.paymentInstrument = paymentInstrument

--- a/Sources/PrimerSDK/Classes/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/Services/API/Primer/PrimerAPI.swift
@@ -63,20 +63,20 @@ extension PrimerAPI {
             return ""
         case .vaultFetchPaymentMethods:
             return "/payment-instruments"
-        case .payPalStartOrderSession(_, let payPalCreateOrderRequest):
-            return payPalCreateOrderRequest.path
-        case .payPalStartBillingAgreementSession(_, let payPalCreateBillingAgreementRequest):
-            return payPalCreateBillingAgreementRequest.path
-        case .payPalConfirmBillingAgreement(_, let payPalConfirmBillingAgreementRequest):
-            return payPalConfirmBillingAgreementRequest.path
-        case .klarnaCreatePaymentSession(_, let klarnaCreatePaymentSessionAPIRequest):
-            return klarnaCreatePaymentSessionAPIRequest.path
-        case .klarnaFinalizePaymentSession(_, let klarnaFinalizePaymentSessionRequest):
-            return klarnaFinalizePaymentSessionRequest.path
-        case .directDebitCreateMandate(_, let mandateRequest):
-            return mandateRequest.path
-        case .tokenizePaymentMethod(_, let paymentMethodTokenizationRequest):
-            return paymentMethodTokenizationRequest.path
+        case .payPalStartOrderSession:
+            return "/paypal/orders/create"
+        case .payPalStartBillingAgreementSession:
+            return "/paypal/billing-agreements/create-agreement"
+        case .payPalConfirmBillingAgreement:
+            return "/paypal/billing-agreements/confirm-agreement"
+        case .klarnaCreatePaymentSession:
+            return "/klarna/payment-sessions"
+        case .klarnaFinalizePaymentSession:
+            return "/klarna/payment-sessions/finalize"
+        case .directDebitCreateMandate:
+            return "/gocardless/mandates"
+        case .tokenizePaymentMethod:
+            return "/payment-instruments"
         }
     }
     


### PR DESCRIPTION
# What this PR does

Move paths back into the API. Having them as part of the Service structs was leading on them being JSON encoded and sent in the body of the request, which our backend doesn't allow.

# Notable decisions & other stuff

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
