### PR TITLE
Feature/che 912 add missing klarna token details

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/Klarna.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Klarna.swift
@@ -117,6 +117,21 @@ public struct KlarnaSessionData: Codable {
     public let orderAmount: Int?
     public let orderLines: [KlarnaSessionOrderLines]
     public let billingAddress: KlarnaBillingAddress?
+    public let tokenDetails: KlarnaSessionDataTokenDetails?
+}
+
+public struct KlarnaSessionDataTokenDetails: Codable {
+    public let brand: String?
+    public let maskedNumber: String?
+    public let type: String
+    public let expiryDate: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case brand = "brand"
+        case maskedNumber = "masked_number"
+        case type = "type"
+        case expiryDate = "expiry_date"
+    }
 }
 
 public struct KlarnaBillingAddress: Codable {

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/OAuthViewController.swift
@@ -91,7 +91,6 @@ internal class OAuthViewController: PrimerViewController {
         webViewController.url = URL(string: urlString)
         webViewController.delegate = self
         webViewController.klarnaWebViewCompletion = { [weak self] (_, err) in
-//            let err: Error?  = KlarnaException.noCoreUrl
             if let err = err {
                 _ = ErrorHandler.shared.handle(error: err)
                 router.show(.error(error: err))

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/WebViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/WebViewController.swift
@@ -111,7 +111,6 @@ internal class WebViewController: PrimerViewController, WKNavigationDelegate {
             
             let state: AppStateProtocol = DependencyContainer.resolve()
 
-            // FIXME: WebView should be agnostic of state and not set it. Debug what happens on
             state.authorizationToken = val
             klarnaWebViewCompletion?(val, nil)
             klarnaWebViewCompletion = nil

--- a/Tests/PrimerSDK_Tests/Services/KlarnaServiceTests.swift
+++ b/Tests/PrimerSDK_Tests/Services/KlarnaServiceTests.swift
@@ -118,7 +118,7 @@ class KlarnaServiceTests: XCTestCase {
     func test_create_client_token_success() throws {
         let expectation = XCTestExpectation(description: "Create Klarna client token | Success")
 
-        let sessionData = KlarnaSessionData(recurringDescription: "subscription", purchaseCountry: "SE", purchaseCurrency: "SEK", locale: "en-SE", orderAmount: 2000, orderLines: [], billingAddress: nil)
+        let sessionData = KlarnaSessionData(recurringDescription: "subscription", purchaseCountry: "SE", purchaseCurrency: "SEK", locale: "en-SE", orderAmount: 2000, orderLines: [], billingAddress: nil, tokenDetails: nil)
         let response = KlarnaCustomerTokenAPIResponse(customerTokenId: "token", sessionData: sessionData)
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: false)
@@ -146,7 +146,7 @@ class KlarnaServiceTests: XCTestCase {
     func test_create_client_token_fail_invalid_response() throws {
         let expectation = XCTestExpectation(description: "Create Klarna client token | Failure: API call failed")
 
-        let sessionData = KlarnaSessionData(recurringDescription: "subscription", purchaseCountry: "SE", purchaseCurrency: "SEK", locale: "en-SE", orderAmount: 2000, orderLines: [], billingAddress: nil)
+        let sessionData = KlarnaSessionData(recurringDescription: "subscription", purchaseCountry: "SE", purchaseCurrency: "SEK", locale: "en-SE", orderAmount: 2000, orderLines: [], billingAddress: nil, tokenDetails: nil)
         let response = KlarnaCustomerTokenAPIResponse(customerTokenId: "token", sessionData: sessionData)
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: true)
@@ -175,7 +175,7 @@ class KlarnaServiceTests: XCTestCase {
     func test_finalize_payment_session_success() throws {
         let expectation = XCTestExpectation(description: "Finalize Klarna payment session | Success")
 
-        let sessionData = KlarnaSessionData(recurringDescription: "subscription", purchaseCountry: "SE", purchaseCurrency: "SEK", locale: "en-SE", orderAmount: 2000, orderLines: [], billingAddress: nil)
+        let sessionData = KlarnaSessionData(recurringDescription: "subscription", purchaseCountry: "SE", purchaseCurrency: "SEK", locale: "en-SE", orderAmount: 2000, orderLines: [], billingAddress: nil, tokenDetails: nil)
         let response = KlarnaFinalizePaymentSessionresponse(sessionData: sessionData)
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: false)
@@ -203,7 +203,7 @@ class KlarnaServiceTests: XCTestCase {
     func test_finalize_payment_session_fail_invalid_response() throws {
         let expectation = XCTestExpectation(description: "Finalize Klarna payment session | Failure: API call failed")
 
-        let sessionData = KlarnaSessionData(recurringDescription: "subscription", purchaseCountry: "SE", purchaseCurrency: "SEK", locale: "en-SE", orderAmount: 2000, orderLines: [], billingAddress: nil)
+        let sessionData = KlarnaSessionData(recurringDescription: "subscription", purchaseCountry: "SE", purchaseCurrency: "SEK", locale: "en-SE", orderAmount: 2000, orderLines: [], billingAddress: nil, tokenDetails: nil)
         let response = KlarnaFinalizePaymentSessionresponse(sessionData: sessionData)
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: true)


### PR DESCRIPTION
CHE-

# What this PR does

Adds missing Klarna token details on tokenization request.

# Notable decisions & other stuff

n/a

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
