### PR TITLE
Feature/che 654 klarna UI tests

### DIFF
--- a/Example/PrimerSDK/Base.lproj/Main.storyboard
+++ b/Example/PrimerSDK/Base.lproj/Main.storyboard
@@ -117,11 +117,11 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xhR-QE-h6v">
                                         <rect key="frame" x="0.0" y="52" width="303" height="40"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="add_klarna_button"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="vault_klarna_button"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="9OY-3P-D9G"/>
                                         </constraints>
-                                        <state key="normal" title="Add Klarna">
+                                        <state key="normal" title="Vault Klarna">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </state>
                                         <connections>

--- a/Example/PrimerSDK/MerchantCheckoutViewController.swift
+++ b/Example/PrimerSDK/MerchantCheckoutViewController.swift
@@ -79,25 +79,25 @@ class MerchantCheckoutViewController: UIViewController {
     }
     
     func configurePrimer() {
-        Primer.shared.configure(settings: applePaySettings)
+        Primer.shared.configure(settings: generalSettings)
         
-       let theme = generatePrimerTheme()
-       Primer.shared.configure(theme: theme)
-
-       Primer.shared.setDirectDebitDetails(
-           firstName: "John",
-           lastName: "Doe",
-           email: "test@mail.com",
-           iban: "FR1420041010050500013M02606",
-           address: Address(
-               addressLine1: "1 Rue",
-               addressLine2: "",
-               city: "Paris",
-               state: "",
-               countryCode: "FR",
-               postalCode: "75001"
-           )
-       )
+        let theme = generatePrimerTheme()
+        Primer.shared.configure(theme: theme)
+        
+        Primer.shared.setDirectDebitDetails(
+            firstName: "John",
+            lastName: "Doe",
+            email: "test@mail.com",
+            iban: "FR1420041010050500013M02606",
+            address: Address(
+                addressLine1: "1 Rue",
+                addressLine2: "",
+                city: "Paris",
+                state: "",
+                countryCode: "FR",
+                postalCode: "75001"
+            )
+        )
     }
 
     // MARK: - ACTIONS
@@ -111,6 +111,7 @@ class MerchantCheckoutViewController: UIViewController {
     }
     
     @IBAction func addKlarnaButtonTapped(_ sender: Any) {
+        Primer.shared.configure(settings: vaultKlarnaSettings)
         Primer.shared.showCheckout(self, flow: .addKlarnaToVault)
     }
     

--- a/Example/PrimerSDKExample_UITests/Base.swift
+++ b/Example/PrimerSDKExample_UITests/Base.swift
@@ -82,6 +82,10 @@ class Base: XCTestCase {
         let webView = app.webViews["primer_webview"]
         expectation(for: exists, evaluatedWith: webView, handler: nil)
         waitForExpectations(timeout: 5, handler: nil)
+        
+        let continueButton = app.webViews.buttons["Continue"]
+        expectation(for: exists, evaluatedWith: continueButton, handler: nil)
+        waitForExpectations(timeout: 30, handler: nil)
     }
 
 }

--- a/Example/PrimerSDKExample_UITests/Base.swift
+++ b/Example/PrimerSDKExample_UITests/Base.swift
@@ -74,14 +74,14 @@ class Base: XCTestCase {
     
     func testInitKlarna() throws {
         try testPresentWallet()
-        
-        app/*@START_MENU_TOKEN@*/.buttons["add_klarna_button"]/*[[".buttons[\"Add Klarna\"]",".buttons[\"add_klarna_button\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
-        
-        let klarnaBuyButton = app.webViews.webViews.webViews/*@START_MENU_TOKEN@*/.buttons["Buy"]/*[[".otherElements.matching(identifier: \"Complete your purchase\").buttons[\"Buy\"]",".buttons[\"Buy\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+
+        app.buttons["vault_klarna_button"].tap()
+
         let exists = NSPredicate(format: "exists == 1")
         
-        expectation(for: exists, evaluatedWith: klarnaBuyButton, handler: nil)
-        waitForExpectations(timeout: 10, handler: nil)
+        let webView = app.webViews["primer_webview"]
+        expectation(for: exists, evaluatedWith: webView, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
 }

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/WebViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/WebViewController.swift
@@ -23,6 +23,9 @@ internal class WebViewController: PrimerViewController, WKNavigationDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        webView.isAccessibilityElement = true
+        webView.accessibilityIdentifier = "primer_webview"
+        
         webView.scrollView.bounces = false
         
         // Control which sites can be visited

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/WebViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/WebViewController.swift
@@ -23,7 +23,7 @@ internal class WebViewController: PrimerViewController, WKNavigationDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        webView.isAccessibilityElement = true
+        webView.isAccessibilityElement = false
         webView.accessibilityIdentifier = "primer_webview"
         
         webView.scrollView.bounces = false


### PR DESCRIPTION
CHE-654

# What this PR does

Test that the Klarna webview is presented.
Test that it includes the `Continue` button when it's loaded.

# Notable decisions & other stuff

n/a

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
