### PR TITLE
Feature/che 858 barebones textfield

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		151431782678A1DF00B4C96D /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151431542678A1DF00B4C96D /* Thenable.swift */; };
 		151431792678A1DF00B4C96D /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151431552678A1DF00B4C96D /* Configuration.swift */; };
 		1514317B2678A52300B4C96D /* PrimerAPIClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1514317A2678A52300B4C96D /* PrimerAPIClient+Promises.swift */; };
+		1589240F268B05A1001280DD /* PrimerTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589240E268B05A1001280DD /* PrimerTextFieldView.swift */; };
 		15892410268B05AA001280DD /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589240C268B04AC001280DD /* PrimerTextField.swift */; };
 		15892412268B062F001280DD /* PrimerNibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892411268B062F001280DD /* PrimerNibView.swift */; };
 		16AF604EFAB8215B9F0879C271AE7A2D /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364D798A53A76D482156C7E07703394 /* FormTextFieldType.swift */; };
@@ -229,6 +230,7 @@
 		151431552678A1DF00B4C96D /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		1514317A2678A52300B4C96D /* PrimerAPIClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+Promises.swift"; sourceTree = "<group>"; };
 		1589240C268B04AC001280DD /* PrimerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
+		1589240E268B05A1001280DD /* PrimerTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerTextFieldView.swift; sourceTree = "<group>"; };
 		15892411268B062F001280DD /* PrimerNibView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerNibView.swift; sourceTree = "<group>"; };
 		15939D76EEF467A182746C99C10F14B6 /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
 		1841E53752535A5BB808AE11B6967728 /* PaymentNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentNetwork.swift; sourceTree = "<group>"; };
@@ -493,6 +495,7 @@
 			isa = PBXGroup;
 			children = (
 				1589240C268B04AC001280DD /* PrimerTextField.swift */,
+				1589240E268B05A1001280DD /* PrimerTextFieldView.swift */,
 				15892411268B062F001280DD /* PrimerNibView.swift */,
 			);
 			path = "Text Fields";
@@ -1248,6 +1251,7 @@
 				2A38B1DEF016374B878FEFC3E12EFA93 /* Validation.swift in Sources */,
 				1514317B2678A52300B4C96D /* PrimerAPIClient+Promises.swift in Sources */,
 				11253BDF4DF375C348E87DF5B34F018A /* VaultCheckoutView.swift in Sources */,
+				1589240F268B05A1001280DD /* PrimerTextFieldView.swift in Sources */,
 				151431582678A1DF00B4C96D /* Cancellable.swift in Sources */,
 				53E1AFE672487F64D1E03D9348B302BC /* VaultCheckoutViewController+ReloadDelegate.swift in Sources */,
 				6767FA45D7125CB4BD583D3E8DE8B680 /* VaultCheckoutViewController.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		15892416268B1ACD001280DD /* PrimerCardNumberFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */; };
 		15892418268B20DF001280DD /* CardNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892417268B20DF001280DD /* CardNetwork.swift */; };
 		1589241E269311AD001280DD /* PrimerExpiryDateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589241D269311AD001280DD /* PrimerExpiryDateFieldView.swift */; };
+		1589242026933D77001280DD /* PrimerCVVFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589241F26933D77001280DD /* PrimerCVVFieldView.swift */; };
 		16AF604EFAB8215B9F0879C271AE7A2D /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364D798A53A76D482156C7E07703394 /* FormTextFieldType.swift */; };
 		16EAA7FA33F257010600B443C71C99B5 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F41D2762B2290B4EE76542889986A16 /* PaymentMethod.swift */; };
 		17CC0E100C8B9EF45824E087493F8CBB /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 522F77B4CB1E9CA3B31E3F74F1962B2B /* fr.lproj */; };
@@ -240,6 +241,7 @@
 		15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerCardNumberFieldView.swift; sourceTree = "<group>"; };
 		15892417268B20DF001280DD /* CardNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNetwork.swift; sourceTree = "<group>"; };
 		1589241D269311AD001280DD /* PrimerExpiryDateFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerExpiryDateFieldView.swift; sourceTree = "<group>"; };
+		1589241F26933D77001280DD /* PrimerCVVFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerCVVFieldView.swift; sourceTree = "<group>"; };
 		15939D76EEF467A182746C99C10F14B6 /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
 		1841E53752535A5BB808AE11B6967728 /* PaymentNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentNetwork.swift; sourceTree = "<group>"; };
 		187BF6D0164EDAB4FF90BEC8F100DD60 /* ResourceBundle-PrimerResources-PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-PrimerResources-PrimerSDK-Info.plist"; sourceTree = "<group>"; };
@@ -508,6 +510,7 @@
 				15892413268B1143001280DD /* PrimerTextFieldView.xib */,
 				15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */,
 				1589241D269311AD001280DD /* PrimerExpiryDateFieldView.swift */,
+				1589241F26933D77001280DD /* PrimerCVVFieldView.swift */,
 			);
 			path = "Text Fields";
 			sourceTree = "<group>";
@@ -1265,6 +1268,7 @@
 				A77B360A5A6472B85E1C85C89D284D88 /* UXMode.swift in Sources */,
 				2A38B1DEF016374B878FEFC3E12EFA93 /* Validation.swift in Sources */,
 				1514317B2678A52300B4C96D /* PrimerAPIClient+Promises.swift in Sources */,
+				1589242026933D77001280DD /* PrimerCVVFieldView.swift in Sources */,
 				11253BDF4DF375C348E87DF5B34F018A /* VaultCheckoutView.swift in Sources */,
 				1589240F268B05A1001280DD /* PrimerTextFieldView.swift in Sources */,
 				151431582678A1DF00B4C96D /* Cancellable.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		1589240F268B05A1001280DD /* PrimerTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589240E268B05A1001280DD /* PrimerTextFieldView.swift */; };
 		15892410268B05AA001280DD /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589240C268B04AC001280DD /* PrimerTextField.swift */; };
 		15892412268B062F001280DD /* PrimerNibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892411268B062F001280DD /* PrimerNibView.swift */; };
+		15892414268B1143001280DD /* PrimerTextFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 15892413268B1143001280DD /* PrimerTextFieldView.xib */; };
+		15892416268B1ACD001280DD /* PrimerCardNumberFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */; };
+		15892418268B20DF001280DD /* CardNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892417268B20DF001280DD /* CardNetwork.swift */; };
 		16AF604EFAB8215B9F0879C271AE7A2D /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364D798A53A76D482156C7E07703394 /* FormTextFieldType.swift */; };
 		16EAA7FA33F257010600B443C71C99B5 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F41D2762B2290B4EE76542889986A16 /* PaymentMethod.swift */; };
 		17CC0E100C8B9EF45824E087493F8CBB /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 522F77B4CB1E9CA3B31E3F74F1962B2B /* fr.lproj */; };
@@ -232,6 +235,9 @@
 		1589240C268B04AC001280DD /* PrimerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
 		1589240E268B05A1001280DD /* PrimerTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerTextFieldView.swift; sourceTree = "<group>"; };
 		15892411268B062F001280DD /* PrimerNibView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerNibView.swift; sourceTree = "<group>"; };
+		15892413268B1143001280DD /* PrimerTextFieldView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrimerTextFieldView.xib; sourceTree = "<group>"; };
+		15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerCardNumberFieldView.swift; sourceTree = "<group>"; };
+		15892417268B20DF001280DD /* CardNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNetwork.swift; sourceTree = "<group>"; };
 		15939D76EEF467A182746C99C10F14B6 /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
 		1841E53752535A5BB808AE11B6967728 /* PaymentNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentNetwork.swift; sourceTree = "<group>"; };
 		187BF6D0164EDAB4FF90BEC8F100DD60 /* ResourceBundle-PrimerResources-PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-PrimerResources-PrimerSDK-Info.plist"; sourceTree = "<group>"; };
@@ -494,9 +500,11 @@
 		1589240B268B0498001280DD /* Text Fields */ = {
 			isa = PBXGroup;
 			children = (
+				15892411268B062F001280DD /* PrimerNibView.swift */,
 				1589240C268B04AC001280DD /* PrimerTextField.swift */,
 				1589240E268B05A1001280DD /* PrimerTextFieldView.swift */,
-				15892411268B062F001280DD /* PrimerNibView.swift */,
+				15892413268B1143001280DD /* PrimerTextFieldView.xib */,
+				15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */,
 			);
 			path = "Text Fields";
 			sourceTree = "<group>";
@@ -681,6 +689,7 @@
 				BFC2161CA55DC783DE736603A18CD1DE /* SuccessMessage.swift */,
 				1923AB6954C93D97B27B17962DF3A408 /* UXMode.swift */,
 				C5B8FAE78A1152F76BEC6E94C222E73B /* PCI */,
+				15892417268B20DF001280DD /* CardNetwork.swift */,
 			);
 			name = "Data Models";
 			path = "Sources/PrimerSDK/Classes/Data Models";
@@ -1103,6 +1112,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				151431662678A1DF00B4C96D /* LICENSE in Resources */,
+				15892414268B1143001280DD /* PrimerTextFieldView.xib in Resources */,
 				4C7139FF7E7397D65CE425EC83A1007B /* PrimerResources.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1212,6 +1222,7 @@
 				FA574C8F23D2537BCE422EBC7681E58D /* PrimerAPIClient.swift in Sources */,
 				3F28DE74B2F49EBD78669F6CF83C7216 /* PrimerButton.swift in Sources */,
 				151431782678A1DF00B4C96D /* Thenable.swift in Sources */,
+				15892416268B1ACD001280DD /* PrimerCardNumberFieldView.swift in Sources */,
 				151431692678A1DF00B4C96D /* after.swift in Sources */,
 				EE88EFD8527ABBD25F733DD7E448EBC8 /* PrimerContent.swift in Sources */,
 				D39ABD5195BCD984D385A957589314C7 /* PrimerDelegate.swift in Sources */,
@@ -1263,6 +1274,7 @@
 				D5E96BB5935FB39F946A9AE4141F10C7 /* VaultService.swift in Sources */,
 				5739C85AE478EB333677BC710B293000 /* WebViewController.swift in Sources */,
 				1514316B2678A1DF00B4C96D /* hang.swift in Sources */,
+				15892418268B20DF001280DD /* CardNetwork.swift in Sources */,
 				151431712678A1DF00B4C96D /* ConcurrencyLimitedDispatcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		151431792678A1DF00B4C96D /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151431552678A1DF00B4C96D /* Configuration.swift */; };
 		1514317B2678A52300B4C96D /* PrimerAPIClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1514317A2678A52300B4C96D /* PrimerAPIClient+Promises.swift */; };
 		1589240D268B04AC001280DD /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589240C268B04AC001280DD /* PrimerTextField.swift */; };
+		15892412268B062F001280DD /* PrimerNibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892411268B062F001280DD /* PrimerNibView.swift */; };
 		16AF604EFAB8215B9F0879C271AE7A2D /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364D798A53A76D482156C7E07703394 /* FormTextFieldType.swift */; };
 		16EAA7FA33F257010600B443C71C99B5 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F41D2762B2290B4EE76542889986A16 /* PaymentMethod.swift */; };
 		17CC0E100C8B9EF45824E087493F8CBB /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 522F77B4CB1E9CA3B31E3F74F1962B2B /* fr.lproj */; };
@@ -228,6 +229,7 @@
 		151431552678A1DF00B4C96D /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		1514317A2678A52300B4C96D /* PrimerAPIClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+Promises.swift"; sourceTree = "<group>"; };
 		1589240C268B04AC001280DD /* PrimerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
+		15892411268B062F001280DD /* PrimerNibView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerNibView.swift; sourceTree = "<group>"; };
 		15939D76EEF467A182746C99C10F14B6 /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
 		1841E53752535A5BB808AE11B6967728 /* PaymentNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentNetwork.swift; sourceTree = "<group>"; };
 		187BF6D0164EDAB4FF90BEC8F100DD60 /* ResourceBundle-PrimerResources-PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-PrimerResources-PrimerSDK-Info.plist"; sourceTree = "<group>"; };
@@ -491,6 +493,7 @@
 			isa = PBXGroup;
 			children = (
 				1589240C268B04AC001280DD /* PrimerTextField.swift */,
+				15892411268B062F001280DD /* PrimerNibView.swift */,
 			);
 			path = "Text Fields";
 			sourceTree = "<group>";
@@ -1139,6 +1142,7 @@
 				151431722678A1DF00B4C96D /* Box.swift in Sources */,
 				1514315D2678A1DF00B4C96D /* ThenableWrappers.swift in Sources */,
 				840679B391D9158648C2531563977624 /* ClientTokenService.swift in Sources */,
+				15892412268B062F001280DD /* PrimerNibView.swift in Sources */,
 				24E25BC0AE84E348C803FD3307B97EF9 /* ConfirmMandateView.swift in Sources */,
 				151431742678A1DF00B4C96D /* LogEvent.swift in Sources */,
 				1514315F2678A1DF00B4C96D /* EnsureWrappers.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		15892414268B1143001280DD /* PrimerTextFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 15892413268B1143001280DD /* PrimerTextFieldView.xib */; };
 		15892416268B1ACD001280DD /* PrimerCardNumberFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */; };
 		15892418268B20DF001280DD /* CardNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892417268B20DF001280DD /* CardNetwork.swift */; };
+		1589241E269311AD001280DD /* PrimerExpiryDateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589241D269311AD001280DD /* PrimerExpiryDateFieldView.swift */; };
 		16AF604EFAB8215B9F0879C271AE7A2D /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364D798A53A76D482156C7E07703394 /* FormTextFieldType.swift */; };
 		16EAA7FA33F257010600B443C71C99B5 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F41D2762B2290B4EE76542889986A16 /* PaymentMethod.swift */; };
 		17CC0E100C8B9EF45824E087493F8CBB /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 522F77B4CB1E9CA3B31E3F74F1962B2B /* fr.lproj */; };
@@ -238,6 +239,7 @@
 		15892413268B1143001280DD /* PrimerTextFieldView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrimerTextFieldView.xib; sourceTree = "<group>"; };
 		15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerCardNumberFieldView.swift; sourceTree = "<group>"; };
 		15892417268B20DF001280DD /* CardNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNetwork.swift; sourceTree = "<group>"; };
+		1589241D269311AD001280DD /* PrimerExpiryDateFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerExpiryDateFieldView.swift; sourceTree = "<group>"; };
 		15939D76EEF467A182746C99C10F14B6 /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
 		1841E53752535A5BB808AE11B6967728 /* PaymentNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentNetwork.swift; sourceTree = "<group>"; };
 		187BF6D0164EDAB4FF90BEC8F100DD60 /* ResourceBundle-PrimerResources-PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-PrimerResources-PrimerSDK-Info.plist"; sourceTree = "<group>"; };
@@ -505,6 +507,7 @@
 				1589240E268B05A1001280DD /* PrimerTextFieldView.swift */,
 				15892413268B1143001280DD /* PrimerTextFieldView.xib */,
 				15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */,
+				1589241D269311AD001280DD /* PrimerExpiryDateFieldView.swift */,
 			);
 			path = "Text Fields";
 			sourceTree = "<group>";
@@ -1225,6 +1228,7 @@
 				15892416268B1ACD001280DD /* PrimerCardNumberFieldView.swift in Sources */,
 				151431692678A1DF00B4C96D /* after.swift in Sources */,
 				EE88EFD8527ABBD25F733DD7E448EBC8 /* PrimerContent.swift in Sources */,
+				1589241E269311AD001280DD /* PrimerExpiryDateFieldView.swift in Sources */,
 				D39ABD5195BCD984D385A957589314C7 /* PrimerDelegate.swift in Sources */,
 				1D6B7233D6C2F577017F5FCDD6400A8C /* PrimerInternalSessionFlow.swift in Sources */,
 				A60E122367DE517EDCBDE827DAA2F57C /* PrimerScrollView.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -54,7 +54,7 @@
 		151431782678A1DF00B4C96D /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151431542678A1DF00B4C96D /* Thenable.swift */; };
 		151431792678A1DF00B4C96D /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151431552678A1DF00B4C96D /* Configuration.swift */; };
 		1514317B2678A52300B4C96D /* PrimerAPIClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1514317A2678A52300B4C96D /* PrimerAPIClient+Promises.swift */; };
-		1589240D268B04AC001280DD /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589240C268B04AC001280DD /* PrimerTextField.swift */; };
+		15892410268B05AA001280DD /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589240C268B04AC001280DD /* PrimerTextField.swift */; };
 		15892412268B062F001280DD /* PrimerNibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892411268B062F001280DD /* PrimerNibView.swift */; };
 		16AF604EFAB8215B9F0879C271AE7A2D /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364D798A53A76D482156C7E07703394 /* FormTextFieldType.swift */; };
 		16EAA7FA33F257010600B443C71C99B5 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F41D2762B2290B4EE76542889986A16 /* PaymentMethod.swift */; };
@@ -134,7 +134,7 @@
 		C77E3E56C2A648E6040B9D7AF2FB8ADA /* FormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265A9972216B70706CA61AF938BD1E7A /* FormViewController.swift */; };
 		C883F99C7CFB9A995908413B99D93463 /* ReloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88472D1A4AEB8BE14C6D1E0A70BAF45C /* ReloadDelegate.swift */; };
 		C94F30411821090F1F68E93854AC1391 /* CardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5101932ECDDD9EDE9593934BBFEDE8 /* CardButton.swift */; };
-		C9973DF2E27D4180AD0D3B18903794C1 /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4303F18CB4F400B9D54FC1A6ABEE600 /* PrimerTextField.swift */; };
+		C9973DF2E27D4180AD0D3B18903794C1 /* PrimerCustomStyleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4303F18CB4F400B9D54FC1A6ABEE600 /* PrimerCustomStyleTextField.swift */; };
 		CB3AF15A48F3B31044F9AEFA80F04912 /* UIDeviceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E281B20B1EBC136873C745C316DB0550 /* UIDeviceExtension.swift */; };
 		CB7E8370E1475BF23A66444906441FEC /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9999FBDE4FE4FE3724CC7AA8CBBB1D98 /* Optional+Extensions.swift */; };
 		CE9CD49B7545DE6751CFB1EF00CC4705 /* RootViewController+Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A18CAD244CC51A04718AB3FA137F673 /* RootViewController+Router.swift */; };
@@ -296,7 +296,7 @@
 		996D4979B7C9A77B5D00A11365BBA23E /* PresentationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PresentationController.swift; sourceTree = "<group>"; };
 		9999FBDE4FE4FE3724CC7AA8CBBB1D98 /* Optional+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		A4303F18CB4F400B9D54FC1A6ABEE600 /* PrimerTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
+		A4303F18CB4F400B9D54FC1A6ABEE600 /* PrimerCustomStyleTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCustomStyleTextField.swift; sourceTree = "<group>"; };
 		A4E7B1C752F38C22267D301DD5A364DF /* Pods-PrimerSDK_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-PrimerSDK_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		A67F345CC9B9B000A894C8D8FC1F352B /* KlarnaService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KlarnaService.swift; sourceTree = "<group>"; };
 		A8B3BC107C2BDC3C03D961866F721265 /* PrimerResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrimerResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -931,7 +931,7 @@
 				309709CCF5CAF06378DA0EAB35DE8A06 /* PrimerButton.swift */,
 				D88E22FCD97898B4C1BCC342595A9C1C /* PrimerScrollView.swift */,
 				1D956B3836AD8351EB6E6928E7BB39D9 /* PrimerTableViewCell.swift */,
-				A4303F18CB4F400B9D54FC1A6ABEE600 /* PrimerTextField.swift */,
+				A4303F18CB4F400B9D54FC1A6ABEE600 /* PrimerCustomStyleTextField.swift */,
 				0EB28F97384012160632AF45B559BA3A /* PrimerViewController.swift */,
 				B775CFB625AB3BC99F0E537196EA9A8E /* PrimerViewExtensions.swift */,
 				DBB6C504042F46D2AE39982E0E22AD03 /* StringExtension.swift */,
@@ -1217,8 +1217,9 @@
 				85060DAE3F9FF88FD603DC1C6A7A2B11 /* PrimerSDK-dummy.m in Sources */,
 				B4350DDF11F73597250A1BCC528420A1 /* PrimerSettings.swift in Sources */,
 				151431732678A1DF00B4C96D /* Catchable.swift in Sources */,
+				15892410268B05AA001280DD /* PrimerTextField.swift in Sources */,
 				804B6D88A05E2B922F5765B3E97ABBBE /* PrimerTableViewCell.swift in Sources */,
-				C9973DF2E27D4180AD0D3B18903794C1 /* PrimerTextField.swift in Sources */,
+				C9973DF2E27D4180AD0D3B18903794C1 /* PrimerCustomStyleTextField.swift in Sources */,
 				151431652678A1DF00B4C96D /* Guarantee.swift in Sources */,
 				1514315B2678A1DF00B4C96D /* RecoverWrappers.swift in Sources */,
 				1ECC73BB4C0A4C15EF55CAF8A4B9E5F7 /* PrimerTheme.swift in Sources */,
@@ -1274,7 +1275,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1589240D268B04AC001280DD /* PrimerTextField.swift in Sources */,
 				2F19BB6B59093986F1240F93B63B6EF1 /* Pods-PrimerSDK_Example-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		15892418268B20DF001280DD /* CardNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15892417268B20DF001280DD /* CardNetwork.swift */; };
 		1589241E269311AD001280DD /* PrimerExpiryDateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589241D269311AD001280DD /* PrimerExpiryDateFieldView.swift */; };
 		1589242026933D77001280DD /* PrimerCVVFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589241F26933D77001280DD /* PrimerCVVFieldView.swift */; };
+		1589242226934373001280DD /* PrimerCardholderFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589242126934373001280DD /* PrimerCardholderFieldView.swift */; };
 		16AF604EFAB8215B9F0879C271AE7A2D /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364D798A53A76D482156C7E07703394 /* FormTextFieldType.swift */; };
 		16EAA7FA33F257010600B443C71C99B5 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F41D2762B2290B4EE76542889986A16 /* PaymentMethod.swift */; };
 		17CC0E100C8B9EF45824E087493F8CBB /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 522F77B4CB1E9CA3B31E3F74F1962B2B /* fr.lproj */; };
@@ -242,6 +243,7 @@
 		15892417268B20DF001280DD /* CardNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNetwork.swift; sourceTree = "<group>"; };
 		1589241D269311AD001280DD /* PrimerExpiryDateFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerExpiryDateFieldView.swift; sourceTree = "<group>"; };
 		1589241F26933D77001280DD /* PrimerCVVFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerCVVFieldView.swift; sourceTree = "<group>"; };
+		1589242126934373001280DD /* PrimerCardholderFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerCardholderFieldView.swift; sourceTree = "<group>"; };
 		15939D76EEF467A182746C99C10F14B6 /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
 		1841E53752535A5BB808AE11B6967728 /* PaymentNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentNetwork.swift; sourceTree = "<group>"; };
 		187BF6D0164EDAB4FF90BEC8F100DD60 /* ResourceBundle-PrimerResources-PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-PrimerResources-PrimerSDK-Info.plist"; sourceTree = "<group>"; };
@@ -511,6 +513,7 @@
 				15892415268B1ACD001280DD /* PrimerCardNumberFieldView.swift */,
 				1589241D269311AD001280DD /* PrimerExpiryDateFieldView.swift */,
 				1589241F26933D77001280DD /* PrimerCVVFieldView.swift */,
+				1589242126934373001280DD /* PrimerCardholderFieldView.swift */,
 			);
 			path = "Text Fields";
 			sourceTree = "<group>";
@@ -1253,6 +1256,7 @@
 				4AD2FD69FB9093E6495ECECBB0AFF1C8 /* RootViewController.swift in Sources */,
 				E7C3CFD182DF2B88B397D4FEC932BA4E /* Route.swift in Sources */,
 				53201CEF7F016F1D0095DC02F0BB82CA /* ScannerView.swift in Sources */,
+				1589242226934373001280DD /* PrimerCardholderFieldView.swift in Sources */,
 				2F7D46820B2AB95810A9B34D168247E6 /* StringExtension.swift in Sources */,
 				0F6EFF3B57B0E3FABF8321F0C04626F7 /* SuccessMessage.swift in Sources */,
 				151431622678A1DF00B4C96D /* FinallyWrappers.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		151431782678A1DF00B4C96D /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151431542678A1DF00B4C96D /* Thenable.swift */; };
 		151431792678A1DF00B4C96D /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151431552678A1DF00B4C96D /* Configuration.swift */; };
 		1514317B2678A52300B4C96D /* PrimerAPIClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1514317A2678A52300B4C96D /* PrimerAPIClient+Promises.swift */; };
+		1589240D268B04AC001280DD /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1589240C268B04AC001280DD /* PrimerTextField.swift */; };
 		16AF604EFAB8215B9F0879C271AE7A2D /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D364D798A53A76D482156C7E07703394 /* FormTextFieldType.swift */; };
 		16EAA7FA33F257010600B443C71C99B5 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F41D2762B2290B4EE76542889986A16 /* PaymentMethod.swift */; };
 		17CC0E100C8B9EF45824E087493F8CBB /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 522F77B4CB1E9CA3B31E3F74F1962B2B /* fr.lproj */; };
@@ -226,6 +227,7 @@
 		151431542678A1DF00B4C96D /* Thenable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Thenable.swift; sourceTree = "<group>"; };
 		151431552678A1DF00B4C96D /* Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		1514317A2678A52300B4C96D /* PrimerAPIClient+Promises.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+Promises.swift"; sourceTree = "<group>"; };
+		1589240C268B04AC001280DD /* PrimerTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
 		15939D76EEF467A182746C99C10F14B6 /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
 		1841E53752535A5BB808AE11B6967728 /* PaymentNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentNetwork.swift; sourceTree = "<group>"; };
 		187BF6D0164EDAB4FF90BEC8F100DD60 /* ResourceBundle-PrimerResources-PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-PrimerResources-PrimerSDK-Info.plist"; sourceTree = "<group>"; };
@@ -485,6 +487,14 @@
 			path = Dispatchers;
 			sourceTree = "<group>";
 		};
+		1589240B268B0498001280DD /* Text Fields */ = {
+			isa = PBXGroup;
+			children = (
+				1589240C268B04AC001280DD /* PrimerTextField.swift */,
+			);
+			path = "Text Fields";
+			sourceTree = "<group>";
+		};
 		1C69793A68B99B63309CC75AFD0213CC /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -507,6 +517,7 @@
 		2D62791E9F1FDC506379E09587FEED82 /* User Interface */ = {
 			isa = PBXGroup;
 			children = (
+				1589240B268B0498001280DD /* Text Fields */,
 				3AF83F7ECA00B65E3E7A79727A2E7AE6 /* Apple Pay */,
 				4109D6A553C6C432B196951559C09094 /* Checkout */,
 				A719AB9D1A3E99B64F9E1EE143E5D7A6 /* Confirm Mandate */,
@@ -1042,6 +1053,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 1100;
+				TargetAttributes = {
+					6C144A762E9B598392AFFEC8F873746A = {
+						LastSwiftMigration = 1250;
+					};
+				};
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1254,6 +1270,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1589240D268B04AC001280DD /* PrimerTextField.swift in Sources */,
 				2F19BB6B59093986F1240F93B63B6EF1 /* Pods-PrimerSDK_Example-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1327,6 +1344,7 @@
 			baseConfigurationReference = 3C474C1A0DABE2A3F404B63D4D59F30C /* Pods-PrimerSDK_Example.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1349,6 +1367,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1394,6 +1414,7 @@
 			baseConfigurationReference = E884507DF2B84FA8A2E8AD8289881542 /* Pods-PrimerSDK_Example.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -1416,6 +1437,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Example/PrimerSDK/AppViewController.swift
+++ b/Example/PrimerSDK/AppViewController.swift
@@ -12,19 +12,26 @@ import UIKit
 class AppViewController: UIViewController, PrimerTextFieldViewDelegate {
     
     @IBOutlet weak var primerTextField: PrimerCardNumberFieldView!
+    @IBOutlet weak var expiryDateFieldView: PrimerExpiryDateFieldView!
+    @IBOutlet weak var cvvFieldView: PrimerCVVFieldView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        primerTextField.backgroundColor = .orange
+        primerTextField.backgroundColor = .lightGray
         primerTextField.delegate = self
-    }
-    
-    func isTextValid(_ isValid: Bool?) {
-        print("isTextValid: \(isValid)")
+        expiryDateFieldView.backgroundColor = .lightGray
+        expiryDateFieldView.delegate = self
+        cvvFieldView.backgroundColor = .lightGray
+        cvvFieldView.placeholder = "CVV"
+        cvvFieldView.delegate = self
     }
     
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, didDetectCardNetwork cardNetwork: CardNetwork) {
         print(cardNetwork)
+    }
+    
+    func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {
+        print("isTextValid: \(isValid)")
     }
 }

--- a/Example/PrimerSDK/AppViewController.swift
+++ b/Example/PrimerSDK/AppViewController.swift
@@ -6,8 +6,25 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
+import PrimerSDK
 import UIKit
 
-class AppViewController: UIViewController {
+class AppViewController: UIViewController, PrimerTextFieldViewDelegate {
     
+    @IBOutlet weak var primerTextField: PrimerCardNumberFieldView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        primerTextField.backgroundColor = .orange
+        primerTextField.delegate = self
+    }
+    
+    func isTextValid(_ isValid: Bool?) {
+        print("isTextValid: \(isValid)")
+    }
+    
+    func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, didDetectCardNetwork cardNetwork: CardNetwork) {
+        print(cardNetwork)
+    }
 }

--- a/Example/PrimerSDK/AppViewController.swift
+++ b/Example/PrimerSDK/AppViewController.swift
@@ -14,17 +14,23 @@ class AppViewController: UIViewController, PrimerTextFieldViewDelegate {
     @IBOutlet weak var primerTextField: PrimerCardNumberFieldView!
     @IBOutlet weak var expiryDateFieldView: PrimerExpiryDateFieldView!
     @IBOutlet weak var cvvFieldView: PrimerCVVFieldView!
+    @IBOutlet weak var cardholderFieldView: PrimerCardholderFieldView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         primerTextField.backgroundColor = .lightGray
+        primerTextField.placeholder = "Card number"
         primerTextField.delegate = self
         expiryDateFieldView.backgroundColor = .lightGray
+        expiryDateFieldView.placeholder = "Expiry date"
         expiryDateFieldView.delegate = self
         cvvFieldView.backgroundColor = .lightGray
         cvvFieldView.placeholder = "CVV"
         cvvFieldView.delegate = self
+        cardholderFieldView.backgroundColor = .lightGray
+        cardholderFieldView.placeholder = "Cardholder"
+        cardholderFieldView.delegate = self
     }
     
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, didDetectCardNetwork cardNetwork: CardNetwork) {

--- a/Example/PrimerSDK/Base.lproj/Main.storyboard
+++ b/Example/PrimerSDK/Base.lproj/Main.storyboard
@@ -42,22 +42,35 @@
                                     <constraint firstAttribute="height" constant="50" id="I3H-Od-r5f"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C1O-8f-gsj" customClass="PrimerCVVFieldView" customModule="PrimerSDK">
+                                <rect key="frame" x="36" y="206" width="303" height="50"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="jne-kJ-hrC"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="C1O-8f-gsj" firstAttribute="height" secondItem="z3P-zC-vmr" secondAttribute="height" id="934-Qr-aFV"/>
+                            <constraint firstItem="C1O-8f-gsj" firstAttribute="leading" secondItem="z3P-zC-vmr" secondAttribute="leading" id="9am-Nw-BMy"/>
                             <constraint firstItem="z3P-zC-vmr" firstAttribute="leading" secondItem="PeS-dP-X3g" secondAttribute="leading" id="9u3-9D-GfU"/>
                             <constraint firstItem="Uou-Rn-KOH" firstAttribute="centerY" secondItem="P7R-MC-LKq" secondAttribute="centerY" id="A4C-4q-2Y2"/>
                             <constraint firstItem="PeS-dP-X3g" firstAttribute="leading" secondItem="P7R-MC-LKq" secondAttribute="leadingMargin" constant="20" id="DVm-pe-4Fl"/>
+                            <constraint firstItem="C1O-8f-gsj" firstAttribute="trailing" secondItem="z3P-zC-vmr" secondAttribute="trailing" id="KWX-ZB-Xot"/>
                             <constraint firstItem="z3P-zC-vmr" firstAttribute="top" secondItem="PeS-dP-X3g" secondAttribute="bottom" constant="8" id="QOo-bc-LXX"/>
                             <constraint firstItem="PeS-dP-X3g" firstAttribute="top" secondItem="Hc4-ia-dRw" secondAttribute="bottom" constant="30" id="Vwe-qU-8Fs"/>
                             <constraint firstAttribute="trailingMargin" secondItem="PeS-dP-X3g" secondAttribute="trailing" constant="20" id="beK-Hg-MMt"/>
                             <constraint firstItem="z3P-zC-vmr" firstAttribute="trailing" secondItem="PeS-dP-X3g" secondAttribute="trailing" id="cU2-hN-gdS"/>
                             <constraint firstItem="z3P-zC-vmr" firstAttribute="height" secondItem="PeS-dP-X3g" secondAttribute="height" id="kLg-47-RN8"/>
+                            <constraint firstItem="C1O-8f-gsj" firstAttribute="top" secondItem="z3P-zC-vmr" secondAttribute="bottom" constant="24" id="mhY-mU-pRR"/>
                             <constraint firstItem="Uou-Rn-KOH" firstAttribute="centerX" secondItem="P7R-MC-LKq" secondAttribute="centerX" id="uIm-xc-nvN"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="kYZ-5n-R2a"/>
                     <connections>
+                        <outlet property="cvvFieldView" destination="C1O-8f-gsj" id="cRj-Rl-Q8l"/>
+                        <outlet property="expiryDateFieldView" destination="z3P-zC-vmr" id="XT2-7Y-EjM"/>
                         <outlet property="primerTextField" destination="PeS-dP-X3g" id="tIB-h0-Ihi"/>
                     </connections>
                 </viewController>

--- a/Example/PrimerSDK/Base.lproj/Main.storyboard
+++ b/Example/PrimerSDK/Base.lproj/Main.storyboard
@@ -49,6 +49,13 @@
                                     <constraint firstAttribute="height" constant="50" id="jne-kJ-hrC"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rA3-j6-lTp" customClass="PrimerCardholderFieldView" customModule="PrimerSDK">
+                                <rect key="frame" x="36" y="271" width="303" height="50"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="b3H-H4-IvK"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
@@ -58,8 +65,12 @@
                             <constraint firstItem="Uou-Rn-KOH" firstAttribute="centerY" secondItem="P7R-MC-LKq" secondAttribute="centerY" id="A4C-4q-2Y2"/>
                             <constraint firstItem="PeS-dP-X3g" firstAttribute="leading" secondItem="P7R-MC-LKq" secondAttribute="leadingMargin" constant="20" id="DVm-pe-4Fl"/>
                             <constraint firstItem="C1O-8f-gsj" firstAttribute="trailing" secondItem="z3P-zC-vmr" secondAttribute="trailing" id="KWX-ZB-Xot"/>
+                            <constraint firstItem="rA3-j6-lTp" firstAttribute="trailing" secondItem="C1O-8f-gsj" secondAttribute="trailing" id="LwN-fC-Mpa"/>
+                            <constraint firstItem="rA3-j6-lTp" firstAttribute="height" secondItem="C1O-8f-gsj" secondAttribute="height" id="Pkg-9f-UAv"/>
                             <constraint firstItem="z3P-zC-vmr" firstAttribute="top" secondItem="PeS-dP-X3g" secondAttribute="bottom" constant="8" id="QOo-bc-LXX"/>
                             <constraint firstItem="PeS-dP-X3g" firstAttribute="top" secondItem="Hc4-ia-dRw" secondAttribute="bottom" constant="30" id="Vwe-qU-8Fs"/>
+                            <constraint firstItem="rA3-j6-lTp" firstAttribute="leading" secondItem="C1O-8f-gsj" secondAttribute="leading" id="WET-5W-kOx"/>
+                            <constraint firstItem="rA3-j6-lTp" firstAttribute="top" secondItem="C1O-8f-gsj" secondAttribute="bottom" constant="15" id="bdg-Ns-llq"/>
                             <constraint firstAttribute="trailingMargin" secondItem="PeS-dP-X3g" secondAttribute="trailing" constant="20" id="beK-Hg-MMt"/>
                             <constraint firstItem="z3P-zC-vmr" firstAttribute="trailing" secondItem="PeS-dP-X3g" secondAttribute="trailing" id="cU2-hN-gdS"/>
                             <constraint firstItem="z3P-zC-vmr" firstAttribute="height" secondItem="PeS-dP-X3g" secondAttribute="height" id="kLg-47-RN8"/>
@@ -69,6 +80,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="kYZ-5n-R2a"/>
                     <connections>
+                        <outlet property="cardholderFieldView" destination="rA3-j6-lTp" id="Qdw-TC-9nq"/>
                         <outlet property="cvvFieldView" destination="C1O-8f-gsj" id="cRj-Rl-Q8l"/>
                         <outlet property="expiryDateFieldView" destination="z3P-zC-vmr" id="XT2-7Y-EjM"/>
                         <outlet property="primerTextField" destination="PeS-dP-X3g" id="tIB-h0-Ihi"/>

--- a/Example/PrimerSDK/Base.lproj/Main.storyboard
+++ b/Example/PrimerSDK/Base.lproj/Main.storyboard
@@ -35,13 +35,24 @@
                                     <constraint firstAttribute="height" constant="50" id="4Tw-OJ-R9n"/>
                                 </constraints>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z3P-zC-vmr" customClass="PrimerExpiryDateFieldView" customModule="PrimerSDK">
+                                <rect key="frame" x="36" y="132" width="303" height="50"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="I3H-Od-r5f"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="z3P-zC-vmr" firstAttribute="leading" secondItem="PeS-dP-X3g" secondAttribute="leading" id="9u3-9D-GfU"/>
                             <constraint firstItem="Uou-Rn-KOH" firstAttribute="centerY" secondItem="P7R-MC-LKq" secondAttribute="centerY" id="A4C-4q-2Y2"/>
                             <constraint firstItem="PeS-dP-X3g" firstAttribute="leading" secondItem="P7R-MC-LKq" secondAttribute="leadingMargin" constant="20" id="DVm-pe-4Fl"/>
+                            <constraint firstItem="z3P-zC-vmr" firstAttribute="top" secondItem="PeS-dP-X3g" secondAttribute="bottom" constant="8" id="QOo-bc-LXX"/>
                             <constraint firstItem="PeS-dP-X3g" firstAttribute="top" secondItem="Hc4-ia-dRw" secondAttribute="bottom" constant="30" id="Vwe-qU-8Fs"/>
                             <constraint firstAttribute="trailingMargin" secondItem="PeS-dP-X3g" secondAttribute="trailing" constant="20" id="beK-Hg-MMt"/>
+                            <constraint firstItem="z3P-zC-vmr" firstAttribute="trailing" secondItem="PeS-dP-X3g" secondAttribute="trailing" id="cU2-hN-gdS"/>
+                            <constraint firstItem="z3P-zC-vmr" firstAttribute="height" secondItem="PeS-dP-X3g" secondAttribute="height" id="kLg-47-RN8"/>
                             <constraint firstItem="Uou-Rn-KOH" firstAttribute="centerX" secondItem="P7R-MC-LKq" secondAttribute="centerX" id="uIm-xc-nvN"/>
                         </constraints>
                     </view>

--- a/Example/PrimerSDK/Base.lproj/Main.storyboard
+++ b/Example/PrimerSDK/Base.lproj/Main.storyboard
@@ -28,14 +28,27 @@
                                     <segue destination="rv5-RJ-1cA" kind="show" id="lRu-Go-hvr"/>
                                 </connections>
                             </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PeS-dP-X3g" customClass="PrimerCardNumberFieldView" customModule="PrimerSDK">
+                                <rect key="frame" x="36" y="74" width="303" height="50"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="4Tw-OJ-R9n"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Uou-Rn-KOH" firstAttribute="centerY" secondItem="P7R-MC-LKq" secondAttribute="centerY" id="A4C-4q-2Y2"/>
+                            <constraint firstItem="PeS-dP-X3g" firstAttribute="leading" secondItem="P7R-MC-LKq" secondAttribute="leadingMargin" constant="20" id="DVm-pe-4Fl"/>
+                            <constraint firstItem="PeS-dP-X3g" firstAttribute="top" secondItem="Hc4-ia-dRw" secondAttribute="bottom" constant="30" id="Vwe-qU-8Fs"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="PeS-dP-X3g" secondAttribute="trailing" constant="20" id="beK-Hg-MMt"/>
                             <constraint firstItem="Uou-Rn-KOH" firstAttribute="centerX" secondItem="P7R-MC-LKq" secondAttribute="centerX" id="uIm-xc-nvN"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="kYZ-5n-R2a"/>
+                    <connections>
+                        <outlet property="primerTextField" destination="PeS-dP-X3g" id="tIB-h0-Ihi"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="AfA-pm-mcm" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/PrimerSDK.podspec
+++ b/PrimerSDK.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |spec|
     spec.name         = "PrimerSDK"
-    spec.version      = "1.7.0"
+    spec.version      = "1.7.1"
     spec.summary      = "Official iOS SDK for Primer"
     spec.description  = <<-DESC
     This library contains the official iOS SDK for Primer. Install this Cocoapod to seemlessly integrate the Primer Checkout & API platform in your app.

--- a/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
@@ -1,0 +1,60 @@
+//
+//  CardNetwork.swift
+//  PrimerSDK
+//
+//  Created by Evangelos Pittas on 29/6/21.
+//
+
+import Foundation
+
+public enum CardNetwork: String {
+    case amex, diners, discover, jcb, maestro, masterCard, visa, unknown, invalid, bancontact
+
+    var fastIdRegex : String {
+        switch self {
+        case .amex:
+            return "^3[47]"
+        case .diners:
+            return "^3[0689]"
+        case .discover:
+            return "^(60|64|65|622)"
+        case .jcb:
+            return "^(2131|1800|35[0-9]{3})"
+        case .maestro:
+            return "^(5018|502|503|506|56|58|639|6220|67)"
+        case .masterCard:
+            return "^(51|52|53|54|55|22|23|24|25|26|27)"
+        case .visa:
+            return "^4"
+        default:
+            return ""
+        }
+    }
+    
+    public var icon: UIImage? {
+        return nil
+    }
+    
+    public init(account: String) {
+        let str = account.withoutWhiteSpace
+        print("Account: \(str)")
+        if str.withoutWhiteSpace.range(of: CardNetwork.masterCard.fastIdRegex, options: .regularExpression, range: nil, locale: nil) != nil {
+            self = .masterCard
+        } else if str.withoutWhiteSpace.range(of: CardNetwork.visa.fastIdRegex, options: .regularExpression, range: nil, locale: nil) != nil {
+            self = .visa
+        } else if str.withoutWhiteSpace.range(of: CardNetwork.maestro.fastIdRegex, options: .regularExpression, range: nil, locale: nil) != nil {
+            self = .maestro
+        } else if str.withoutWhiteSpace.range(of: CardNetwork.amex.fastIdRegex, options: .regularExpression, range: nil, locale: nil) != nil {
+            self = .amex
+        } else if str.withoutWhiteSpace.range(of: CardNetwork.diners.fastIdRegex, options: .regularExpression, range: nil, locale: nil) != nil {
+            self = .diners
+        } else if str.withoutWhiteSpace.range(of: CardNetwork.discover.fastIdRegex, options: .regularExpression, range: nil, locale: nil) != nil {
+            self = .discover
+        } else if str.withoutWhiteSpace.range(of: CardNetwork.jcb.fastIdRegex, options: .regularExpression, range: nil, locale: nil) != nil {
+            self = .jcb
+        } else {
+            self = .unknown
+        }
+    }
+    
+}

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/DateExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/DateExtension.swift
@@ -9,6 +9,19 @@ import Foundation
 
 internal extension Date {
     
+    var startOfMonth: Date {
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents([.year, .month], from: self)
+        return  calendar.date(from: components)!
+    }
+    
+    var endOfMonth: Date {
+        var components = DateComponents()
+        components.month = 1
+        components.second = -1
+        return Calendar(identifier: .gregorian).date(byAdding: components, to: startOfMonth)!
+    }
+    
     // swiftlint:disable identifier_name
     func toString(withFormat f: String = "yyyy-MM-dd'T'HH:mm:ss.SSSZ", timeZone: TimeZone? = nil, calendar: Calendar? = nil) -> String {
         let df = DateFormatter()

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerCustomStyleTextField.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerCustomStyleTextField.swift
@@ -32,7 +32,7 @@ enum TextFieldState {
     }
 }
 
-internal class PrimerTextField: UITextField {
+internal class PrimerCustomStyleTextField: UITextField {
 
     var validationIsOptional = false
 

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
@@ -47,6 +47,57 @@ internal extension String {
     var isValidCardNumber: Bool {
         return count >= 13 && count <= 19 && isValidLuhn
     }
+    
+    var isTypingValidExpiryDate: Bool? {
+        // swiftlint:disable identifier_name
+        let _self = self.replacingOccurrences(of: "/", with: "")
+        // swiftlint:enable identifier_name
+        if _self.count > 4 {
+            return false
+            
+        } else if _self.count == 3 {
+            return nil
+            
+        } else if _self.count == 2 {
+            if let month = Int(_self) {
+                if month < 1 || month > 12 {
+                    return false
+                } else {
+                    return nil
+                }
+            }
+            
+        } else if _self.count == 1 {
+            if ["0", "1"].contains(_self.prefix(1)) {
+                return nil
+            } else {
+                return false
+            }
+            
+        } else if _self.isEmpty {
+            return nil
+        }
+        
+        // Case where count is 4 will arrive here
+        guard let date = toDate(withFormat: "MMyy") else { return false }
+        return date.endOfMonth > Date()
+    }
+    
+    var isValidExpiryDate: Bool {
+        // swiftlint:disable identifier_name
+        let _self = self.replacingOccurrences(of: "/", with: "")
+        // swiftlint:enable identifier_name
+        if _self.count != 4 {
+            return false
+        }
+        
+        if !_self.isNumeric {
+            return false
+        }
+        
+        guard let date = toDate(withFormat: "MMyy") else { return false }
+        return date.endOfMonth > Date()
+    }
 
     var isValidEmail: Bool {
         let emailRegEx = "(?:[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}" +

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
@@ -43,6 +43,11 @@ internal extension String {
         let inputP = NSPredicate(format: "SELF MATCHES %@", regex)
         return inputP.evaluate(with: self)
     }
+    
+    var isOnlyLatinCharacters: Bool {
+        let set = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ")
+        return !(self.rangeOfCharacter(from: set.inverted) != nil)
+    }
 
     var isValidCardNumber: Bool {
         return count >= 13 && count <= 19 && isValidLuhn
@@ -108,6 +113,15 @@ internal extension String {
     
     var isValidCVV: Bool {
         return isNumeric && count >= 3 && count <= 4
+    }
+    
+    var isTypingValidCardholderName: Bool? {
+        if isValidCardholderName { return true }
+        return nil
+    }
+    
+    var isValidCardholderName: Bool {
+        return self.replacingOccurrences(of: " ", with: "").withoutWhiteSpace.isOnlyLatinCharacters && self.split(separator: " ").count >= 2
     }
 
     var isValidEmail: Bool {

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
@@ -12,7 +12,7 @@ import Foundation
 internal extension String {
 
     var withoutWhiteSpace: String {
-        return self.replacingOccurrences(of: " ", with: "")
+        return self.replacingOccurrences(of: " ", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     var isNotValidIBAN: Bool {
@@ -109,6 +109,12 @@ internal extension String {
 
     var isValidAccountNumber: Bool {
         return !self.isEmpty
+    }
+    
+    func separate(every: Int, with separator: String) -> String {
+        return String(stride(from: 0, to: Array(self).count, by: every).map {
+            Array(Array(self)[$0..<min($0 + every, Array(self).count)])
+        }.joined(separator: separator))
     }
 
 }

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
@@ -98,6 +98,17 @@ internal extension String {
         guard let date = toDate(withFormat: "MMyy") else { return false }
         return date.endOfMonth > Date()
     }
+    
+    var isTypingValidCVV: Bool? {
+        if !isNumeric && !isEmpty { return false }
+        if count > 4 { return false }
+        if count >= 3 && count <= 4 { return true }
+        return nil
+    }
+    
+    var isValidCVV: Bool {
+        return isNumeric && count >= 3 && count <= 4
+    }
 
     var isValidEmail: Bool {
         let emailRegEx = "(?:[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}" +

--- a/Sources/PrimerSDK/Classes/User Interface/Form/FormView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Form/FormView.swift
@@ -34,7 +34,7 @@ internal class FormView: PrimerView {
     let contentView = UIScrollView()
 
     var textFields: [[UITextField]] = []
-    var countryPickerTextField: PrimerTextField?
+    var countryPickerTextField: PrimerCustomStyleTextField?
     var validatedFields: [[Bool]] = []
 
     let countries = CountryCode.all
@@ -185,7 +185,7 @@ internal class FormView: PrimerView {
 
     private func configureTextField(_ model: FormTextFieldType, column: Int, row: Int, index: Int) -> Int {
         guard let delegate = delegate else { return 0 }
-        let textField = PrimerTextField()
+        let textField = PrimerCustomStyleTextField()
         textFields[row].append(textField)
 
         switch model {
@@ -498,7 +498,7 @@ internal class FormView: PrimerView {
 
     private func validateTextField(_ sender: UITextField, markError: Bool = true, showValidity: Bool = true) {
         guard let delegate = delegate else { return }
-        guard let textField = sender as? PrimerTextField else { return }
+        guard let textField = sender as? PrimerCustomStyleTextField else { return }
 
         if textField.validationIsOptional {
             textField.renderSubViews(validationState: .default)
@@ -538,7 +538,7 @@ internal class FormView: PrimerView {
         
         textFields.forEach { row in
             row.forEach {
-                guard let textField = $0 as? PrimerTextField else { return }
+                guard let textField = $0 as? PrimerCustomStyleTextField else { return }
                 let column: Int = textField.tag % 10
                 let row: Int = (textField.tag - column) / 10
                 guard let type = delegate?.formType.textFields[row][column] else { return }

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCVVFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCVVFieldView.swift
@@ -1,0 +1,42 @@
+//
+//  PrimerCVVFieldView.swift
+//  PrimerSDK
+//
+//  Created by Evangelos Pittas on 5/7/21.
+//
+
+import UIKit
+
+public final class PrimerCVVFieldView: PrimerTextFieldView {
+            
+    override func xibSetup() {
+        super.xibSetup()
+        
+        textField.delegate = self
+        isValid = { text in
+            return text.isTypingValidCVV
+        }
+    }
+    
+    public override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let primerTextField = textField as? PrimerTextField else { return true }
+        let currentText = primerTextField._text ?? ""
+        let newText = (currentText as NSString).replacingCharacters(in: range, with: string) as String
+        if !(newText.isNumeric || newText.isEmpty) { return false }
+        if string != "" && newText.withoutWhiteSpace.count >= 5 { return false }
+        
+        switch self.isValid?(newText) {
+        case true:
+            validation = .valid
+        case false:
+            validation = .invalid(NSError(domain: "primer", code: 100, userInfo: [NSLocalizedDescriptionKey: "Invalid value."]))
+        default:
+            validation = .notAvailable
+        }
+        
+        primerTextField._text = newText
+        primerTextField.text = newText
+        return false
+    }
+    
+}

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCardNumberFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCardNumberFieldView.swift
@@ -5,4 +5,32 @@
 //  Created by Evangelos Pittas on 29/6/21.
 //
 
-import Foundation
+import UIKit
+
+public final class PrimerCardNumberFieldView: PrimerTextFieldView {
+        
+    var cardNetwork: CardNetwork = .unknown
+    
+    override func xibSetup() {
+        super.xibSetup()
+        
+        textField.delegate = self
+        isValid = { text in
+            return text.isValidCardNumber
+        }
+    }
+    
+    public override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let primerTextField = textField as? PrimerTextField else { return true }
+        let currentText = primerTextField._text ?? ""
+        if string != "" && currentText.withoutWhiteSpace.count == 19 { return false }
+        let newText = (currentText as NSString).replacingCharacters(in: range, with: string) as String
+        primerTextField._text = newText
+        cardNetwork = CardNetwork(account: primerTextField._text ?? "")
+        delegate?.primerTextFieldView(self, didDetectCardNetwork: cardNetwork)
+        validation = (self.isValid?(primerTextField._text?.withoutWhiteSpace ?? "") ?? false) ? .valid : .invalid(NSError(domain: "primer", code: 100, userInfo: [NSLocalizedDescriptionKey: "Invalid value."]))
+        primerTextField.text = newText.withoutWhiteSpace.separate(every: 4, with: " ")
+        return false
+    }
+    
+}

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCardNumberFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCardNumberFieldView.swift
@@ -1,0 +1,8 @@
+//
+//  PrimerCardNumberFieldView.swift
+//  PrimerSDK
+//
+//  Created by Evangelos Pittas on 29/6/21.
+//
+
+import Foundation

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCardholderFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCardholderFieldView.swift
@@ -1,0 +1,40 @@
+//
+//  PrimerCardholderFieldView.swift
+//  PrimerSDK
+//
+//  Created by Evangelos Pittas on 5/7/21.
+//
+
+import UIKit
+
+public final class PrimerCardholderFieldView: PrimerTextFieldView {
+            
+    override func xibSetup() {
+        super.xibSetup()
+        
+        textField.delegate = self
+        isValid = { text in
+            return text.isTypingValidCardholderName
+        }
+    }
+    
+    public override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let primerTextField = textField as? PrimerTextField else { return true }
+        let currentText = primerTextField._text ?? ""
+        let newText = (currentText as NSString).replacingCharacters(in: range, with: string) as String
+
+        switch self.isValid?(newText) {
+        case true:
+            validation = .valid
+        case false:
+            validation = .invalid(NSError(domain: "primer", code: 100, userInfo: [NSLocalizedDescriptionKey: "Invalid value."]))
+        default:
+            validation = .notAvailable
+        }
+        
+        primerTextField._text = newText
+        primerTextField.text = newText
+        return false
+    }
+    
+}

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerExpiryDateFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerExpiryDateFieldView.swift
@@ -46,9 +46,6 @@ public final class PrimerExpiryDateFieldView: PrimerTextFieldView {
         }
         
         primerTextField._text = newText
-
-//        delegate?.primerTextFieldView(self, didDetectCardNetwork: cardNetwork)
-//        validation = (self.isValid?(primerTextField._text?.withoutWhiteSpace ?? "") ?? false) ? .valid : .invalid(NSError(domain: "primer", code: 100, userInfo: [NSLocalizedDescriptionKey: "Invalid value."]))
         primerTextField.text = newText
         return false
     }

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerExpiryDateFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerExpiryDateFieldView.swift
@@ -1,0 +1,56 @@
+//
+//  PrimerExpiryDateFieldView.swift
+//  PrimerSDK
+//
+//  Created by Evangelos Pittas on 5/7/21.
+//
+
+import UIKit
+
+public final class PrimerExpiryDateFieldView: PrimerTextFieldView {
+            
+    override func xibSetup() {
+        super.xibSetup()
+        
+        textField.delegate = self
+        isValid = { text in
+            let isValid = text.isTypingValidExpiryDate
+            print(isValid)
+            return isValid
+        }
+    }
+    
+    public override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let primerTextField = textField as? PrimerTextField else { return true }
+        let currentText = primerTextField._text ?? ""
+        var newText = (currentText as NSString).replacingCharacters(in: range, with: string) as String
+        newText = newText.replacingOccurrences(of: "/", with: "")
+        if !(newText.isNumeric || newText.isEmpty) { return false }
+        if string != "" && newText.withoutWhiteSpace.count >= 5 { return false }
+        
+        validation = (self.isValid?(newText) ?? false) ? .valid : .invalid(NSError(domain: "primer", code: 100, userInfo: [NSLocalizedDescriptionKey: "Invalid value."]))
+        
+        if string != "" {   // Typing
+            if newText.count == 2 {
+                newText += "/"
+            } else {
+                newText = newText.separate(every: 2, with: "/")
+            }
+            
+        } else {            // Deleting
+            if newText.count == 2 {
+    //            newText += "/"
+            } else {
+                newText = newText.separate(every: 2, with: "/")
+            }
+        }
+        
+        primerTextField._text = newText
+
+//        delegate?.primerTextFieldView(self, didDetectCardNetwork: cardNetwork)
+//        validation = (self.isValid?(primerTextField._text?.withoutWhiteSpace ?? "") ?? false) ? .valid : .invalid(NSError(domain: "primer", code: 100, userInfo: [NSLocalizedDescriptionKey: "Invalid value."]))
+        primerTextField.text = newText
+        return false
+    }
+    
+}

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 public class PrimerNibView: UIView {
     
-    public var view: UIView!
+    internal var view: UIView!
     
     override internal init(frame: CGRect) {
         super.init(frame: frame)
@@ -47,14 +47,8 @@ internal extension PrimerNibView {
         let bundle = Bundle(for: type(of: self))
         var nibName = type(of: self).description().components(separatedBy: ".").last!
         
-        if nibName == "PrimerCardNumberField" {
-            nibName = "PrimerPCITextField"
-        } else if nibName == "PrimerExpiryDateField" {
-            nibName = "PrimerPCITextField"
-        } else if nibName == "PrimerCVVField" {
-            nibName = "PrimerPCITextField"
-        } else if nibName == "PrimerNameField" {
-            nibName = "PrimerPCITextField"
+        if nibName == "PrimerCardNumberFieldView" {
+            nibName = "PrimerTextFieldView"
         }
         
         let nib = UINib(nibName: nibName, bundle: bundle)

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
@@ -1,0 +1,63 @@
+//
+//  PrimerNibView.swift
+//  PrimerSDK
+//
+//  Created by Evangelos Pittas on 29/6/21.
+//
+
+import UIKit
+
+public class PrimerNibView: UIView {
+    
+    public var view: UIView!
+    
+    override internal init(frame: CGRect) {
+        super.init(frame: frame)
+        xibSetup()
+    }
+    
+    required internal init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        xibSetup()
+    }
+    
+    internal func xibSetup() {
+        backgroundColor = UIColor.clear
+        view = loadNib()
+        // use bounds not frame or it'll be offset
+        view.frame = bounds
+        // Adding custom subview on top of our view
+        addSubview(view)
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[childView]|",
+                                                      options: [],
+                                                      metrics: nil,
+                                                      views: ["childView": view]))
+        addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[childView]|",
+                                                      options: [],
+                                                      metrics: nil,
+                                                      views: ["childView": view]))
+    }
+}
+
+internal extension PrimerNibView {
+    /** Loads instance from nib with the same name. */
+    func loadNib() -> UIView {
+        let bundle = Bundle(for: type(of: self))
+        var nibName = type(of: self).description().components(separatedBy: ".").last!
+        
+        if nibName == "PrimerCardNumberField" {
+            nibName = "PrimerPCITextField"
+        } else if nibName == "PrimerExpiryDateField" {
+            nibName = "PrimerPCITextField"
+        } else if nibName == "PrimerCVVField" {
+            nibName = "PrimerPCITextField"
+        } else if nibName == "PrimerNameField" {
+            nibName = "PrimerPCITextField"
+        }
+        
+        let nib = UINib(nibName: nibName, bundle: bundle)
+        return nib.instantiate(withOwner: self, options: nil).first as! UIView
+    }
+}

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
@@ -54,6 +54,9 @@ internal extension PrimerNibView {
         } else if nibName == "PrimerCVVFieldView" {
             nibName = "PrimerTextFieldView"
         }
+        else if nibName == "PrimerCardholderFieldView" {
+           nibName = "PrimerTextFieldView"
+       }
         
         let nib = UINib(nibName: nibName, bundle: bundle)
         return nib.instantiate(withOwner: self, options: nil).first as! UIView

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
@@ -49,6 +49,8 @@ internal extension PrimerNibView {
         
         if nibName == "PrimerCardNumberFieldView" {
             nibName = "PrimerTextFieldView"
+        } else if nibName == "PrimerExpiryDateFieldView" {
+            nibName = "PrimerTextFieldView"
         }
         
         let nib = UINib(nibName: nibName, bundle: bundle)

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
@@ -51,6 +51,8 @@ internal extension PrimerNibView {
             nibName = "PrimerTextFieldView"
         } else if nibName == "PrimerExpiryDateFieldView" {
             nibName = "PrimerTextFieldView"
+        } else if nibName == "PrimerCVVFieldView" {
+            nibName = "PrimerTextFieldView"
         }
         
         let nib = UINib(nibName: nibName, bundle: bundle)

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextField.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextField.swift
@@ -18,7 +18,9 @@ internal class PrimerTextField: UITextField {
             return super.delegate
         }
         set {
-
+            if let primerTextFieldView = newValue as? PrimerTextFieldView {
+                super.delegate = primerTextFieldView
+            }
         }
     }
     

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextField.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextField.swift
@@ -22,8 +22,10 @@ internal class PrimerTextField: UITextField {
         }
     }
     
+    // swiftlint:disable identifier_name
     internal var _text: String?
-    
+    // swiftlint:enable identifier_name
+        
     override var text: String? {
         get {
             return "****"

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextField.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextField.swift
@@ -1,0 +1,37 @@
+//
+//  PrimerTextField.swift
+//  Pods-PrimerSDK_Example
+//
+//  Created by Evangelos Pittas on 29/6/21.
+//
+
+import UIKit
+
+internal class PrimerTextField: UITextField {
+    
+    internal enum Validation {
+        case valid, invalid(_ error: Error?), notAvailable
+    }
+    
+    override var delegate: UITextFieldDelegate? {
+        get {
+            return super.delegate
+        }
+        set {
+
+        }
+    }
+    
+    internal var _text: String?
+    
+    override var text: String? {
+        get {
+            return "****"
+        }
+        set {
+            super.text = newValue
+            _text = super.text
+        }
+    }
+        
+}

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.swift
@@ -1,0 +1,43 @@
+//
+//  PrimerTextFieldView.swift
+//  PrimerSDK
+//
+//  Created by Evangelos Pittas on 29/6/21.
+//
+
+import UIKit
+
+public protocol PrimerTextFieldViewDelegate {
+    func isTextValid(_ isValid: Bool?)
+}
+
+public extension PrimerTextFieldViewDelegate {
+    func isTextValid(_ isValid: Bool?) {}
+}
+
+public class PrimerTextFieldView: PrimerNibView, UITextFieldDelegate {
+    
+    @IBOutlet internal weak var textField: PrimerTextField!
+    
+    // MARK: - PROXY
+    
+    public var text: String? { didSet { textField.text = text } }
+    public var attributedText: NSAttributedString? { didSet { textField.attributedText = attributedText } }
+    public var textColor: UIColor? { didSet { textField.textColor = textColor } }
+    public var font: UIFont? { didSet { textField.font = font } }
+    public var textAlignment: NSTextAlignment = .left { didSet { textField.textAlignment = textAlignment } }
+    public var borderStyle: UITextField.BorderStyle = .none { didSet { textField.borderStyle = borderStyle } }
+    public var defaultTextAttributes: [NSAttributedString.Key: Any] = [:] { didSet { textField.defaultTextAttributes = defaultTextAttributes } }
+    public var placeholder: String? { didSet { textField.placeholder = placeholder } }
+    public var attributedPlaceholder: NSAttributedString? { didSet { textField.attributedPlaceholder = attributedPlaceholder } }
+    public var clearsOnBeginEditing: Bool = false { didSet { textField.clearsOnBeginEditing = clearsOnBeginEditing } }
+    public var adjustsFontSizeToFitWidth: Bool = false { didSet { textField.adjustsFontSizeToFitWidth = adjustsFontSizeToFitWidth } }
+    public var minimumFontSize: CGFloat = 0.0 { didSet { textField.minimumFontSize = minimumFontSize } }
+    public var background: UIImage? { didSet { textField.background = background } }
+    public var disabledBackground: UIImage? { didSet { textField.disabledBackground = disabledBackground } }
+    public var isEditing: Bool {
+        return textField.isEditing
+    }
+    
+}
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.swift
@@ -22,7 +22,7 @@ public extension PrimerTextFieldViewDelegate {
 public class PrimerTextFieldView: PrimerNibView, UITextFieldDelegate {
     
     @IBOutlet internal weak var textField: PrimerTextField!
-    internal var isValid: ((_ text: String) -> Bool)?
+    internal var isValid: ((_ text: String) -> Bool?)?
     public var delegate: PrimerTextFieldViewDelegate?
     
     internal var validation: PrimerTextField.Validation = .notAvailable {
@@ -109,22 +109,22 @@ public class PrimerTextFieldView: PrimerNibView, UITextFieldDelegate {
         return textField.drawPlaceholder(in: rect)
     }
     
-    public override var inputView: UIView? {
-        get {
-            return textField.inputView
-        }
-        set {
-            textField.inputView = newValue
-        }
-    }
-    public override var inputAccessoryView: UIView? {
-        get {
-            return textField.inputAccessoryView
-        }
-        set {
-            textField.inputAccessoryView = newValue
-        }
-    }
+//    public override var inputView: UIView? {
+//        get {
+//            return textField.inputView
+//        }
+//        set {
+//            textField.inputView = newValue
+//        }
+//    }
+//    public override var inputAccessoryView: UIView? {
+//        get {
+//            return textField.inputAccessoryView
+//        }
+//        set {
+//            textField.inputAccessoryView = newValue
+//        }
+//    }
     public var clearsOnInsertion: Bool = false { didSet { textField.clearsOnInsertion = clearsOnInsertion }}
     
     

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.xib
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.xib
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        </view>
+    </objects>
+</document>

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.xib
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.xib
@@ -1,18 +1,44 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PrimerTextFieldView" customModule="PrimerSDK" customModuleProvider="target">
+            <connections>
+                <outlet property="textField" destination="pRF-UB-ra3" id="FcH-5d-P2X"/>
+            </connections>
+        </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <subviews>
+                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="pRF-UB-ra3" customClass="PrimerTextField" customModule="PrimerSDK" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+            </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="pRF-UB-ra3" secondAttribute="trailing" id="TfK-v3-Wwo"/>
+                <constraint firstItem="pRF-UB-ra3" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="lrg-jP-aGY"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="pRF-UB-ra3" secondAttribute="bottom" id="vEQ-qt-IVV"/>
+                <constraint firstItem="pRF-UB-ra3" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="w1G-Lk-ocY"/>
+            </constraints>
+            <point key="canvasLocation" x="26" y="141"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
CHE-858

# What this PR does

Adds custom textfield components that carry card fields' validation functionality.

# Notable decisions & other stuff

n/a

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
