### PR TITLE
[CHE-798] Show error message for failed PayPal init

### DIFF
--- a/Example/PrimerSDK.xcodeproj/project.pbxproj
+++ b/Example/PrimerSDK.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		15F97C72262470CB00DCB3BA /* MerchantCheckoutViewController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F97C71262470CB00DCB3BA /* MerchantCheckoutViewController+Helpers.swift */; };
 		15F97C772624718800DCB3BA /* PaymentMethodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F97C762624718800DCB3BA /* PaymentMethodCell.swift */; };
 		15F97C7D2624730800DCB3BA /* UIViewController+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F97C7C2624730800DCB3BA /* UIViewController+API.swift */; };
+		1D30D5DB2678ED2E001C7812 /* OAuthViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D30D5D92678ECCB001C7812 /* OAuthViewControllerTests.swift */; };
 		1DC7EE0C261FA39200BCBFFC /* SpinnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC7EE0B261FA39200BCBFFC /* SpinnerViewController.swift */; };
 		1DC7EE14261FA3D400BCBFFC /* CreateClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC7EE13261FA3D400BCBFFC /* CreateClientToken.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
@@ -112,6 +113,7 @@
 		15F97C71262470CB00DCB3BA /* MerchantCheckoutViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MerchantCheckoutViewController+Helpers.swift"; sourceTree = "<group>"; };
 		15F97C762624718800DCB3BA /* PaymentMethodCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodCell.swift; sourceTree = "<group>"; };
 		15F97C7C2624730800DCB3BA /* UIViewController+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+API.swift"; sourceTree = "<group>"; };
+		1D30D5D92678ECCB001C7812 /* OAuthViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthViewControllerTests.swift; sourceTree = "<group>"; };
 		1DC7EE0B261FA39200BCBFFC /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		1DC7EE13261FA3D400BCBFFC /* CreateClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateClientToken.swift; sourceTree = "<group>"; };
 		3B55FBF1D40BE6B25F29A5D9 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 		1582B958260A3F2900C80BD7 /* PrimerSDK_Tests */ = {
 			isa = PBXGroup;
 			children = (
+				1D30D5DD2679046E001C7812 /* ViewControllers */,
 				1582B959260A3F2900C80BD7 /* Mocks */,
 				1582B969260A3F2900C80BD7 /* ViewModels */,
 				1582B96F260A3F2900C80BD7 /* Utils */,
@@ -283,6 +286,14 @@
 				15F97C7C2624730800DCB3BA /* UIViewController+API.swift */,
 			);
 			name = Extensions;
+			sourceTree = "<group>";
+		};
+		1D30D5DD2679046E001C7812 /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				1D30D5D92678ECCB001C7812 /* OAuthViewControllerTests.swift */,
+			);
+			path = ViewControllers;
 			sourceTree = "<group>";
 		};
 		1DC7EE00261FA2A800BCBFFC /* Data Models */ = {
@@ -636,6 +647,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1D30D5DB2678ED2E001C7812 /* OAuthViewControllerTests.swift in Sources */,
 				1582B97A260A3F2900C80BD7 /* ConfirmMandateViewModel.swift in Sources */,
 				1582B981260A3F2900C80BD7 /* PayPalService.swift in Sources */,
 				1582B991260A3F2900C80BD7 /* ClientTokenServiceTests.swift in Sources */,

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
@@ -49,9 +49,12 @@ internal class OAuthViewController: PrimerViewController {
                     
                     let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
                     
+                    let routerDelegate: RouterDelegate = DependencyContainer.resolve()
+                    
+                    let router = routerDelegate as! Router
+                    
                     if settings.hasDisabledSuccessScreen {
-                        let routerDelegate: RouterDelegate = DependencyContainer.resolve()
-                        let router = routerDelegate as! Router
+                        
                         let rootViewController = router.root
                         
                         UIView.animate(withDuration: 0.3) {
@@ -59,6 +62,8 @@ internal class OAuthViewController: PrimerViewController {
                         } completion: { (_) in
                             rootViewController?.dismiss(animated: true, completion: nil)
                         }
+                    } else {
+                        router.show(.error(error: error))
                     }
                     
                 case .success(let urlString):

--- a/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
+++ b/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
@@ -8,6 +8,7 @@
 #if canImport(UIKit)
 
 @testable import PrimerSDK
+import XCTest
 
 var mockClientToken = DecodedClientToken(
     accessToken: "bla",
@@ -226,7 +227,7 @@ class MockLocator {
         DependencyContainer.register(MockFormViewModel() as FormViewModelProtocol)
         DependencyContainer.register(MockExternalViewModel() as ExternalViewModelProtocol)
         DependencyContainer.register(MockRouter() as RouterDelegate)
-
+        DependencyContainer.register(PrimerTheme() as PrimerThemeProtocol)
     }
 }
 
@@ -236,34 +237,44 @@ class MockDirectDebitService: DirectDebitServiceProtocol {
     }
 }
 
-class MockRouter: RouterDelegate {
-    func presentSuccessScreen(for successScreenType: SuccessScreenType) {
+class MockRouter: Router {
+    
+    override func presentSuccessScreen(for successScreenType: SuccessScreenType) {
         
     }
     
-    func presentErrorScreen(with err: Error) {
+    override func presentErrorScreen(with err: Error) {
         
     }
+
     
-    var root: RootViewController?
+    override func setRoot(_ root: RootViewController) {
+
+    }
     
-    func setRoot(_ root: RootViewController) {
+    var showCalled = false
+    
+    var callback: (() -> Void)?
+    
+    func setShowCalledTrue() {
+        showCalled = true
+        guard let callback = callback else { return }
+        callback()
+    }
+
+    override func show(_ route: Route) {
+        setShowCalledTrue()
+    }
+
+    override func pop() {
+        
+    }
+
+    override func popAllAndShow(_ route: Route) {
 
     }
 
-    func show(_ route: Route) {
-
-    }
-
-    func pop() {
-
-    }
-
-    func popAllAndShow(_ route: Route) {
-
-    }
-
-    func popAndShow(_ route: Route) {
+    override func popAndShow(_ route: Route) {
 
     }
 }

--- a/Tests/PrimerSDK_Tests/Mocks/ViewModels/OAuthViewModel.swift
+++ b/Tests/PrimerSDK_Tests/Mocks/ViewModels/OAuthViewModel.swift
@@ -10,6 +10,10 @@
 @testable import PrimerSDK
 
 class MockOAuthViewModel: OAuthViewModelProtocol {
+    
+    var generateOAuthURLThrows = false
+    
+    
     var urlSchemeIdentifier: String? { return "urlSchemeIdentifier" }
 
     var generateOAuthURLCalled = false
@@ -17,6 +21,11 @@ class MockOAuthViewModel: OAuthViewModelProtocol {
 
     func generateOAuthURL(_ host: OAuthHost, with completion: @escaping (Result<String, Error>) -> Void) {
         generateOAuthURLCalled = true
+        if (generateOAuthURLThrows) {
+            completion(.failure(PrimerError.payPalSessionFailed))
+        } else {
+            completion(.success("https://paypal.com/session"))
+        }
     }
 
     func tokenize(_ host: OAuthHost, with completion: @escaping (Error?) -> Void) {

--- a/Tests/PrimerSDK_Tests/ViewControllers/OAuthViewControllerTests.swift
+++ b/Tests/PrimerSDK_Tests/ViewControllers/OAuthViewControllerTests.swift
@@ -1,0 +1,46 @@
+//
+//  OAuthViewControllerTests.swift
+//  PrimerSDK_Example
+//
+//  Created by Carl Eriksson on 15/06/2021.
+//  Copyright © 2021 CocoaPods. All rights reserved.
+//
+
+#if canImport(UIKit)
+
+import XCTest
+@testable import PrimerSDK
+
+@available(iOS 11.0, *)
+class OAuthViewControllerTests: XCTestCase {
+
+    func test_paypal_load_exception_shows_error_screen() throws {
+        let expectation = XCTestExpectation(description: "Load PayPal failed | Error message shown.")
+        let viewModel = MockOAuthViewModel()
+        viewModel.generateOAuthURLThrows = true
+        let settings = mockSettings
+        settings.isInitialLoadingHidden = true
+        settings.hasDisabledSuccessScreen = false
+        let router = MockRouter()
+        
+        router.callback = {
+            XCTAssertTrue(viewModel.generateOAuthURLCalled)
+            XCTAssertTrue(router.showCalled)
+            expectation.fulfill()
+        }
+
+        MockLocator.registerDependencies()
+
+        DependencyContainer.register(viewModel as OAuthViewModelProtocol)
+        DependencyContainer.register(router as RouterDelegate)
+        DependencyContainer.register(settings as PrimerSettingsProtocol)
+
+        let viewController = OAuthViewController(host: .paypal)
+
+        viewController.viewDidLoad()
+        
+        wait(for: [expectation], timeout: 10.0)
+    }
+}
+
+#endif


### PR DESCRIPTION
CHE-798

# What this PR does

When the developer has not disabled error UI, the error view is shown on error.

The scroll view acts weird in the simulator. Let's discuss below.

Also, let's discuss ways to write a UI test for this scenario. It's been tested on live device for both PayPal & Klarna but testing requires tinkering with the example app config files we pass in on init.

_QA_

- [x] I manually tested this with a demo application (simulator)
- [x] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
