### PR TITLE
Feature/che 543 expose errors

### DIFF
--- a/Example/PrimerSDK/MerchantCheckoutViewController.swift
+++ b/Example/PrimerSDK/MerchantCheckoutViewController.swift
@@ -145,6 +145,10 @@ extension MerchantCheckoutViewController: PrimerDelegate {
         fetchPaymentMethods()
     }
     
+    func checkoutFailed(with error: Error) {
+        print("MERCHANT CHECKOUT VIEW CONTROLLER\nError: \(error as NSError)")
+    }
+    
 }
 
 // MARK: - TABLE VIEW DATA SOURCE & DELEGATE

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
@@ -29,6 +29,7 @@ public protocol PrimerDelegate: class {
     func tokenAddedToVault(_ token: PaymentMethodToken)
     func authorizePayment(_ result: PaymentMethodToken, _ completion:  @escaping (Error?) -> Void)
     func onCheckoutDismissed()
+    func checkoutFailed(with error: Error)
 }
 
 class MockPrimerDelegate: PrimerDelegate {
@@ -47,6 +48,10 @@ class MockPrimerDelegate: PrimerDelegate {
 
     func onCheckoutDismissed() {
 
+    }
+    
+    func checkoutFailed(with error: Error) {
+        
     }
     
 }

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -143,6 +143,10 @@ class MockDelegate: PrimerDelegate {
 
     }
     
+    func checkoutFailed(with error: Error) {
+        
+    }
+    
 }
 
 #endif

--- a/Sources/PrimerSDK/Classes/Error Handler/Error.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/Error.swift
@@ -211,6 +211,7 @@ enum NetworkServiceError: PrimerErrorProtocol {
 
 enum PrimerError: PrimerErrorProtocol {
 
+    case generic
     case clientTokenNull
     case customerIDNull
     case payPalSessionFailed
@@ -221,6 +222,7 @@ enum PrimerError: PrimerErrorProtocol {
     case configFetchFailed
     case tokenizationPreRequestFailed
     case tokenizationRequestFailed
+    case failedToLoadSession
 
     static var errorDomain: String = "primer"
 
@@ -242,6 +244,13 @@ enum PrimerError: PrimerErrorProtocol {
 
     var errorDescription: String? {
         switch self {
+        case .generic:
+            return NSLocalizedString("primer-error-message-generic",
+                                     tableName: nil,
+                                     bundle: Bundle.primerResources,
+                                     value: "Something went wrong",
+                                     comment: "Something went wrong - Primer error message")
+            
         case .clientTokenNull:
             return NSLocalizedString("primer-error-message-client-token-missing",
                                      tableName: nil,
@@ -311,6 +320,12 @@ enum PrimerError: PrimerErrorProtocol {
                                      bundle: Bundle.primerResources,
                                      value: "Connection error, your payment method was not saved. Please try again.",
                                      comment: "Connection error, your payment method was not saved. Please try again. - Primer error message")
+        case .failedToLoadSession:
+            return NSLocalizedString("primer-error-message-failed-to-load-session",
+                                     tableName: nil,
+                                     bundle: Bundle.primerResources,
+                                     value: "Failed to load session, please close and try again.",
+                                     comment: "Failed to load session, please close and try again. - Primer error message")
         }
     }
 

--- a/Sources/PrimerSDK/Classes/Error Handler/ErrorHandler.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/ErrorHandler.swift
@@ -39,6 +39,8 @@ class ErrorHandler {
 
         } else if let primerError = error as? PrimerError {
             switch primerError {
+            case .generic:
+                break
             case .clientTokenNull:
                 break
             case .customerIDNull:
@@ -58,6 +60,8 @@ class ErrorHandler {
             case .tokenizationPreRequestFailed:
                 break
             case .tokenizationRequestFailed:
+                break
+            case .failedToLoadSession:
                 break
             }
 

--- a/Sources/PrimerSDK/Classes/User Interface/Checkout/VaultCheckoutViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Checkout/VaultCheckoutViewController.swift
@@ -140,7 +140,7 @@ extension VaultCheckoutViewController: VaultCheckoutViewDelegate {
         viewModel.authorizePayment({ [weak self] error in
             DispatchQueue.main.async {
                 if error.exists {
-                    router.show(.error())
+                    router.show(.error(error: PrimerError.generic))
                     return
                 }
                 router.show(.success(type: .regular))

--- a/Sources/PrimerSDK/Classes/User Interface/Confirm Mandate/ConfirmMandateViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Confirm Mandate/ConfirmMandateViewController.swift
@@ -31,7 +31,7 @@ class ConfirmMandateViewController: UIViewController {
             DispatchQueue.main.async {
                 if error.exists {
                     let router: RouterDelegate = DependencyContainer.resolve()
-                    router.show(.error(message: "failed to load session, please close and try again."))
+                    router.show(.error(error: PrimerError.failedToLoadSession))
                     return
                 }
                 self?.subView.render()
@@ -101,7 +101,7 @@ extension ConfirmMandateViewController: ConfirmMandateViewDelegate {
             DispatchQueue.main.async {
                 let router: RouterDelegate = DependencyContainer.resolve()
                 if error.exists {
-                    router.show(.error(message: PrimerError.directDebitSessionFailed.localizedDescription))
+                    router.show(.error(error: PrimerError.directDebitSessionFailed))
                     return
                 } else {
                     router.show(.success(type: .directDebit))

--- a/Sources/PrimerSDK/Classes/User Interface/Form/FormViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Form/FormViewModel.swift
@@ -120,8 +120,8 @@ class FormViewModel: FormViewModelProtocol {
         case .cardForm:
             submit { error in
                 DispatchQueue.main.async { [weak self] in
-                    if error.exists {
-                        router.show(.error(message: error!.localizedDescription))
+                    if let error = error {
+                        router.show(.error(error: error))
                     } else {
                         router.show(.success(type: .regular))
                     }

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
@@ -87,7 +87,7 @@ class OAuthViewController: UIViewController {
                     let router: RouterDelegate = DependencyContainer.resolve()
 
                     if (error is PrimerError) {
-                        router.show(.error())
+                        router.show(.error(error: error!))
                     } else if (error.exists) {
                         router.pop()
                     } else {
@@ -106,7 +106,7 @@ class OAuthViewController: UIViewController {
 
             guard let authURL = URL(string: urlString) else {
                 let router: RouterDelegate = DependencyContainer.resolve()
-                router.show(.error())
+                router.show(.error(error: PrimerError.generic))
                 return
             }
 
@@ -116,7 +116,7 @@ class OAuthViewController: UIViewController {
                 callbackURLScheme: viewModel.urlSchemeIdentifier,
                 completionHandler: { [weak self] (url, error) in
                     let router: RouterDelegate = DependencyContainer.resolve()
-                    error.exists ? router.show(.error()) : self?.onOAuthCompleted(callbackURL: url)
+                    error.exists ? router.show(.error(error: PrimerError.generic)) : self?.onOAuthCompleted(callbackURL: url)
                 }
             )
 
@@ -130,7 +130,7 @@ class OAuthViewController: UIViewController {
         viewModel.tokenize(host, with: { [weak self] error in
             DispatchQueue.main.async {
                 let router: RouterDelegate = DependencyContainer.resolve()
-                error.exists ? router.show(.error()) : router.show(.success(type: .regular))
+                error.exists ? router.show(.error(error: PrimerError.generic)) : router.show(.success(type: .regular))
             }
         })
     }
@@ -152,7 +152,7 @@ extension OAuthViewController: ReloadDelegate {
         viewModel.tokenize(host, with: { [weak self] error in
             DispatchQueue.main.async {
                 let router: RouterDelegate = DependencyContainer.resolve()
-                error.exists ? router.show(.error()) : router.show(.success(type: .regular))
+                error.exists ? router.show(.error(error: PrimerError.generic)) : router.show(.success(type: .regular))
             }
         })
     }

--- a/Sources/PrimerSDK/Classes/User Interface/Root/Route.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/Route.swift
@@ -58,6 +58,7 @@ enum Route {
             vc.screenType = screenType
             return vc
         case .error(let error):
+            Primer.shared.delegate?.checkoutFailed(with: error)
             return ErrorViewController(message: error.localizedDescription)
         case .confirmMandate:
             return ConfirmMandateViewController()

--- a/Sources/PrimerSDK/Classes/User Interface/Root/Route.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/Route.swift
@@ -23,7 +23,7 @@ enum Route {
     case oAuth(host: OAuthHost)
     case applePay
     case success(type: SuccessScreenType)
-    case error(message: String = "")
+    case error(error: Error)
     case confirmMandate
     case form(type: FormType, closeOnSubmit: Bool = false)
 
@@ -57,8 +57,8 @@ enum Route {
             let vc = SuccessViewController()
             vc.screenType = screenType
             return vc
-        case .error(let message):
-            return ErrorViewController(message: message)
+        case .error(let error):
+            return ErrorViewController(message: error.localizedDescription)
         case .confirmMandate:
             return ConfirmMandateViewController()
         case .form(let type, _):

--- a/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
+++ b/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
@@ -66,6 +66,10 @@ class MockPrimerDelegate: PrimerDelegate {
     func onCheckoutDismissed() {
         onCheckoutDismissedCalled = true
     }
+    
+    func checkoutFailed(with error: Error) {
+        
+    }
 }
 
 struct MockPrimerSettings: PrimerSettingsProtocol {


### PR DESCRIPTION
CHE-543

# What this PR does

All errors that are shown on the error view, are no exposed through a delegate method to the developer.

# Notable decisions & other stuff

I preferred to implement the logic on the line that we are presenting the error view, since it's only those errors that we need to expose.

# Before merging

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
