### PR TITLE
Feature/che 631 cleanup

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Payment Services/ClientTokenService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/ClientTokenService.swift
@@ -27,12 +27,10 @@ class ClientTokenService: ClientTokenServiceProtocol {
                 guard let jwtTokenPayload = token.jwtTokenPayload,
                       let expDate = jwtTokenPayload.expDate
                 else {
-                    Primer.shared.delegate?.checkoutFailed(with: PrimerError.clientTokenNull)
                     return completion(PrimerError.clientTokenNull)
                 }
                 
                 if expDate < Date() {
-                    Primer.shared.delegate?.checkoutFailed(with: PrimerError.tokenExpired)
                     return completion(PrimerError.tokenExpired)
                 }
                 

--- a/Sources/PrimerSDK/Classes/User Interface/Checkout/DirectCheckoutViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Checkout/DirectCheckoutViewModel.swift
@@ -49,9 +49,13 @@ class DirectCheckoutViewModel: DirectCheckoutViewModelProtocol {
             paymentMethodConfigService.fetchConfig(completion)
         } else {
             let clientTokenService: ClientTokenServiceProtocol = DependencyContainer.resolve()
-            clientTokenService.loadCheckoutConfig({ [weak self] _ in
-                let paymentMethodConfigService: PaymentMethodConfigServiceProtocol = DependencyContainer.resolve()
-                paymentMethodConfigService.fetchConfig(completion)
+            clientTokenService.loadCheckoutConfig({ err in
+                if let err = err {
+                    completion(err)
+                } else {
+                    let paymentMethodConfigService: PaymentMethodConfigServiceProtocol = DependencyContainer.resolve()
+                    paymentMethodConfigService.fetchConfig(completion)
+                }
             })
         }
     }

--- a/Sources/PrimerSDK/Classes/User Interface/Checkout/VaultCheckoutViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Checkout/VaultCheckoutViewModel.swift
@@ -57,18 +57,30 @@ class VaultCheckoutViewModel: VaultCheckoutViewModelProtocol {
         let state: AppStateProtocol = DependencyContainer.resolve()
         if state.decodedClientToken.exists {
             let paymentMethodConfigService: PaymentMethodConfigServiceProtocol = DependencyContainer.resolve()
-            paymentMethodConfigService.fetchConfig({ [weak self] _ in
-                let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
-                vaultService.loadVaultedPaymentMethods(completion)
+            paymentMethodConfigService.fetchConfig({ err in
+                if let err = err {
+                    completion(err)
+                } else {
+                    let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
+                    vaultService.loadVaultedPaymentMethods(completion)
+                }
             })
         } else {
             let clientTokenService: ClientTokenServiceProtocol = DependencyContainer.resolve()
-            clientTokenService.loadCheckoutConfig({ [weak self] _ in
-                let paymentMethodConfigService: PaymentMethodConfigServiceProtocol = DependencyContainer.resolve()
-                paymentMethodConfigService.fetchConfig({ [weak self] _ in
-                    let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
-                    vaultService.loadVaultedPaymentMethods(completion)
-                })
+            clientTokenService.loadCheckoutConfig({ err in
+                if let err = err {
+                    completion(err)
+                } else {
+                    let paymentMethodConfigService: PaymentMethodConfigServiceProtocol = DependencyContainer.resolve()
+                    paymentMethodConfigService.fetchConfig({ err in
+                        if let err = err {
+                            completion(err)
+                        } else {
+                            let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
+                            vaultService.loadVaultedPaymentMethods(completion)
+                        }
+                    })
+                }
             })
         }
     }

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
@@ -52,6 +52,7 @@ class OAuthViewController: UIViewController {
 //                    self?.dismiss(animated: true, completion: nil)
 //                }))
 //                alert.show()
+                Primer.shared.delegate?.checkoutFailed(with: error)
             case .success(let urlString):
                 DispatchQueue.main.async {
                     // if klarna show webview, otherwise oauth

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
@@ -47,11 +47,11 @@ class OAuthViewController: UIViewController {
             switch result {
             case .failure(let error):
                 _ = ErrorHandler.shared.handle(error: error)
-                let alert = AlertController(title: "ERROR!", message: error.localizedDescription, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { (_) in
-                    self?.dismiss(animated: true, completion: nil)
-                }))
-                alert.show()
+//                let alert = AlertController(title: "ERROR!", message: error.localizedDescription, preferredStyle: .alert)
+//                alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { (_) in
+//                    self?.dismiss(animated: true, completion: nil)
+//                }))
+//                alert.show()
             case .success(let urlString):
                 DispatchQueue.main.async {
                     // if klarna show webview, otherwise oauth

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
@@ -128,9 +128,13 @@ class OAuthViewController: UIViewController {
             session = SFAuthenticationSession(
                 url: authURL,
                 callbackURLScheme: viewModel.urlSchemeIdentifier,
-                completionHandler: { [weak self] (url, error) in
-                    let router: RouterDelegate = DependencyContainer.resolve()
-                    error.exists ? router.show(.error(error: PrimerError.generic)) : self?.onOAuthCompleted(callbackURL: url)
+                completionHandler: { [weak self] (url, err) in
+                    if let err = err {
+                        let router: RouterDelegate = DependencyContainer.resolve()
+                        router.show(.error(error: PrimerError.generic))
+                    } else {
+                        self?.onOAuthCompleted(callbackURL: url)
+                    }
                 }
             )
 
@@ -141,10 +145,17 @@ class OAuthViewController: UIViewController {
     private func onOAuthCompleted(callbackURL: URL?) {
         let viewModel: OAuthViewModelProtocol = DependencyContainer.resolve()
         
-        viewModel.tokenize(host, with: { [weak self] error in
+        viewModel.tokenize(host, with: { err in
+            // FIXME: Is switching to the main thread really needed here? If it's needed by the Router that's handling
+            // various UI procedeures, shouldn't it be moved in there?
             DispatchQueue.main.async {
                 let router: RouterDelegate = DependencyContainer.resolve()
-                error.exists ? router.show(.error(error: PrimerError.generic)) : router.show(.success(type: .regular))
+                
+                if let err = err {
+                    router.show(.error(error: PrimerError.generic))
+                } else {
+                    router.show(.success(type: .regular))
+                }
             }
         })
     }
@@ -163,10 +174,19 @@ extension OAuthViewController: ASWebAuthenticationPresentationContextProviding {
 extension OAuthViewController: ReloadDelegate {
     func reload() {
         let viewModel: OAuthViewModelProtocol = DependencyContainer.resolve()
-        viewModel.tokenize(host, with: { [weak self] error in
+        viewModel.tokenize(host, with: { err in
             DispatchQueue.main.async {
                 let router: RouterDelegate = DependencyContainer.resolve()
-                error.exists ? router.show(.error(error: PrimerError.generic)) : router.show(.success(type: .regular))
+                
+                if let err = err {
+                    _ = ErrorHandler.shared.handle(error: err)
+                    // FIXME: I'm not feeling comfortable doing nothing with the error, showing an error screen and passing a generic error
+                    // to the developer from the Router (which has not information about it). Also, this means that the Router is taking
+                    // a decision based on a UI element (i.e. whether the vc is of type ErrorViewController).
+                    router.show(.error(error: PrimerError.generic))
+                } else {
+                    router.show(.success(type: .regular))
+                }
             }
         })
     }

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewModel.swift
@@ -36,15 +36,15 @@ class OAuthViewModel: OAuthViewModelProtocol {
 
     private func loadConfig(_ host: OAuthHost, _ completion: @escaping (Result<String, Error>) -> Void) {
         let clientTokenService: ClientTokenServiceProtocol = DependencyContainer.resolve()
-        clientTokenService.loadCheckoutConfig({ [weak self] error in
-            if error != nil {
-                ErrorHandler.shared.handle(error: error!)
+        clientTokenService.loadCheckoutConfig({ err in
+            if let err = err {
+                ErrorHandler.shared.handle(error: err)
                 completion(.failure(PrimerError.payPalSessionFailed))
             } else {
                 let paymentMethodConfigService: PaymentMethodConfigServiceProtocol = DependencyContainer.resolve()
-                paymentMethodConfigService.fetchConfig({ [weak self] error in
-                    if error != nil {
-                        ErrorHandler.shared.handle(error: error!)
+                paymentMethodConfigService.fetchConfig({ [weak self] err in
+                    if let err = err {
+                        ErrorHandler.shared.handle(error: err)
                         completion(.failure(PrimerError.payPalSessionFailed))
                     } else {
                         self?.generateOAuthURL(host, with: completion)
@@ -87,6 +87,7 @@ class OAuthViewModel: OAuthViewModelProtocol {
             switch result {
             case .failure(let error):
                 log(logLevel: .error, title: "ERROR!", message: error.localizedDescription, prefix: nil, suffix: nil, bundle: nil, file: #file, className: String(describing: Self.self), function: #function, line: #line)
+                completion(PrimerError.payPalSessionFailed)
             case .success:
                 self?.tokenize(host, with: completion)
             }

--- a/Sources/PrimerSDK/Classes/User Interface/Primer/ExternalViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Primer/ExternalViewModel.swift
@@ -24,27 +24,30 @@ class ExternalViewModel: ExternalViewModelProtocol {
         
         if state.decodedClientToken.exists {
             let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
-            vaultService.loadVaultedPaymentMethods({ [weak self] error in
-                if let error = error { completion(.failure(error)) }
-                let paymentMethods = state.paymentMethods
-                completion(.success(paymentMethods))
+            vaultService.loadVaultedPaymentMethods({ err in
+                if let err = err {
+                    completion(.failure(err))
+                } else {
+                    let paymentMethods = state.paymentMethods
+                    completion(.success(paymentMethods))
+                }
             })
         } else {
             let clientTokenService: ClientTokenServiceProtocol = DependencyContainer.resolve()
-            clientTokenService.loadCheckoutConfig({ [weak self] error in
-                if let error = error {
-                    return completion(.failure(error))
+            clientTokenService.loadCheckoutConfig({ err in
+                if let err = err {
+                    completion(.failure(err))
+                } else {
+                    let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
+                    vaultService.loadVaultedPaymentMethods({ err in
+                        if let err = err {
+                            completion(.failure(err))
+                        } else {
+                            let paymentMethods = state.paymentMethods
+                            completion(.success(paymentMethods))
+                        }
+                    })
                 }
-                
-                let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
-                vaultService.loadVaultedPaymentMethods({ [weak self] error in
-                    if let error = error {
-                        return completion(.failure(error))
-                    }
-                    
-                    let paymentMethods = state.paymentMethods
-                    completion(.success(paymentMethods))
-                })
             })
         }
     }


### PR DESCRIPTION
CHE-631

# What this PR does

Adds missing completion handlers. Fixes non-escaping completion handlers. Rewrites hard-to-read one-liners into if-else statements.

Move checkoutFailed call into OAuthViewController

# Notable decisions & other stuff

n/a

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
