### PR TITLE
Feature/che 715 klarna locale fixes

### DIFF
--- a/Example/PrimerSDK/CreateClientToken.swift
+++ b/Example/PrimerSDK/CreateClientToken.swift
@@ -11,4 +11,5 @@ import Foundation
 
 struct CreateClientTokenRequest: Codable {
     let customerId: String
+    let customerCountryCode: String?
 }

--- a/Example/PrimerSDK/MerchantCheckoutViewController.swift
+++ b/Example/PrimerSDK/MerchantCheckoutViewController.swift
@@ -119,7 +119,7 @@ extension MerchantCheckoutViewController: PrimerDelegate {
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         
-        let body = CreateClientTokenRequest(customerId: "customer123")
+        let body = CreateClientTokenRequest(customerId: "customer123", customerCountryCode: nil)
         
         do {
             request.httpBody = try JSONEncoder().encode(body)

--- a/Example/PrimerSDK/MerchantCheckoutViewController.swift
+++ b/Example/PrimerSDK/MerchantCheckoutViewController.swift
@@ -28,8 +28,6 @@ class MerchantCheckoutViewController: UIViewController {
     )
     
     let vaultKlarnaSettings = PrimerSettings(
-        currency: .SEK,
-        countryCode: .se,
         klarnaSessionType: .recurringPayment,
         hasDisabledSuccessScreen: true,
         isInitialLoadingHidden: true
@@ -64,25 +62,25 @@ class MerchantCheckoutViewController: UIViewController {
     }
     
     func configurePrimer() {
-        Primer.shared.configure(settings: generalSettings)
+        Primer.shared.configure(settings: vaultKlarnaSettings)
         
-        let theme = generatePrimerTheme()
-        Primer.shared.configure(theme: theme)
-
-        Primer.shared.setDirectDebitDetails(
-            firstName: "John",
-            lastName: "Doe",
-            email: "test@mail.com",
-            iban: "FR1420041010050500013M02606",
-            address: Address(
-                addressLine1: "1 Rue",
-                addressLine2: "",
-                city: "Paris",
-                state: "",
-                countryCode: "FR",
-                postalCode: "75001"
-            )
-        )
+//        let theme = generatePrimerTheme()
+//        Primer.shared.configure(theme: theme)
+//
+//        Primer.shared.setDirectDebitDetails(
+//            firstName: "John",
+//            lastName: "Doe",
+//            email: "test@mail.com",
+//            iban: "FR1420041010050500013M02606",
+//            address: Address(
+//                addressLine1: "1 Rue",
+//                addressLine2: "",
+//                city: "Paris",
+//                state: "",
+//                countryCode: "FR",
+//                postalCode: "75001"
+//            )
+//        )
     }
 
     // MARK: - ACTIONS
@@ -90,9 +88,7 @@ class MerchantCheckoutViewController: UIViewController {
     @IBAction func addCardButtonTapped(_ sender: Any) {
         Primer.shared.showCheckout(self, flow: .addCardToVault)
     }
-    
-    var klarnaNumberOfTimesPresented = 0
-    
+        
     @IBAction func addKlarnaButtonTapped(_ sender: Any) {
         Primer.shared.showCheckout(self, flow: .addKlarnaToVault)
     }

--- a/Example/PrimerSDK/UIViewController+API.swift
+++ b/Example/PrimerSDK/UIViewController+API.swift
@@ -30,6 +30,13 @@ enum NetworkError: Error {
 extension UIViewController {
 
     func callApi(_ req: URLRequest, completion: @escaping (_ result: Result<Data, Error>) -> Void) {
+        print("URL: \(req.url?.absoluteString)")
+        print("Headers:\n\(req.allHTTPHeaderFields)")
+        
+        if let body = req.httpBody, let json = try? JSONSerialization.jsonObject(with: body, options: .allowFragments) {
+            print("Body:\n\(json)")
+        }
+        
         URLSession.shared.dataTask(with: req, completionHandler: { (data, response, err) in
 
             if err != nil {

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/KlarnaService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/KlarnaService.swift
@@ -72,10 +72,7 @@ class KlarnaService: KlarnaServiceProtocol {
             body = KlarnaCreatePaymentSessionAPIRequest(
                 paymentMethodConfigId: configId,
                 sessionType: klarnaSessionType,
-                localeData: KlarnaLocaleData(
-                    countryCode: settings.countryCode?.rawValue,
-                    currencyCode: settings.currency?.rawValue,
-                    localeCode: settings.countryCode?.klarnaLocaleCode),
+                localeData: settings.localeData,
                 description: klarnaSessionType == .recurringPayment ? settings.klarnaPaymentDescription : nil,
                 redirectUrl: "https://primer.io/success",
                 totalAmount: amount,
@@ -84,6 +81,7 @@ class KlarnaService: KlarnaServiceProtocol {
             body = KlarnaCreatePaymentSessionAPIRequest(
                 paymentMethodConfigId: configId,
                 sessionType: klarnaSessionType,
+                localeData: settings.localeData,
                 description: klarnaSessionType == .recurringPayment ? settings.klarnaPaymentDescription : nil,
                 redirectUrl: "https://primer.io/success",
                 totalAmount: amount,
@@ -117,9 +115,7 @@ class KlarnaService: KlarnaServiceProtocol {
 
         guard let configId = state.paymentMethodConfig?.getConfigId(for: .klarna),
               let authorizationToken = state.authorizationToken,
-              let sessionId = state.sessionId,
-              let countryCode = settings.countryCode,
-              let currency = settings.currency else {
+              let sessionId = state.sessionId else {
             return completion(.failure(KlarnaException.noPaymentMethodConfigId))
         }
 
@@ -128,11 +124,7 @@ class KlarnaService: KlarnaServiceProtocol {
             sessionId: sessionId,
             authorizationToken: authorizationToken,
             description: settings.klarnaPaymentDescription,
-            localeData: KlarnaLocaleData(
-                countryCode: countryCode.rawValue,
-                currencyCode: currency.rawValue,
-                localeCode: countryCode.klarnaLocaleCode
-            )
+            localeData: settings.localeData
         )
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()

--- a/Sources/PrimerSDK/Classes/Data Models/CountryCode.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CountryCode.swift
@@ -536,7 +536,8 @@ extension CountryCode {
             return "es-ES"
         case .it:
             return "it-IT"
-        default: return "n/a"
+        default:
+            return "n/a"
         }
     }
 

--- a/Sources/PrimerSDK/Classes/Data Models/Klarna.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Klarna.swift
@@ -13,9 +13,9 @@ public enum KlarnaSessionType: String, Codable {
 }
 
 struct KlarnaLocaleData: Codable {
-    let countryCode: String
-    let currencyCode: String
-    let localeCode: String
+    let countryCode: String?
+    let currencyCode: String?
+    let localeCode: String?
 }
 
 // MARK: CREATE PAYMENT SESSION DATA MODELS
@@ -23,7 +23,7 @@ struct KlarnaLocaleData: Codable {
 struct KlarnaCreatePaymentSessionAPIRequest: Codable {
     let paymentMethodConfigId: String
     let sessionType: KlarnaSessionType
-    let localeData: KlarnaLocaleData
+    var localeData: KlarnaLocaleData?
     let description: String?
     let redirectUrl: String?
     let totalAmount: Int?

--- a/Sources/PrimerSDK/Classes/Data Models/Klarna.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Klarna.swift
@@ -12,10 +12,23 @@ public enum KlarnaSessionType: String, Codable {
     case recurringPayment = "RECURRING_PAYMENT"
 }
 
-struct KlarnaLocaleData: Codable {
-    let countryCode: String?
-    let currencyCode: String?
-    let localeCode: String?
+public struct LocaleData: Codable {
+    let languageCode: String?
+    var localeCode: String?
+    let regionCode: String?
+    
+    public init(languageCode: String?, regionCode: String?) {
+        self.languageCode = languageCode ?? Locale.current.languageCode
+        self.regionCode = regionCode ?? Locale.current.regionCode
+        
+        if let languageCode = self.languageCode {
+            if let regionCode = self.regionCode {
+                self.localeCode = "\(languageCode)-\(regionCode)"
+            } else {
+                self.localeCode = "\(languageCode)"
+            }
+        }
+    }
 }
 
 // MARK: CREATE PAYMENT SESSION DATA MODELS
@@ -23,7 +36,7 @@ struct KlarnaLocaleData: Codable {
 struct KlarnaCreatePaymentSessionAPIRequest: Codable {
     let paymentMethodConfigId: String
     let sessionType: KlarnaSessionType
-    var localeData: KlarnaLocaleData?
+    var localeData: LocaleData?
     let description: String?
     let redirectUrl: String?
     let totalAmount: Int?
@@ -48,7 +61,7 @@ struct CreateKlarnaCustomerTokenAPIRequest: Codable {
     let sessionId: String
     let authorizationToken: String
     let description: String?
-    let localeData: KlarnaLocaleData
+    let localeData: LocaleData
 }
 
 struct KlarnaCustomerTokenAPIResponse: Codable {

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -24,6 +24,7 @@ protocol PrimerSettingsProtocol {
     var directDebitHasNoAmount: Bool { get }
     var orderItems: [OrderItem] { get }
     var isInitialLoadingHidden: Bool { get }
+    var localeData: LocaleData { get }
 }
 
 /**
@@ -65,6 +66,7 @@ public class PrimerSettings: PrimerSettingsProtocol {
     internal(set) public var directDebitHasNoAmount: Bool
     internal(set) public var orderItems: [OrderItem]
     internal(set) public var isInitialLoadingHidden: Bool
+    internal(set) public var localeData: LocaleData
 
     public var clientTokenRequestCallback: ClientTokenCallBack {
         return Primer.shared.delegate?.clientTokenCallback ?? { _ in }
@@ -98,7 +100,8 @@ public class PrimerSettings: PrimerSettingsProtocol {
         businessDetails: BusinessDetails? = nil,
         directDebitHasNoAmount: Bool = false,
         orderItems: [OrderItem] = [],
-        isInitialLoadingHidden: Bool = false
+        isInitialLoadingHidden: Bool = false,
+        localeData: LocaleData? = nil
     ) {
         self.amount = amount
         self.currency = currency
@@ -116,6 +119,7 @@ public class PrimerSettings: PrimerSettingsProtocol {
         self.directDebitHasNoAmount = directDebitHasNoAmount
         self.orderItems = orderItems
         self.isInitialLoadingHidden = isInitialLoadingHidden
+        self.localeData = localeData ?? LocaleData(languageCode: nil, regionCode: nil)
     }
 }
 

--- a/Sources/PrimerSDK/Classes/Error Handler/Error.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/Error.swift
@@ -98,7 +98,7 @@ enum KlarnaException: PrimerErrorProtocol {
             return NSLocalizedString("primer-klarna-error-message-failed-to-find-country-code",
                                      tableName: nil,
                                      bundle: Bundle.primerResources,
-                                     value: "Failed to find currency",
+                                     value: "Failed to find country code",
                                      comment: "Failed to find country code - Error message")
 
         case .noPaymentMethodConfigId:

--- a/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
+++ b/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
@@ -76,6 +76,8 @@ class MockPrimerDelegate: PrimerDelegate {
 }
 
 struct MockPrimerSettings: PrimerSettingsProtocol {
+    var localeData: LocaleData
+    
     var isInitialLoadingHidden: Bool = false
     
     var klarnaPaymentDescription: String?
@@ -130,6 +132,7 @@ struct MockPrimerSettings: PrimerSettingsProtocol {
         self.clientTokenRequestCallback = clientTokenRequestCallback
         self.authorizePayment = authorizePayment
         self.onCheckoutDismiss = onCheckoutDismiss
+        self.localeData = LocaleData(languageCode: nil, regionCode: nil)
     }
 }
 


### PR DESCRIPTION
CHE-715

# What this PR does

Contains PR-710
Fixes Klarna locale. Exposes locale on the developer settings. Defaults to system locale if no locale provided.

# Notable decisions & other stuff

n/a

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
