### PR TITLE
DEX-204 Add framework version on headers

### DIFF
--- a/Sources/PrimerSDK/Classes/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/Services/API/Primer/PrimerAPI.swift
@@ -106,11 +106,14 @@ internal extension PrimerAPI {
 
     // MARK: Headers
     var headers: [String: String]? {
+        let frameworkVersion = Bundle.primerFramework.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        
         var headers: [String: String] = [
             "Content-Type": "application/json",
-            "Primer-SDK-Version": "1.0.0-beta.0",
+            "Primer-SDK-Version": frameworkVersion ?? "n/a",
             "Primer-SDK-Client": "IOS_NATIVE"
         ]
+        
         switch self {
         case .directDebitCreateMandate(let clientToken, _),
              .vaultDeletePaymentMethod(let clientToken, _),


### PR DESCRIPTION
DEX-204

# What this PR does

Adds framework version on headers

# Notable decisions & other stuff

n/a

# Instructions on how to test this

On the debugger or on data dog

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
