### PR TITLE
Feature/che 721 deprecate and rename

### DIFF
--- a/Example/PrimerSDK/MerchantCheckoutViewController.swift
+++ b/Example/PrimerSDK/MerchantCheckoutViewController.swift
@@ -174,13 +174,45 @@ extension MerchantCheckoutViewController: PrimerDelegate {
     }
     
     func authorizePayment(_ result: PaymentMethodToken, _ completion: @escaping (Error?) -> Void) {
-        guard let token = result.token else { return completion(NetworkError.missingParams) }
+//        guard let token = result.token else { return completion(NetworkError.missingParams) }
+//
+//        guard let url = URL(string: "\(endpoint)/transaction") else {
+//            return completion(NetworkError.missingParams)
+//        }
+//
+//        let type = result.paymentInstrumentType
+//
+//        var request = URLRequest(url: url)
+//
+//        request.httpMethod = "POST"
+//        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+//        
+//        let body = AuthorizationRequest(paymentMethod: token, amount: amount, type: type.rawValue, capture: true, currencyCode: "GBP")
+//        
+//        do {
+//            request.httpBody = try JSONEncoder().encode(body)
+//        } catch {
+//            return completion(NetworkError.missingParams)
+//        }
+//        
+//        callApi(request) { (result) in
+//            switch result {
+//            case .success:
+//                completion(nil)
+//            case .failure(let err):
+//                completion(err)
+//            }
+//        }
+    }
+    
+    func onTokenizeSuccess(_ paymentMethodToken: PaymentMethodToken, _ completion: @escaping (Error?) -> Void) {
+        guard let token = paymentMethodToken.token else { return completion(NetworkError.missingParams) }
 
         guard let url = URL(string: "\(endpoint)/transaction") else {
             return completion(NetworkError.missingParams)
         }
 
-        let type = result.paymentInstrumentType
+        let type = paymentMethodToken.paymentInstrumentType
 
         var request = URLRequest(url: url)
 

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/KlarnaService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/KlarnaService.swift
@@ -57,7 +57,7 @@ internal class KlarnaService: KlarnaServiceProtocol {
                 return completion(.failure(KlarnaException.missingOrderItems))
             }
             
-            if settings.orderItems.filter({ $0.unitAmount == nil }).isEmpty {
+            if !settings.orderItems.filter({ $0.unitAmount == nil }).isEmpty {
                 return completion(.failure(KlarnaException.orderItemMissesAmount))
             }
             

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
@@ -27,13 +27,14 @@ import UIKit
 public protocol PrimerDelegate: class {
     func clientTokenCallback(_ completion: @escaping (Result<String, Error>) -> Void)
     func tokenAddedToVault(_ token: PaymentMethodToken)
+    @available(*, deprecated, renamed: "onTokenizeSuccess")
     func authorizePayment(_ result: PaymentMethodToken, _ completion:  @escaping (Error?) -> Void)
+    func onTokenizeSuccess(_ paymentMethodToken: PaymentMethodToken, _ completion:  @escaping (Error?) -> Void)
     func onCheckoutDismissed()
     func checkoutFailed(with error: Error)
 }
 
 internal class MockPrimerDelegate: PrimerDelegate {
-    
     func clientTokenCallback(_ completion: @escaping (Result<String, Error>) -> Void) {
 
     }
@@ -44,6 +45,10 @@ internal class MockPrimerDelegate: PrimerDelegate {
 
     func authorizePayment(_ result: PaymentMethodToken, _ completion: @escaping (Error?) -> Void) {
 
+    }
+    
+    func onTokenizeSuccess(_ paymentMethodToken: PaymentMethodToken, _ completion: @escaping (Error?) -> Void) {
+        
     }
 
     func onCheckoutDismissed() {

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -2,6 +2,7 @@
 
 public typealias ClientTokenCallBack = (_ completionHandler: @escaping (Result<String, Error>) -> Void) -> Void
 public typealias PaymentMethodTokenCallBack = (_ result: PaymentMethodToken, _ completion:  @escaping (Error?) -> Void) -> Void
+public typealias TokenizationSuccessCallBack = (_ paymentMethodToken: PaymentMethodToken, _ completion:  @escaping (Error?) -> Void) -> Void
 public typealias CheckoutDismissalCallback = () -> Void
 
 internal protocol PrimerSettingsProtocol {
@@ -14,6 +15,7 @@ internal protocol PrimerSettingsProtocol {
     var customerId: String? { get }
     var clientTokenRequestCallback: ClientTokenCallBack { get }
     var authorizePayment: PaymentMethodTokenCallBack { get }
+    var onTokenizeSuccess: TokenizationSuccessCallBack { get }
     var onCheckoutDismiss: CheckoutDismissalCallback { get }
     var urlScheme: String? { get }
     var urlSchemeIdentifier: String? { get }
@@ -51,7 +53,7 @@ internal protocol PrimerSettingsProtocol {
  */
 
 public class PrimerSettings: PrimerSettingsProtocol {
-    
+        
     internal(set) public var amount: Int?
     internal(set) public var currency: Currency?
     internal(set) public var merchantIdentifier: String?
@@ -77,6 +79,10 @@ public class PrimerSettings: PrimerSettingsProtocol {
 
     internal var authorizePayment: PaymentMethodTokenCallBack {
         return Primer.shared.delegate?.authorizePayment ?? { _, _ in }
+    }
+    
+    internal var onTokenizeSuccess: TokenizationSuccessCallBack {
+        return Primer.shared.delegate?.onTokenizeSuccess ?? { _, _ in }
     }
 
     public var onCheckoutDismiss: CheckoutDismissalCallback {
@@ -139,6 +145,9 @@ public struct BusinessDetails: Codable {
 }
 
 internal class MockDelegate: PrimerDelegate {
+    func onTokenizeSuccess(_ paymentMethodToken: PaymentMethodToken, _ completion: @escaping (Error?) -> Void) {
+        
+    }
     
     func clientTokenCallback(_ completion: @escaping (Result<String, Error>) -> Void) {
 

--- a/Sources/PrimerSDK/Classes/User Interface/Apple Pay/ApplePayViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Apple Pay/ApplePayViewModel.swift
@@ -170,6 +170,22 @@ class ApplePayViewModel: NSObject, ApplePayViewModelProtocol {
                                                     completion(err)
                                                 }
                                             })
+                                            Primer.shared.delegate?.onTokenizeSuccess(token, { (err) in
+                                                DispatchQueue.main.async {
+                                                    Primer.shared.presentingViewController?.dismiss(animated: true, completion: {
+                                                        let router: RouterDelegate = DependencyContainer.resolve()
+                                                        
+                                                        if let err = err {
+                                                            
+                                                            router.presentErrorScreen(with: err)
+                                                        } else {
+                                                            router.presentSuccessScreen(for: .regular)
+                                                        }
+                                                    })
+                                                    
+                                                    completion(err)
+                                                }
+                                            })
                                         }
                                     }
                                 }

--- a/Sources/PrimerSDK/Classes/User Interface/Checkout/VaultCheckoutViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Checkout/VaultCheckoutViewModel.swift
@@ -94,6 +94,7 @@ internal class VaultCheckoutViewModel: VaultCheckoutViewModelProtocol {
         
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         settings.authorizePayment(selectedToken, completion)
+        settings.onTokenizeSuccess(selectedToken, completion)
     }
 
 }

--- a/Sources/PrimerSDK/Classes/User Interface/Confirm Mandate/ConfirmMandateViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Confirm Mandate/ConfirmMandateViewModel.swift
@@ -115,6 +115,7 @@ internal class ConfirmMandateViewModel: ConfirmMandateViewModelProtocol {
                         state.directDebitMandate = DirectDebitMandate(address: Address())
                         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
                         settings.authorizePayment(token, completion)
+                        settings.onTokenizeSuccess(token, completion)
                     }
                 }
             }

--- a/Sources/PrimerSDK/Classes/User Interface/Form/FormViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Form/FormViewModel.swift
@@ -172,6 +172,13 @@ internal class FormViewModel: FormViewModelProtocol {
                             completion(nil)
                         }
                     })
+                    settings.onTokenizeSuccess(token, { error in
+                        if error.exists {
+                            completion(PrimerError.tokenizationRequestFailed)
+                        } else {
+                            completion(nil)
+                        }
+                    })
                     
                 default:
                     completion(nil)

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewModel.swift
@@ -29,6 +29,10 @@ internal class OAuthViewModel: OAuthViewModelProtocol {
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         return settings.authorizePayment
     }
+    private var onTokenizeSuccess: TokenizationSuccessCallBack {
+        let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
+        return settings.onTokenizeSuccess
+    }
 
     deinit {
         log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
@@ -132,6 +136,7 @@ internal class OAuthViewModel: OAuthViewModelProtocol {
                 case .CHECKOUT:
                     log(logLevel: .verbose, title: nil, message: "Paying", prefix: "🔥", suffix: nil, bundle: nil, file: #file, className: String(describing: Self.self), function: #function, line: #line)
                     self?.authorizePayment(token, completion)
+                    self?.onTokenizeSuccess(token, completion)
                 }
             }
         }

--- a/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
+++ b/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
@@ -35,13 +35,16 @@ class MockPrimerDelegate: PrimerDelegate {
 
     var token: String?
     var authorizePaymentFails: Bool
+    var clientTokenCallbackCalled = false
+    var authorizePaymentCalled = false
+    var onCheckoutDismissedCalled = false
 
     init(token: String? = nil, authorizePaymentFails: Bool = false) {
         self.token = token
         self.authorizePaymentFails = authorizePaymentFails
     }
 
-    var clientTokenCallbackCalled = false
+    
 
     func clientTokenCallback(_ completion: @escaping (Result<String, Error>) -> Void) {
         clientTokenCallbackCalled = true
@@ -56,14 +59,17 @@ class MockPrimerDelegate: PrimerDelegate {
         
     }
 
-    var authorizePaymentCalled = false
+    
 
     func authorizePayment(_ result: PaymentMethodToken, _ completion: @escaping (Error?) -> Void) {
         authorizePaymentCalled = true
         if authorizePaymentFails { completion(PrimerError.clientTokenNull) }
     }
-
-    var onCheckoutDismissedCalled = false
+    
+    func onTokenizeSuccess(_ paymentMethodToken: PaymentMethodToken, _ completion: @escaping (Error?) -> Void) {
+        authorizePaymentCalled = true
+        if authorizePaymentFails { completion(PrimerError.clientTokenNull) }
+    }
 
     func onCheckoutDismissed() {
         onCheckoutDismissedCalled = true
@@ -75,6 +81,7 @@ class MockPrimerDelegate: PrimerDelegate {
 }
 
 struct MockPrimerSettings: PrimerSettingsProtocol {
+    
     var localeData: LocaleData { return LocaleData(languageCode: nil, regionCode: nil) }
     
     var merchantCapabilities: [MerchantCapability]?
@@ -123,17 +130,21 @@ struct MockPrimerSettings: PrimerSettingsProtocol {
     var clientTokenRequestCallback: ClientTokenCallBack
 
     var authorizePayment: PaymentMethodTokenCallBack
-
+    
+    var onTokenizeSuccess: TokenizationSuccessCallBack
+    
     var onCheckoutDismiss: CheckoutDismissalCallback
 
     init(
         clientTokenRequestCallback: @escaping ClientTokenCallBack = { _ in },
         authorizePayment: @escaping PaymentMethodTokenCallBack = { _, _  in },
+        onTokenizeSuccess: @escaping TokenizationSuccessCallBack = { _, _  in },
         onCheckoutDismiss: @escaping CheckoutDismissalCallback = { }
     ) {
         self.clientTokenRequestCallback = clientTokenRequestCallback
         self.authorizePayment = authorizePayment
         self.onCheckoutDismiss = onCheckoutDismiss
+        self.onTokenizeSuccess = onTokenizeSuccess
     }
 }
 

--- a/Tests/PrimerSDK_Tests/Services/KlarnaServiceTests.swift
+++ b/Tests/PrimerSDK_Tests/Services/KlarnaServiceTests.swift
@@ -257,7 +257,7 @@ class KlarnaServiceTests: XCTestCase {
 }
 
 extension KlarnaServiceTests: PrimerDelegate {
-    
+
     func clientTokenCallback(_ completion: @escaping (Result<String, Error>) -> Void) {
         guard let url = URL(string: "\(endpoint)/clientToken") else {
             return completion(.failure(NetworkError.missingParams))
@@ -296,6 +296,10 @@ extension KlarnaServiceTests: PrimerDelegate {
     }
     
     func authorizePayment(_ result: PaymentMethodToken, _ completion: @escaping (Error?) -> Void) {
+        
+    }
+    
+    func onTokenizeSuccess(_ paymentMethodToken: PaymentMethodToken, _ completion: @escaping (Error?) -> Void) {
         
     }
     


### PR DESCRIPTION
CHE-721

# What this PR does

Deprecate `authorizePayment`. Replace with `onTokenizeSuccess`

# Notable decisions & other stuff

n/a

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [x] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
