### PR TITLE
Feature/che 544 provide a way to hide initial loading

### DIFF
--- a/Example/PrimerSDK/MerchantCheckoutViewController.swift
+++ b/Example/PrimerSDK/MerchantCheckoutViewController.swift
@@ -34,7 +34,9 @@ class MerchantCheckoutViewController: UIViewController {
             currency: .SEK,
             countryCode: .se,
             klarnaSessionType: .recurringPayment,
-            klarnaPaymentDescription: "Scooter Rental"
+            klarnaPaymentDescription: "Scooter Rental",
+            hasDisabledSuccessScreen: true,
+            isInitialLoadingHidden: true
         )
         Primer.shared.configure(settings: settings)
         

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -23,6 +23,7 @@ protocol PrimerSettingsProtocol {
     var businessDetails: BusinessDetails? { get }
     var directDebitHasNoAmount: Bool { get }
     var orderItems: [OrderItem] { get }
+    var isInitialLoadingHidden: Bool { get }
 }
 
 /**
@@ -63,6 +64,7 @@ public class PrimerSettings: PrimerSettingsProtocol {
     internal(set) public var businessDetails: BusinessDetails?
     internal(set) public var directDebitHasNoAmount: Bool
     internal(set) public var orderItems: [OrderItem]
+    internal(set) public var isInitialLoadingHidden: Bool
 
     public var clientTokenRequestCallback: ClientTokenCallBack {
         return Primer.shared.delegate?.clientTokenCallback ?? { _ in }
@@ -95,7 +97,8 @@ public class PrimerSettings: PrimerSettingsProtocol {
         hasDisabledSuccessScreen: Bool = false,
         businessDetails: BusinessDetails? = nil,
         directDebitHasNoAmount: Bool = false,
-        orderItems: [OrderItem] = []
+        orderItems: [OrderItem] = [],
+        isInitialLoadingHidden: Bool = false
     ) {
         self.amount = amount
         self.currency = currency
@@ -112,6 +115,7 @@ public class PrimerSettings: PrimerSettingsProtocol {
         self.businessDetails = businessDetails
         self.directDebitHasNoAmount = directDebitHasNoAmount
         self.orderItems = orderItems
+        self.isInitialLoadingHidden = isInitialLoadingHidden
     }
 }
 

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PresentationController.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PresentationController.swift
@@ -28,7 +28,17 @@ public class PresentationController: UIPresentationController {
         self.blurEffectView.alpha = 0
         self.containerView?.addSubview(blurEffectView)
         self.presentedViewController.transitionCoordinator?.animate(alongsideTransition: { (_) in
-            self.blurEffectView.alpha = 0.7
+            let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
+            
+            switch Primer.shared.flow {
+            case .addKlarnaToVault,
+                 .addPayPalToVault,
+                 .checkoutWithKlarna:
+                self.blurEffectView.alpha = settings.isInitialLoadingHidden ? 0 : 0.7
+            default:
+                self.blurEffectView.alpha = 0.7
+            }
+            
         }, completion: { (_) in })
     }
 

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
@@ -34,6 +34,11 @@ class OAuthViewController: UIViewController {
         indicator.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
         indicator.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         indicator.startAnimating()
+        
+        let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
+        if settings.isInitialLoadingHidden {
+            indicator.isHidden = true
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -61,6 +66,15 @@ class OAuthViewController: UIViewController {
     }
 
     private func presentWebview(_ urlString: String) {
+        let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
+        let routerDelegate: RouterDelegate = DependencyContainer.resolve()
+        let router = routerDelegate as! Router
+        let rootViewController = router.root
+        
+        UIView.animate(withDuration: 0.3) {
+            (rootViewController?.presentationController as? PresentationController)?.blurEffectView.alpha = 0.7
+        }
+        
         let webViewController = WebViewController()
         webViewController.url = URL(string: urlString)
         webViewController.delegate = self
@@ -217,6 +231,24 @@ class WebViewController: UIViewController, WKNavigationDelegate {
 
             decisionHandler(.cancel)
 
+            let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
+            let routerDelegate: RouterDelegate = DependencyContainer.resolve()
+            let router = routerDelegate as! Router
+            let rootViewController = router.root
+            
+            if settings.hasDisabledSuccessScreen == false && settings.isInitialLoadingHidden == true {
+                let theme: PrimerThemeProtocol = DependencyContainer.resolve()
+                rootViewController?.mainView.backgroundColor = theme.colorTheme.main1
+                if #available(iOS 11.0, *) {
+                    (rootViewController?.children.first as? OAuthViewController)?.indicator.isHidden = false
+                }
+                
+            } else if settings.hasDisabledSuccessScreen && settings.isInitialLoadingHidden {
+                UIView.animate(withDuration: 0.3) {
+                    (rootViewController?.presentationController as? PresentationController)?.blurEffectView.alpha = 0.0
+                }
+            }
+            
             dismiss(animated: true, completion: nil)
 
             return

--- a/Sources/PrimerSDK/Classes/User Interface/Root/RootViewController+Router.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/RootViewController+Router.swift
@@ -32,16 +32,21 @@ class Router: RouterDelegate {
     func show(_ route: Route) {
         guard let root = self.root else { return }
         guard let vc = route.viewController else { return }
+        let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
 
         if vc is SuccessViewController {
-            let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
-            
             if settings.hasDisabledSuccessScreen {
                 return root.dismiss(animated: true, completion: nil)
             }
 
             root.view.endEditing(true)
 
+        } else if vc is ErrorViewController {
+            if settings.hasDisabledSuccessScreen {
+                return root.dismiss(animated: true, completion: nil)
+            }
+            
+            root.view.endEditing(true)
         }
 
         root.add(vc, height: route.height)

--- a/Sources/PrimerSDK/Classes/User Interface/Root/RootViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/RootViewController.swift
@@ -47,8 +47,16 @@ class RootViewController: UIViewController {
     override func viewDidLoad() {
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         let theme: PrimerThemeProtocol = DependencyContainer.resolve()
+        
+        switch Primer.shared.flow {
+        case .addKlarnaToVault,
+             .addPayPalToVault,
+             .checkoutWithKlarna:
+            mainView.backgroundColor = settings.isInitialLoadingHidden ? .clear : theme.colorTheme.main1
+        default:
+            mainView.backgroundColor = theme.colorTheme.main1
+        }
 
-        mainView.backgroundColor = theme.colorTheme.main1
         view.addSubview(backdropView)
         backdropView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(mainView)

--- a/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
+++ b/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
@@ -69,6 +69,8 @@ class MockPrimerDelegate: PrimerDelegate {
 }
 
 struct MockPrimerSettings: PrimerSettingsProtocol {
+    var isInitialLoadingHidden: Bool = false
+    
     var klarnaPaymentDescription: String?
     
     var klarnaSessionType: KlarnaSessionType?


### PR DESCRIPTION
CHE-544

# What this PR does

Hides initial loading view if `isInitialLoadingHidden` is set to `true`.

# Notable decisions & other stuff

I didn't hide the view, I made it transparent. Reason is that there were other views that their sizes were calculated with this view as reference, so I was ending up with views that had wrong sizes.

# Before merging

This is a hard one to test. There are 3 boolean cases that need to be tested.

- `isInitialLoadingHidden`
- `hasDisabledSuccessScreen`
- Force the SDK to throw error by adding the two lines below in `TokenizationService.swift` line 45 (see screenshot).
```
onTokenizeSuccess(.failure( PrimerError.tokenizationRequestFailed ))
return
```


- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
