### PR TITLE
Feature/dex 563 fix config parse

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
@@ -31,6 +31,10 @@ public enum ConfigPaymentMethodType: String, Codable {
             return false
         }
     }
+    
+    public init(from decoder: Decoder) throws {
+        self = (try? ConfigPaymentMethodType(rawValue: decoder.singleValueContainer().decode(RawValue.self))) ?? .unknown
+    }
 }
 
 internal extension PaymentMethodConfig {

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
@@ -20,6 +20,7 @@ public enum ConfigPaymentMethodType: String, Codable {
     case klarna = "KLARNA"
     case payNlIdeal = "PAY_NL_IDEAL"
     case apaya = "APAYA"
+    case hoolah = "HOOLAH"
     
     case unknown
     


### PR DESCRIPTION
DEX-563

# What this PR does

Fixes config parse failing because of not defined payment method type.
If not defined, it defaults to unknown without breaking the config parse.
Adds Hoolah in enum.

# Notable decisions & other stuff

List & explain ...

# Instructions on how to test this

Let other reviewers know how they can test this.

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
