### PR TITLE
[CHE-557] Hide card scan button

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/Form/FormView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Form/FormView.swift
@@ -9,6 +9,8 @@
 
 import UIKit
 
+let ENABLE_CARD_SCANNER = false
+
 protocol FormViewDelegate: class, UITextFieldDelegate {
     var formType: FormType { get }
     var submitButtonTitle: String { get }
@@ -102,7 +104,10 @@ class FormView: UIView {
 
         if let formType = delegate?.formType {
             switch formType {
-            case .cardForm: configureScannerButton()
+            case .cardForm:
+                if ENABLE_CARD_SCANNER {
+                    configureScannerButton()
+                }
             default: break
             }
         }


### PR DESCRIPTION
CHE-557

# What this PR does

Hide the card scan button behind a flag

# Notable decisions & other stuff

Maybe there's better way to do that?

# Before merging

_QA_

- [ ] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
