### PR TITLE
Feature/che 806 dismiss screen issue

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
@@ -47,6 +47,20 @@ internal class OAuthViewController: PrimerViewController {
                     _ = ErrorHandler.shared.handle(error: error)
                     Primer.shared.delegate?.checkoutFailed(with: error)
                     
+                    let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
+                    
+                    if settings.hasDisabledSuccessScreen {
+                        let routerDelegate: RouterDelegate = DependencyContainer.resolve()
+                        let router = routerDelegate as! Router
+                        let rootViewController = router.root
+                        
+                        UIView.animate(withDuration: 0.3) {
+                            (rootViewController?.presentationController as? PresentationController)?.blurEffectView.alpha = 0.0
+                        } completion: { (_) in
+                            rootViewController?.dismiss(animated: true, completion: nil)
+                        }
+                    }
+                    
                 case .success(let urlString):
                     // if Klarna show WebView, otherwise OAuth
                     if self?.host == OAuthHost.klarna {
@@ -106,6 +120,8 @@ internal class OAuthViewController: PrimerViewController {
             } else if settings.hasDisabledSuccessScreen && settings.isInitialLoadingHidden {
                 UIView.animate(withDuration: 0.3) {
                     (rootViewController?.presentationController as? PresentationController)?.blurEffectView.alpha = 0.0
+                } completion: { (_) in
+                    rootViewController?.dismiss(animated: true, completion: nil)
                 }
             }
             

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
@@ -86,6 +86,7 @@ internal class OAuthViewController: PrimerViewController {
         webViewController.url = URL(string: urlString)
         webViewController.delegate = self
         webViewController.klarnaWebViewCompletion = { [weak self] (_, err) in
+//            let err: Error?  = KlarnaException.noCoreUrl
             if let err = err {
                 _ = ErrorHandler.shared.handle(error: err)
                 router.show(.error(error: err))


### PR DESCRIPTION
CHE-806

# What this PR does

Automatically dismiss root view controller on error, if success/failure SDK screen has been disabled by the developer.

# Notable decisions & other stuff

Tested throwing errors on various places in the flow.
Also tested when dev has set to show the success/error screen (i.e. screen should not dismiss)

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
