### PR TITLE
Feature/che 680 fix vault title

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/PCI/FormType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PCI/FormType.swift
@@ -122,12 +122,8 @@ enum FormType {
                               comment: "SEPA Direct Debit Mandate - Form Type Main Title (Direct Debit)")
         case .email: return ""
         case .address: return ""
-        case .cardForm: return ""
-//            return NSLocalizedString("primer-form-type-main-title-sepa-direct-debit-mandate",
-//                              tableName: nil,
-//                              bundle: Bundle.primerResources,
-//                              value: "SEPA Direct Debit Mandate",
-//                              comment: "SEPA Direct Debit Mandate - Form Type Main Title (Direct Debit)")
+        case .cardForm:
+            return ""
         }
     }
 

--- a/Sources/PrimerSDK/Classes/User Interface/Checkout/VaultCheckoutView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Checkout/VaultCheckoutView.swift
@@ -17,6 +17,7 @@ class VaultCheckoutView: UIView, ReactiveView {
 
     let indicator = UIActivityIndicatorView()
     let navBar = UINavigationBar()
+    let titleLabel = UILabel()
     let amountLabelView = UILabel()
     let savedCardTitleLabel = UILabel()
     var savedCardButton = CardButton()
@@ -39,6 +40,7 @@ class VaultCheckoutView: UIView, ReactiveView {
     func render(isBusy: Bool = false) {
         addSubview(indicator)
         addSubview(navBar)
+        addSubview(titleLabel)
         addSubview(amountLabelView)
         addSubview(savedCardTitleLabel)
         addSubview(savedCardButton)
@@ -56,6 +58,7 @@ class VaultCheckoutView: UIView, ReactiveView {
             indicator.startAnimating()
         } else {
             configureNavBar()
+            configureTitleLabel()
             configureTableView()
             configurePayButton()
             configureAmountLabelView()
@@ -115,6 +118,20 @@ extension VaultCheckoutView {
 
     @objc private func cancel() {
         delegate?.cancel()
+    }
+    
+    private func configureTitleLabel() {
+        titleLabel.font = .boldSystemFont(ofSize: 17)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.topAnchor.constraint(equalTo: navBar.bottomAnchor, constant: -28).isActive = true
+        titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20).isActive = true
+        titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20).isActive = true
+        titleLabel.textAlignment = .center
+        titleLabel.text = NSLocalizedString("primer-vault-checkout-nav-bar-title",
+                                            tableName: nil,
+                                            bundle: Bundle.primerResources,
+                                            value: "Choose payment method",
+                                            comment: "Choose payment method - Vault Checkout Navigation Bar Title")
     }
 
     private func configureAmountLabelView() {
@@ -257,14 +274,18 @@ extension VaultCheckoutView {
                 otherMethodsTitleLabel.textColor = theme.colorTheme.secondaryText1
                 otherMethodsTitleLabel.font = .systemFont(ofSize: 12, weight: .light)
 
-                otherMethodsTitleLabel.topAnchor.constraint(equalTo: navBar.bottomAnchor, constant: 0).isActive = true
+                otherMethodsTitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 16).isActive = true
                 otherMethodsTitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: theme.layout.safeMargin).isActive = true
             } else {
                 otherMethodsTitleLabel.text = ""
                 otherMethodsTitleLabel.topAnchor.constraint(equalTo: seeAllLinkLabel.bottomAnchor, constant: 0).isActive = true
             }
         } else {
-            otherMethodsTitleLabel.topAnchor.constraint(equalTo: seeAllLinkLabel.bottomAnchor, constant: 0).isActive = true
+            if seeAllLinkLabel.isHidden {
+                otherMethodsTitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 16).isActive = true
+            } else {
+                otherMethodsTitleLabel.topAnchor.constraint(equalTo: seeAllLinkLabel.bottomAnchor, constant: 0).isActive = true
+            }
         }
     }
 

--- a/Sources/PrimerSDK/Classes/User Interface/Form/FormView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Form/FormView.swift
@@ -26,6 +26,7 @@ class FormView: UIView {
     // MARK: - PROPERTIES
 
     let navBar = UINavigationBar()
+    let navBarTitleLabel = UILabel()
     let title = UILabel()
     let link = UILabel()
     let button = UIButton()
@@ -58,6 +59,8 @@ class FormView: UIView {
         addSubview(button)
         addSubview(scannerButton)
         addSubview(contentView)
+        
+        addSubview(navBarTitleLabel)
         contentView.addSubview(title)
 
     }
@@ -134,14 +137,27 @@ class FormView: UIView {
         // remove default shadow
         navBar.setBackgroundImage(UIImage(), for: UIBarMetrics.default)
         navBar.shadowImage = UIImage()
+        navBar.layer.zPosition = -1
 
         // attach items to navbar
         navBar.setItems([navItem], animated: false)
 
         // add top title if theme toggled true
         if theme.layout.showTopTitle {
-            // FIXME: This custom navigation bar does not have a title at the moment. You're assuming that the topItem is the nav bar's title's label, when it actually is the left bar button.
-            navBar.topItem?.title = "delegate.formType.topTitle"
+            // FIXME: This needs to be fixed properly. We don't need a nav bar. We need a stackview!
+            navBarTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+            navBarTitleLabel.textAlignment = .center
+            navBarTitleLabel.font = UIFont.boldSystemFont(ofSize: 17)
+            navBarTitleLabel.textColor = .black
+            navBarTitleLabel.text = NSLocalizedString("primer-form-type-main-title-card-form",
+                                                      tableName: nil,
+                                                      bundle: Bundle.primerResources,
+                                                      value: "Enter your card details",
+                                                      comment: "Enter your card details - Form Type Main Title (Card)")
+            navBarTitleLabel.topAnchor.constraint(equalTo: topAnchor, constant: 15).isActive = true
+            navBarTitleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20).isActive = true
+            navBarTitleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20).isActive = true
+            navBarTitleLabel.layer.zPosition = 100
         }
 
         navBar.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
CHE-680

# What this PR does

Adds title labels on vault and card form.

# Notable decisions & other stuff

This is a really hacky way, but the best I could find at this point with our UI architecture.

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk

![Simulator Screen Shot - iPhone 12 - 2021-05-14 at 15 39 54](https://user-images.githubusercontent.com/5053148/118272211-f2830b80-b4ca-11eb-963e-54594a038cff.png)
![Simulator Screen Shot - iPhone 12 - 2021-05-14 at 15 39 42](https://user-images.githubusercontent.com/5053148/118272220-f57dfc00-b4ca-11eb-8b40-4c389899d91d.png)
