### PR TITLE
[CHE-556] Remove "Add new card" button from vault manager

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
@@ -45,10 +45,7 @@ extension VaultPaymentMethodViewController: UITableViewDelegate, UITableViewData
             alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
 
             alert.addAction(UIAlertAction(title: "Delete", style: .destructive, handler: { [weak self] _ in
-                let viewModel: VaultPaymentMethodViewModelProtocol = DependencyContainer.resolve()
-                viewModel.deletePaymentMethod(with: methodId, and: { [weak self] _ in
-                    DispatchQueue.main.async { self?.subView.tableView.reloadData() }
-                })
+                self?.deletePaymentMethod(methodId)
             }))
 
             alert.show()
@@ -58,12 +55,31 @@ extension VaultPaymentMethodViewController: UITableViewDelegate, UITableViewData
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 10
     }
+    
+    private func deletePaymentMethod(_ paymentMethodToken: String) {
+        let viewModel: VaultPaymentMethodViewModelProtocol = DependencyContainer.resolve()
+        viewModel.deletePaymentMethod(with: paymentMethodToken, and: { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.subView.tableView.reloadData()
+                
+                // Going back if no payment method remains
+                if viewModel.paymentMethods.count == 0 {
+                    self?.cancel()
+                }
+            }
+        })
+    }
 
     @objc private func deleteMethod(sender: UIButton) {
         let viewModel: VaultPaymentMethodViewModelProtocol = DependencyContainer.resolve()
         guard let methodId = viewModel.paymentMethods[sender.tag].token else { return }
         viewModel.deletePaymentMethod(with: methodId, and: { [weak self] _ in
-            DispatchQueue.main.async { self?.subView.tableView.reloadData() }
+            DispatchQueue.main.async {
+                self?.subView.tableView.reloadData()
+                if viewModel.paymentMethods.count == 0 {
+                    self?.cancel()
+                }
+            }
         })
     }
 

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
@@ -69,7 +69,11 @@ extension VaultPaymentMethodViewController: UITableViewDelegate, UITableViewData
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let viewModel: VaultPaymentMethodViewModelProtocol = DependencyContainer.resolve()
-        return viewModel.paymentMethods.count + 1
+        
+        /// TODO(at): Only return the number of saved payment instruments while we figure the design
+        return viewModel.paymentMethods.count
+        
+        // return viewModel.paymentMethods.count + 1 /* "Add card" button */
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
@@ -70,19 +70,6 @@ extension VaultPaymentMethodViewController: UITableViewDelegate, UITableViewData
         })
     }
 
-    @objc private func deleteMethod(sender: UIButton) {
-        let viewModel: VaultPaymentMethodViewModelProtocol = DependencyContainer.resolve()
-        guard let methodId = viewModel.paymentMethods[sender.tag].token else { return }
-        viewModel.deletePaymentMethod(with: methodId, and: { [weak self] _ in
-            DispatchQueue.main.async {
-                self?.subView.tableView.reloadData()
-                if viewModel.paymentMethods.count == 0 {
-                    self?.cancel()
-                }
-            }
-        })
-    }
-
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let viewModel: VaultPaymentMethodViewModelProtocol = DependencyContainer.resolve()
         

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
@@ -63,7 +63,7 @@ extension VaultPaymentMethodViewController: UITableViewDelegate, UITableViewData
                 self?.subView.tableView.reloadData()
                 
                 // Going back if no payment method remains
-                if viewModel.paymentMethods.count == 0 {
+                if viewModel.paymentMethods.isEmpty {
                     self?.cancel()
                 }
             }

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController+TableView.swift
@@ -73,7 +73,7 @@ extension VaultPaymentMethodViewController: UITableViewDelegate, UITableViewData
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         let viewModel: VaultPaymentMethodViewModelProtocol = DependencyContainer.resolve()
         
-        /// TODO(at): Only return the number of saved payment instruments while we figure the design
+        // TODO: Only return the number of saved payment instruments while we figure the design
         return viewModel.paymentMethods.count
         
         // return viewModel.paymentMethods.count + 1 /* "Add card" button */


### PR DESCRIPTION
CHE-556

# What this PR does

This PR removes "Add new card" button from the vault manager in the Universal Checkout.

# Notable decisions & other stuff

When deleting the last vaulted payment method, this PR goes back to the Universla Checkout.

If we ship the vault manager as a standalone module, we would need to implement a proper empty screen. But we can do that for another ticket.

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
