### PR TITLE
Feature/dex 581 Remove decoded client token from state

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
+++ b/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
@@ -168,7 +168,7 @@ class ThreeDSService: ThreeDSServiceProtocol {
     ) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             completion(.failure(PrimerError.clientTokenNull))
             return
         }
@@ -369,13 +369,13 @@ class ThreeDSService: ThreeDSServiceProtocol {
                          completion: @escaping (Result<ThreeDS.BeginAuthResponse, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.vaultFetchFailed))
         }
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
         
-        api.threeDSBeginAuth(clientToken: clientToken, paymentMethod: paymentMethod, threeDSecureBeginAuthRequest: threeDSecureBeginAuthRequest, completion: { result in
+        api.threeDSBeginAuth(clientToken: decodedClientToken, paymentMethod: paymentMethod, threeDSecureBeginAuthRequest: threeDSecureBeginAuthRequest, completion: { result in
             switch result {
             case .failure(let err):
                 completion(.failure(err))
@@ -388,12 +388,12 @@ class ThreeDSService: ThreeDSServiceProtocol {
     func continueRemoteAuth(threeDSTokenId: String, completion: @escaping (Result<ThreeDS.PostAuthResponse, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.vaultFetchFailed))
         }
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
-        api.threeDSContinueAuth(clientToken: clientToken, threeDSTokenId: threeDSTokenId) { result in
+        api.threeDSContinueAuth(clientToken: decodedClientToken, threeDSTokenId: threeDSTokenId) { result in
             switch result {
             case .failure(let err):
                 completion(.failure(err))
@@ -426,9 +426,7 @@ class MockThreeDSService: ThreeDSServiceProtocol {
     }
     
     func beginRemoteAuth(paymentMethod: PaymentMethod, threeDSecureBeginAuthRequest: ThreeDS.BeginAuthRequest, completion: @escaping (Result<ThreeDS.BeginAuthResponse, Error>) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.vaultFetchFailed))
         }
         
@@ -436,13 +434,11 @@ class MockThreeDSService: ThreeDSServiceProtocol {
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         api.response = response
         
-        api.threeDSBeginAuth(clientToken: clientToken, paymentMethod: paymentMethod, threeDSecureBeginAuthRequest: threeDSecureBeginAuthRequest, completion: completion)
+        api.threeDSBeginAuth(clientToken: decodedClientToken, paymentMethod: paymentMethod, threeDSecureBeginAuthRequest: threeDSecureBeginAuthRequest, completion: completion)
     }
     
     func continueRemoteAuth(threeDSTokenId: String, completion: @escaping (Result<ThreeDS.PostAuthResponse, Error>) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.vaultFetchFailed))
         }
         
@@ -450,7 +446,7 @@ class MockThreeDSService: ThreeDSServiceProtocol {
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         api.response = response
         
-        api.threeDSContinueAuth(clientToken: clientToken, threeDSTokenId: threeDSTokenId, completion: completion)
+        api.threeDSContinueAuth(clientToken: decodedClientToken, threeDSTokenId: threeDSTokenId, completion: completion)
     }
 }
 

--- a/Sources/PrimerSDK/Classes/Core/PCI/TokenizationService.swift
+++ b/Sources/PrimerSDK/Classes/Core/PCI/TokenizationService.swift
@@ -22,16 +22,14 @@ internal class TokenizationService: TokenizationServiceProtocol {
     func tokenize(
         request: TokenizationRequest,
         onTokenizeSuccess: @escaping (Result<PaymentMethod, PrimerError>) -> Void
-    ) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
-        guard let clientToken = state.decodedClientToken else {
+    ) {        
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return onTokenizeSuccess(.failure(PrimerError.tokenizationPreRequestFailed))
         }
 
-        log(logLevel: .verbose, title: nil, message: "Client Token: \(clientToken)", prefix: nil, suffix: nil, bundle: nil, file: #file, className: String(describing: Self.self), function: #function, line: #line)
+        log(logLevel: .verbose, title: nil, message: "Client Token: \(decodedClientToken)", prefix: nil, suffix: nil, bundle: nil, file: #file, className: String(describing: Self.self), function: #function, line: #line)
 
-        guard let pciURL = clientToken.pciUrl else {
+        guard let pciURL = decodedClientToken.pciUrl else {
             return onTokenizeSuccess(.failure(PrimerError.tokenizationPreRequestFailed))
         }
 
@@ -45,7 +43,7 @@ internal class TokenizationService: TokenizationServiceProtocol {
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
         
-        api.tokenizePaymentMethod(clientToken: clientToken, paymentMethodTokenizationRequest: request) { (result) in
+        api.tokenizePaymentMethod(clientToken: decodedClientToken, paymentMethodTokenizationRequest: request) { (result) in
             switch result {
             case .failure:
                 DispatchQueue.main.async {
@@ -87,7 +85,7 @@ internal class TokenizationService: TokenizationServiceProtocol {
 
                     threeDSService.perform3DS(
                         paymentMethod: paymentMethod,
-                        protocolVersion: state.decodedClientToken?.env == "PRODUCTION" ? .v1 : .v2,
+                        protocolVersion: ClientTokenService.decodedClientToken?.env == "PRODUCTION" ? .v1 : .v2,
                         beginAuthExtraData: threeDSBeginAuthExtraData,
                             sdkDismissed: { () in
 

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/ClientTokenService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/ClientTokenService.swift
@@ -3,37 +3,52 @@
 import Foundation
 
 internal protocol ClientTokenServiceProtocol {
+    static var decodedClientToken: DecodedClientToken? { get }
     static func storeClientToken(_ clientToken: String) throws
     func fetchClientToken(_ completion: @escaping (Error?) -> Void)
+    static func resetClientToken()
 }
 
 internal class ClientTokenService: ClientTokenServiceProtocol {
     
-    static func storeClientToken(_ clientToken: String) throws {
-        guard var jwtTokenPayload = clientToken.jwtTokenPayload,
-              let expDate = jwtTokenPayload.expDate
+    deinit {
+        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
+    }
+    
+    static var decodedClientToken: DecodedClientToken? {
+        let state: AppStateProtocol = DependencyContainer.resolve()
+        
+        guard let clientToken = state.clientToken,
+              let decodedClientToken = clientToken.jwtTokenPayload
         else {
+            return nil
+        }
+        
+        do {
+            try decodedClientToken.validate()
+        } catch {
+            return nil
+        }
+        
+        return decodedClientToken
+    }
+    
+    static func storeClientToken(_ clientToken: String) throws {
+        guard var decodedClientToken = clientToken.jwtTokenPayload else {
             throw PrimerError.clientTokenNull
         }
         
-        if expDate < Date() {
-            throw PrimerError.clientTokenExpired
-        }
+        try decodedClientToken.validate()
         
         let state: AppStateProtocol = DependencyContainer.resolve()
-        let previousEnv = state.decodedClientToken?.env
+        let previousEnv = ClientTokenService.decodedClientToken?.env
         
-        if jwtTokenPayload.env == nil {
+        if decodedClientToken.env == nil {
             // That's because the clientToken returned for dynamic 3DS doesn't contain an env.
-            jwtTokenPayload.env = previousEnv
+            decodedClientToken.env = previousEnv
         }
 
-        state.decodedClientToken = jwtTokenPayload
-        state.accessToken = clientToken
-    }
-    
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
+        state.clientToken = clientToken
     }
 
     /**
@@ -58,6 +73,11 @@ internal class ClientTokenService: ClientTokenServiceProtocol {
                 }
             }
         })
+    }
+    
+    static func resetClientToken() {
+        let state: AppStateProtocol = DependencyContainer.resolve()
+        state.clientToken = nil
     }
 
 }

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/DirectDebitService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/DirectDebitService.swift
@@ -20,7 +20,7 @@ internal class DirectDebitService: DirectDebitServiceProtocol {
     func createMandate(_ completion: @escaping (Error?) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(PrimerError.directDebitSessionFailed)
         }
 

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/PayPalService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/PayPalService.swift
@@ -17,7 +17,7 @@ internal class PayPalService: PayPalServiceProtocol {
     private func prepareUrlAndTokenAndId(path: String) -> (DecodedClientToken, URL, String)? {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return nil
         }
 
@@ -25,7 +25,7 @@ internal class PayPalService: PayPalServiceProtocol {
             return nil
         }
 
-        guard let coreURL = clientToken.coreUrl else {
+        guard let coreURL = decodedClientToken.coreUrl else {
             return nil
         }
 
@@ -33,13 +33,13 @@ internal class PayPalService: PayPalServiceProtocol {
             return nil
         }
 
-        return (clientToken, url, configId)
+        return (decodedClientToken, url, configId)
     }
 
     func startOrderSession(_ completion: @escaping (Result<String, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.clientTokenNull))
         }
 
@@ -75,7 +75,7 @@ internal class PayPalService: PayPalServiceProtocol {
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
 
-        api.payPalStartOrderSession(clientToken: clientToken, payPalCreateOrderRequest: body) { [weak self] (result) in
+        api.payPalStartOrderSession(clientToken: decodedClientToken, payPalCreateOrderRequest: body) { [weak self] (result) in
             switch result {
             case .failure:
                 completion(.failure(PrimerError.payPalSessionFailed))
@@ -89,7 +89,7 @@ internal class PayPalService: PayPalServiceProtocol {
     func startBillingAgreementSession(_ completion: @escaping (Result<String, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.payPalSessionFailed))
         }
 
@@ -115,7 +115,7 @@ internal class PayPalService: PayPalServiceProtocol {
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
 
-        api.payPalStartBillingAgreementSession(clientToken: clientToken, payPalCreateBillingAgreementRequest: body) { [weak self] (result) in
+        api.payPalStartBillingAgreementSession(clientToken: decodedClientToken, payPalCreateBillingAgreementRequest: body) { [weak self] (result) in
             switch result {
             case .failure:
                 completion(.failure(PrimerError.payPalSessionFailed))
@@ -129,7 +129,7 @@ internal class PayPalService: PayPalServiceProtocol {
     func confirmBillingAgreement(_ completion: @escaping (Result<PayPalConfirmBillingAgreementResponse, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.payPalSessionFailed))
         }
 
@@ -145,7 +145,7 @@ internal class PayPalService: PayPalServiceProtocol {
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
 
-        api.payPalConfirmBillingAgreement(clientToken: clientToken, payPalConfirmBillingAgreementRequest: body) { [weak self] (result) in
+        api.payPalConfirmBillingAgreement(clientToken: decodedClientToken, payPalConfirmBillingAgreementRequest: body) { (result) in
             switch result {
             case .failure:
                 completion(.failure(PrimerError.payPalSessionFailed))

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/PaymentMethodConfigService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/PaymentMethodConfigService.swift
@@ -15,7 +15,7 @@ internal class PaymentMethodConfigService: PaymentMethodConfigServiceProtocol {
     func fetchConfig(_ completion: @escaping (Error?) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(PrimerError.configFetchFailed)
         }
         

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/VaultService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/VaultService.swift
@@ -17,14 +17,14 @@ internal class VaultService: VaultServiceProtocol {
     func loadVaultedPaymentMethods(_ completion: @escaping (Error?) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(PrimerError.vaultFetchFailed)
         }
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
         
         firstly {
-            api.vaultFetchPaymentMethods(clientToken: clientToken)
+            api.vaultFetchPaymentMethods(clientToken: decodedClientToken)
         }
         .done { paymentMethods in
             state.paymentMethods = paymentMethods.data
@@ -43,16 +43,14 @@ internal class VaultService: VaultServiceProtocol {
         }
     }
 
-    func deleteVaultedPaymentMethod(with id: String, _ completion: @escaping (Error?) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
-        guard let clientToken = state.decodedClientToken else {
+    func deleteVaultedPaymentMethod(with id: String, _ completion: @escaping (Error?) -> Void) {        
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(PrimerError.vaultDeleteFailed)
         }
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
 
-        api.vaultDeletePaymentMethod(clientToken: clientToken, id: id) { (result) in
+        api.vaultDeletePaymentMethod(clientToken: decodedClientToken, id: id) { (result) in
             switch result {
             case .failure:
                 completion(PrimerError.vaultDeleteFailed)

--- a/Sources/PrimerSDK/Classes/Core/Primer/AppState.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/AppState.swift
@@ -8,11 +8,10 @@
 #if canImport(UIKit)
 
 internal protocol AppStateProtocol: AnyObject {
+    var clientToken: String? { get set }
     var paymentMethods: [PaymentMethod] { get set }
     var selectedPaymentMethod: String { get set }
-    var decodedClientToken: DecodedClientToken? { get set }
     var paymentMethodConfig: PrimerConfiguration? { get set }
-    var accessToken: String? { get set }
     var billingAgreementToken: String? { get set }
     var orderId: String? { get set }
     var confirmedBillingAgreement: PayPalConfirmBillingAgreementResponse? { get set }
@@ -27,11 +26,10 @@ internal protocol AppStateProtocol: AnyObject {
 }
 
 internal class AppState: AppStateProtocol {
+    var clientToken: String?
     var paymentMethods: [PaymentMethod] = []
     var selectedPaymentMethod: String = ""
-    var decodedClientToken: DecodedClientToken?
     var paymentMethodConfig: PrimerConfiguration?
-    var accessToken: String?
     var billingAgreementToken: String?
     var orderId: String?
     var confirmedBillingAgreement: PayPalConfirmBillingAgreementResponse?

--- a/Sources/PrimerSDK/Classes/Data Models/Apaya.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Apaya.swift
@@ -70,7 +70,7 @@ public struct Apaya {
             }
             
             let state: AppStateProtocol = DependencyContainer.resolve()
-            guard state.decodedClientToken != nil,
+            guard ClientTokenService.decodedClientToken != nil,
                   let merchantAccountId = state.paymentMethodConfig?.getProductId(for: .apaya)
             else {
                 throw ApayaException.invalidWebViewResult

--- a/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
@@ -235,9 +235,7 @@ public enum CardNetwork: String, CaseIterable {
         return nil
     }
     
-    var directoryServerId: String? {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
+    var directoryServerId: String? {        
         switch self {
         case .visa:
             return "A000000003"
@@ -252,7 +250,7 @@ public enum CardNetwork: String, CaseIterable {
         case .unionpay:
             return "A000000333"
         default:
-            if let clientToken = state.decodedClientToken,
+            if let clientToken = ClientTokenService.decodedClientToken,
                let env = clientToken.env {
                 if env.uppercased() == "PRODUCTION" {
                     return nil

--- a/Sources/PrimerSDK/Classes/Data Models/ClientToken.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ClientToken.swift
@@ -28,16 +28,17 @@ struct DecodedClientToken: Decodable {
     }
     
     func validate() throws {
-        if accessToken == nil {
+        guard !(accessToken ?? "").isEmpty else {
             throw PrimerError.clientTokenNull
         }
         
         guard let expDate = expDate else {
-            throw PrimerError.clientTokenExpirationMissing
+            throw PrimerError.invalidExpiryDate
         }
         
         if expDate < Date() {
             throw PrimerError.clientTokenExpired
         }
+        
     }
 }

--- a/Sources/PrimerSDK/Classes/Data Models/VaultCheckoutViewModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/VaultCheckoutViewModel.swift
@@ -71,8 +71,7 @@ internal class VaultCheckoutViewModel: VaultCheckoutViewModelProtocol {
     }
 
     func loadConfig(_ completion: @escaping (Error?) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        if state.decodedClientToken.exists {
+        if ClientTokenService.decodedClientToken != nil {
             let paymentMethodConfigService: PaymentMethodConfigServiceProtocol = DependencyContainer.resolve()
             paymentMethodConfigService.fetchConfig({ err in
                 if let err = err {

--- a/Sources/PrimerSDK/Classes/User Interface/Primer/ExternalViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Primer/ExternalViewModel.swift
@@ -22,7 +22,7 @@ internal class ExternalViewModel: ExternalViewModelProtocol {
     func fetchVaultedPaymentMethods(_ completion: @escaping (Result<[PaymentMethod], Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        if state.decodedClientToken.exists {
+        if ClientTokenService.decodedClientToken != nil {
             let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
             vaultService.loadVaultedPaymentMethods({ err in
                 if let err = err {

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/CardComponentsManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/CardComponentsManager.swift
@@ -55,8 +55,7 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
     public var amount: Int?
     public var currency: Currency?
     internal var decodedClientToken: DecodedClientToken? {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        return state.decodedClientToken
+        return ClientTokenService.decodedClientToken
     }
     internal var paymentMethodsConfig: PrimerConfiguration?
     private(set) public var isLoading: Bool = false
@@ -78,7 +77,7 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
         
         self.cardholderField = cardholderNameField
         
-        if let clientToken = clientToken, let decodedClientToken = clientToken.jwtTokenPayload {
+        if let clientToken = clientToken {
             try? ClientTokenService.storeClientToken(clientToken)
         }
     }
@@ -103,8 +102,7 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
                 } else if let clientToken = clientToken {
                     do {
                         try ClientTokenService.storeClientToken(clientToken)
-                        let state: AppStateProtocol = DependencyContainer.resolve()
-                        if let decodedClientToken = state.decodedClientToken {
+                        if let decodedClientToken = ClientTokenService.decodedClientToken {
                             seal.fulfill(decodedClientToken)
                         } else {
                             seal.reject(PrimerError.clientTokenNull)
@@ -287,7 +285,7 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
 
                             threeDSService.perform3DS(
                                 paymentMethod: paymentMethod,
-                                protocolVersion: state.decodedClientToken?.env == "PRODUCTION" ? .v1 : .v2,
+                                protocolVersion: ClientTokenService.decodedClientToken?.env == "PRODUCTION" ? .v1 : .v2,
                                 beginAuthExtraData: beginAuthExtraData,
                                     sdkDismissed: { () in
 
@@ -357,8 +355,7 @@ internal class MockCardComponentsManager: CardComponentsManagerProtocol {
     var currency: Currency?
     
     var decodedClientToken: DecodedClientToken? {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        return state.decodedClientToken
+        return ClientTokenService.decodedClientToken
     }
     
     var paymentMethodsConfig: PrimerConfiguration?

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApayaTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApayaTokenizationViewModel.swift
@@ -26,7 +26,7 @@ class ApayaTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPayme
         let state: AppStateProtocol = DependencyContainer.resolve()
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken, decodedClientToken.isValid else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             let err = PaymentException.missingClientToken
             _ = ErrorHandler.shared.handle(error: err)
             throw err
@@ -105,7 +105,7 @@ class ApayaTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPayme
     
     private func generateWebViewUrl(_ completion: @escaping (Result<String, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
-        guard let clientToken = state.decodedClientToken,
+        guard let clientToken = ClientTokenService.decodedClientToken,
               let merchantAccountId = state.paymentMethodConfig?.getProductId(for: .apaya)
         else {
             return completion(.failure(ApayaException.noToken))
@@ -222,14 +222,14 @@ class ApayaTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPayme
             state: state
         )
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             completion(nil, PrimerError.clientTokenNull)
             return
         }
         
         let apiClient: PrimerAPIClientProtocol = DependencyContainer.resolve()
         apiClient.tokenizePaymentMethod(
-            clientToken: clientToken,
+            clientToken: decodedClientToken,
             paymentMethodTokenizationRequest: request) { result in
                 switch result {
                 case .success(let paymentMethod):

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -39,10 +39,9 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPa
     }
     
     override func validate() throws {
-        let state: AppStateProtocol = DependencyContainer.resolve()
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken, decodedClientToken.isValid else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             let err = PaymentException.missingClientToken
             _ = ErrorHandler.shared.handle(error: err)
             throw err
@@ -151,10 +150,15 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPa
     }
     
     private func payWithApple(completion: @escaping (PaymentMethod?, Error?) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        let decodedClientToken = state.decodedClientToken!
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
+            let err = PaymentException.missingClientToken
+            _ = ErrorHandler.shared.handle(error: err)
+            completion(nil, err)
+            return
+        }
+        
         let countryCode = settings.countryCode!
         let currency = settings.currency!
         let merchantIdentifier = settings.merchantIdentifier!

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/KlarnaTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/KlarnaTokenizationViewModel.swift
@@ -18,10 +18,9 @@ class KlarnaTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPaym
     }
     
     override func validate() throws {
-        let state: AppStateProtocol = DependencyContainer.resolve()
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken, decodedClientToken.isValid else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             let err = PaymentException.missingClientToken
             _ = ErrorHandler.shared.handle(error: err)
             throw err
@@ -180,7 +179,7 @@ class KlarnaTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPaym
     
     private func generateWebViewUrl(completion: @escaping (Result<URL, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
-        guard let clientToken = state.decodedClientToken else {
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(ApayaException.noToken))
         }
         
@@ -317,7 +316,7 @@ class KlarnaTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPaym
     private func createKlarnaCustomerToken(authorizationToken: String, completion: @escaping (Result<KlarnaCustomerTokenAPIResponse, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(KlarnaException.noToken))
         }
         
@@ -364,7 +363,7 @@ class KlarnaTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPaym
     private func finalizePaymentSession(completion: @escaping (Result<KlarnaCustomerTokenAPIResponse, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(KlarnaException.noToken))
         }
 

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PayPalTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PayPalTokenizationViewModel.swift
@@ -20,7 +20,7 @@ class PayPalTokenizationViewModel: PaymentMethodTokenizationViewModel, AsyncPaym
         let state: AppStateProtocol = DependencyContainer.resolve()
 //        let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken, decodedClientToken.isValid else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             let err = PaymentException.missingClientToken
             _ = ErrorHandler.shared.handle(error: err)
             throw err

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewModel.swift
@@ -24,8 +24,7 @@ internal class VaultPaymentMethodViewModel: VaultPaymentMethodViewModelProtocol 
         }
     }
     private var clientToken: DecodedClientToken? {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        return state.decodedClientToken
+        return ClientTokenService.decodedClientToken
     }
 
     deinit {

--- a/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
+++ b/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
@@ -10,16 +10,9 @@
 @testable import PrimerSDK
 import XCTest
 
-var mockClientToken = DecodedClientToken(
-    accessToken: "bla",
-    configurationUrl: "bla",
-    paymentFlow: "bla",
-    threeDSecureInitUrl: "bla",
-    threeDSecureToken: "bla",
-    coreUrl: "https://primer.io",
-    pciUrl: "https://primer.io",
-    env: "bla"
-)
+var mockClientToken = """
+    eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjI2MzQ2Mjc3MDcsImFjY2Vzc1Rva2VuIjoiYmxhIiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9wcmltZXIuaW8iLCJpbnRlbnQiOiJibGEiLCJjb25maWd1cmF0aW9uVXJsIjoiYmxhIiwiY29yZVVybCI6Imh0dHBzOi8vcHJpbWVyLmlvIiwicGNpVXJsIjoiaHR0cHM6Ly9wcmltZXIuaW8iLCJlbnYiOiJibGEiLCJwYXltZW50RmxvdyI6ImJsYSJ9._GH4xNFOhlfY3CmyH8JcUEdqDIxZF8qYILcGY4YF7Vc
+    """
 
 var mockSettings = PrimerSettings(
     merchantIdentifier: "mid",
@@ -169,6 +162,7 @@ let mockPaymentMethodConfig = PrimerConfiguration(
 )
 
 class MockAppState: AppStateProtocol {
+    var clientToken: String? = "access_token"
     
     var customerToken: String? = "customerToken"
 
@@ -188,11 +182,7 @@ class MockAppState: AppStateProtocol {
 
     var selectedPaymentMethod: String = ""
 
-    var decodedClientToken: DecodedClientToken? = mockClientToken
-
     var paymentMethodConfig: PrimerConfiguration?
-
-    var accessToken: String? = "accessToken"
 
     var billingAgreementToken: String? = "token"
 
@@ -203,7 +193,7 @@ class MockAppState: AppStateProtocol {
     var approveURL: String? = "approveUrl"
 
     init(
-        decodedClientToken: DecodedClientToken? = mockClientToken,
+        clientToken: String? = mockClientToken,
         paymentMethodConfig: PrimerConfiguration? = PrimerConfiguration(
             coreUrl: "url",
             pciUrl: "url",
@@ -215,7 +205,7 @@ class MockAppState: AppStateProtocol {
             keys: nil
         )
     ) {
-        self.decodedClientToken = decodedClientToken
+        self.clientToken = clientToken
         self.paymentMethodConfig = paymentMethodConfig
     }
 }

--- a/Tests/PrimerSDK_Tests/Mocks/Services/ClientTokenService.swift
+++ b/Tests/PrimerSDK_Tests/Mocks/Services/ClientTokenService.swift
@@ -14,29 +14,23 @@ class MockClientTokenService: ClientTokenServiceProtocol {
     let tokenIsNil: Bool
     var throwError: Bool
 
-    init (tokenIsNil: Bool = false, throwError: Bool = false) {
-        self.tokenIsNil = tokenIsNil
+    init (clientToken: String? = nil, throwError: Bool = false) {
+        self.tokenIsNil = (clientToken == nil)
         self.throwError = throwError
+        
+        if let clientToken = clientToken {
+            try? ClientTokenService.storeClientToken(clientToken)
+        }
     }
 
-    var decodedClientToken: DecodedClientToken? {
-        if tokenIsNil { return nil }
-        return DecodedClientToken(
-            accessToken: "bla",
-            configurationUrl: "bla",
-            paymentFlow: "bla",
-            threeDSecureInitUrl: "bla",
-            threeDSecureToken: "bla",
-            coreUrl: "bla",
-            pciUrl: "bla",
-            env: "bla"
-        )
+    static var decodedClientToken: DecodedClientToken? {
+        return ClientTokenService.decodedClientToken
     }
 
     var loadCheckoutConfigCalled = false
     
     static func storeClientToken(_ clientToken: String) throws {
-        
+        try ClientTokenService.storeClientToken(clientToken)
     }
     
     func fetchClientToken(_ completion: @escaping (Error?) -> Void) {
@@ -44,6 +38,11 @@ class MockClientTokenService: ClientTokenServiceProtocol {
         if (throwError) { return completion(PrimerError.generic) }
         return completion(nil)
     }
+    
+    static func resetClientToken() {
+        
+    }
+    
 }
 
 #endif

--- a/Tests/PrimerSDK_Tests/Services/ClientTokenServiceTests.swift
+++ b/Tests/PrimerSDK_Tests/Services/ClientTokenServiceTests.swift
@@ -11,29 +11,16 @@ import XCTest
 @testable import PrimerSDK
 
 class ClientTokenServiceTests: XCTestCase {
+    
+    let clientToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjI2MjA0NTI2MDksImFjY2Vzc1Rva2VuIjoiZGNjNGI1NjUtZmM2Mi00NDVmLWEzNzktYTdmMDdkYzkwOTM3IiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9hbmFseXRpY3MuYXBpLnNhbmRib3guY29yZS5wcmltZXIuaW8vbWl4cGFuZWwiLCJpbnRlbnQiOiJDSEVDS09VVCIsImNvbmZpZ3VyYXRpb25VcmwiOiJodHRwczovL2FwaS5zYW5kYm94LnByaW1lci5pby9jbGllbnQtc2RrL2NvbmZpZ3VyYXRpb24iLCJjb3JlVXJsIjoiaHR0cHM6Ly9hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJwY2lVcmwiOiJodHRwczovL3Nkay5hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJlbnYiOiJTQU5EQk9YIiwidGhyZWVEU2VjdXJlSW5pdFVybCI6Imh0dHBzOi8vc29uZ2JpcmRzdGFnLmNhcmRpbmFsY29tbWVyY2UuY29tL2NhcmRpbmFsY3J1aXNlL3YxL3NvbmdiaXJkLmpzIiwidGhyZWVEU2VjdXJlVG9rZW4iOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKcWRHa2lPaUpoWlRSaVltRTRNUzFqTm1WakxUUTJZVGt0WVdRell5MWhNV0V3T1RJMk1UYzBPVEVpTENKcFlYUWlPakUyTWpBek5qWXlNRGtzSW1semN5STZJalZsWWpWaVlXVmpaVFpsWXpjeU5tVmhOV1ppWVRkbE5TSXNJazl5WjFWdWFYUkpaQ0k2SWpWbFlqVmlZVFF4WkRRNFptSmtOakE0T0RoaU9HVTBOQ0o5LmlIbGhjbWRMVE1sVURKMXREY0hFVkhjT01hZUstUUJTTGFXczJVVVJnOGsiLCJwYXltZW50RmxvdyI6IlBSRUZFUl9WQVVMVCJ9.RMqc8MjYhltrlfNmXK3R0IZOaHQvIzhJdNL_nScy08Y"
+    var throwError: Error?
 
-    func test_loadCheckoutConfig_calls_clientTokenRequestCallback() throws {
-        let expectation = XCTestExpectation(description: "Load checkout config")
-
-        let accessToken = "dcc4b565-fc62-445f-a379-a7f07dc90937"
-        let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2MjA0NTI2MDksImFjY2Vzc1Rva2VuIjoiZGNjNGI1NjUtZmM2Mi00NDVmLWEzNzktYTdmMDdkYzkwOTM3IiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9hbmFseXRpY3MuYXBpLnNhbmRib3guY29yZS5wcmltZXIuaW8vbWl4cGFuZWwiLCJpbnRlbnQiOiJDSEVDS09VVCIsImNvbmZpZ3VyYXRpb25VcmwiOiJodHRwczovL2FwaS5zYW5kYm94LnByaW1lci5pby9jbGllbnQtc2RrL2NvbmZpZ3VyYXRpb24iLCJjb3JlVXJsIjoiaHR0cHM6Ly9hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJwY2lVcmwiOiJodHRwczovL3Nkay5hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJlbnYiOiJTQU5EQk9YIiwidGhyZWVEU2VjdXJlSW5pdFVybCI6Imh0dHBzOi8vc29uZ2JpcmRzdGFnLmNhcmRpbmFsY29tbWVyY2UuY29tL2NhcmRpbmFsY3J1aXNlL3YxL3NvbmdiaXJkLmpzIiwidGhyZWVEU2VjdXJlVG9rZW4iOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKcWRHa2lPaUpoWlRSaVltRTRNUzFqTm1WakxUUTJZVGt0WVdRell5MWhNV0V3T1RJMk1UYzBPVEVpTENKcFlYUWlPakUyTWpBek5qWXlNRGtzSW1semN5STZJalZsWWpWaVlXVmpaVFpsWXpjeU5tVmhOV1ppWVRkbE5TSXNJazl5WjFWdWFYUkpaQ0k2SWpWbFlqVmlZVFF4WkRRNFptSmtOakE0T0RoaU9HVTBOQ0o5LmlIbGhjbWRMVE1sVURKMXREY0hFVkhjT01hZUstUUJTTGFXczJVVVJnOGsiLCJwYXltZW50RmxvdyI6IlBSRUZFUl9WQVVMVCJ9.7v55XlO8zpIjsKTtMDtowdT2nfyULuLNTaw-B1qEi2I"
-
-        var clientTokenRequestCallbackCalled = false
-
-        let settings = MockPrimerSettings(clientTokenRequestCallback: { completion in
-            clientTokenRequestCallbackCalled = true
-            completion(token, nil)
-            XCTAssertEqual(clientTokenRequestCallbackCalled, true)
-            expectation.fulfill()
-        })
-
-        MockLocator.registerDependencies()
-        let state = MockAppState()
-        DependencyContainer.register(state as AppStateProtocol)
-        DependencyContainer.register(settings as PrimerSettingsProtocol)
+    func test_clientTokenRequestCallback() throws {
+        let expectation = XCTestExpectation(description: "Load clientToken")
         
-        let service = ClientTokenService()
+        Primer.shared.delegate = self
 
+        let service = ClientTokenService()
         service.fetchClientToken { (err) in
             if let err = err {
                 if case PrimerError.clientTokenExpired = err {
@@ -42,13 +29,26 @@ class ClientTokenServiceTests: XCTestCase {
                     XCTAssert(false, err.localizedDescription)
                 }
             } else {
-                XCTAssertEqual(state.decodedClientToken?.accessToken, accessToken)
+                XCTAssertEqual(ClientTokenService.decodedClientToken?.accessToken, "dcc4b565-fc62-445f-a379-a7f07dc90937")
+                expectation.fulfill()
             }
         }
 
         wait(for: [expectation], timeout: 30.0)
     }
 
+}
+
+extension ClientTokenServiceTests: PrimerDelegate {
+    func clientTokenCallback(_ completion: @escaping (String?, Error?) -> Void) {
+        Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { _ in
+            if let throwError = self.throwError {
+                completion(nil, throwError)
+            } else {
+                completion(self.clientToken, nil)
+            }
+        }
+    }
 }
 
 #endif

--- a/Tests/PrimerSDK_Tests/Services/PayPalServiceTests.swift
+++ b/Tests/PrimerSDK_Tests/Services/PayPalServiceTests.swift
@@ -51,7 +51,7 @@ class PayPalServiceTests: XCTestCase {
         let response = PayPalCreateOrderResponse(orderId: "oid", approvalUrl: "primer.io")
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: true)
-        let state = MockAppState(decodedClientToken: nil)
+        let state = MockAppState(clientToken: nil, paymentMethodConfig: nil)
 
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         DependencyContainer.register(state as AppStateProtocol)
@@ -141,7 +141,7 @@ class PayPalServiceTests: XCTestCase {
         let response = PayPalCreateBillingAgreementResponse(tokenId: "tid", approvalUrl: "https://primer.io")
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: false)
-        let state = MockAppState(decodedClientToken: nil)
+        let state = MockAppState(clientToken: nil)
 
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         DependencyContainer.register(state as AppStateProtocol)
@@ -230,7 +230,7 @@ class PayPalServiceTests: XCTestCase {
         let response = mockPayPalBillingAgreement
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: false)
-        let state = MockAppState(decodedClientToken: nil)
+        let state = MockAppState(clientToken: nil)
 
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         DependencyContainer.register(state as AppStateProtocol)

--- a/Tests/PrimerSDK_Tests/ViewModels/VaultCheckoutViewModelTests.swift
+++ b/Tests/PrimerSDK_Tests/ViewModels/VaultCheckoutViewModelTests.swift
@@ -14,7 +14,7 @@ class VaultCheckoutViewModelTests: XCTestCase {
 
     func test_loadConfig_calls_clientTokenService_if_client_token_nil() throws {
         let clientTokenService = MockClientTokenService()
-        let state = MockAppState(decodedClientToken: nil)
+        let state = MockAppState(clientToken: nil)
 
         MockLocator.registerDependencies()
         DependencyContainer.register(clientTokenService as ClientTokenServiceProtocol)


### PR DESCRIPTION
DEX-581

# What this PR does

Remove decoded client token from state

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
