### PR TITLE
[DEX-796] Dynamic zip code field

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,210 +7,211 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		011B9C56E2C170286CDA60A359985118 /* Primer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C948C1F7E8EE5E96738F6371DDA600F2 /* Primer.swift */; };
-		037ACDD580F6E3820ABDCF3F384415D0 /* UserDefaultsExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5A2ED05B14DFAB58CE3E4249503BEF /* UserDefaultsExtension.swift */; };
-		039EF8CC0B0F5FE4A90E4514518BFBF1 /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C936F410A52394FAC8439E6341BE700E /* PrimerTextField.swift */; };
-		04C129B28FD28CC378551444403AEA72 /* DependencyInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58E028F4D268A3B122B0DA0685D6DE9 /* DependencyInjection.swift */; };
+		005F380B401552DCCA59C9B1BF78E918 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEA04339ED7699A38D77CEFE77A8A5A /* firstly.swift */; };
+		00E16B30C4EAA4EF0436DDD03AB0D4AC /* ErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 365A35FAA97E130AA03B0EBC47809E5B /* ErrorViewController.swift */; };
+		01E2AE456438A5724A23AFAA8F4C3594 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A12F8ADBB1CFBF51FA0283583A1EF9 /* Configuration.swift */; };
+		04D52BC2193D64F60BA5F7799FA33DB7 /* PrimerZipCodeFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE10EC9869350060266B863C4EE488E7 /* PrimerZipCodeFieldView.swift */; };
+		0580B985B940F5A73952CC8F58A42125 /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E44E599E516BE7177CE953A93B5167 /* BundleExtension.swift */; };
 		06037AD0612C370180C55CA860921682 /* Pods-PrimerSDK_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 3780FF276696624E5AD4A629D4CC4AD8 /* Pods-PrimerSDK_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		09BC12039C0955D27F4B31FE9257E8DD /* 3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635E9B6784F533B88E460B498167E8B2 /* 3DS.swift */; };
-		0A20B73A5A2FF134F199559886BF42BF /* PaymentMethodConfigService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E0CF3328DE334C73B16E95B7EFE3BC /* PaymentMethodConfigService.swift */; };
-		0A48F149DA2D39F313179F24C1449909 /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DA056EE7BC0B599074D93026A90CBC /* Currency.swift */; };
-		0AA692875A5DEE8DE205EA7970EB0B6D /* 3DSService+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC665B70217B0032458821BE4D6A0A0 /* 3DSService+Promises.swift */; };
-		0EC825450C2311F9BA04D455B615D951 /* ConcurrencyLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340B7BAA8C95A8847FA01E2B324AA10A /* ConcurrencyLimitedDispatcher.swift */; };
-		101FCF6D05E8B5F2657A905736EFC46C /* CancellablePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B044A3CCEC0673694E9A446D17D429 /* CancellablePromise.swift */; };
-		10D799E03336B9754E36DCF1EAE2846B /* PaymentMethodToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F74BC0096AFAFFB4BA4CD72E36183D /* PaymentMethodToken.swift */; };
-		12028E2AE5738803640802F52A042E79 /* PaymentMethodsGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38449BCC19F96664FF3AE08F52DA516 /* PaymentMethodsGroupView.swift */; };
-		1224A62614FADDB5952614717A2EF0BE /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317DD242800B725D01A11C2D6753828D /* CountryCode.swift */; };
-		12C3BF6E9DC78EE22A5A69E29AE26F50 /* PaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECE7634193F678EF3CDAFE7C6A682012 /* PaymentMethodTokenizationViewModel.swift */; };
-		142E6E8004D14092A5275A77C07AE3FF /* PrimerContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8AF71486DE64327BAD92D2DC2438E5 /* PrimerContainerViewController.swift */; };
-		1505375C9D0E886D42155973709F7AA7 /* VaultPaymentMethodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0111976A042BCF1B0989D095EB2AF3B /* VaultPaymentMethodViewModel.swift */; };
+		0A0176FAAC042018F9E30F028516C807 /* PayPal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0EB874D08252DD489CAEFA1720AEA /* PayPal.swift */; };
+		0A287515AD7D0CA932FEEFF6A090FE74 /* FinallyWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2440D26687ACF484988B227774D0C3EA /* FinallyWrappers.swift */; };
+		0C40424E09182F42A58BF014628195A3 /* PaymentMethodButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DBA76083F59BD8D1D6205688D0C690 /* PaymentMethodButtonView.swift */; };
+		0D022249DBFFAB19243F929E9EC5ACC0 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418DFBE8A9B28B8E11B4859D41D8ABE6 /* Optional+Extensions.swift */; };
+		0EAF41B77AA4645C867488B13FA729C1 /* PaymentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB84173F2CC643DBB424A1998EEE061F /* PaymentResponse.swift */; };
+		10C739FBB7825EC498B960BA0168FB4A /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E3B95C1FD987460452CB0348520EAC /* hang.swift */; };
+		11976F99565D6A7DED50219DC7A2A332 /* PrimerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E7A88FC18A3CD4A52AC4A183717ECD6 /* PrimerViewController.swift */; };
+		11BC7BEA4BF609BCDAC859A6B03F05DA /* PrimerAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D260A9B1159A7C7DC008A2E91113A19C /* PrimerAPIClient.swift */; };
+		16F8B1E92EF2D9676811FB597D12C283 /* StrictRateLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BBFDBDBD8AFE8E7FC1714187DF9741 /* StrictRateLimitedDispatcher.swift */; };
 		178443E9C88007877F57C1552C9AE76E /* Primer3DSProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DF772EBD0552229B3F76D49A0EF5F2 /* Primer3DSProtocols.swift */; };
-		17A500A2FA70EAD93038EF1871FC3543 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D66EA769A3601ADD44386E314CE19C6 /* Logger.swift */; };
-		1841DDD9200DB25CFBE4D1AB48EE8502 /* ClientSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72B2ADD48DCEE728FB64C5D3C0B8F44 /* ClientSession.swift */; };
-		1864470E47D66952043701619ABCF4FA /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88124DD06F241A84D772C2F458A258DE /* Queue.swift */; };
-		1C7B53AD3AAB92D437FBEACAFBCB59BA /* FinallyWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2440D26687ACF484988B227774D0C3EA /* FinallyWrappers.swift */; };
-		1F6EE7D5CD54C7A2A115914DDE085047 /* PrimerSDK-PrimerResources in Resources */ = {isa = PBXBuildFile; fileRef = A8B3BC107C2BDC3C03D961866F721265 /* PrimerSDK-PrimerResources */; };
-		1FBB53231DC039B401DE5DAA5141EAA0 /* PrimerViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B4A1EA2080101E10F69C7FFEDC114C /* PrimerViewExtensions.swift */; };
-		228155869AA955071F83193C3C8EB384 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6BF1C9E0DE439B9F9BEB92D11E9CFE /* when.swift */; };
-		22C6DAAB4D0919B99266D58739449D4B /* DirectDebitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932A9EECF519BDC8A32BFDEB5F905779 /* DirectDebitService.swift */; };
-		260A5AA0236B7D797930DCD54943B7C4 /* ResumeHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9531A1A287CC36E9490F3D82C35C13D1 /* ResumeHandlerProtocol.swift */; };
+		184FD965FB5E9882DF3F421BBBA3F47F /* ClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B1F4EA655F4EF76C5D37E7565D633C /* ClientToken.swift */; };
+		18A3B6D1DBEDDA807FF2C1450C6FAFD0 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E0B607D634362D4D74BC7D65C30BBD /* race.swift */; };
+		1C674551BE75EB023BD1686C4D1A03A3 /* VaultPaymentMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC1CDD880298AC074A183DC236C657C /* VaultPaymentMethodViewController.swift */; };
+		1F55B0E44700F89E670BCDC7C1B873E1 /* URLExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54C8A10B9D67A543E712A5E77A8C2A2 /* URLExtension.swift */; };
+		1F8CC1ADB9C3BC7EC40875B805936F36 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4582F8F818FBB860DFADA18C823B9B /* DateExtension.swift */; };
+		203A56A4FAAACA5B632D2CD9FC79A068 /* PrimerAPIClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142F32C1793D5D21D9B75E31362D2360 /* PrimerAPIClient+Promises.swift */; };
+		21AA497F11A97EF5BCA2CA3AD33BFE92 /* PrimerNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AEEF130C3F4DA15752F6045F7A87683 /* PrimerNavigationBar.swift */; };
+		22B103FA92EE14C294A19B5ED251399C /* PaymentMethodConfigService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E0CF3328DE334C73B16E95B7EFE3BC /* PaymentMethodConfigService.swift */; };
 		270CFF0FC749F57C0605262D27016D14 /* Pods-PrimerSDK_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D66C3890C3566F38C935A2FFD9A237B0 /* Pods-PrimerSDK_Tests-dummy.m */; };
-		290A5DAA1237D4710CCC18C96A6344BC /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB030EA4964D853C5886AA067E89E15 /* Guarantee.swift */; };
-		2945FB8683198733EE30546D090E28E4 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEA04339ED7699A38D77CEFE77A8A5A /* firstly.swift */; };
-		29BD8F9963F2E40D343357A13BF1E18D /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4582F8F818FBB860DFADA18C823B9B /* DateExtension.swift */; };
-		29E321E05B431D7CA49B4180BCD499CD /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D10EA3F5FF3298A3D81FB18C179FA0 /* AppState.swift */; };
-		2C97137DAE3B39C8A9092EB9FD3B79A7 /* VaultPaymentMethodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24A7878915D7981887F488408AE5A371 /* VaultPaymentMethodView.swift */; };
-		2DC970C58D4CD60A1A0DC1981AD68312 /* PrimerRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FF29DE64C78302BC3468299755CEA7 /* PrimerRootViewController.swift */; };
-		2DE91E028E4020F01312D4596F76A062 /* ExternalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5748EE8FF997A16AE7DA3F2B22A84D13 /* ExternalViewModel.swift */; };
-		2E17FDB9F27416F48AC9FBD8794236BA /* PrimerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DA4748340CB7574C2452A493DAA6DE /* PrimerAPI.swift */; };
-		30A86E0C6F98B1BEB9FF2D1A479292CB /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = A481D7E1DA3B573F12BA3D33A8812844 /* Error.swift */; };
-		31298E6601328B981850047B623BD097 /* TokenizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAB998D29F1BEFB5A180AD12B05DF3 /* TokenizationService.swift */; };
+		2A4458201DFAFEE9F11724B3878080A0 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51938AABD8535CB2BBEE645AFBA2C8A6 /* AnyEncodable.swift */; };
+		2FB90D9EF50337B634ED37E001E50FF2 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D66EA769A3601ADD44386E314CE19C6 /* Logger.swift */; };
 		32D4F85BE1557ED62536344CFAB75F88 /* Primer3DS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A163D166B27F20FF6EEF83F5121C4CEA /* Primer3DS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		33023537B0D302E32E6BA054392CE754 /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E3B95C1FD987460452CB0348520EAC /* hang.swift */; };
-		33211366A4079EF7D2784820A904CCC5 /* ErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6763FA6BE823C089AC3F6C2F18E488 /* ErrorViewController.swift */; };
-		3347A98D25817D1E3961D731DD5928EC /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A18EBB1CEF7C09E725EB41093FC1A0 /* UIColorExtension.swift */; };
-		3600F3AC13EACBE1260F02E23645D67C /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF51BAA5D9B19AEE1E35014335A18E6 /* StringExtension.swift */; };
-		361CED62C1CCBA461FA5593FCA389517 /* FormTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E8B455039BCA1C2B74A3052CBFB174 /* FormTokenizationViewModel.swift */; };
-		3782B855831A57DF8B66431555530B8A /* CancellableThenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE02BBEB7831C76E65254BB8122A3214 /* CancellableThenable.swift */; };
-		37B57C4A5926C57E3807A90A40593409 /* PrimerImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5B53E83E5F322F6E8808CBA9F2CA1 /* PrimerImage.swift */; };
-		37F38EBC188F894B631744AB6F5E16F0 /* VaultPaymentMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461BF04CC03243EBB876BD7AEECD6976 /* VaultPaymentMethodViewController.swift */; };
-		38CA194F74C68B942BEB8B66C0A9F627 /* PayPalTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E8780917E6DFAEFF818196058FC684 /* PayPalTokenizationViewModel.swift */; };
-		39DFCEABE4400E1156511398BAEB290F /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C68A718EF043D9EEF01B8B97091189 /* LogEvent.swift */; };
-		3C9D8C384F2A82621414A673AAEDEF29 /* PrimerCardFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B23ABF6D9F8C7A5EE74B8C41555F7FAE /* PrimerCardFormViewController.swift */; };
-		3D2840B996E8C7A627A425BCA3FBF17D /* RecoverWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A90263B351CA8CC8A59CAE0C289672 /* RecoverWrappers.swift */; };
-		3D91A7E508B8C0CFED54D9046C014214 /* PaymentMethodConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A5C37BCDB8875B1F4D36BB7067653D /* PaymentMethodConfig.swift */; };
+		33691FCAE1F0CE6AD51D8CF7219AC219 /* UserDefaultsExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5A2ED05B14DFAB58CE3E4249503BEF /* UserDefaultsExtension.swift */; };
+		3433E20CCF58C2F3F89F19A087BD47BA /* Mask.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63CC5E517E7F34CD4D9918E1E39219E /* Mask.swift */; };
+		356D2D89002EC6FEF4F59D0E613EBCE1 /* PrimerContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C22BC67900415B28514EC3146A82CF /* PrimerContainerViewController.swift */; };
+		3725FD22EDC476C48ED35C314D4B6BB1 /* PrimerSDK-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D2E0829A9CF5AACE43592141857A21A /* PrimerSDK-dummy.m */; };
+		37DEDD5BC1F41B62D21AC6B3B85B9174 /* PaymentMethodToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F74BC0096AFAFFB4BA4CD72E36183D /* PaymentMethodToken.swift */; };
+		3B1E9C482666076DE8BA552B8E250377 /* PrimerViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4B4A1EA2080101E10F69C7FFEDC114C /* PrimerViewExtensions.swift */; };
+		3BAE97615E0F52BAB4F49028F8573E8D /* PrimerSDK-PrimerResources in Resources */ = {isa = PBXBuildFile; fileRef = A8B3BC107C2BDC3C03D961866F721265 /* PrimerSDK-PrimerResources */; };
+		3C0EB77E1D503D218AFB868B816DE9D8 /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB6F2137FFC47970DBE20DAE214DFBF /* Catchable.swift */; };
+		3DC29307D45FE28E4165BC5F42C718DD /* UXMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE4A49EB349C598C0BE16639A75DE14 /* UXMode.swift */; };
+		3E2426C09EDD89907994CBFDFCD0F0AB /* RateLimitedDispatcherBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C8393F5837E560C71ABAFA98656B73 /* RateLimitedDispatcherBase.swift */; };
 		3EB7A6B9A397005CB3B77FDC9DA30691 /* Primer3DSStructures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7492CBAABC98EBF5377CFAD0DED3516E /* Primer3DSStructures.swift */; };
-		3F007C2AB779B101CDD4F738C903C2B7 /* PaymentMethodTokenizationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F6AF392ED546A98F16C2B3560CC8A /* PaymentMethodTokenizationRequest.swift */; };
-		3F0977C10DB743282A251C4AF323F893 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E0B607D634362D4D74BC7D65C30BBD /* race.swift */; };
-		3F26925521E7BD0A99CE6FCDD9956C2C /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0CD89C365F46AEA64F8A5A2479D80794 /* Icons.xcassets */; };
-		3F526632B147133502CD8C76762568D8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */; };
-		4059E8C8312480FC1D3D88692060EF8C /* PrimerNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935CC0CE0A85C435B8707D9136C80BF7 /* PrimerNavigationController.swift */; };
-		40720C985CC67A7ACD806E7D0DB18759 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4767916A260904C828CC5ACDB209A11 /* AnyCodable.swift */; };
-		424FB2619977B0721366BE46C4D42E3D /* EnsureWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB696E308D624224328B2FB8CC325C05 /* EnsureWrappers.swift */; };
-		42939A057DC9BFB2D45A3E124A18C131 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E940BBABE470AECD0B93ECB3D6749FF6 /* ErrorHandler.swift */; };
-		4356553496529243AF9C70BAB9649134 /* CancelContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6998E1B99D5FCA9CD5CDB878FF583068 /* CancelContext.swift */; };
-		457EC5EC374D5A3B278124DAA9FA5671 /* SuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7395C8587402F73BB2932319D195F6BD /* SuccessViewController.swift */; };
-		457F558CDDF3984219201B1D6CA32AF8 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B4670B3C995E50A746A314A2C55D01 /* Endpoint.swift */; };
-		46E5E9B184F3F4C1C7169DCA20DF5AE0 /* CardComponentsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB3A8E4383766C3794D51E3C30C8C10 /* CardComponentsManager.swift */; };
-		47424648AE121382D7D27A314E4D96C9 /* VaultService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8689759975DFDF5482A37409D9B7CB6 /* VaultService.swift */; };
-		488DACCDDAFEEC0333FC0E1F31181D87 /* FormType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA62AC66E4C8E3226DB7C10B85C0DB9 /* FormType.swift */; };
-		51813EC291EC81E4B4404B1B6DBD3EE9 /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFF6D4F0C169A30AF4F8ACA7D9276FC /* Validation.swift */; };
-		52D989A137F422EA246DFECA8349E01E /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E44E599E516BE7177CE953A93B5167 /* BundleExtension.swift */; };
-		5441B319E3E701830AF466359D42E6CC /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = C650C5EDB5C46126ACD98C7854EC53E2 /* Box.swift */; };
-		5836B463EBB53695D9AC4F077C2797C6 /* CardNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9520519D63B352DA3D0865DFD551D267 /* CardNetwork.swift */; };
-		5ADC01E868C5967C582B93D93DFE3BB9 /* PaymentMethodButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE4E730C17B5C8A299D14B95209AA74 /* PaymentMethodButtonView.swift */; };
-		5BEF19BBB9CBC2E0ACF2762C03271EEB /* PayPal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A0EB874D08252DD489CAEFA1720AEA /* PayPal.swift */; };
-		5F53AD3A36113AE9F09BCB49AA87C5FB /* PrimerCustomStyleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7A8C5A3CD900CF1C18E1E50CB4F937 /* PrimerCustomStyleTextField.swift */; };
-		6051DB6F09F6C11203E6057BBAC42F6C /* ApayaTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7C90FA318FF3F6D3F0FD11A59C7FF7 /* ApayaTokenizationViewModel.swift */; };
-		6059AE38AE8CA1C58D64B70D00136113 /* CardScannerViewController+SimpleScanDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E8099CCB587C0698B8FABF500CF0EB /* CardScannerViewController+SimpleScanDelegate.swift */; };
-		61B4E5EE07E73BC8AE7E7084018D289F /* StrictRateLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BBFDBDBD8AFE8E7FC1714187DF9741 /* StrictRateLimitedDispatcher.swift */; };
-		62FBF250B2F3AC665D10435EA8C572FD /* PrimerCVVFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD071B3BCDB032043ACCC502F007A54B /* PrimerCVVFieldView.swift */; };
-		6394E05E41F5507B0D79C5268504A319 /* ClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B1F4EA655F4EF76C5D37E7565D633C /* ClientToken.swift */; };
-		64A669287417775F48192B8D0F2E4782 /* PrimerFlowEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D31B1B291212C429C6A47B7E2B2A6 /* PrimerFlowEnums.swift */; };
-		68C674BF46D446021FC140A95F0FF36F /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 8B5A6E8DEBF7EFFED939740F0F69B764 /* fr.lproj */; };
-		6BA3FA87B3D3F64DD440AB57CC490183 /* SequenceWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD783851B56A7AAA6FE4D4FCC5967A70 /* SequenceWrappers.swift */; };
-		6EE8E9B856BA36F45435EE3DCF518323 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2E754A3930F4F5ADC8AA3FBE67D834 /* Parser.swift */; };
-		6F5B9C8B330CC26FBE2032AFD73B940C /* 3DSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D6F7D77660E09187A535AE3C5DA872 /* 3DSService.swift */; };
-		7241C56DF8838EFB88FDEF48717465DC /* PrimerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE5C74477C1EADA33D6FEA4CD398E88 /* PrimerTableViewCell.swift */; };
-		73991BA06AD041AA9075DB89B913B8F6 /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FB6F2137FFC47970DBE20DAE214DFBF /* Catchable.swift */; };
-		7452412BC432FF587E4F8C8FD787DB9A /* Apaya.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B744B62A9D19AC83AE999DB5329327 /* Apaya.swift */; };
+		3FAD8B6C5616F93ECF2C1ABAA2D795BB /* PaymentMethodComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3BBCA45A6833039A8CBE7B8E6D5FE4B /* PaymentMethodComponent.swift */; };
+		40A727508C9329EBF19EA6B9504C65DD /* PayPalTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A4F88263E51566E031711E398FAF182 /* PayPalTokenizationViewModel.swift */; };
+		4153C357A728C5261CBB5FA2E075FA07 /* PayPalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DCC5251CD931E96CBBAB8F22C46FC8 /* PayPalService.swift */; };
+		428AE8F6F5A1C56875D18DA1B438632B /* VaultPaymentMethodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9242EDDEBEE53335B56CC10B1E8C9D8 /* VaultPaymentMethodView.swift */; };
+		430AB5BAE58A0440D664591F14841775 /* SuccessMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F2D0980398D62F87F1AD0433B12B71 /* SuccessMessage.swift */; };
+		4939C44E7AF08537C4E737C0EDC865C1 /* PrimerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62031A6CE2BE2D955FD495B28A3C52B4 /* PrimerButton.swift */; };
+		4AD3AEFA88A2BF21BBD0F52D85BD880E /* PrimerNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42B5FE491F26661A194B410657B6B34A /* PrimerNavigationController.swift */; };
+		4BC74C659A9953340578F3BCEBD35795 /* PrimerRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198B7E3042A98B0CA2FA0E877FB22B07 /* PrimerRootViewController.swift */; };
+		4C9A9471D6AAF43B0163B5205F13B50C /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1297A88000826E8C308557DDF66F355D /* Resolver.swift */; };
+		4D42B127EE2BAD0CC1AC123BB8D42801 /* CancellablePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B044A3CCEC0673694E9A446D17D429 /* CancellablePromise.swift */; };
+		503CA6A5FA47C548175AF925667A8373 /* fr.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 8B5A6E8DEBF7EFFED939740F0F69B764 /* fr.lproj */; };
+		505E7F807EACDE59CEDAD906FF47D3EA /* PrimerCardholderNameFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C071B6E0B01BDE73C6D4DE1527FC8C7 /* PrimerCardholderNameFieldView.swift */; };
+		515843580CA5FF6BF1688FC60101D88B /* FormType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CA62AC66E4C8E3226DB7C10B85C0DB9 /* FormType.swift */; };
+		552B92FD21BCC1D9BDEBD6A5D9E982CA /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF51BAA5D9B19AEE1E35014335A18E6 /* StringExtension.swift */; };
+		55920F3DB2A43F24AFE758F28DCC89B0 /* ResumeHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9531A1A287CC36E9490F3D82C35C13D1 /* ResumeHandlerProtocol.swift */; };
+		56328633A51ED11BBF55CA8A14830B52 /* RecoverWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A90263B351CA8CC8A59CAE0C289672 /* RecoverWrappers.swift */; };
+		56D0A8374C2B675E00931A1F5B1C397C /* CardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B52D3EF0B8517FF366A29433442CDAD /* CardButton.swift */; };
+		56EF118161AE123A5DCF984A203ECB28 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88124DD06F241A84D772C2F458A258DE /* Queue.swift */; };
+		57022B8ABE290F956F030B55CEDD3C2D /* URLSessionStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7714B05688C8E2F063CCD475DC69796F /* URLSessionStack.swift */; };
+		590FD6829606886B3A4147DDB594741C /* SequenceWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD783851B56A7AAA6FE4D4FCC5967A70 /* SequenceWrappers.swift */; };
+		59F690432733CB82706CA7C7FF3E4CB2 /* KlarnaTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C864749E7106990A76835AF250AB05BC /* KlarnaTokenizationViewModel.swift */; };
+		5A12C6F6EB0A89387296E5D6D9D0A8A5 /* UIDeviceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9BC6F7F54F02A21E78359C1986324E /* UIDeviceExtension.swift */; };
+		5DEEC4A7B67F0E026B69AAD734C8D4C2 /* IntExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A20B256BF98480E1CB0F77D6C2AD8B /* IntExtension.swift */; };
+		5E92A916800C8A1EA03B1F1E5E9D7171 /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B1E602D15549B266623FD0F1A3BC18 /* LoadingViewController.swift */; };
+		5EB92EE3752048B2A61E69F1804B17E5 /* GuaranteeWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EA73064D29F30F64FF256CF02047E0 /* GuaranteeWrappers.swift */; };
+		5F7E2BAA48ACEA97DA146B0F5EA7883B /* PrimerSDK-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C1C216B34934B8F586C68707318953BF /* PrimerSDK-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6739CFD691C095B93D0833142035061D /* PaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC588EC125AB52E793E08BA29AD1A96E /* PaymentMethodTokenizationViewModel.swift */; };
+		67F1693ADA96F86B1A62BD0F7FF48D95 /* PrimerFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A93DE0AECB42E5A44B54B269F693360 /* PrimerFormViewController.swift */; };
+		68AD671ECDA79D29A2BA115777A468AB /* PrimerContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1030545030581A5FC5A97ABB4DF317BF /* PrimerContent.swift */; };
+		6E702BC623F1652F77B2E939679D8394 /* CardScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E57C6308EE4CAFE912E2C572582C6227 /* CardScannerViewController.swift */; };
+		6EA16A531E40087B85541D3E1375C86F /* PrimerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C436700807E5517EE1666E21FBBB06 /* PrimerSettings.swift */; };
+		7020DD2A0FBFD59FE70381BF48DB1EFC /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046D7463BD80AD5E3AF815ED1D2F4C10 /* Cancellable.swift */; };
+		707001A87C41031F7EF6E80E71459AE5 /* PrimerTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34926D5B928AAF03BF648FC7D037D9B8 /* PrimerTheme.swift */; };
+		726B41AD03E38B51EE6AF8FCF1997FD9 /* WrapperProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4FB4E7EC7552E04F3CE8FAD4DB0E22 /* WrapperProtocols.swift */; };
+		7334A08896EE1C65C31EEB6F05ED17D4 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0CD89C365F46AEA64F8A5A2479D80794 /* Icons.xcassets */; };
+		74343DE46954355266974A78BB0D42E3 /* PaymentMethodTokenizationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4F6AF392ED546A98F16C2B3560CC8A /* PaymentMethodTokenizationRequest.swift */; };
+		75D3E3B59D03610F50BDA05141030A6A /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C33481F1BB24D7E4F925312CDE98D7 /* Thenable.swift */; };
+		7870E8FA3D394F2CD44CD703499E5ACD /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4767916A260904C828CC5ACDB209A11 /* AnyCodable.swift */; };
+		78D9BE7643529BF77112B1758BF6D9A9 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A36FC2065CDA450277FFA2035E2CD03 /* Promise.swift */; };
 		792188862A988C31237DA81868320D2D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		7CB9B6ABD3FB936F31BF1570B904867E /* CardScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B29BF9B21F3B3FBCE8F498625225F87 /* CardScannerViewController.swift */; };
-		7D543893C78B96F875E57239A1873AD2 /* WrapperProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4FB4E7EC7552E04F3CE8FAD4DB0E22 /* WrapperProtocols.swift */; };
-		812906F0629730B3497D5A38C4BF29E3 /* PrimerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62031A6CE2BE2D955FD495B28A3C52B4 /* PrimerButton.swift */; };
-		831FB8E8EE501EFA4F3CF78213163825 /* PrimerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E7A88FC18A3CD4A52AC4A183717ECD6 /* PrimerViewController.swift */; };
-		846276AA0DA16A81F5F970E1B96B2BC5 /* PrimerSDK-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D2E0829A9CF5AACE43592141857A21A /* PrimerSDK-dummy.m */; };
-		84A1C2B1CA9C3A96DB1DF1B8E03982C3 /* PrimerAPIClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142F32C1793D5D21D9B75E31362D2360 /* PrimerAPIClient+Promises.swift */; };
+		7BD02D494CF241D75EC68DD2589830E2 /* CancelContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6998E1B99D5FCA9CD5CDB878FF583068 /* CancelContext.swift */; };
+		7D0CF3AA55BF5D9370AE30FFD304A065 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = A481D7E1DA3B573F12BA3D33A8812844 /* Error.swift */; };
+		7D2E668F19FD4CD9DE14AC44F3DEF4D7 /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFF6D4F0C169A30AF4F8ACA7D9276FC /* Validation.swift */; };
+		7D41385B61AD87EC0E9AECDB14AC8244 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A18EBB1CEF7C09E725EB41093FC1A0 /* UIColorExtension.swift */; };
+		7EB18A3C80F5A4AB171DE1BDC7336819 /* AlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B77149296B3C606FC3B9950936F862 /* AlertController.swift */; };
+		7F0890A4664937B8A832B10C3C9E2C6F /* PrimerScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E815334BE355762ECEC45B5F079CDF2F /* PrimerScrollView.swift */; };
+		7F0A41166A5461F766A2C72D450284F8 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = D083E91A46DFE33F37B699729BBC35AD /* after.swift */; };
+		80529FB71592A3929D1D0FEA16524049 /* PaymentMethodConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A5C37BCDB8875B1F4D36BB7067653D /* PaymentMethodConfig.swift */; };
+		8102283EF88928829CDB2AB211C1AE06 /* CancellableCatchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDCAC4FB22422BB52BB3CF13655ECD3 /* CancellableCatchable.swift */; };
+		81B54BD70607F71978CB0F67953D2FA7 /* PrimerCustomStyleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F7A8C5A3CD900CF1C18E1E50CB4F937 /* PrimerCustomStyleTextField.swift */; };
+		84694E32195490902C4EC61A9053DA5F /* PrimerVaultManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA3C755F190F5EAF4410F7A1B417830 /* PrimerVaultManagerViewController.swift */; };
 		8548D98B63B0CE7C33DA6C183E9A9BF0 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */; };
-		86041156CD76B6123B7CA08B1279F414 /* UXMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DE4A49EB349C598C0BE16639A75DE14 /* UXMode.swift */; };
-		875EA50677DF482547673A5ABA9CBCCB /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375849D2F7A4023E8AD7637FFD24B0CA /* NetworkService.swift */; };
-		8B7154EA2CA9A9FF7E945EDBAF7A19D3 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = D083E91A46DFE33F37B699729BBC35AD /* after.swift */; };
-		8C4F87AC1B57290262138A0B8B6C638D /* DirectDebitMandate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E12AAEFE8F7D2A1497226B913AB4257 /* DirectDebitMandate.swift */; };
-		8D5E08131EE717C7366A26874EA88E57 /* ImageName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4B287C77745CCB7F259B6D6DC5A71B /* ImageName.swift */; };
+		87AA643FF56DA176E0617AF2D65AB697 /* PaymentMethodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B81799AA6AC6BB41C9AF0666239CFE9 /* PaymentMethodViewModel.swift */; };
+		87BF1554B55CF61306951365597C3016 /* CancellableThenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE02BBEB7831C76E65254BB8122A3214 /* CancellableThenable.swift */; };
+		88659DBDCCD8BE6565FB6B69C2000444 /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FF0DE2962E8F3B9D6BF57C6146E9F8 /* FormTextFieldType.swift */; };
+		88CE158B028FF224675A2456D45DAE58 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */; };
+		8B88BD22EF051F5CF68ED364579369E6 /* CatchWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE309238BFA5AAAA424F799C23B73A2 /* CatchWrappers.swift */; };
+		8C47BFF8ADA6CA1A00257C0950423D06 /* 3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635E9B6784F533B88E460B498167E8B2 /* 3DS.swift */; };
+		8C7573AC54DA4F4585341FEB30F2B705 /* PrimerCVVFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A097C6298A67F5148DAA64E119C8C6 /* PrimerCVVFieldView.swift */; };
+		8C9E6578A403411DCBB4B1C1BD934804 /* DirectDebitMandate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E12AAEFE8F7D2A1497226B913AB4257 /* DirectDebitMandate.swift */; };
+		8D68E66B4FF25E8E7CFDF124D9BD2CEA /* PrimerTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF09426091AF05C33FF6E6D802EFF36 /* PrimerTextFieldView.swift */; };
 		8DCD5215EFE7493AFC08C496176C410D /* Primer3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3E9F209C857157575A473FE948A03D /* Primer3DS.swift */; };
-		8E0118C5400B82D64B75ABFA7E161C7F /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F857FE94F5E208A20BEB72D0EE986028 /* Dispatcher.swift */; };
-		8E8C4FC783A015C683F1229093D18151 /* PrimerTextFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3BA50D42F3FCD1A5038156BD89179A9E /* PrimerTextFieldView.xib */; };
-		8EB0595516275DC4A11B72F66F110FA5 /* PrimerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117CCC13435EA953A29A6A2FB6DD79C3 /* PrimerError.swift */; };
-		8F6466A5E82BE2DDE393D7DE1ED9F27F /* PaymentMethodComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5069325F99CEF220B901E6E9C3F6D303 /* PaymentMethodComponent.swift */; };
+		8DDC93443292B833FAA506472F8387E5 /* ImageName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4B287C77745CCB7F259B6D6DC5A71B /* ImageName.swift */; };
+		8E8CA1441847AB9536AB71C661075E19 /* Apaya.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B744B62A9D19AC83AE999DB5329327 /* Apaya.swift */; };
+		8EC2B0F5851EABB7A56180CD500D7561 /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06E85D9D9B251CB826E2D5F7A6681B53 /* PrimerTextField.swift */; };
 		8FB4A3F4485390CD362B1D2FF8A83B1F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
 		8FE23AF4662809E6F0EB6C49B1B1A9BA /* Pods-PrimerSDK_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 21F4ACB1142B1B9457658584BF5CD35A /* Pods-PrimerSDK_Example-dummy.m */; };
-		91C3ACC467F941B4BAFA96FA9B77B33E /* PrimerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AA7AA9AE945A1D4168CEB257C0E3D4 /* PrimerDelegate.swift */; };
-		92B8BD60D26C82AFEB46758E24AD4CD2 /* URLSessionStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7714B05688C8E2F063CCD475DC69796F /* URLSessionStack.swift */; };
-		93E2DC016FA9919028EB3A91DAC6E713 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		959DC6DC1040920DE1BF84EB3A0FC57A /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B65D82816B20660AAFBFF339FE796FE /* JSONParser.swift */; };
-		96B1EF8E4B55C77293D44F9C0E3AAE70 /* PrimerNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F04E0BADD8EF8C80C41A484A9BCEE7C /* PrimerNavigationBar.swift */; };
-		98D8BCFE7AA29474257F9A87703D72AC /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418DFBE8A9B28B8E11B4859D41D8ABE6 /* Optional+Extensions.swift */; };
-		9B87D2DC49137F36641485A879C024D5 /* AlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B77149296B3C606FC3B9950936F862 /* AlertController.swift */; };
-		9CC2B5BD7A84B2B93F2D96197EA38837 /* IntExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A20B256BF98480E1CB0F77D6C2AD8B /* IntExtension.swift */; };
-		9D1A0D728D936CBF3CDC4E29F730798A /* Mask.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63CC5E517E7F34CD4D9918E1E39219E /* Mask.swift */; };
-		9DE14F3248AB4F0DA0F3B2DD00FCF406 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285058AFFBC5CDA72B91771A878EB118 /* AnyDecodable.swift */; };
-		9E46CD7C67C81E9858D0B5898086D998 /* PrimerWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCAED5681785E7E8CD0931199F40B248 /* PrimerWebViewController.swift */; };
-		9F8BEDF2D9C6D5954613769B01CA8917 /* ApplePay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9986F98DE69FDEE115549F1B408D64E4 /* ApplePay.swift */; };
-		A0F05E2E3C5ECBBD1120B40F3B1DA9E4 /* PrimerTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34926D5B928AAF03BF648FC7D037D9B8 /* PrimerTheme.swift */; };
-		A0F8233F03B1261C8B22AE11371FD68B /* PrimerAPIClient+3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86DE2D2509CEE15ACC23ACA69683DB4 /* PrimerAPIClient+3DS.swift */; };
-		A59060FF0ACFD87481CB7CA2ACDAC0FE /* SuccessMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F2D0980398D62F87F1AD0433B12B71 /* SuccessMessage.swift */; };
-		A8E82015955E1730E1E8B53657F17E83 /* PrimerAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D260A9B1159A7C7DC008A2E91113A19C /* PrimerAPIClient.swift */; };
-		A9C94DE87EB38FE644E61408779BF472 /* PrimerExpiryDateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF32D34EC52B6AD84DE4468A1441BA01 /* PrimerExpiryDateFieldView.swift */; };
-		AAFDFCBA03FAB0D3B2CD6F564821E774 /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046D7463BD80AD5E3AF815ED1D2F4C10 /* Cancellable.swift */; };
-		AC5ED17493592194AA1C06ABB4F42B88 /* PaymentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB84173F2CC643DBB424A1998EEE061F /* PaymentResponse.swift */; };
-		AE56A0C3B92C692A316EB3006555F20B /* KlarnaTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C4458603983DCCB53E87B62EE43AFB /* KlarnaTokenizationViewModel.swift */; };
-		B1878961375A6220019D98478EB4D190 /* ApplePayTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD64658599068462FB8DD7A59DD73DF /* ApplePayTokenizationViewModel.swift */; };
-		B2BDFC700D104B9F7D7617BF07FAA062 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A12F8ADBB1CFBF51FA0283583A1EF9 /* Configuration.swift */; };
-		B551DA2FDA1B8157597224A60C9226FF /* PresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44899879A8B45D7EEB64959270B0A34 /* PresentationController.swift */; };
-		B637C83E54841D16491147E20103FCFD /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46278C1314899E6124F0A8B90E71A2E0 /* LoadingViewController.swift */; };
-		B6A246CEB9C0C2670A69A1866F31BA51 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A36FC2065CDA450277FFA2035E2CD03 /* Promise.swift */; };
-		B6DDFD9E58C9CEA1DDD884A16475473F /* FormTextFieldType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FF0DE2962E8F3B9D6BF57C6146E9F8 /* FormTextFieldType.swift */; };
-		B70F64434A227E1104206897DFA81FAA /* PayPalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DCC5251CD931E96CBBAB8F22C46FC8 /* PayPalService.swift */; };
-		B78D6750E0D3DDC7CD04384BE69619BE /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C33481F1BB24D7E4F925312CDE98D7 /* Thenable.swift */; };
-		BF7337170D48230EB99CAB422E22070A /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1297A88000826E8C308557DDF66F355D /* Resolver.swift */; };
-		BFA186AF51CA3DBFCFAFEFC2A105EF20 /* Klarna.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7CFD3F081A786F3FE3BDB532B18B54 /* Klarna.swift */; };
-		C0158591EA286F3F6D91653545F150B4 /* en.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 73309764D9290B8BDF68349AD3201DF0 /* en.lproj */; };
-		C052058A9F03C96948A79FFC8491EFED /* URLExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54C8A10B9D67A543E712A5E77A8C2A2 /* URLExtension.swift */; };
-		C31FADF26050B4F4F31C62997464AA74 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DF1583396B02B469A4CF5A67C2AF05 /* CustomStringConvertible.swift */; };
-		C6A0C501DB038DC66540E6C5AF3592A9 /* PrimerNibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E81A2AC8B8AD22C4991BDC1A330F4F7 /* PrimerNibView.swift */; };
-		C9E2806E48F9EE31D434F914FF5F21C8 /* Consolable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26D5B4B089E7B777183F47DF99B4BE5 /* Consolable.swift */; };
-		CD25F5398AE303F2C810214F5E745910 /* CancellableCatchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDCAC4FB22422BB52BB3CF13655ECD3 /* CancellableCatchable.swift */; };
-		CD2652B5171E26B536415A23D5E5E7FB /* ClientTokenService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19520A134CDE220BBCA194216FFE253 /* ClientTokenService.swift */; };
-		CDA98F87605CDF30DD226EE070A0F7BE /* PrimerLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0594C2B00372CB1A08DA90D92A15D8 /* PrimerLoadingViewController.swift */; };
-		D42248567E8B629537F2133860011D7D /* CatchWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE309238BFA5AAAA424F799C23B73A2 /* CatchWrappers.swift */; };
-		D42A7B4150F24B1DC071A1340C392F44 /* GuaranteeWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9EA73064D29F30F64FF256CF02047E0 /* GuaranteeWrappers.swift */; };
-		D431FE112CCC540B66EB7B815F66EE65 /* ReloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC8DE2B1FCA6FE90F4ECEAC5D60C727 /* ReloadDelegate.swift */; };
+		9071B04A36BFB8ECA4548BA6A5E49BB1 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55B4670B3C995E50A746A314A2C55D01 /* Endpoint.swift */; };
+		912A40B2B7BE1C91BBBCD94A40A90572 /* 3DSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D6F7D77660E09187A535AE3C5DA872 /* 3DSService.swift */; };
+		928855FE86251D94C1AB370CC87EFBE7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
+		95C80CAB9D9A4C135A26A9263FAC61E6 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DF1583396B02B469A4CF5A67C2AF05 /* CustomStringConvertible.swift */; };
+		963C6EB4E8A8AC6247C5078E415364BD /* PrimerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117CCC13435EA953A29A6A2FB6DD79C3 /* PrimerError.swift */; };
+		996CE7BDBC71B0B25030F90A8B9E282E /* PrimerTextFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3BA50D42F3FCD1A5038156BD89179A9E /* PrimerTextFieldView.xib */; };
+		9A0AA7D04037C99B66F86834390E919C /* CardComponentsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EF93FFFB8659A8ADBE7F35011B2B91 /* CardComponentsManager.swift */; };
+		9D5F2F39147499BAE9CF44915A0DC4E7 /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB030EA4964D853C5886AA067E89E15 /* Guarantee.swift */; };
+		9F4E90F05027793C9A2410DF28304DAF /* PrimerAPIClient+3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86DE2D2509CEE15ACC23ACA69683DB4 /* PrimerAPIClient+3DS.swift */; };
+		A0A1FE82FA65E8782CE1222B0C0F0573 /* sv.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 13291E7078EE5E18DC7F4F94E0CF4843 /* sv.lproj */; };
+		A1D378CB13BF7C4B433434EFC67B6B29 /* Primer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C948C1F7E8EE5E96738F6371DDA600F2 /* Primer.swift */; };
+		A5CE2ED92EF701C7494C5ED789490FEA /* PrimerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AA7AA9AE945A1D4168CEB257C0E3D4 /* PrimerDelegate.swift */; };
+		A6BE38323F29503A754E36876D6AD0D0 /* ReloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E3F7FE72F278C500D00B7085856DA9 /* ReloadDelegate.swift */; };
+		AB05C497ABF788803FC4F35081675EA5 /* ThenableWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746E27159DA65B67173A76DCD7B3E7F /* ThenableWrappers.swift */; };
+		AC45AEDCD4FB368BBFB74B4BB4359DD6 /* Klarna.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7CFD3F081A786F3FE3BDB532B18B54 /* Klarna.swift */; };
+		AEA44F49836330ABDDB634544E42CE94 /* PresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E44899879A8B45D7EEB64959270B0A34 /* PresentationController.swift */; };
+		B184DC52361EF63F41653A3498FA32D3 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F857FE94F5E208A20BEB72D0EE986028 /* Dispatcher.swift */; };
+		B1CF5AE484E18B74829370EC27EE632B /* ExternalPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F31DDA98B2B959AD3611D8841B7DA35 /* ExternalPaymentMethodTokenizationViewModel.swift */; };
+		B2698C9423108BA962FEC93D21D35EA2 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285058AFFBC5CDA72B91771A878EB118 /* AnyDecodable.swift */; };
+		B284F619C85357CA9625F9471D9C510D /* ApplePayTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16ACFDC91E3D96AAD50A5B53124D1C2F /* ApplePayTokenizationViewModel.swift */; };
+		B4C7982CBD8C7ED8E0F1BDD52555FC44 /* PrimerLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF534F5F5EE5211727397B2CE33A5AC /* PrimerLoadingViewController.swift */; };
+		B575FF6D07BFD673A42549BA40528EB7 /* PrimerCardFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8A80CF4EBAD186B086E0A959259E92 /* PrimerCardFormViewController.swift */; };
+		B5905161A4FEEFDEAD175D8C7D6781AF /* 3DSService+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC665B70217B0032458821BE4D6A0A0 /* 3DSService+Promises.swift */; };
+		B78BAE03C6DBDC86617A84D11E6F577E /* PaymentMethodsGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AC3BB8D8A9917010EC7D5ED6D4031FF /* PaymentMethodsGroupView.swift */; };
+		B97B6CFD6D8F110A31662EA276C98C19 /* CardNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9520519D63B352DA3D0865DFD551D267 /* CardNetwork.swift */; };
+		B98CCFD70CACA44A82F533EB3E2A7463 /* DirectDebitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932A9EECF519BDC8A32BFDEB5F905779 /* DirectDebitService.swift */; };
+		BA0A68ACAF12F87B1396794600F75CB3 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E940BBABE470AECD0B93ECB3D6749FF6 /* ErrorHandler.swift */; };
+		BBA9B26831C3A272E7FA45704379A936 /* PrimerCardNumberFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F908BC1D8441341FE0288F1D0777F5E /* PrimerCardNumberFieldView.swift */; };
+		BCCFCF52ED1B99FD72C74120FC2B6421 /* PrimerUniversalCheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF99E2A69A948F79205A3327B8F992CA /* PrimerUniversalCheckoutViewController.swift */; };
+		BDB12E3F6F38B5095AFE2AB500668497 /* VaultCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA20E5EF3DB14C553CB6DA4BF50CDD2D /* VaultCheckoutViewModel.swift */; };
+		BE3A06136D553F53A85BDA364E6330A6 /* PrimerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DA4748340CB7574C2452A493DAA6DE /* PrimerAPI.swift */; };
+		BEEC1D66B08994414B9FD7CBF18A3A04 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = C650C5EDB5C46126ACD98C7854EC53E2 /* Box.swift */; };
+		C182ED9335AE4629B2937F696C74C356 /* CoreDataDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517AA59C3DE74CD95A8590BDF9706D06 /* CoreDataDispatcher.swift */; };
+		C32834B0893273CCAEF01062FF790FF6 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375849D2F7A4023E8AD7637FFD24B0CA /* NetworkService.swift */; };
+		C8F60750179E56BD090F83ABBDAB88F8 /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 317DD242800B725D01A11C2D6753828D /* CountryCode.swift */; };
+		C9637DB4E5DC81FBBCDF3B7B17BAF3C4 /* ExternalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3025D63AF9C04D51A4ED35863C6FE8 /* ExternalViewModel.swift */; };
+		CD498BED075E02D79B53920A781D28DE /* WebViewUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3311FEF28B4C2F698D556D8B86C57E /* WebViewUtil.swift */; };
+		D1718D7B29D0275DE2818DD6CF9F6530 /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DA056EE7BC0B599074D93026A90CBC /* Currency.swift */; };
+		D220050236DF9975F140A136512F8F61 /* RateLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135C42CDA9371B5342616A6B7D839C17 /* RateLimitedDispatcher.swift */; };
+		D546F64774DA94F21E6E3F411575E29B /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37D10EA3F5FF3298A3D81FB18C179FA0 /* AppState.swift */; };
 		D596E2B41C673AD5018AEA0A0321E51C /* Pods-PrimerSDK_Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = EE9674DAD0C961C92687877090E1E047 /* Pods-PrimerSDK_Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D6800284DFAF663EEEF6E90273723299 /* ThenableWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746E27159DA65B67173A76DCD7B3E7F /* ThenableWrappers.swift */; };
-		D955CB3850172875BFC37B85100F16EC /* WebViewUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3311FEF28B4C2F698D556D8B86C57E /* WebViewUtil.swift */; };
-		DB08D54D6A89083F954CA468DE1F6B25 /* UIDeviceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9BC6F7F54F02A21E78359C1986324E /* UIDeviceExtension.swift */; };
-		DC1F24BBE411BAF40EA0BDF856C23C06 /* PrimerCardNumberFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF304DE0EA1EB8581DC5CBA6A160BB59 /* PrimerCardNumberFieldView.swift */; };
-		DEBFFC54578E55382750A7BE315FF694 /* PaymentMethodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B81799AA6AC6BB41C9AF0666239CFE9 /* PaymentMethodViewModel.swift */; };
+		D7FA258B32DB223A8F6CE53EF0C1FA03 /* ApplePay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9986F98DE69FDEE115549F1B408D64E4 /* ApplePay.swift */; };
+		D9D9FAEEFDA4E394C637765FAED0285C /* TokenizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FAB998D29F1BEFB5A180AD12B05DF3 /* TokenizationService.swift */; };
+		DB4856876537DB89E9CF821E9BFF949C /* VaultService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8689759975DFDF5482A37409D9B7CB6 /* VaultService.swift */; };
+		DBB81075AACFAD6B26B7F0382A0102BD /* ApayaTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6809EC1C52439BA3E299A7E6FF91C242 /* ApayaTokenizationViewModel.swift */; };
+		DBD817D57E7F7D07FEC64FC150B094CC /* PrimerNibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86E5460EABC8B6FDD38D450BDEC0512 /* PrimerNibView.swift */; };
+		DCD061DA08A71B83A2C464ED1394F109 /* en.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 73309764D9290B8BDF68349AD3201DF0 /* en.lproj */; };
+		E03C9862065B5EDF6CC9D10C49C70C50 /* VaultPaymentMethodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90572073E531EA76281BE2A5CD16D1FD /* VaultPaymentMethodViewModel.swift */; };
 		E150EB1E3DDC0F59C4FDE4E1058FCAF7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		E288E4675C9CF0C934FD21E3960E7457 /* CardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDCBD510F10476C95077777A5E2CE74 /* CardButton.swift */; };
-		E3F880D31FDD2C8C4CAF018AAB7C437F /* PrimerUniversalCheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD753E15933C2CE97F1B7D38BB8929B /* PrimerUniversalCheckoutViewController.swift */; };
-		E5830B5F2E9A1DCA6B3A7C469A5F1A97 /* PrimerCardholderNameFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B81A558B8ADC76AE2F29D349BD9247F /* PrimerCardholderNameFieldView.swift */; };
-		E7B406996606B3595C986C9EA86CAB12 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51938AABD8535CB2BBEE645AFBA2C8A6 /* AnyEncodable.swift */; };
-		EBFA88DE2A7E9ECAAF35E4EE244A69D2 /* RateLimitedDispatcherBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C8393F5837E560C71ABAFA98656B73 /* RateLimitedDispatcherBase.swift */; };
-		EC8E1AA2BC11D8242E336751FA552B66 /* PrimerScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E815334BE355762ECEC45B5F079CDF2F /* PrimerScrollView.swift */; };
-		EFE0FEDAC2CF0FFF0E68C904F95D0A22 /* VaultCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA20E5EF3DB14C553CB6DA4BF50CDD2D /* VaultCheckoutViewModel.swift */; };
-		F11AEADC3E70D7329A3DB4964E0103A8 /* PrimerContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1030545030581A5FC5A97ABB4DF317BF /* PrimerContent.swift */; };
-		F3154903F96DF47858C79BD6A1A753DD /* PrimerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C436700807E5517EE1666E21FBBB06 /* PrimerSettings.swift */; };
-		F325B03FD4121E34EC6B9E1BD147FB93 /* ExternalPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EEF522C6A55B0454E90C42BFBA9EA3 /* ExternalPaymentMethodTokenizationViewModel.swift */; };
+		E33F7FDCB55E6B2AAE0201E5A313995C /* OrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58788B6C7E8A3EA75014A648F0FC38F7 /* OrderItem.swift */; };
+		E3CD5DBDD9C87FAABED3B6920DEF452B /* CardScannerViewController+SimpleScanDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC76812909B414D516B3452DF0BA871C /* CardScannerViewController+SimpleScanDelegate.swift */; };
+		E58D3747D2851888D26E56F2D539AFEF /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C68A718EF043D9EEF01B8B97091189 /* LogEvent.swift */; };
+		E613FC9A2EA66256790AC7BB96C42588 /* ConcurrencyLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340B7BAA8C95A8847FA01E2B324AA10A /* ConcurrencyLimitedDispatcher.swift */; };
+		E972C7D6DA897B3A82595591B49F76F2 /* PrimerExpiryDateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74425AA3013E87EE7A33C9AC88C886FD /* PrimerExpiryDateFieldView.swift */; };
+		E9AD69473F16FB9994C0C5BDC5960F6B /* SuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F4D7C582F37746602C089CB85C7EA8 /* SuccessViewController.swift */; };
+		EA6537C8D791AA54F869570A0BC93028 /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B65D82816B20660AAFBFF339FE796FE /* JSONParser.swift */; };
+		EC62159BDCCF66B5450CC8B00A412A03 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2E754A3930F4F5ADC8AA3FBE67D834 /* Parser.swift */; };
+		EEAFFC2EF5CEEB5DDEAC101D97D0536A /* PrimerFlowEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0D31B1B291212C429C6A47B7E2B2A6 /* PrimerFlowEnums.swift */; };
+		EF353CFB4EBD1B81EAB763628C539CB1 /* FormTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14EA5628923624A46A707B5CB3C4ED5B /* FormTokenizationViewModel.swift */; };
+		F08C3B642FFF8FBBAB5A059115D84A83 /* ClientSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E72B2ADD48DCEE728FB64C5D3C0B8F44 /* ClientSession.swift */; };
+		F13EF926323254BB3034050FA10AA992 /* PrimerImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89F5B53E83E5F322F6E8808CBA9F2CA1 /* PrimerImage.swift */; };
+		F186F689EEDAC0A64EA4F78796C8A163 /* Consolable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26D5B4B089E7B777183F47DF99B4BE5 /* Consolable.swift */; };
+		F1F4DA5E95ADD32DE6C5F0D13612B9B5 /* DependencyInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C58E028F4D268A3B122B0DA0685D6DE9 /* DependencyInjection.swift */; };
+		F2FC1D70BC8F392067DCC245FB586473 /* EnsureWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB696E308D624224328B2FB8CC325C05 /* EnsureWrappers.swift */; };
+		F3F6C3E02ECBDAB98EBF5DE596275D03 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6BF1C9E0DE439B9F9BEB92D11E9CFE /* when.swift */; };
 		F4B688753C11BA192EC0E3E61A466CB2 /* Primer3DS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 77393D72E4B2EFF88AF10EE9F64BB174 /* Primer3DS-dummy.m */; };
-		F7E5DC5010061740EF773E046E3255AA /* PrimerFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7515AD62D1A91B1252148977372478C /* PrimerFormViewController.swift */; };
-		F861FD50102DDF42B268BAE7B0A2536E /* RateLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135C42CDA9371B5342616A6B7D839C17 /* RateLimitedDispatcher.swift */; };
-		F8882DF81BE923D56BD06F16A85BED91 /* CoreDataDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517AA59C3DE74CD95A8590BDF9706D06 /* CoreDataDispatcher.swift */; };
-		FAA74ADF06E9E1BA688D352864E0F3E3 /* sv.lproj in Resources */ = {isa = PBXBuildFile; fileRef = 13291E7078EE5E18DC7F4F94E0CF4843 /* sv.lproj */; };
-		FAD25A0F403A0B01BFEA3016C84B98F1 /* PrimerSDK-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C1C216B34934B8F586C68707318953BF /* PrimerSDK-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FE923ACA9E398A6B612797B7CCB51679 /* OrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58788B6C7E8A3EA75014A648F0FC38F7 /* OrderItem.swift */; };
-		FFA1F481CA80E630CB539489CAAFE3CB /* PrimerTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4125C6FE5FDDEF3DE5077A11EC877C /* PrimerTextFieldView.swift */; };
-		FFAE8356946C693178D9F73A323CF952 /* PrimerVaultManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8564B420BBB9044490D45194A61BC65A /* PrimerVaultManagerViewController.swift */; };
+		F94EDC5FE0B1111E6D3A7DF5B877FF48 /* PrimerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE5C74477C1EADA33D6FEA4CD398E88 /* PrimerTableViewCell.swift */; };
+		FB9D7785457432AF2B979FCDEF9695F2 /* PrimerWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165C86EC58E59C2F5E2F772A0E710C90 /* PrimerWebViewController.swift */; };
+		FBBEAE5BA89C66DFBFEED5740C9D0842 /* ClientTokenService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19520A134CDE220BBCA194216FFE253 /* ClientTokenService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		259998575A76C054286417DC81CC473E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 6C144A762E9B598392AFFEC8F873746A;
-			remoteInfo = "Pods-PrimerSDK_Example";
-		};
-		259CB00C50CFEB4135D2297C73F31C0D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F3BE9108C53B53949406218CEA55E0B2;
-			remoteInfo = PrimerSDK;
-		};
-		3575ABC5AB88595F2BB694DE7023E0BB /* PBXContainerItemProxy */ = {
+		0702CFC25B82340476045A41D5266396 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 6F5F0A81CAE773CFE5371059A81B5B6A;
 			remoteInfo = Primer3DS;
 		};
-		A3C97C74AE4B0B5629C31FA17A9254F6 /* PBXContainerItemProxy */ = {
+		52C5067C56A4F6B9F335815AC526DEFF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F3BE9108C53B53949406218CEA55E0B2;
+			remoteInfo = PrimerSDK;
+		};
+		BEC14992AB391075E76E7EC74BFCA2F2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 6E6525C7043FBA7BB34A249010AF5593;
 			remoteInfo = "PrimerSDK-PrimerResources";
+		};
+		F4DF06DB694F548A9D63E84355BE7CFA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6C144A762E9B598392AFFEC8F873746A;
+			remoteInfo = "Pods-PrimerSDK_Example";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -221,11 +222,11 @@
 		04DCC5251CD931E96CBBAB8F22C46FC8 /* PayPalService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalService.swift; sourceTree = "<group>"; };
 		0677C6E9834BB4B812F956E42A88E8F3 /* PrimerSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerSDK.debug.xcconfig; sourceTree = "<group>"; };
 		06E0CF3328DE334C73B16E95B7EFE3BC /* PaymentMethodConfigService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodConfigService.swift; sourceTree = "<group>"; };
+		06E85D9D9B251CB826E2D5F7A6681B53 /* PrimerTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
 		0A36FC2065CDA450277FFA2035E2CD03 /* Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
 		0A6BF1C9E0DE439B9F9BEB92D11E9CFE /* when.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = when.swift; sourceTree = "<group>"; };
 		0A7CFD3F081A786F3FE3BDB532B18B54 /* Klarna.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Klarna.swift; sourceTree = "<group>"; };
-		0BD753E15933C2CE97F1B7D38BB8929B /* PrimerUniversalCheckoutViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUniversalCheckoutViewController.swift; sourceTree = "<group>"; };
-		0C8AF71486DE64327BAD92D2DC2438E5 /* PrimerContainerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerContainerViewController.swift; sourceTree = "<group>"; };
+		0B52D3EF0B8517FF366A29433442CDAD /* CardButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardButton.swift; sourceTree = "<group>"; };
 		0CD89C365F46AEA64F8A5A2479D80794 /* Icons.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = Sources/PrimerSDK/Resources/Icons.xcassets; sourceTree = "<group>"; };
 		0D2E0829A9CF5AACE43592141857A21A /* PrimerSDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PrimerSDK-dummy.m"; sourceTree = "<group>"; };
 		0D7556526B4459F4DDEB5A24A012B617 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
@@ -236,7 +237,13 @@
 		13291E7078EE5E18DC7F4F94E0CF4843 /* sv.lproj */ = {isa = PBXFileReference; includeInIndex = 1; path = sv.lproj; sourceTree = "<group>"; };
 		135C42CDA9371B5342616A6B7D839C17 /* RateLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RateLimitedDispatcher.swift; sourceTree = "<group>"; };
 		142F32C1793D5D21D9B75E31362D2360 /* PrimerAPIClient+Promises.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+Promises.swift"; sourceTree = "<group>"; };
+		14EA5628923624A46A707B5CB3C4ED5B /* FormTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormTokenizationViewModel.swift; sourceTree = "<group>"; };
+		165C86EC58E59C2F5E2F772A0E710C90 /* PrimerWebViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerWebViewController.swift; sourceTree = "<group>"; };
+		16ACFDC91E3D96AAD50A5B53124D1C2F /* ApplePayTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePayTokenizationViewModel.swift; sourceTree = "<group>"; };
+		16F4D7C582F37746602C089CB85C7EA8 /* SuccessViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuccessViewController.swift; sourceTree = "<group>"; };
 		1746E27159DA65B67173A76DCD7B3E7F /* ThenableWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThenableWrappers.swift; sourceTree = "<group>"; };
+		198B7E3042A98B0CA2FA0E877FB22B07 /* PrimerRootViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRootViewController.swift; sourceTree = "<group>"; };
+		1A4F88263E51566E031711E398FAF182 /* PayPalTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalTokenizationViewModel.swift; sourceTree = "<group>"; };
 		1B81799AA6AC6BB41C9AF0666239CFE9 /* PaymentMethodViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodViewModel.swift; sourceTree = "<group>"; };
 		1E7A88FC18A3CD4A52AC4A183717ECD6 /* PrimerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerViewController.swift; sourceTree = "<group>"; };
 		1EB79EC7D2058D018AB15B71DA0904C3 /* Primer3DS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Primer3DS-prefix.pch"; sourceTree = "<group>"; };
@@ -244,64 +251,63 @@
 		21A5C37BCDB8875B1F4D36BB7067653D /* PaymentMethodConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodConfig.swift; sourceTree = "<group>"; };
 		21F4ACB1142B1B9457658584BF5CD35A /* Pods-PrimerSDK_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PrimerSDK_Example-dummy.m"; sourceTree = "<group>"; };
 		22DF1583396B02B469A4CF5A67C2AF05 /* CustomStringConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomStringConvertible.swift; sourceTree = "<group>"; };
+		23E3F7FE72F278C500D00B7085856DA9 /* ReloadDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReloadDelegate.swift; sourceTree = "<group>"; };
 		23FD1D157B8C8E7148BE8A7D354A051F /* Pods-PrimerSDK_Tests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-PrimerSDK_Tests"; path = Pods_PrimerSDK_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2440D26687ACF484988B227774D0C3EA /* FinallyWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FinallyWrappers.swift; sourceTree = "<group>"; };
-		24A7878915D7981887F488408AE5A371 /* VaultPaymentMethodView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodView.swift; sourceTree = "<group>"; };
 		26E44E599E516BE7177CE953A93B5167 /* BundleExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
 		2796B517334A85FE273247C85E3F7711 /* ThreeDS_SDK.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = ThreeDS_SDK.xcframework; path = Sources/Frameworks/ThreeDS_SDK.xcframework; sourceTree = "<group>"; };
 		285058AFFBC5CDA72B91771A878EB118 /* AnyDecodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
 		28E47791C9F9D0A9BA05C719761A4F3F /* PrimerSDK */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PrimerSDK; path = PrimerSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		2B29BF9B21F3B3FBCE8F498625225F87 /* CardScannerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardScannerViewController.swift; sourceTree = "<group>"; };
+		2A93DE0AECB42E5A44B54B269F693360 /* PrimerFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFormViewController.swift; sourceTree = "<group>"; };
+		2DC1CDD880298AC074A183DC236C657C /* VaultPaymentMethodViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodViewController.swift; sourceTree = "<group>"; };
 		317DD242800B725D01A11C2D6753828D /* CountryCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryCode.swift; sourceTree = "<group>"; };
 		340B7BAA8C95A8847FA01E2B324AA10A /* ConcurrencyLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConcurrencyLimitedDispatcher.swift; sourceTree = "<group>"; };
 		34926D5B928AAF03BF648FC7D037D9B8 /* PrimerTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTheme.swift; sourceTree = "<group>"; };
+		365A35FAA97E130AA03B0EBC47809E5B /* ErrorViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		375849D2F7A4023E8AD7637FFD24B0CA /* NetworkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		3780FF276696624E5AD4A629D4CC4AD8 /* Pods-PrimerSDK_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PrimerSDK_Example-umbrella.h"; sourceTree = "<group>"; };
 		37B744B62A9D19AC83AE999DB5329327 /* Apaya.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Apaya.swift; sourceTree = "<group>"; };
 		37BD3457C9DA0596324E3CDCC658CF05 /* Primer3DS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Primer3DS.release.xcconfig; sourceTree = "<group>"; };
 		37D10EA3F5FF3298A3D81FB18C179FA0 /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		3BA50D42F3FCD1A5038156BD89179A9E /* PrimerTextFieldView.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = PrimerTextFieldView.xib; sourceTree = "<group>"; };
+		3C071B6E0B01BDE73C6D4DE1527FC8C7 /* PrimerCardholderNameFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardholderNameFieldView.swift; sourceTree = "<group>"; };
 		3C474C1A0DABE2A3F404B63D4D59F30C /* Pods-PrimerSDK_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PrimerSDK_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		3C7C90FA318FF3F6D3F0FD11A59C7FF7 /* ApayaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApayaTokenizationViewModel.swift; sourceTree = "<group>"; };
-		3D6763FA6BE823C089AC3F6C2F18E488 /* ErrorViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
+		3F908BC1D8441341FE0288F1D0777F5E /* PrimerCardNumberFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardNumberFieldView.swift; sourceTree = "<group>"; };
 		40AA7AA9AE945A1D4168CEB257C0E3D4 /* PrimerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerDelegate.swift; sourceTree = "<group>"; };
 		40D6F7D77660E09187A535AE3C5DA872 /* 3DSService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = 3DSService.swift; sourceTree = "<group>"; };
 		418DFBE8A9B28B8E11B4859D41D8ABE6 /* Optional+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
+		42B5FE491F26661A194B410657B6B34A /* PrimerNavigationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationController.swift; sourceTree = "<group>"; };
 		43F74BC0096AFAFFB4BA4CD72E36183D /* PaymentMethodToken.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodToken.swift; sourceTree = "<group>"; };
 		45C33481F1BB24D7E4F925312CDE98D7 /* Thenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Thenable.swift; sourceTree = "<group>"; };
-		461BF04CC03243EBB876BD7AEECD6976 /* VaultPaymentMethodViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodViewController.swift; sourceTree = "<group>"; };
-		46278C1314899E6124F0A8B90E71A2E0 /* LoadingViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
 		48627A99264E6679D85F177DBB79DA83 /* Pods-PrimerSDK_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PrimerSDK_Tests-Info.plist"; sourceTree = "<group>"; };
-		4AB3A8E4383766C3794D51E3C30C8C10 /* CardComponentsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardComponentsManager.swift; sourceTree = "<group>"; };
-		4B81A558B8ADC76AE2F29D349BD9247F /* PrimerCardholderNameFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardholderNameFieldView.swift; sourceTree = "<group>"; };
+		4CA3C755F190F5EAF4410F7A1B417830 /* PrimerVaultManagerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultManagerViewController.swift; sourceTree = "<group>"; };
 		4D3869E0A461E802A5916AA6523517A4 /* Pods-PrimerSDK_Example */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-PrimerSDK_Example"; path = Pods_PrimerSDK_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D66EA769A3601ADD44386E314CE19C6 /* Logger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
-		4F04E0BADD8EF8C80C41A484A9BCEE7C /* PrimerNavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationBar.swift; sourceTree = "<group>"; };
-		4FC8DE2B1FCA6FE90F4ECEAC5D60C727 /* ReloadDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReloadDelegate.swift; sourceTree = "<group>"; };
-		5069325F99CEF220B901E6E9C3F6D303 /* PaymentMethodComponent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodComponent.swift; sourceTree = "<group>"; };
+		4F31DDA98B2B959AD3611D8841B7DA35 /* ExternalPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExternalPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
 		517AA59C3DE74CD95A8590BDF9706D06 /* CoreDataDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoreDataDispatcher.swift; sourceTree = "<group>"; };
 		51938AABD8535CB2BBEE645AFBA2C8A6 /* AnyEncodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		52A18EBB1CEF7C09E725EB41093FC1A0 /* UIColorExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		52BBFDBDBD8AFE8E7FC1714187DF9741 /* StrictRateLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StrictRateLimitedDispatcher.swift; sourceTree = "<group>"; };
 		55B4670B3C995E50A746A314A2C55D01 /* Endpoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
-		5748EE8FF997A16AE7DA3F2B22A84D13 /* ExternalViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExternalViewModel.swift; sourceTree = "<group>"; };
 		57A12F8ADBB1CFBF51FA0283583A1EF9 /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		582FD3213F3E32AF1194EEDF7C3BCD3F /* Pods-PrimerSDK_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PrimerSDK_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		58788B6C7E8A3EA75014A648F0FC38F7 /* OrderItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrderItem.swift; sourceTree = "<group>"; };
-		5BDCBD510F10476C95077777A5E2CE74 /* CardButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardButton.swift; sourceTree = "<group>"; };
 		5C3311FEF28B4C2F698D556D8B86C57E /* WebViewUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewUtil.swift; sourceTree = "<group>"; };
 		5C4F6AF392ED546A98F16C2B3560CC8A /* PaymentMethodTokenizationRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodTokenizationRequest.swift; sourceTree = "<group>"; };
 		5DE309238BFA5AAAA424F799C23B73A2 /* CatchWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatchWrappers.swift; sourceTree = "<group>"; };
 		5E0D31B1B291212C429C6A47B7E2B2A6 /* PrimerFlowEnums.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFlowEnums.swift; sourceTree = "<group>"; };
 		5E2E754A3930F4F5ADC8AA3FBE67D834 /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		5E5A2ED05B14DFAB58CE3E4249503BEF /* UserDefaultsExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtension.swift; sourceTree = "<group>"; };
+		60DBA76083F59BD8D1D6205688D0C690 /* PaymentMethodButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodButtonView.swift; sourceTree = "<group>"; };
 		62031A6CE2BE2D955FD495B28A3C52B4 /* PrimerButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerButton.swift; sourceTree = "<group>"; };
 		6301B7A842E934AB51C3D1A5965B19C8 /* Primer3DS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Primer3DS.modulemap; sourceTree = "<group>"; };
 		635E9B6784F533B88E460B498167E8B2 /* 3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = 3DS.swift; sourceTree = "<group>"; };
 		639AE4928116FBD4FAE7B3DD6BD21271 /* Pods-PrimerSDK_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PrimerSDK_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		6809EC1C52439BA3E299A7E6FF91C242 /* ApayaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApayaTokenizationViewModel.swift; sourceTree = "<group>"; };
 		68553CD924D242319DF36DF6E249141A /* PrimerSDK-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerSDK-prefix.pch"; sourceTree = "<group>"; };
 		6998E1B99D5FCA9CD5CDB878FF583068 /* CancelContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancelContext.swift; sourceTree = "<group>"; };
 		6AB8BD7A248834907AE087649B5D2CFA /* PrimerSDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PrimerSDK.modulemap; sourceTree = "<group>"; };
+		6B8A80CF4EBAD186B086E0A959259E92 /* PrimerCardFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardFormViewController.swift; sourceTree = "<group>"; };
 		6BEA04339ED7699A38D77CEFE77A8A5A /* firstly.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = firstly.swift; sourceTree = "<group>"; };
 		6CDCAC4FB22422BB52BB3CF13655ECD3 /* CancellableCatchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellableCatchable.swift; sourceTree = "<group>"; };
 		6D615C192F3ED0841230C2EDE0FFEC28 /* PrimerSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerSDK.release.xcconfig; sourceTree = "<group>"; };
@@ -309,46 +315,41 @@
 		6DE4A49EB349C598C0BE16639A75DE14 /* UXMode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UXMode.swift; sourceTree = "<group>"; };
 		6E4FB4E7EC7552E04F3CE8FAD4DB0E22 /* WrapperProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WrapperProtocols.swift; sourceTree = "<group>"; };
 		6F62EC7E7FE74F53F207CFD74D2416CA /* Pods-PrimerSDK_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PrimerSDK_Example-Info.plist"; sourceTree = "<group>"; };
-		70E8099CCB587C0698B8FABF500CF0EB /* CardScannerViewController+SimpleScanDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CardScannerViewController+SimpleScanDelegate.swift"; sourceTree = "<group>"; };
-		71EEF522C6A55B0454E90C42BFBA9EA3 /* ExternalPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExternalPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
 		73309764D9290B8BDF68349AD3201DF0 /* en.lproj */ = {isa = PBXFileReference; includeInIndex = 1; path = en.lproj; sourceTree = "<group>"; };
-		7395C8587402F73BB2932319D195F6BD /* SuccessViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuccessViewController.swift; sourceTree = "<group>"; };
+		74425AA3013E87EE7A33C9AC88C886FD /* PrimerExpiryDateFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerExpiryDateFieldView.swift; sourceTree = "<group>"; };
 		7492CBAABC98EBF5377CFAD0DED3516E /* Primer3DSStructures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSStructures.swift; path = Sources/Primer3DS/Classes/Primer3DSStructures.swift; sourceTree = "<group>"; };
 		74B044A3CCEC0673694E9A446D17D429 /* CancellablePromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellablePromise.swift; sourceTree = "<group>"; };
+		75A097C6298A67F5148DAA64E119C8C6 /* PrimerCVVFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCVVFieldView.swift; sourceTree = "<group>"; };
 		7714B05688C8E2F063CCD475DC69796F /* URLSessionStack.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLSessionStack.swift; sourceTree = "<group>"; };
 		77393D72E4B2EFF88AF10EE9F64BB174 /* Primer3DS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Primer3DS-dummy.m"; sourceTree = "<group>"; };
+		77B1E602D15549B266623FD0F1A3BC18 /* LoadingViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LoadingViewController.swift; sourceTree = "<group>"; };
 		77C68A718EF043D9EEF01B8B97091189 /* LogEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogEvent.swift; sourceTree = "<group>"; };
 		77D5B477F719114CAC4457D3E84F43D3 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
 		79A0EB874D08252DD489CAEFA1720AEA /* PayPal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPal.swift; sourceTree = "<group>"; };
+		7AEEF130C3F4DA15752F6045F7A87683 /* PrimerNavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationBar.swift; sourceTree = "<group>"; };
 		7CA62AC66E4C8E3226DB7C10B85C0DB9 /* FormType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormType.swift; sourceTree = "<group>"; };
 		7FF51BAA5D9B19AEE1E35014335A18E6 /* StringExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		80DA4748340CB7574C2452A493DAA6DE /* PrimerAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPI.swift; sourceTree = "<group>"; };
-		83FF29DE64C78302BC3468299755CEA7 /* PrimerRootViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRootViewController.swift; sourceTree = "<group>"; };
-		8564B420BBB9044490D45194A61BC65A /* PrimerVaultManagerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultManagerViewController.swift; sourceTree = "<group>"; };
 		86B77149296B3C606FC3B9950936F862 /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
 		87DA056EE7BC0B599074D93026A90CBC /* Currency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		88124DD06F241A84D772C2F458A258DE /* Queue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		89F5B53E83E5F322F6E8808CBA9F2CA1 /* PrimerImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerImage.swift; sourceTree = "<group>"; };
-		8AE4E730C17B5C8A299D14B95209AA74 /* PaymentMethodButtonView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodButtonView.swift; sourceTree = "<group>"; };
+		8AC3BB8D8A9917010EC7D5ED6D4031FF /* PaymentMethodsGroupView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodsGroupView.swift; sourceTree = "<group>"; };
 		8B5A6E8DEBF7EFFED939740F0F69B764 /* fr.lproj */ = {isa = PBXFileReference; includeInIndex = 1; path = fr.lproj; sourceTree = "<group>"; };
 		8EB030EA4964D853C5886AA067E89E15 /* Guarantee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Guarantee.swift; sourceTree = "<group>"; };
 		8F2F21CB381261AB34E4F7C0F8C2F446 /* Primer3DS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Primer3DS-Info.plist"; sourceTree = "<group>"; };
+		90572073E531EA76281BE2A5CD16D1FD /* VaultPaymentMethodViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodViewModel.swift; sourceTree = "<group>"; };
 		932A9EECF519BDC8A32BFDEB5F905779 /* DirectDebitService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DirectDebitService.swift; sourceTree = "<group>"; };
-		935CC0CE0A85C435B8707D9136C80BF7 /* PrimerNavigationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationController.swift; sourceTree = "<group>"; };
 		9520519D63B352DA3D0865DFD551D267 /* CardNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardNetwork.swift; sourceTree = "<group>"; };
 		9531A1A287CC36E9490F3D82C35C13D1 /* ResumeHandlerProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResumeHandlerProtocol.swift; sourceTree = "<group>"; };
 		96A90263B351CA8CC8A59CAE0C289672 /* RecoverWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecoverWrappers.swift; sourceTree = "<group>"; };
 		9986F98DE69FDEE115549F1B408D64E4 /* ApplePay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePay.swift; sourceTree = "<group>"; };
 		9B65D82816B20660AAFBFF339FE796FE /* JSONParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
+		9D3025D63AF9C04D51A4ED35863C6FE8 /* ExternalViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExternalViewModel.swift; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9E81A2AC8B8AD22C4991BDC1A330F4F7 /* PrimerNibView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNibView.swift; sourceTree = "<group>"; };
 		9F7A8C5A3CD900CF1C18E1E50CB4F937 /* PrimerCustomStyleTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCustomStyleTextField.swift; sourceTree = "<group>"; };
 		9FB6F2137FFC47970DBE20DAE214DFBF /* Catchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Catchable.swift; sourceTree = "<group>"; };
-		A0111976A042BCF1B0989D095EB2AF3B /* VaultPaymentMethodViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodViewModel.swift; sourceTree = "<group>"; };
-		A0C4458603983DCCB53E87B62EE43AFB /* KlarnaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KlarnaTokenizationViewModel.swift; sourceTree = "<group>"; };
 		A163D166B27F20FF6EEF83F5121C4CEA /* Primer3DS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Primer3DS-umbrella.h"; sourceTree = "<group>"; };
-		A1E8B455039BCA1C2B74A3052CBFB174 /* FormTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormTokenizationViewModel.swift; sourceTree = "<group>"; };
-		A38449BCC19F96664FF3AE08F52DA516 /* PaymentMethodsGroupView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodsGroupView.swift; sourceTree = "<group>"; };
 		A481D7E1DA3B573F12BA3D33A8812844 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		A4E7B1C752F38C22267D301DD5A364DF /* Pods-PrimerSDK_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-PrimerSDK_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
 		A63CC5E517E7F34CD4D9918E1E39219E /* Mask.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Mask.swift; sourceTree = "<group>"; };
@@ -357,44 +358,46 @@
 		A9E3B95C1FD987460452CB0348520EAC /* hang.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = hang.swift; sourceTree = "<group>"; };
 		AA3E9F209C857157575A473FE948A03D /* Primer3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DS.swift; path = Sources/Primer3DS/Classes/Primer3DS.swift; sourceTree = "<group>"; };
 		AA80C9C550CB6B8B521015719AA66526 /* Pods-PrimerSDK_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-PrimerSDK_Example.modulemap"; sourceTree = "<group>"; };
-		AD071B3BCDB032043ACCC502F007A54B /* PrimerCVVFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCVVFieldView.swift; sourceTree = "<group>"; };
 		AD0B97C8230EA27F9505EF79D6BC64A1 /* PrimerSDK.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = PrimerSDK.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		AD783851B56A7AAA6FE4D4FCC5967A70 /* SequenceWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SequenceWrappers.swift; sourceTree = "<group>"; };
-		AF304DE0EA1EB8581DC5CBA6A160BB59 /* PrimerCardNumberFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardNumberFieldView.swift; sourceTree = "<group>"; };
-		B23ABF6D9F8C7A5EE74B8C41555F7FAE /* PrimerCardFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardFormViewController.swift; sourceTree = "<group>"; };
 		B429083200B13F604ED3C87DFFC0C016 /* Pods-PrimerSDK_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-PrimerSDK_Tests.modulemap"; sourceTree = "<group>"; };
 		B4767916A260904C828CC5ACDB209A11 /* AnyCodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
 		B54C8A10B9D67A543E712A5E77A8C2A2 /* URLExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLExtension.swift; sourceTree = "<group>"; };
 		B5FAB998D29F1BEFB5A180AD12B05DF3 /* TokenizationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationService.swift; sourceTree = "<group>"; };
 		B7B1F4EA655F4EF76C5D37E7565D633C /* ClientToken.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientToken.swift; sourceTree = "<group>"; };
+		B9242EDDEBEE53335B56CC10B1E8C9D8 /* VaultPaymentMethodView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodView.swift; sourceTree = "<group>"; };
 		BA20E5EF3DB14C553CB6DA4BF50CDD2D /* VaultCheckoutViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultCheckoutViewModel.swift; sourceTree = "<group>"; };
 		BB9BC6F7F54F02A21E78359C1986324E /* UIDeviceExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIDeviceExtension.swift; sourceTree = "<group>"; };
-		BCAED5681785E7E8CD0931199F40B248 /* PrimerWebViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerWebViewController.swift; sourceTree = "<group>"; };
+		BC76812909B414D516B3452DF0BA871C /* CardScannerViewController+SimpleScanDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "CardScannerViewController+SimpleScanDelegate.swift"; sourceTree = "<group>"; };
+		BE10EC9869350060266B863C4EE488E7 /* PrimerZipCodeFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerZipCodeFieldView.swift; sourceTree = "<group>"; };
 		C1C216B34934B8F586C68707318953BF /* PrimerSDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerSDK-umbrella.h"; sourceTree = "<group>"; };
+		C2C22BC67900415B28514EC3146A82CF /* PrimerContainerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerContainerViewController.swift; sourceTree = "<group>"; };
 		C58E028F4D268A3B122B0DA0685D6DE9 /* DependencyInjection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependencyInjection.swift; sourceTree = "<group>"; };
 		C650C5EDB5C46126ACD98C7854EC53E2 /* Box.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
+		C6EF93FFFB8659A8ADBE7F35011B2B91 /* CardComponentsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardComponentsManager.swift; sourceTree = "<group>"; };
+		C864749E7106990A76835AF250AB05BC /* KlarnaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KlarnaTokenizationViewModel.swift; sourceTree = "<group>"; };
+		C86E5460EABC8B6FDD38D450BDEC0512 /* PrimerNibView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNibView.swift; sourceTree = "<group>"; };
 		C8FF0DE2962E8F3B9D6BF57C6146E9F8 /* FormTextFieldType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormTextFieldType.swift; sourceTree = "<group>"; };
-		C936F410A52394FAC8439E6341BE700E /* PrimerTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
 		C948C1F7E8EE5E96738F6371DDA600F2 /* Primer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Primer.swift; sourceTree = "<group>"; };
-		CA0594C2B00372CB1A08DA90D92A15D8 /* PrimerLoadingViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerLoadingViewController.swift; sourceTree = "<group>"; };
+		CC588EC125AB52E793E08BA29AD1A96E /* PaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
 		CDA121516581B97C473067E099C72804 /* PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PrimerSDK-Info.plist"; sourceTree = "<group>"; };
-		CE4125C6FE5FDDEF3DE5077A11EC877C /* PrimerTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextFieldView.swift; sourceTree = "<group>"; };
-		CF32D34EC52B6AD84DE4468A1441BA01 /* PrimerExpiryDateFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerExpiryDateFieldView.swift; sourceTree = "<group>"; };
+		CEF534F5F5EE5211727397B2CE33A5AC /* PrimerLoadingViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerLoadingViewController.swift; sourceTree = "<group>"; };
 		D083E91A46DFE33F37B699729BBC35AD /* after.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = after.swift; sourceTree = "<group>"; };
 		D1E0B607D634362D4D74BC7D65C30BBD /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = race.swift; sourceTree = "<group>"; };
 		D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		D260A9B1159A7C7DC008A2E91113A19C /* PrimerAPIClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPIClient.swift; sourceTree = "<group>"; };
 		D264B4E57DF7DB00D71275605D100971 /* Pods-PrimerSDK_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-PrimerSDK_Example-frameworks.sh"; sourceTree = "<group>"; };
+		D3BBCA45A6833039A8CBE7B8E6D5FE4B /* PaymentMethodComponent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodComponent.swift; sourceTree = "<group>"; };
 		D4B4A1EA2080101E10F69C7FFEDC114C /* PrimerViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerViewExtensions.swift; sourceTree = "<group>"; };
 		D66C3890C3566F38C935A2FFD9A237B0 /* Pods-PrimerSDK_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PrimerSDK_Tests-dummy.m"; sourceTree = "<group>"; };
-		D7515AD62D1A91B1252148977372478C /* PrimerFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFormViewController.swift; sourceTree = "<group>"; };
 		D9EA73064D29F30F64FF256CF02047E0 /* GuaranteeWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GuaranteeWrappers.swift; sourceTree = "<group>"; };
 		DB696E308D624224328B2FB8CC325C05 /* EnsureWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EnsureWrappers.swift; sourceTree = "<group>"; };
+		DDF09426091AF05C33FF6E6D802EFF36 /* PrimerTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextFieldView.swift; sourceTree = "<group>"; };
 		DDFF6D4F0C169A30AF4F8ACA7D9276FC /* Validation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
 		DF6E4F8E7C26A7BBEC17AAD4042A317D /* Pods-PrimerSDK_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PrimerSDK_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		E1B945985145643C12B1E91600B680DE /* Pods-PrimerSDK_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-PrimerSDK_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		E1E8780917E6DFAEFF818196058FC684 /* PayPalTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalTokenizationViewModel.swift; sourceTree = "<group>"; };
 		E44899879A8B45D7EEB64959270B0A34 /* PresentationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PresentationController.swift; sourceTree = "<group>"; };
+		E57C6308EE4CAFE912E2C572582C6227 /* CardScannerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardScannerViewController.swift; sourceTree = "<group>"; };
 		E6DF772EBD0552229B3F76D49A0EF5F2 /* Primer3DSProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSProtocols.swift; path = Sources/Primer3DS/Classes/Primer3DSProtocols.swift; sourceTree = "<group>"; };
 		E72B2ADD48DCEE728FB64C5D3C0B8F44 /* ClientSession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientSession.swift; sourceTree = "<group>"; };
 		E7C436700807E5517EE1666E21FBBB06 /* PrimerSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSettings.swift; sourceTree = "<group>"; };
@@ -406,8 +409,6 @@
 		EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		EB8217820F639BC79E07FFCC65E74429 /* Primer3DS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Primer3DS.debug.xcconfig; sourceTree = "<group>"; };
 		EB84173F2CC643DBB424A1998EEE061F /* PaymentResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentResponse.swift; sourceTree = "<group>"; };
-		ECD64658599068462FB8DD7A59DD73DF /* ApplePayTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePayTokenizationViewModel.swift; sourceTree = "<group>"; };
-		ECE7634193F678EF3CDAFE7C6A682012 /* PaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
 		ED4582F8F818FBB860DFADA18C823B9B /* DateExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
 		EDE5C74477C1EADA33D6FEA4CD398E88 /* PrimerTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTableViewCell.swift; sourceTree = "<group>"; };
 		EE02BBEB7831C76E65254BB8122A3214 /* CancellableThenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellableThenable.swift; sourceTree = "<group>"; };
@@ -418,6 +419,7 @@
 		F7B48CC82297D62E27EA98AE7A13D3DA /* Pods-PrimerSDK_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PrimerSDK_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		F857FE94F5E208A20BEB72D0EE986028 /* Dispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
 		F8689759975DFDF5482A37409D9B7CB6 /* VaultService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultService.swift; sourceTree = "<group>"; };
+		FF99E2A69A948F79205A3327B8F992CA /* PrimerUniversalCheckoutViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUniversalCheckoutViewController.swift; sourceTree = "<group>"; };
 		FFE8CD355A453EF1396E2D5E8E370F7A /* Primer3DS */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Primer3DS; path = Primer3DS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -430,10 +432,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3E50A307E9F0EEA8DC667720C5B5C4B1 /* Frameworks */ = {
+		50B54828BF7F066E470CEF1729FF5B41 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		531C92A5A012B5313BA63AC8F08B1B60 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				928855FE86251D94C1AB370CC87EFBE7 /* Foundation.framework in Frameworks */,
+				88CE158B028FF224675A2456D45DAE58 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -454,15 +465,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BDF3C896569D10C1D503420D98CF73AC /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				93E2DC016FA9919028EB3A91DAC6E713 /* Foundation.framework in Frameworks */,
-				3F526632B147133502CD8C76762568D8 /* UIKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -476,32 +478,6 @@
 				A8B3BC107C2BDC3C03D961866F721265 /* PrimerSDK-PrimerResources */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		0253E146DD41125AC8B52759BB617B13 /* Vault */ = {
-			isa = PBXGroup;
-			children = (
-				24A7878915D7981887F488408AE5A371 /* VaultPaymentMethodView.swift */,
-				461BF04CC03243EBB876BD7AEECD6976 /* VaultPaymentMethodViewController.swift */,
-				A0111976A042BCF1B0989D095EB2AF3B /* VaultPaymentMethodViewModel.swift */,
-			);
-			name = Vault;
-			path = Vault;
-			sourceTree = "<group>";
-		};
-		08F80F8C944725E20DC7913FBBD5A23C /* TokenizationViewModels */ = {
-			isa = PBXGroup;
-			children = (
-				3C7C90FA318FF3F6D3F0FD11A59C7FF7 /* ApayaTokenizationViewModel.swift */,
-				ECD64658599068462FB8DD7A59DD73DF /* ApplePayTokenizationViewModel.swift */,
-				71EEF522C6A55B0454E90C42BFBA9EA3 /* ExternalPaymentMethodTokenizationViewModel.swift */,
-				A1E8B455039BCA1C2B74A3052CBFB174 /* FormTokenizationViewModel.swift */,
-				A0C4458603983DCCB53E87B62EE43AFB /* KlarnaTokenizationViewModel.swift */,
-				ECE7634193F678EF3CDAFE7C6A682012 /* PaymentMethodTokenizationViewModel.swift */,
-				E1E8780917E6DFAEFF818196058FC684 /* PayPalTokenizationViewModel.swift */,
-			);
-			name = TokenizationViewModels;
-			path = TokenizationViewModels;
 			sourceTree = "<group>";
 		};
 		09897E262329EBF5281A1CFB5473F43A /* PromiseKit */ = {
@@ -531,15 +507,6 @@
 			path = PromiseKit;
 			sourceTree = "<group>";
 		};
-		12FA5B09E6DE4D1D0ED74EC60AA24078 /* UI Delegates */ = {
-			isa = PBXGroup;
-			children = (
-				4FC8DE2B1FCA6FE90F4ECEAC5D60C727 /* ReloadDelegate.swift */,
-			);
-			name = "UI Delegates";
-			path = "UI Delegates";
-			sourceTree = "<group>";
-		};
 		1577D86830A5DE0BFE0676B6A9263C66 /* Localizable */ = {
 			isa = PBXGroup;
 			children = (
@@ -559,13 +526,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		1D314D0F170FA60AEDE85ABB1ECB9B66 /* OAuth */ = {
+		1C0DCE4909C0BCE655CC0CBCDAF6343A /* Vault */ = {
 			isa = PBXGroup;
 			children = (
-				BCAED5681785E7E8CD0931199F40B248 /* PrimerWebViewController.swift */,
+				B9242EDDEBEE53335B56CC10B1E8C9D8 /* VaultPaymentMethodView.swift */,
+				2DC1CDD880298AC074A183DC236C657C /* VaultPaymentMethodViewController.swift */,
+				90572073E531EA76281BE2A5CD16D1FD /* VaultPaymentMethodViewModel.swift */,
 			);
-			name = OAuth;
-			path = OAuth;
+			name = Vault;
+			path = Vault;
 			sourceTree = "<group>";
 		};
 		28F0D5ADADF6A2C614FFCBE982380827 /* Support Files */ = {
@@ -672,6 +641,15 @@
 			path = Sources/PrimerSDK/Classes/Services;
 			sourceTree = "<group>";
 		};
+		449AE24B96F5F496FC48B0BAC90BDF02 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				365A35FAA97E130AA03B0EBC47809E5B /* ErrorViewController.swift */,
+			);
+			name = Error;
+			path = Error;
+			sourceTree = "<group>";
+		};
 		4F21438FC2D43B65EAFD3C8ADF97040D /* Nibs */ = {
 			isa = PBXGroup;
 			children = (
@@ -679,6 +657,15 @@
 			);
 			name = Nibs;
 			path = Sources/PrimerSDK/Resources/Nibs;
+			sourceTree = "<group>";
+		};
+		505E17B78778E90B2805310B399E9368 /* Buttons */ = {
+			isa = PBXGroup;
+			children = (
+				60DBA76083F59BD8D1D6205688D0C690 /* PaymentMethodButtonView.swift */,
+			);
+			name = Buttons;
+			path = Buttons;
 			sourceTree = "<group>";
 		};
 		56409D50D0FA1C19C592518252ACCB45 /* Targets Support Files */ = {
@@ -702,7 +689,7 @@
 				4F21438FC2D43B65EAFD3C8ADF97040D /* Nibs */,
 				43A68637A4A198A4AA75111088D75EC4 /* Services */,
 				7E310FD35FE21026C1E4A6C3BF78F7B7 /* Third Party */,
-				70227BA1BAE9763089F83E9C31CADB12 /* User Interface */,
+				C7DF354F486D8519CB1172C5E4B34A83 /* User Interface */,
 			);
 			name = Core;
 			sourceTree = "<group>";
@@ -750,27 +737,6 @@
 			path = "Sources/PrimerSDK/Classes/Data Models";
 			sourceTree = "<group>";
 		};
-		70227BA1BAE9763089F83E9C31CADB12 /* User Interface */ = {
-			isa = PBXGroup;
-			children = (
-				46278C1314899E6124F0A8B90E71A2E0 /* LoadingViewController.swift */,
-				A38449BCC19F96664FF3AE08F52DA516 /* PaymentMethodsGroupView.swift */,
-				AED1770FC214FF715F71036300B5B1B3 /* Buttons */,
-				8F55A5F2F55FD4EC3D9255058ADF50BE /* Error */,
-				1D314D0F170FA60AEDE85ABB1ECB9B66 /* OAuth */,
-				736EDC1B93BC268E482B8B46925BC6BB /* PCI */,
-				EED8664DC8DE96D2158C53BE9AEA7E57 /* Primer */,
-				9E4F8542A9D9730110BAD625190B107E /* Root */,
-				C465716C9FB49940D4E5804F243C84AF /* Success */,
-				92D6B2DADB59679B9499A4D5DCF68D9B /* Text Fields */,
-				08F80F8C944725E20DC7913FBBD5A23C /* TokenizationViewModels */,
-				12FA5B09E6DE4D1D0ED74EC60AA24078 /* UI Delegates */,
-				0253E146DD41125AC8B52759BB617B13 /* Vault */,
-			);
-			name = "User Interface";
-			path = "Sources/PrimerSDK/Classes/User Interface";
-			sourceTree = "<group>";
-		};
 		7247ACD97AB79769C7D29E910A7E0D09 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -779,13 +745,13 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		736EDC1B93BC268E482B8B46925BC6BB /* PCI */ = {
+		7B2106576FB7A9D37A3240CBE6C2706B /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
-				D462C300C1D760C93FA52637BD0A58A7 /* CardScanner */,
+				165C86EC58E59C2F5E2F772A0E710C90 /* PrimerWebViewController.swift */,
 			);
-			name = PCI;
-			path = PCI;
+			name = OAuth;
+			path = OAuth;
 			sourceTree = "<group>";
 		};
 		7BDB69DDBF793BCDC6EF5717A545152A /* Primer */ = {
@@ -846,15 +812,6 @@
 			path = ../..;
 			sourceTree = "<group>";
 		};
-		8F55A5F2F55FD4EC3D9255058ADF50BE /* Error */ = {
-			isa = PBXGroup;
-			children = (
-				3D6763FA6BE823C089AC3F6C2F18E488 /* ErrorViewController.swift */,
-			);
-			name = Error;
-			path = Error;
-			sourceTree = "<group>";
-		};
 		9192AD83C8A5E14E7F671EBCA7F7C912 /* Data Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -862,22 +819,6 @@
 			);
 			name = "Data Models";
 			path = "Data Models";
-			sourceTree = "<group>";
-		};
-		92D6B2DADB59679B9499A4D5DCF68D9B /* Text Fields */ = {
-			isa = PBXGroup;
-			children = (
-				4AB3A8E4383766C3794D51E3C30C8C10 /* CardComponentsManager.swift */,
-				4B81A558B8ADC76AE2F29D349BD9247F /* PrimerCardholderNameFieldView.swift */,
-				AF304DE0EA1EB8581DC5CBA6A160BB59 /* PrimerCardNumberFieldView.swift */,
-				AD071B3BCDB032043ACCC502F007A54B /* PrimerCVVFieldView.swift */,
-				CF32D34EC52B6AD84DE4468A1441BA01 /* PrimerExpiryDateFieldView.swift */,
-				9E81A2AC8B8AD22C4991BDC1A330F4F7 /* PrimerNibView.swift */,
-				C936F410A52394FAC8439E6341BE700E /* PrimerTextField.swift */,
-				CE4125C6FE5FDDEF3DE5077A11EC877C /* PrimerTextFieldView.swift */,
-			);
-			name = "Text Fields";
-			path = "Text Fields";
 			sourceTree = "<group>";
 		};
 		9448AF66A975C50C90B6C2B4E72D90AC /* Pods */ = {
@@ -888,30 +829,58 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		9E4F8542A9D9730110BAD625190B107E /* Root */ = {
+		9493A5CA1A21AE89F658C4A37B01E514 /* Text Fields */ = {
 			isa = PBXGroup;
 			children = (
-				B23ABF6D9F8C7A5EE74B8C41555F7FAE /* PrimerCardFormViewController.swift */,
-				0C8AF71486DE64327BAD92D2DC2438E5 /* PrimerContainerViewController.swift */,
-				D7515AD62D1A91B1252148977372478C /* PrimerFormViewController.swift */,
-				CA0594C2B00372CB1A08DA90D92A15D8 /* PrimerLoadingViewController.swift */,
-				4F04E0BADD8EF8C80C41A484A9BCEE7C /* PrimerNavigationBar.swift */,
-				935CC0CE0A85C435B8707D9136C80BF7 /* PrimerNavigationController.swift */,
-				83FF29DE64C78302BC3468299755CEA7 /* PrimerRootViewController.swift */,
-				0BD753E15933C2CE97F1B7D38BB8929B /* PrimerUniversalCheckoutViewController.swift */,
-				8564B420BBB9044490D45194A61BC65A /* PrimerVaultManagerViewController.swift */,
+				C6EF93FFFB8659A8ADBE7F35011B2B91 /* CardComponentsManager.swift */,
+				3C071B6E0B01BDE73C6D4DE1527FC8C7 /* PrimerCardholderNameFieldView.swift */,
+				3F908BC1D8441341FE0288F1D0777F5E /* PrimerCardNumberFieldView.swift */,
+				75A097C6298A67F5148DAA64E119C8C6 /* PrimerCVVFieldView.swift */,
+				74425AA3013E87EE7A33C9AC88C886FD /* PrimerExpiryDateFieldView.swift */,
+				C86E5460EABC8B6FDD38D450BDEC0512 /* PrimerNibView.swift */,
+				06E85D9D9B251CB826E2D5F7A6681B53 /* PrimerTextField.swift */,
+				DDF09426091AF05C33FF6E6D802EFF36 /* PrimerTextFieldView.swift */,
+				BE10EC9869350060266B863C4EE488E7 /* PrimerZipCodeFieldView.swift */,
+			);
+			name = "Text Fields";
+			path = "Text Fields";
+			sourceTree = "<group>";
+		};
+		9DE4535425753D2AF17288759E0C5827 /* Success */ = {
+			isa = PBXGroup;
+			children = (
+				16F4D7C582F37746602C089CB85C7EA8 /* SuccessViewController.swift */,
+			);
+			name = Success;
+			path = Success;
+			sourceTree = "<group>";
+		};
+		A9FDC92D44E34DBE62B2C83EAD2A3DB8 /* Root */ = {
+			isa = PBXGroup;
+			children = (
+				6B8A80CF4EBAD186B086E0A959259E92 /* PrimerCardFormViewController.swift */,
+				C2C22BC67900415B28514EC3146A82CF /* PrimerContainerViewController.swift */,
+				2A93DE0AECB42E5A44B54B269F693360 /* PrimerFormViewController.swift */,
+				CEF534F5F5EE5211727397B2CE33A5AC /* PrimerLoadingViewController.swift */,
+				7AEEF130C3F4DA15752F6045F7A87683 /* PrimerNavigationBar.swift */,
+				42B5FE491F26661A194B410657B6B34A /* PrimerNavigationController.swift */,
+				198B7E3042A98B0CA2FA0E877FB22B07 /* PrimerRootViewController.swift */,
+				FF99E2A69A948F79205A3327B8F992CA /* PrimerUniversalCheckoutViewController.swift */,
+				4CA3C755F190F5EAF4410F7A1B417830 /* PrimerVaultManagerViewController.swift */,
 			);
 			name = Root;
 			path = Root;
 			sourceTree = "<group>";
 		};
-		AED1770FC214FF715F71036300B5B1B3 /* Buttons */ = {
+		B725D02D2A4B89C0DE20E1EB9FDE5FFC /* Primer */ = {
 			isa = PBXGroup;
 			children = (
-				8AE4E730C17B5C8A299D14B95209AA74 /* PaymentMethodButtonView.swift */,
+				0B52D3EF0B8517FF366A29433442CDAD /* CardButton.swift */,
+				9D3025D63AF9C04D51A4ED35863C6FE8 /* ExternalViewModel.swift */,
+				D3BBCA45A6833039A8CBE7B8E6D5FE4B /* PaymentMethodComponent.swift */,
 			);
-			name = Buttons;
-			path = Buttons;
+			name = Primer;
+			path = Primer;
 			sourceTree = "<group>";
 		};
 		C2BDB947A59F1824BD6FD9BA76637B43 /* Network */ = {
@@ -937,13 +906,40 @@
 			path = 3DS;
 			sourceTree = "<group>";
 		};
-		C465716C9FB49940D4E5804F243C84AF /* Success */ = {
+		C4790434C44BF350AB419D0270B0BED7 /* TokenizationViewModels */ = {
 			isa = PBXGroup;
 			children = (
-				7395C8587402F73BB2932319D195F6BD /* SuccessViewController.swift */,
+				6809EC1C52439BA3E299A7E6FF91C242 /* ApayaTokenizationViewModel.swift */,
+				16ACFDC91E3D96AAD50A5B53124D1C2F /* ApplePayTokenizationViewModel.swift */,
+				4F31DDA98B2B959AD3611D8841B7DA35 /* ExternalPaymentMethodTokenizationViewModel.swift */,
+				14EA5628923624A46A707B5CB3C4ED5B /* FormTokenizationViewModel.swift */,
+				C864749E7106990A76835AF250AB05BC /* KlarnaTokenizationViewModel.swift */,
+				CC588EC125AB52E793E08BA29AD1A96E /* PaymentMethodTokenizationViewModel.swift */,
+				1A4F88263E51566E031711E398FAF182 /* PayPalTokenizationViewModel.swift */,
 			);
-			name = Success;
-			path = Success;
+			name = TokenizationViewModels;
+			path = TokenizationViewModels;
+			sourceTree = "<group>";
+		};
+		C7DF354F486D8519CB1172C5E4B34A83 /* User Interface */ = {
+			isa = PBXGroup;
+			children = (
+				77B1E602D15549B266623FD0F1A3BC18 /* LoadingViewController.swift */,
+				8AC3BB8D8A9917010EC7D5ED6D4031FF /* PaymentMethodsGroupView.swift */,
+				505E17B78778E90B2805310B399E9368 /* Buttons */,
+				449AE24B96F5F496FC48B0BAC90BDF02 /* Error */,
+				7B2106576FB7A9D37A3240CBE6C2706B /* OAuth */,
+				D7D212063B3085027A0E4284D625492B /* PCI */,
+				B725D02D2A4B89C0DE20E1EB9FDE5FFC /* Primer */,
+				A9FDC92D44E34DBE62B2C83EAD2A3DB8 /* Root */,
+				9DE4535425753D2AF17288759E0C5827 /* Success */,
+				9493A5CA1A21AE89F658C4A37B01E514 /* Text Fields */,
+				C4790434C44BF350AB419D0270B0BED7 /* TokenizationViewModels */,
+				E83080C01B6533BCAAD1F88BA2999ADC /* UI Delegates */,
+				1C0DCE4909C0BCE655CC0CBCDAF6343A /* Vault */,
+			);
+			name = "User Interface";
+			path = "Sources/PrimerSDK/Classes/User Interface";
 			sourceTree = "<group>";
 		};
 		C99317E726DB0D5CA94A6EFE2CA8C63E /* Pods-PrimerSDK_Tests */ = {
@@ -1010,14 +1006,13 @@
 			path = API;
 			sourceTree = "<group>";
 		};
-		D462C300C1D760C93FA52637BD0A58A7 /* CardScanner */ = {
+		D7D212063B3085027A0E4284D625492B /* PCI */ = {
 			isa = PBXGroup;
 			children = (
-				2B29BF9B21F3B3FBCE8F498625225F87 /* CardScannerViewController.swift */,
-				70E8099CCB587C0698B8FABF500CF0EB /* CardScannerViewController+SimpleScanDelegate.swift */,
+				DF000D4C5EA90B71E259C43EAD7842FA /* CardScanner */,
 			);
-			name = CardScanner;
-			path = CardScanner;
+			name = PCI;
+			path = PCI;
 			sourceTree = "<group>";
 		};
 		D82494199A059C99208CDA68B3E49D35 /* Parser */ = {
@@ -1047,6 +1042,16 @@
 			path = "Target Support Files/Pods-PrimerSDK_Example";
 			sourceTree = "<group>";
 		};
+		DF000D4C5EA90B71E259C43EAD7842FA /* CardScanner */ = {
+			isa = PBXGroup;
+			children = (
+				E57C6308EE4CAFE912E2C572582C6227 /* CardScannerViewController.swift */,
+				BC76812909B414D516B3452DF0BA871C /* CardScannerViewController+SimpleScanDelegate.swift */,
+			);
+			name = CardScanner;
+			path = CardScanner;
+			sourceTree = "<group>";
+		};
 		E0C88C672E33FCBB7B24CDB6A36D22A3 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -1063,6 +1068,15 @@
 			path = "Example/Pods/Target Support Files/PrimerSDK";
 			sourceTree = "<group>";
 		};
+		E83080C01B6533BCAAD1F88BA2999ADC /* UI Delegates */ = {
+			isa = PBXGroup;
+			children = (
+				23E3F7FE72F278C500D00B7085856DA9 /* ReloadDelegate.swift */,
+			);
+			name = "UI Delegates";
+			path = "UI Delegates";
+			sourceTree = "<group>";
+		};
 		E8B2650F4C079C1489FA970FB4240184 /* PCI */ = {
 			isa = PBXGroup;
 			children = (
@@ -1071,17 +1085,6 @@
 			);
 			name = PCI;
 			path = PCI;
-			sourceTree = "<group>";
-		};
-		EED8664DC8DE96D2158C53BE9AEA7E57 /* Primer */ = {
-			isa = PBXGroup;
-			children = (
-				5BDCBD510F10476C95077777A5E2CE74 /* CardButton.swift */,
-				5748EE8FF997A16AE7DA3F2B22A84D13 /* ExternalViewModel.swift */,
-				5069325F99CEF220B901E6E9C3F6D303 /* PaymentMethodComponent.swift */,
-			);
-			name = Primer;
-			path = Primer;
 			sourceTree = "<group>";
 		};
 		F832AE03A209936694708628F606646E /* Primer */ = {
@@ -1138,11 +1141,11 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		792E01CCFA9F1449787B5401D712745C /* Headers */ = {
+		707ECF02EE160E950AD5F365790D3200 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FAD25A0F403A0B01BFEA3016C84B98F1 /* PrimerSDK-umbrella.h in Headers */,
+				5F7E2BAA48ACEA97DA146B0F5EA7883B /* PrimerSDK-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1185,7 +1188,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				5EA794910219824D940E80D6FFFEB3A2 /* PBXTargetDependency */,
+				12CA1BF2EFC9DE739AED18753033A3E2 /* PBXTargetDependency */,
 			);
 			name = "Pods-PrimerSDK_Tests";
 			productName = Pods_PrimerSDK_Tests;
@@ -1204,8 +1207,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				62A572B726242063D646FE3F07AD59B0 /* PBXTargetDependency */,
-				728A87570CCEE620F8F5194BA5451A93 /* PBXTargetDependency */,
+				E5D379E1D83066D65EA21433327A0F0C /* PBXTargetDependency */,
+				851771426A02DB874D8E871AA74886C4 /* PBXTargetDependency */,
 			);
 			name = "Pods-PrimerSDK_Example";
 			productName = Pods_PrimerSDK_Example;
@@ -1214,11 +1217,11 @@
 		};
 		6E6525C7043FBA7BB34A249010AF5593 /* PrimerSDK-PrimerResources */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = E2098B3698202F16C9D5E913A83DE867 /* Build configuration list for PBXNativeTarget "PrimerSDK-PrimerResources" */;
+			buildConfigurationList = 52917C9F96BFF045553844198FFE9FDC /* Build configuration list for PBXNativeTarget "PrimerSDK-PrimerResources" */;
 			buildPhases = (
-				7A71D5F4B1D48F386B173A6AE98FEF98 /* Sources */,
-				3E50A307E9F0EEA8DC667720C5B5C4B1 /* Frameworks */,
-				E8161E3F2FE7E3433AF9D4B0F175AA21 /* Resources */,
+				525A2536C7AB23097E70AC3A6EBAE27A /* Sources */,
+				50B54828BF7F066E470CEF1729FF5B41 /* Frameworks */,
+				F46D1231EFB7DE34573DF9CD35FF9767 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -1250,17 +1253,17 @@
 		};
 		F3BE9108C53B53949406218CEA55E0B2 /* PrimerSDK */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 8957AEC5C219D4BF22CCF76E9B204F09 /* Build configuration list for PBXNativeTarget "PrimerSDK" */;
+			buildConfigurationList = 18402F0B7DAD998CDEC84565CC556308 /* Build configuration list for PBXNativeTarget "PrimerSDK" */;
 			buildPhases = (
-				792E01CCFA9F1449787B5401D712745C /* Headers */,
-				BC3E7CFA0DDB0D5039F0EF3F20D94EA7 /* Sources */,
-				BDF3C896569D10C1D503420D98CF73AC /* Frameworks */,
-				EA0B3B6C0398E8B507DAE497C77E8F2C /* Resources */,
+				707ECF02EE160E950AD5F365790D3200 /* Headers */,
+				9188813EE9B708E6C2CE0F44B358E434 /* Sources */,
+				531C92A5A012B5313BA63AC8F08B1B60 /* Frameworks */,
+				D2BA18E849076972DCB36698CB7A3007 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				BBCDBC668C706BCAC835566AA7EC2928 /* PBXTargetDependency */,
+				7552A570584B41308B2BF5EF5CED3428 /* PBXTargetDependency */,
 			);
 			name = PrimerSDK;
 			productName = PrimerSDK;
@@ -1322,23 +1325,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E8161E3F2FE7E3433AF9D4B0F175AA21 /* Resources */ = {
+		D2BA18E849076972DCB36698CB7A3007 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C0158591EA286F3F6D91653545F150B4 /* en.lproj in Resources */,
-				68C674BF46D446021FC140A95F0FF36F /* fr.lproj in Resources */,
-				3F26925521E7BD0A99CE6FCDD9956C2C /* Icons.xcassets in Resources */,
-				8E8C4FC783A015C683F1229093D18151 /* PrimerTextFieldView.xib in Resources */,
-				FAA74ADF06E9E1BA688D352864E0F3E3 /* sv.lproj in Resources */,
+				3BAE97615E0F52BAB4F49028F8573E8D /* PrimerSDK-PrimerResources in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EA0B3B6C0398E8B507DAE497C77E8F2C /* Resources */ = {
+		F46D1231EFB7DE34573DF9CD35FF9767 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1F6EE7D5CD54C7A2A115914DDE085047 /* PrimerSDK-PrimerResources in Resources */,
+				DCD061DA08A71B83A2C464ED1394F109 /* en.lproj in Resources */,
+				503CA6A5FA47C548175AF925667A8373 /* fr.lproj in Resources */,
+				7334A08896EE1C65C31EEB6F05ED17D4 /* Icons.xcassets in Resources */,
+				996CE7BDBC71B0B25030F90A8B9E282E /* PrimerTextFieldView.xib in Resources */,
+				A0A1FE82FA65E8782CE1222B0C0F0573 /* sv.lproj in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1366,6 +1369,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		525A2536C7AB23097E70AC3A6EBAE27A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		657DD73F5C7DB1E89B7A0B1F728C532B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1385,169 +1395,163 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7A71D5F4B1D48F386B173A6AE98FEF98 /* Sources */ = {
+		9188813EE9B708E6C2CE0F44B358E434 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BC3E7CFA0DDB0D5039F0EF3F20D94EA7 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				09BC12039C0955D27F4B31FE9257E8DD /* 3DS.swift in Sources */,
-				6F5B9C8B330CC26FBE2032AFD73B940C /* 3DSService.swift in Sources */,
-				0AA692875A5DEE8DE205EA7970EB0B6D /* 3DSService+Promises.swift in Sources */,
-				8B7154EA2CA9A9FF7E945EDBAF7A19D3 /* after.swift in Sources */,
-				9B87D2DC49137F36641485A879C024D5 /* AlertController.swift in Sources */,
-				40720C985CC67A7ACD806E7D0DB18759 /* AnyCodable.swift in Sources */,
-				9DE14F3248AB4F0DA0F3B2DD00FCF406 /* AnyDecodable.swift in Sources */,
-				E7B406996606B3595C986C9EA86CAB12 /* AnyEncodable.swift in Sources */,
-				7452412BC432FF587E4F8C8FD787DB9A /* Apaya.swift in Sources */,
-				6051DB6F09F6C11203E6057BBAC42F6C /* ApayaTokenizationViewModel.swift in Sources */,
-				9F8BEDF2D9C6D5954613769B01CA8917 /* ApplePay.swift in Sources */,
-				B1878961375A6220019D98478EB4D190 /* ApplePayTokenizationViewModel.swift in Sources */,
-				29E321E05B431D7CA49B4180BCD499CD /* AppState.swift in Sources */,
-				5441B319E3E701830AF466359D42E6CC /* Box.swift in Sources */,
-				52D989A137F422EA246DFECA8349E01E /* BundleExtension.swift in Sources */,
-				4356553496529243AF9C70BAB9649134 /* CancelContext.swift in Sources */,
-				AAFDFCBA03FAB0D3B2CD6F564821E774 /* Cancellable.swift in Sources */,
-				CD25F5398AE303F2C810214F5E745910 /* CancellableCatchable.swift in Sources */,
-				101FCF6D05E8B5F2657A905736EFC46C /* CancellablePromise.swift in Sources */,
-				3782B855831A57DF8B66431555530B8A /* CancellableThenable.swift in Sources */,
-				E288E4675C9CF0C934FD21E3960E7457 /* CardButton.swift in Sources */,
-				46E5E9B184F3F4C1C7169DCA20DF5AE0 /* CardComponentsManager.swift in Sources */,
-				5836B463EBB53695D9AC4F077C2797C6 /* CardNetwork.swift in Sources */,
-				7CB9B6ABD3FB936F31BF1570B904867E /* CardScannerViewController.swift in Sources */,
-				6059AE38AE8CA1C58D64B70D00136113 /* CardScannerViewController+SimpleScanDelegate.swift in Sources */,
-				73991BA06AD041AA9075DB89B913B8F6 /* Catchable.swift in Sources */,
-				D42248567E8B629537F2133860011D7D /* CatchWrappers.swift in Sources */,
-				1841DDD9200DB25CFBE4D1AB48EE8502 /* ClientSession.swift in Sources */,
-				6394E05E41F5507B0D79C5268504A319 /* ClientToken.swift in Sources */,
-				CD2652B5171E26B536415A23D5E5E7FB /* ClientTokenService.swift in Sources */,
-				0EC825450C2311F9BA04D455B615D951 /* ConcurrencyLimitedDispatcher.swift in Sources */,
-				B2BDFC700D104B9F7D7617BF07FAA062 /* Configuration.swift in Sources */,
-				C9E2806E48F9EE31D434F914FF5F21C8 /* Consolable.swift in Sources */,
-				F8882DF81BE923D56BD06F16A85BED91 /* CoreDataDispatcher.swift in Sources */,
-				1224A62614FADDB5952614717A2EF0BE /* CountryCode.swift in Sources */,
-				0A48F149DA2D39F313179F24C1449909 /* Currency.swift in Sources */,
-				C31FADF26050B4F4F31C62997464AA74 /* CustomStringConvertible.swift in Sources */,
-				29BD8F9963F2E40D343357A13BF1E18D /* DateExtension.swift in Sources */,
-				04C129B28FD28CC378551444403AEA72 /* DependencyInjection.swift in Sources */,
-				8C4F87AC1B57290262138A0B8B6C638D /* DirectDebitMandate.swift in Sources */,
-				22C6DAAB4D0919B99266D58739449D4B /* DirectDebitService.swift in Sources */,
-				8E0118C5400B82D64B75ABFA7E161C7F /* Dispatcher.swift in Sources */,
-				457F558CDDF3984219201B1D6CA32AF8 /* Endpoint.swift in Sources */,
-				424FB2619977B0721366BE46C4D42E3D /* EnsureWrappers.swift in Sources */,
-				30A86E0C6F98B1BEB9FF2D1A479292CB /* Error.swift in Sources */,
-				42939A057DC9BFB2D45A3E124A18C131 /* ErrorHandler.swift in Sources */,
-				33211366A4079EF7D2784820A904CCC5 /* ErrorViewController.swift in Sources */,
-				F325B03FD4121E34EC6B9E1BD147FB93 /* ExternalPaymentMethodTokenizationViewModel.swift in Sources */,
-				2DE91E028E4020F01312D4596F76A062 /* ExternalViewModel.swift in Sources */,
-				1C7B53AD3AAB92D437FBEACAFBCB59BA /* FinallyWrappers.swift in Sources */,
-				2945FB8683198733EE30546D090E28E4 /* firstly.swift in Sources */,
-				B6DDFD9E58C9CEA1DDD884A16475473F /* FormTextFieldType.swift in Sources */,
-				361CED62C1CCBA461FA5593FCA389517 /* FormTokenizationViewModel.swift in Sources */,
-				488DACCDDAFEEC0333FC0E1F31181D87 /* FormType.swift in Sources */,
-				290A5DAA1237D4710CCC18C96A6344BC /* Guarantee.swift in Sources */,
-				D42A7B4150F24B1DC071A1340C392F44 /* GuaranteeWrappers.swift in Sources */,
-				33023537B0D302E32E6BA054392CE754 /* hang.swift in Sources */,
-				8D5E08131EE717C7366A26874EA88E57 /* ImageName.swift in Sources */,
-				9CC2B5BD7A84B2B93F2D96197EA38837 /* IntExtension.swift in Sources */,
-				959DC6DC1040920DE1BF84EB3A0FC57A /* JSONParser.swift in Sources */,
-				BFA186AF51CA3DBFCFAFEFC2A105EF20 /* Klarna.swift in Sources */,
-				AE56A0C3B92C692A316EB3006555F20B /* KlarnaTokenizationViewModel.swift in Sources */,
-				B637C83E54841D16491147E20103FCFD /* LoadingViewController.swift in Sources */,
-				39DFCEABE4400E1156511398BAEB290F /* LogEvent.swift in Sources */,
-				17A500A2FA70EAD93038EF1871FC3543 /* Logger.swift in Sources */,
-				9D1A0D728D936CBF3CDC4E29F730798A /* Mask.swift in Sources */,
-				875EA50677DF482547673A5ABA9CBCCB /* NetworkService.swift in Sources */,
-				98D8BCFE7AA29474257F9A87703D72AC /* Optional+Extensions.swift in Sources */,
-				FE923ACA9E398A6B612797B7CCB51679 /* OrderItem.swift in Sources */,
-				6EE8E9B856BA36F45435EE3DCF518323 /* Parser.swift in Sources */,
-				5ADC01E868C5967C582B93D93DFE3BB9 /* PaymentMethodButtonView.swift in Sources */,
-				8F6466A5E82BE2DDE393D7DE1ED9F27F /* PaymentMethodComponent.swift in Sources */,
-				3D91A7E508B8C0CFED54D9046C014214 /* PaymentMethodConfig.swift in Sources */,
-				0A20B73A5A2FF134F199559886BF42BF /* PaymentMethodConfigService.swift in Sources */,
-				12028E2AE5738803640802F52A042E79 /* PaymentMethodsGroupView.swift in Sources */,
-				10D799E03336B9754E36DCF1EAE2846B /* PaymentMethodToken.swift in Sources */,
-				3F007C2AB779B101CDD4F738C903C2B7 /* PaymentMethodTokenizationRequest.swift in Sources */,
-				12C3BF6E9DC78EE22A5A69E29AE26F50 /* PaymentMethodTokenizationViewModel.swift in Sources */,
-				DEBFFC54578E55382750A7BE315FF694 /* PaymentMethodViewModel.swift in Sources */,
-				AC5ED17493592194AA1C06ABB4F42B88 /* PaymentResponse.swift in Sources */,
-				5BEF19BBB9CBC2E0ACF2762C03271EEB /* PayPal.swift in Sources */,
-				B70F64434A227E1104206897DFA81FAA /* PayPalService.swift in Sources */,
-				38CA194F74C68B942BEB8B66C0A9F627 /* PayPalTokenizationViewModel.swift in Sources */,
-				B551DA2FDA1B8157597224A60C9226FF /* PresentationController.swift in Sources */,
-				011B9C56E2C170286CDA60A359985118 /* Primer.swift in Sources */,
-				2E17FDB9F27416F48AC9FBD8794236BA /* PrimerAPI.swift in Sources */,
-				A8E82015955E1730E1E8B53657F17E83 /* PrimerAPIClient.swift in Sources */,
-				A0F8233F03B1261C8B22AE11371FD68B /* PrimerAPIClient+3DS.swift in Sources */,
-				84A1C2B1CA9C3A96DB1DF1B8E03982C3 /* PrimerAPIClient+Promises.swift in Sources */,
-				812906F0629730B3497D5A38C4BF29E3 /* PrimerButton.swift in Sources */,
-				3C9D8C384F2A82621414A673AAEDEF29 /* PrimerCardFormViewController.swift in Sources */,
-				E5830B5F2E9A1DCA6B3A7C469A5F1A97 /* PrimerCardholderNameFieldView.swift in Sources */,
-				DC1F24BBE411BAF40EA0BDF856C23C06 /* PrimerCardNumberFieldView.swift in Sources */,
-				142E6E8004D14092A5275A77C07AE3FF /* PrimerContainerViewController.swift in Sources */,
-				F11AEADC3E70D7329A3DB4964E0103A8 /* PrimerContent.swift in Sources */,
-				5F53AD3A36113AE9F09BCB49AA87C5FB /* PrimerCustomStyleTextField.swift in Sources */,
-				62FBF250B2F3AC665D10435EA8C572FD /* PrimerCVVFieldView.swift in Sources */,
-				91C3ACC467F941B4BAFA96FA9B77B33E /* PrimerDelegate.swift in Sources */,
-				8EB0595516275DC4A11B72F66F110FA5 /* PrimerError.swift in Sources */,
-				A9C94DE87EB38FE644E61408779BF472 /* PrimerExpiryDateFieldView.swift in Sources */,
-				64A669287417775F48192B8D0F2E4782 /* PrimerFlowEnums.swift in Sources */,
-				F7E5DC5010061740EF773E046E3255AA /* PrimerFormViewController.swift in Sources */,
-				37B57C4A5926C57E3807A90A40593409 /* PrimerImage.swift in Sources */,
-				CDA98F87605CDF30DD226EE070A0F7BE /* PrimerLoadingViewController.swift in Sources */,
-				96B1EF8E4B55C77293D44F9C0E3AAE70 /* PrimerNavigationBar.swift in Sources */,
-				4059E8C8312480FC1D3D88692060EF8C /* PrimerNavigationController.swift in Sources */,
-				C6A0C501DB038DC66540E6C5AF3592A9 /* PrimerNibView.swift in Sources */,
-				2DC970C58D4CD60A1A0DC1981AD68312 /* PrimerRootViewController.swift in Sources */,
-				EC8E1AA2BC11D8242E336751FA552B66 /* PrimerScrollView.swift in Sources */,
-				846276AA0DA16A81F5F970E1B96B2BC5 /* PrimerSDK-dummy.m in Sources */,
-				F3154903F96DF47858C79BD6A1A753DD /* PrimerSettings.swift in Sources */,
-				7241C56DF8838EFB88FDEF48717465DC /* PrimerTableViewCell.swift in Sources */,
-				039EF8CC0B0F5FE4A90E4514518BFBF1 /* PrimerTextField.swift in Sources */,
-				FFA1F481CA80E630CB539489CAAFE3CB /* PrimerTextFieldView.swift in Sources */,
-				A0F05E2E3C5ECBBD1120B40F3B1DA9E4 /* PrimerTheme.swift in Sources */,
-				E3F880D31FDD2C8C4CAF018AAB7C437F /* PrimerUniversalCheckoutViewController.swift in Sources */,
-				FFAE8356946C693178D9F73A323CF952 /* PrimerVaultManagerViewController.swift in Sources */,
-				831FB8E8EE501EFA4F3CF78213163825 /* PrimerViewController.swift in Sources */,
-				1FBB53231DC039B401DE5DAA5141EAA0 /* PrimerViewExtensions.swift in Sources */,
-				9E46CD7C67C81E9858D0B5898086D998 /* PrimerWebViewController.swift in Sources */,
-				B6A246CEB9C0C2670A69A1866F31BA51 /* Promise.swift in Sources */,
-				1864470E47D66952043701619ABCF4FA /* Queue.swift in Sources */,
-				3F0977C10DB743282A251C4AF323F893 /* race.swift in Sources */,
-				F861FD50102DDF42B268BAE7B0A2536E /* RateLimitedDispatcher.swift in Sources */,
-				EBFA88DE2A7E9ECAAF35E4EE244A69D2 /* RateLimitedDispatcherBase.swift in Sources */,
-				3D2840B996E8C7A627A425BCA3FBF17D /* RecoverWrappers.swift in Sources */,
-				D431FE112CCC540B66EB7B815F66EE65 /* ReloadDelegate.swift in Sources */,
-				BF7337170D48230EB99CAB422E22070A /* Resolver.swift in Sources */,
-				260A5AA0236B7D797930DCD54943B7C4 /* ResumeHandlerProtocol.swift in Sources */,
-				6BA3FA87B3D3F64DD440AB57CC490183 /* SequenceWrappers.swift in Sources */,
-				61B4E5EE07E73BC8AE7E7084018D289F /* StrictRateLimitedDispatcher.swift in Sources */,
-				3600F3AC13EACBE1260F02E23645D67C /* StringExtension.swift in Sources */,
-				A59060FF0ACFD87481CB7CA2ACDAC0FE /* SuccessMessage.swift in Sources */,
-				457EC5EC374D5A3B278124DAA9FA5671 /* SuccessViewController.swift in Sources */,
-				B78D6750E0D3DDC7CD04384BE69619BE /* Thenable.swift in Sources */,
-				D6800284DFAF663EEEF6E90273723299 /* ThenableWrappers.swift in Sources */,
-				31298E6601328B981850047B623BD097 /* TokenizationService.swift in Sources */,
-				3347A98D25817D1E3961D731DD5928EC /* UIColorExtension.swift in Sources */,
-				DB08D54D6A89083F954CA468DE1F6B25 /* UIDeviceExtension.swift in Sources */,
-				C052058A9F03C96948A79FFC8491EFED /* URLExtension.swift in Sources */,
-				92B8BD60D26C82AFEB46758E24AD4CD2 /* URLSessionStack.swift in Sources */,
-				037ACDD580F6E3820ABDCF3F384415D0 /* UserDefaultsExtension.swift in Sources */,
-				86041156CD76B6123B7CA08B1279F414 /* UXMode.swift in Sources */,
-				51813EC291EC81E4B4404B1B6DBD3EE9 /* Validation.swift in Sources */,
-				EFE0FEDAC2CF0FFF0E68C904F95D0A22 /* VaultCheckoutViewModel.swift in Sources */,
-				2C97137DAE3B39C8A9092EB9FD3B79A7 /* VaultPaymentMethodView.swift in Sources */,
-				37F38EBC188F894B631744AB6F5E16F0 /* VaultPaymentMethodViewController.swift in Sources */,
-				1505375C9D0E886D42155973709F7AA7 /* VaultPaymentMethodViewModel.swift in Sources */,
-				47424648AE121382D7D27A314E4D96C9 /* VaultService.swift in Sources */,
-				D955CB3850172875BFC37B85100F16EC /* WebViewUtil.swift in Sources */,
-				228155869AA955071F83193C3C8EB384 /* when.swift in Sources */,
-				7D543893C78B96F875E57239A1873AD2 /* WrapperProtocols.swift in Sources */,
+				8C47BFF8ADA6CA1A00257C0950423D06 /* 3DS.swift in Sources */,
+				912A40B2B7BE1C91BBBCD94A40A90572 /* 3DSService.swift in Sources */,
+				B5905161A4FEEFDEAD175D8C7D6781AF /* 3DSService+Promises.swift in Sources */,
+				7F0A41166A5461F766A2C72D450284F8 /* after.swift in Sources */,
+				7EB18A3C80F5A4AB171DE1BDC7336819 /* AlertController.swift in Sources */,
+				7870E8FA3D394F2CD44CD703499E5ACD /* AnyCodable.swift in Sources */,
+				B2698C9423108BA962FEC93D21D35EA2 /* AnyDecodable.swift in Sources */,
+				2A4458201DFAFEE9F11724B3878080A0 /* AnyEncodable.swift in Sources */,
+				8E8CA1441847AB9536AB71C661075E19 /* Apaya.swift in Sources */,
+				DBB81075AACFAD6B26B7F0382A0102BD /* ApayaTokenizationViewModel.swift in Sources */,
+				D7FA258B32DB223A8F6CE53EF0C1FA03 /* ApplePay.swift in Sources */,
+				B284F619C85357CA9625F9471D9C510D /* ApplePayTokenizationViewModel.swift in Sources */,
+				D546F64774DA94F21E6E3F411575E29B /* AppState.swift in Sources */,
+				BEEC1D66B08994414B9FD7CBF18A3A04 /* Box.swift in Sources */,
+				0580B985B940F5A73952CC8F58A42125 /* BundleExtension.swift in Sources */,
+				7BD02D494CF241D75EC68DD2589830E2 /* CancelContext.swift in Sources */,
+				7020DD2A0FBFD59FE70381BF48DB1EFC /* Cancellable.swift in Sources */,
+				8102283EF88928829CDB2AB211C1AE06 /* CancellableCatchable.swift in Sources */,
+				4D42B127EE2BAD0CC1AC123BB8D42801 /* CancellablePromise.swift in Sources */,
+				87BF1554B55CF61306951365597C3016 /* CancellableThenable.swift in Sources */,
+				56D0A8374C2B675E00931A1F5B1C397C /* CardButton.swift in Sources */,
+				9A0AA7D04037C99B66F86834390E919C /* CardComponentsManager.swift in Sources */,
+				B97B6CFD6D8F110A31662EA276C98C19 /* CardNetwork.swift in Sources */,
+				6E702BC623F1652F77B2E939679D8394 /* CardScannerViewController.swift in Sources */,
+				E3CD5DBDD9C87FAABED3B6920DEF452B /* CardScannerViewController+SimpleScanDelegate.swift in Sources */,
+				3C0EB77E1D503D218AFB868B816DE9D8 /* Catchable.swift in Sources */,
+				8B88BD22EF051F5CF68ED364579369E6 /* CatchWrappers.swift in Sources */,
+				F08C3B642FFF8FBBAB5A059115D84A83 /* ClientSession.swift in Sources */,
+				184FD965FB5E9882DF3F421BBBA3F47F /* ClientToken.swift in Sources */,
+				FBBEAE5BA89C66DFBFEED5740C9D0842 /* ClientTokenService.swift in Sources */,
+				E613FC9A2EA66256790AC7BB96C42588 /* ConcurrencyLimitedDispatcher.swift in Sources */,
+				01E2AE456438A5724A23AFAA8F4C3594 /* Configuration.swift in Sources */,
+				F186F689EEDAC0A64EA4F78796C8A163 /* Consolable.swift in Sources */,
+				C182ED9335AE4629B2937F696C74C356 /* CoreDataDispatcher.swift in Sources */,
+				C8F60750179E56BD090F83ABBDAB88F8 /* CountryCode.swift in Sources */,
+				D1718D7B29D0275DE2818DD6CF9F6530 /* Currency.swift in Sources */,
+				95C80CAB9D9A4C135A26A9263FAC61E6 /* CustomStringConvertible.swift in Sources */,
+				1F8CC1ADB9C3BC7EC40875B805936F36 /* DateExtension.swift in Sources */,
+				F1F4DA5E95ADD32DE6C5F0D13612B9B5 /* DependencyInjection.swift in Sources */,
+				8C9E6578A403411DCBB4B1C1BD934804 /* DirectDebitMandate.swift in Sources */,
+				B98CCFD70CACA44A82F533EB3E2A7463 /* DirectDebitService.swift in Sources */,
+				B184DC52361EF63F41653A3498FA32D3 /* Dispatcher.swift in Sources */,
+				9071B04A36BFB8ECA4548BA6A5E49BB1 /* Endpoint.swift in Sources */,
+				F2FC1D70BC8F392067DCC245FB586473 /* EnsureWrappers.swift in Sources */,
+				7D0CF3AA55BF5D9370AE30FFD304A065 /* Error.swift in Sources */,
+				BA0A68ACAF12F87B1396794600F75CB3 /* ErrorHandler.swift in Sources */,
+				00E16B30C4EAA4EF0436DDD03AB0D4AC /* ErrorViewController.swift in Sources */,
+				B1CF5AE484E18B74829370EC27EE632B /* ExternalPaymentMethodTokenizationViewModel.swift in Sources */,
+				C9637DB4E5DC81FBBCDF3B7B17BAF3C4 /* ExternalViewModel.swift in Sources */,
+				0A287515AD7D0CA932FEEFF6A090FE74 /* FinallyWrappers.swift in Sources */,
+				005F380B401552DCCA59C9B1BF78E918 /* firstly.swift in Sources */,
+				88659DBDCCD8BE6565FB6B69C2000444 /* FormTextFieldType.swift in Sources */,
+				EF353CFB4EBD1B81EAB763628C539CB1 /* FormTokenizationViewModel.swift in Sources */,
+				515843580CA5FF6BF1688FC60101D88B /* FormType.swift in Sources */,
+				9D5F2F39147499BAE9CF44915A0DC4E7 /* Guarantee.swift in Sources */,
+				5EB92EE3752048B2A61E69F1804B17E5 /* GuaranteeWrappers.swift in Sources */,
+				10C739FBB7825EC498B960BA0168FB4A /* hang.swift in Sources */,
+				8DDC93443292B833FAA506472F8387E5 /* ImageName.swift in Sources */,
+				5DEEC4A7B67F0E026B69AAD734C8D4C2 /* IntExtension.swift in Sources */,
+				EA6537C8D791AA54F869570A0BC93028 /* JSONParser.swift in Sources */,
+				AC45AEDCD4FB368BBFB74B4BB4359DD6 /* Klarna.swift in Sources */,
+				59F690432733CB82706CA7C7FF3E4CB2 /* KlarnaTokenizationViewModel.swift in Sources */,
+				5E92A916800C8A1EA03B1F1E5E9D7171 /* LoadingViewController.swift in Sources */,
+				E58D3747D2851888D26E56F2D539AFEF /* LogEvent.swift in Sources */,
+				2FB90D9EF50337B634ED37E001E50FF2 /* Logger.swift in Sources */,
+				3433E20CCF58C2F3F89F19A087BD47BA /* Mask.swift in Sources */,
+				C32834B0893273CCAEF01062FF790FF6 /* NetworkService.swift in Sources */,
+				0D022249DBFFAB19243F929E9EC5ACC0 /* Optional+Extensions.swift in Sources */,
+				E33F7FDCB55E6B2AAE0201E5A313995C /* OrderItem.swift in Sources */,
+				EC62159BDCCF66B5450CC8B00A412A03 /* Parser.swift in Sources */,
+				0C40424E09182F42A58BF014628195A3 /* PaymentMethodButtonView.swift in Sources */,
+				3FAD8B6C5616F93ECF2C1ABAA2D795BB /* PaymentMethodComponent.swift in Sources */,
+				80529FB71592A3929D1D0FEA16524049 /* PaymentMethodConfig.swift in Sources */,
+				22B103FA92EE14C294A19B5ED251399C /* PaymentMethodConfigService.swift in Sources */,
+				B78BAE03C6DBDC86617A84D11E6F577E /* PaymentMethodsGroupView.swift in Sources */,
+				37DEDD5BC1F41B62D21AC6B3B85B9174 /* PaymentMethodToken.swift in Sources */,
+				74343DE46954355266974A78BB0D42E3 /* PaymentMethodTokenizationRequest.swift in Sources */,
+				6739CFD691C095B93D0833142035061D /* PaymentMethodTokenizationViewModel.swift in Sources */,
+				87AA643FF56DA176E0617AF2D65AB697 /* PaymentMethodViewModel.swift in Sources */,
+				0EAF41B77AA4645C867488B13FA729C1 /* PaymentResponse.swift in Sources */,
+				0A0176FAAC042018F9E30F028516C807 /* PayPal.swift in Sources */,
+				4153C357A728C5261CBB5FA2E075FA07 /* PayPalService.swift in Sources */,
+				40A727508C9329EBF19EA6B9504C65DD /* PayPalTokenizationViewModel.swift in Sources */,
+				AEA44F49836330ABDDB634544E42CE94 /* PresentationController.swift in Sources */,
+				A1D378CB13BF7C4B433434EFC67B6B29 /* Primer.swift in Sources */,
+				BE3A06136D553F53A85BDA364E6330A6 /* PrimerAPI.swift in Sources */,
+				11BC7BEA4BF609BCDAC859A6B03F05DA /* PrimerAPIClient.swift in Sources */,
+				9F4E90F05027793C9A2410DF28304DAF /* PrimerAPIClient+3DS.swift in Sources */,
+				203A56A4FAAACA5B632D2CD9FC79A068 /* PrimerAPIClient+Promises.swift in Sources */,
+				4939C44E7AF08537C4E737C0EDC865C1 /* PrimerButton.swift in Sources */,
+				B575FF6D07BFD673A42549BA40528EB7 /* PrimerCardFormViewController.swift in Sources */,
+				505E7F807EACDE59CEDAD906FF47D3EA /* PrimerCardholderNameFieldView.swift in Sources */,
+				BBA9B26831C3A272E7FA45704379A936 /* PrimerCardNumberFieldView.swift in Sources */,
+				356D2D89002EC6FEF4F59D0E613EBCE1 /* PrimerContainerViewController.swift in Sources */,
+				68AD671ECDA79D29A2BA115777A468AB /* PrimerContent.swift in Sources */,
+				81B54BD70607F71978CB0F67953D2FA7 /* PrimerCustomStyleTextField.swift in Sources */,
+				8C7573AC54DA4F4585341FEB30F2B705 /* PrimerCVVFieldView.swift in Sources */,
+				A5CE2ED92EF701C7494C5ED789490FEA /* PrimerDelegate.swift in Sources */,
+				963C6EB4E8A8AC6247C5078E415364BD /* PrimerError.swift in Sources */,
+				E972C7D6DA897B3A82595591B49F76F2 /* PrimerExpiryDateFieldView.swift in Sources */,
+				EEAFFC2EF5CEEB5DDEAC101D97D0536A /* PrimerFlowEnums.swift in Sources */,
+				67F1693ADA96F86B1A62BD0F7FF48D95 /* PrimerFormViewController.swift in Sources */,
+				F13EF926323254BB3034050FA10AA992 /* PrimerImage.swift in Sources */,
+				B4C7982CBD8C7ED8E0F1BDD52555FC44 /* PrimerLoadingViewController.swift in Sources */,
+				21AA497F11A97EF5BCA2CA3AD33BFE92 /* PrimerNavigationBar.swift in Sources */,
+				4AD3AEFA88A2BF21BBD0F52D85BD880E /* PrimerNavigationController.swift in Sources */,
+				DBD817D57E7F7D07FEC64FC150B094CC /* PrimerNibView.swift in Sources */,
+				4BC74C659A9953340578F3BCEBD35795 /* PrimerRootViewController.swift in Sources */,
+				7F0890A4664937B8A832B10C3C9E2C6F /* PrimerScrollView.swift in Sources */,
+				3725FD22EDC476C48ED35C314D4B6BB1 /* PrimerSDK-dummy.m in Sources */,
+				6EA16A531E40087B85541D3E1375C86F /* PrimerSettings.swift in Sources */,
+				F94EDC5FE0B1111E6D3A7DF5B877FF48 /* PrimerTableViewCell.swift in Sources */,
+				8EC2B0F5851EABB7A56180CD500D7561 /* PrimerTextField.swift in Sources */,
+				8D68E66B4FF25E8E7CFDF124D9BD2CEA /* PrimerTextFieldView.swift in Sources */,
+				707001A87C41031F7EF6E80E71459AE5 /* PrimerTheme.swift in Sources */,
+				BCCFCF52ED1B99FD72C74120FC2B6421 /* PrimerUniversalCheckoutViewController.swift in Sources */,
+				84694E32195490902C4EC61A9053DA5F /* PrimerVaultManagerViewController.swift in Sources */,
+				11976F99565D6A7DED50219DC7A2A332 /* PrimerViewController.swift in Sources */,
+				3B1E9C482666076DE8BA552B8E250377 /* PrimerViewExtensions.swift in Sources */,
+				FB9D7785457432AF2B979FCDEF9695F2 /* PrimerWebViewController.swift in Sources */,
+				04D52BC2193D64F60BA5F7799FA33DB7 /* PrimerZipCodeFieldView.swift in Sources */,
+				78D9BE7643529BF77112B1758BF6D9A9 /* Promise.swift in Sources */,
+				56EF118161AE123A5DCF984A203ECB28 /* Queue.swift in Sources */,
+				18A3B6D1DBEDDA807FF2C1450C6FAFD0 /* race.swift in Sources */,
+				D220050236DF9975F140A136512F8F61 /* RateLimitedDispatcher.swift in Sources */,
+				3E2426C09EDD89907994CBFDFCD0F0AB /* RateLimitedDispatcherBase.swift in Sources */,
+				56328633A51ED11BBF55CA8A14830B52 /* RecoverWrappers.swift in Sources */,
+				A6BE38323F29503A754E36876D6AD0D0 /* ReloadDelegate.swift in Sources */,
+				4C9A9471D6AAF43B0163B5205F13B50C /* Resolver.swift in Sources */,
+				55920F3DB2A43F24AFE758F28DCC89B0 /* ResumeHandlerProtocol.swift in Sources */,
+				590FD6829606886B3A4147DDB594741C /* SequenceWrappers.swift in Sources */,
+				16F8B1E92EF2D9676811FB597D12C283 /* StrictRateLimitedDispatcher.swift in Sources */,
+				552B92FD21BCC1D9BDEBD6A5D9E982CA /* StringExtension.swift in Sources */,
+				430AB5BAE58A0440D664591F14841775 /* SuccessMessage.swift in Sources */,
+				E9AD69473F16FB9994C0C5BDC5960F6B /* SuccessViewController.swift in Sources */,
+				75D3E3B59D03610F50BDA05141030A6A /* Thenable.swift in Sources */,
+				AB05C497ABF788803FC4F35081675EA5 /* ThenableWrappers.swift in Sources */,
+				D9D9FAEEFDA4E394C637765FAED0285C /* TokenizationService.swift in Sources */,
+				7D41385B61AD87EC0E9AECDB14AC8244 /* UIColorExtension.swift in Sources */,
+				5A12C6F6EB0A89387296E5D6D9D0A8A5 /* UIDeviceExtension.swift in Sources */,
+				1F55B0E44700F89E670BCDC7C1B873E1 /* URLExtension.swift in Sources */,
+				57022B8ABE290F956F030B55CEDD3C2D /* URLSessionStack.swift in Sources */,
+				33691FCAE1F0CE6AD51D8CF7219AC219 /* UserDefaultsExtension.swift in Sources */,
+				3DC29307D45FE28E4165BC5F42C718DD /* UXMode.swift in Sources */,
+				7D2E668F19FD4CD9DE14AC44F3DEF4D7 /* Validation.swift in Sources */,
+				BDB12E3F6F38B5095AFE2AB500668497 /* VaultCheckoutViewModel.swift in Sources */,
+				428AE8F6F5A1C56875D18DA1B438632B /* VaultPaymentMethodView.swift in Sources */,
+				1C674551BE75EB023BD1686C4D1A03A3 /* VaultPaymentMethodViewController.swift in Sources */,
+				E03C9862065B5EDF6CC9D10C49C70C50 /* VaultPaymentMethodViewModel.swift in Sources */,
+				DB4856876537DB89E9CF821E9BFF949C /* VaultService.swift in Sources */,
+				CD498BED075E02D79B53920A781D28DE /* WebViewUtil.swift in Sources */,
+				F3F6C3E02ECBDAB98EBF5DE596275D03 /* when.swift in Sources */,
+				726B41AD03E38B51EE6AF8FCF1997FD9 /* WrapperProtocols.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1562,29 +1566,29 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		5EA794910219824D940E80D6FFFEB3A2 /* PBXTargetDependency */ = {
+		12CA1BF2EFC9DE739AED18753033A3E2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-PrimerSDK_Example";
 			target = 6C144A762E9B598392AFFEC8F873746A /* Pods-PrimerSDK_Example */;
-			targetProxy = 259998575A76C054286417DC81CC473E /* PBXContainerItemProxy */;
+			targetProxy = F4DF06DB694F548A9D63E84355BE7CFA /* PBXContainerItemProxy */;
 		};
-		62A572B726242063D646FE3F07AD59B0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Primer3DS;
-			target = 6F5F0A81CAE773CFE5371059A81B5B6A /* Primer3DS */;
-			targetProxy = 3575ABC5AB88595F2BB694DE7023E0BB /* PBXContainerItemProxy */;
-		};
-		728A87570CCEE620F8F5194BA5451A93 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PrimerSDK;
-			target = F3BE9108C53B53949406218CEA55E0B2 /* PrimerSDK */;
-			targetProxy = 259CB00C50CFEB4135D2297C73F31C0D /* PBXContainerItemProxy */;
-		};
-		BBCDBC668C706BCAC835566AA7EC2928 /* PBXTargetDependency */ = {
+		7552A570584B41308B2BF5EF5CED3428 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "PrimerSDK-PrimerResources";
 			target = 6E6525C7043FBA7BB34A249010AF5593 /* PrimerSDK-PrimerResources */;
-			targetProxy = A3C97C74AE4B0B5629C31FA17A9254F6 /* PBXContainerItemProxy */;
+			targetProxy = BEC14992AB391075E76E7EC74BFCA2F2 /* PBXContainerItemProxy */;
+		};
+		851771426A02DB874D8E871AA74886C4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PrimerSDK;
+			target = F3BE9108C53B53949406218CEA55E0B2 /* PrimerSDK */;
+			targetProxy = 52C5067C56A4F6B9F335815AC526DEFF /* PBXContainerItemProxy */;
+		};
+		E5D379E1D83066D65EA21433327A0F0C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Primer3DS;
+			target = 6F5F0A81CAE773CFE5371059A81B5B6A /* Primer3DS */;
+			targetProxy = 0702CFC25B82340476045A41D5266396 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1622,9 +1626,9 @@
 			};
 			name = Debug;
 		};
-		268A14F4C66C99179D06DDCC3433C2AC /* Release */ = {
+		3F1078CC7C6031B40FE9FD12B6067A74 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6D615C192F3ED0841230C2EDE0FFEC28 /* PrimerSDK.release.xcconfig */;
+			baseConfigurationReference = 0677C6E9834BB4B812F956E42A88E8F3 /* PrimerSDK.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -1648,27 +1652,10 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
-		};
-		4545D8CA1F0E5197CAC49E15AED0FCA7 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6D615C192F3ED0841230C2EDE0FFEC28 /* PrimerSDK.release.xcconfig */;
-			buildSettings = {
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/PrimerSDK";
-				IBSC_MODULE = PrimerSDK;
-				INFOPLIST_FILE = "Target Support Files/PrimerSDK/ResourceBundle-PrimerResources-PrimerSDK-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = PrimerResources;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Release;
+			name = Debug;
 		};
 		4E687C4A86CAA9AEFEB474630D7B5288 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -1702,9 +1689,9 @@
 			};
 			name = Release;
 		};
-		74EDC340ADC91D8359721F32FC495396 /* Debug */ = {
+		63E838D14EBA68BFCB0A0A9B4F6755CC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0677C6E9834BB4B812F956E42A88E8F3 /* PrimerSDK.debug.xcconfig */;
+			baseConfigurationReference = 6D615C192F3ED0841230C2EDE0FFEC28 /* PrimerSDK.release.xcconfig */;
 			buildSettings = {
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/PrimerSDK";
 				IBSC_MODULE = PrimerSDK;
@@ -1716,7 +1703,39 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = bundle;
 			};
-			name = Debug;
+			name = Release;
+		};
+		73F02D1481A891DB0BF089019473FAF8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6D615C192F3ED0841230C2EDE0FFEC28 /* PrimerSDK.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/PrimerSDK/PrimerSDK-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PrimerSDK/PrimerSDK-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/PrimerSDK/PrimerSDK.modulemap";
+				PRODUCT_MODULE_NAME = PrimerSDK;
+				PRODUCT_NAME = PrimerSDK;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
 		};
 		7EE7A78859F657F6BEFC651185B43192 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -1847,6 +1866,22 @@
 			};
 			name = Debug;
 		};
+		994DC434BEB45B6D50ABD5B409A3AF20 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0677C6E9834BB4B812F956E42A88E8F3 /* PrimerSDK.debug.xcconfig */;
+			buildSettings = {
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/PrimerSDK";
+				IBSC_MODULE = PrimerSDK;
+				INFOPLIST_FILE = "Target Support Files/PrimerSDK/ResourceBundle-PrimerResources-PrimerSDK-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				PRODUCT_NAME = PrimerResources;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
 		AFEA03A91650290E443E2FD0FB7850F7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E884507DF2B84FA8A2E8AD8289881542 /* Pods-PrimerSDK_Example.release.xcconfig */;
@@ -1880,37 +1915,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
-		};
-		D235275A15F11B3A89E9BF0340055B3B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0677C6E9834BB4B812F956E42A88E8F3 /* PrimerSDK.debug.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/PrimerSDK/PrimerSDK-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PrimerSDK/PrimerSDK-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/PrimerSDK/PrimerSDK.modulemap";
-				PRODUCT_MODULE_NAME = PrimerSDK;
-				PRODUCT_NAME = PrimerSDK;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
 		};
 		D299434AB35E7FD6F7921C8EF24742FF /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2012,6 +2016,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		18402F0B7DAD998CDEC84565CC556308 /* Build configuration list for PBXNativeTarget "PrimerSDK" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3F1078CC7C6031B40FE9FD12B6067A74 /* Debug */,
+				73F02D1481A891DB0BF089019473FAF8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2021,20 +2034,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		52917C9F96BFF045553844198FFE9FDC /* Build configuration list for PBXNativeTarget "PrimerSDK-PrimerResources" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				994DC434BEB45B6D50ABD5B409A3AF20 /* Debug */,
+				63E838D14EBA68BFCB0A0A9B4F6755CC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		6004DC48EAFFC21734C2180D1DDDFCC5 /* Build configuration list for PBXNativeTarget "Primer3DS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				E41365A7221C88C2F388DCB1E55286A7 /* Debug */,
 				4E687C4A86CAA9AEFEB474630D7B5288 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8957AEC5C219D4BF22CCF76E9B204F09 /* Build configuration list for PBXNativeTarget "PrimerSDK" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D235275A15F11B3A89E9BF0340055B3B /* Debug */,
-				268A14F4C66C99179D06DDCC3433C2AC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -2053,15 +2066,6 @@
 			buildConfigurations = (
 				05B9E071CFCA1E8A62F14905A80EE6EF /* Debug */,
 				80F45997CD1F5DAB4F3B62FA0301BC70 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		E2098B3698202F16C9D5E913A83DE867 /* Build configuration list for PBXNativeTarget "PrimerSDK-PrimerResources" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				74EDC340ADC91D8359721F32FC495396 /* Debug */,
-				4545D8CA1F0E5197CAC49E15AED0FCA7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/PrimerSDK.xcodeproj/project.pbxproj
+++ b/Example/PrimerSDK.xcodeproj/project.pbxproj
@@ -44,8 +44,8 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
-		BF35CB0122D7571B6167BE74 /* Pods_PrimerSDK_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AC2B5A1BE99679BEF2442429 /* Pods_PrimerSDK_Example.framework */; };
-		E73BE4C7AABFD86BCE2C77E9 /* Pods_PrimerSDK_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AED8E5B1A3836C42416189F1 /* Pods_PrimerSDK_Tests.framework */; };
+		7EE85B0BA7C92DC04C7EA4C5 /* Pods_PrimerSDK_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 230AED131BB79CE6CA9EB05D /* Pods_PrimerSDK_Example.framework */; };
+		FA7A6FA0E893B746B631F273 /* Pods_PrimerSDK_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5903211547877C65257C1F52 /* Pods_PrimerSDK_Tests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,7 +66,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		03ADFE2D4FCF3A920E197658 /* Pods-PrimerSDK_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Tests.debug.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Tests/Pods-PrimerSDK_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		0BEFFA023E994EF5B370A80C /* PrimerSDK.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = PrimerSDK.podspec; path = ../PrimerSDK.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		151B09F4267B7F9400FB49B8 /* 3DSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 3DSTests.swift; sourceTree = "<group>"; };
 		151B0A1B267CE24B00FB49B8 /* 3DSConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 3DSConstants.swift; sourceTree = "<group>"; };
@@ -119,8 +118,11 @@
 		1DC7EE0B261FA39200BCBFFC /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		1DC7EE13261FA3D400BCBFFC /* CreateClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateClientToken.swift; sourceTree = "<group>"; };
 		1DEBE0DE26B6FD06004E3064 /* ApayaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApayaTests.swift; sourceTree = "<group>"; };
+		230AED131BB79CE6CA9EB05D /* Pods_PrimerSDK_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrimerSDK_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B55FBF1D40BE6B25F29A5D9 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		42F5EEFEBB58DEBB1800AA22 /* Pods-PrimerSDK_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Example.release.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example.release.xcconfig"; sourceTree = "<group>"; };
 		45CA532A34F52954A21835C5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		5903211547877C65257C1F52 /* Pods_PrimerSDK_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrimerSDK_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD01AFB9204008FA782 /* PrimerSDK_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PrimerSDK_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACD51AFB9204008FA782 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -128,11 +130,9 @@
 		607FACDC1AFB9204008FA782 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		607FACE51AFB9204008FA782 /* PrimerSDK_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrimerSDK_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		78A1FA21A3A6EB479233D1B2 /* Pods-PrimerSDK_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Example.release.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example.release.xcconfig"; sourceTree = "<group>"; };
-		931BD8D1DE1FE9F011AEE24B /* Pods-PrimerSDK_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Example.debug.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		9D117F31D6CF410A5E8D53FC /* Pods-PrimerSDK_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Tests.release.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Tests/Pods-PrimerSDK_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		AC2B5A1BE99679BEF2442429 /* Pods_PrimerSDK_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrimerSDK_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AED8E5B1A3836C42416189F1 /* Pods_PrimerSDK_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrimerSDK_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		64F771B13433E562EA7CD6E0 /* Pods-PrimerSDK_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Tests.release.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Tests/Pods-PrimerSDK_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		88C0BE13BA9ECBC36AD5E81D /* Pods-PrimerSDK_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Tests.debug.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Tests/Pods-PrimerSDK_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		A428C8ED157F1E4DE41DBA8E /* Pods-PrimerSDK_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Example.debug.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,7 +147,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF35CB0122D7571B6167BE74 /* Pods_PrimerSDK_Example.framework in Frameworks */,
+				7EE85B0BA7C92DC04C7EA4C5 /* Pods_PrimerSDK_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -155,13 +155,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E73BE4C7AABFD86BCE2C77E9 /* Pods_PrimerSDK_Tests.framework in Frameworks */,
+				FA7A6FA0E893B746B631F273 /* Pods_PrimerSDK_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1414C0DDDD93C2D575AD1133 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				230AED131BB79CE6CA9EB05D /* Pods_PrimerSDK_Example.framework */,
+				5903211547877C65257C1F52 /* Pods_PrimerSDK_Tests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		151219E426E5F4EC007EFEA1 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
@@ -354,7 +363,7 @@
 				607FACD11AFB9204008FA782 /* Products */,
 				714FB3DC2580A763B394EB27 /* Pods */,
 				151219E426E5F4EC007EFEA1 /* Recovered References */,
-				7C52DBAB33FCBAA60A254435 /* Frameworks */,
+				1414C0DDDD93C2D575AD1133 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -395,21 +404,12 @@
 		714FB3DC2580A763B394EB27 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				931BD8D1DE1FE9F011AEE24B /* Pods-PrimerSDK_Example.debug.xcconfig */,
-				78A1FA21A3A6EB479233D1B2 /* Pods-PrimerSDK_Example.release.xcconfig */,
-				03ADFE2D4FCF3A920E197658 /* Pods-PrimerSDK_Tests.debug.xcconfig */,
-				9D117F31D6CF410A5E8D53FC /* Pods-PrimerSDK_Tests.release.xcconfig */,
+				A428C8ED157F1E4DE41DBA8E /* Pods-PrimerSDK_Example.debug.xcconfig */,
+				42F5EEFEBB58DEBB1800AA22 /* Pods-PrimerSDK_Example.release.xcconfig */,
+				88C0BE13BA9ECBC36AD5E81D /* Pods-PrimerSDK_Tests.debug.xcconfig */,
+				64F771B13433E562EA7CD6E0 /* Pods-PrimerSDK_Tests.release.xcconfig */,
 			);
 			path = Pods;
-			sourceTree = "<group>";
-		};
-		7C52DBAB33FCBAA60A254435 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				AC2B5A1BE99679BEF2442429 /* Pods_PrimerSDK_Example.framework */,
-				AED8E5B1A3836C42416189F1 /* Pods_PrimerSDK_Tests.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -437,11 +437,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACEF1AFB9204008FA782 /* Build configuration list for PBXNativeTarget "PrimerSDK_Example" */;
 			buildPhases = (
-				428A8E09C48AE3485B658FF9 /* [CP] Check Pods Manifest.lock */,
+				CB54074EDC3D7AC67A15EDA7 /* [CP] Check Pods Manifest.lock */,
 				607FACCC1AFB9204008FA782 /* Sources */,
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
-				B42D7895A491E75E0C60FABC /* [CP] Embed Pods Frameworks */,
+				5BA1DD106C58854B4A75AC36 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -456,7 +456,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACF21AFB9204008FA782 /* Build configuration list for PBXNativeTarget "PrimerSDK_Tests" */;
 			buildPhases = (
-				6B7BFD146977AFD3D5DE04AA /* [CP] Check Pods Manifest.lock */,
+				19216BBF0030389D4A41B322 /* [CP] Check Pods Manifest.lock */,
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
@@ -556,29 +556,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		428A8E09C48AE3485B658FF9 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-PrimerSDK_Example-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6B7BFD146977AFD3D5DE04AA /* [CP] Check Pods Manifest.lock */ = {
+		19216BBF0030389D4A41B322 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -600,7 +578,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B42D7895A491E75E0C60FABC /* [CP] Embed Pods Frameworks */ = {
+		5BA1DD106C58854B4A75AC36 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -620,6 +598,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CB54074EDC3D7AC67A15EDA7 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-PrimerSDK_Example-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -898,7 +898,7 @@
 		};
 		607FACF01AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 931BD8D1DE1FE9F011AEE24B /* Pods-PrimerSDK_Example.debug.xcconfig */;
+			baseConfigurationReference = A428C8ED157F1E4DE41DBA8E /* Pods-PrimerSDK_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = PrimerSDK_Example.entitlements;
@@ -922,7 +922,7 @@
 		};
 		607FACF11AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 78A1FA21A3A6EB479233D1B2 /* Pods-PrimerSDK_Example.release.xcconfig */;
+			baseConfigurationReference = 42F5EEFEBB58DEBB1800AA22 /* Pods-PrimerSDK_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = PrimerSDK_Example.entitlements;
@@ -946,7 +946,7 @@
 		};
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 03ADFE2D4FCF3A920E197658 /* Pods-PrimerSDK_Tests.debug.xcconfig */;
+			baseConfigurationReference = 88C0BE13BA9ECBC36AD5E81D /* Pods-PrimerSDK_Tests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
@@ -975,7 +975,7 @@
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9D117F31D6CF410A5E8D53FC /* Pods-PrimerSDK_Tests.release.xcconfig */;
+			baseConfigurationReference = 64F771B13433E562EA7CD6E0 /* Pods-PrimerSDK_Tests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";

--- a/Example/PrimerSDK.xcodeproj/project.pbxproj
+++ b/Example/PrimerSDK.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		15F97C772624718800DCB3BA /* PaymentMethodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F97C762624718800DCB3BA /* PaymentMethodCell.swift */; };
 		15F97C7D2624730800DCB3BA /* UIViewController+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F97C7C2624730800DCB3BA /* UIViewController+API.swift */; };
 		15F9E67D2678C88000F6B6C1 /* UniversalCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F9E67C2678C88000F6B6C1 /* UniversalCheckout.swift */; };
+		19C41222FAA61EC18D929589 /* Pods_PrimerSDK_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17C5DC4D957ECF53E0ACA5CA /* Pods_PrimerSDK_Example.framework */; };
 		1D0B17C2274528BE0050A89C /* Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0B17C1274528BD0050A89C /* Actions.swift */; };
 		1DC7EE0C261FA39200BCBFFC /* SpinnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC7EE0B261FA39200BCBFFC /* SpinnerViewController.swift */; };
 		1DC7EE14261FA3D400BCBFFC /* CreateClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC7EE13261FA3D400BCBFFC /* CreateClientToken.swift */; };
@@ -45,8 +46,7 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
-		7EE85B0BA7C92DC04C7EA4C5 /* Pods_PrimerSDK_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 230AED131BB79CE6CA9EB05D /* Pods_PrimerSDK_Example.framework */; };
-		FA7A6FA0E893B746B631F273 /* Pods_PrimerSDK_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5903211547877C65257C1F52 /* Pods_PrimerSDK_Tests.framework */; };
+		62BC56C0A16E6DB831961B3C /* Pods_PrimerSDK_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD4124170A31FCF520CD1DA5 /* Pods_PrimerSDK_Tests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +68,7 @@
 
 /* Begin PBXFileReference section */
 		0BEFFA023E994EF5B370A80C /* PrimerSDK.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = PrimerSDK.podspec; path = ../PrimerSDK.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		1140A1BC7FE73D274C87C325 /* Pods-PrimerSDK_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Tests.debug.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Tests/Pods-PrimerSDK_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		151B09F4267B7F9400FB49B8 /* 3DSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 3DSTests.swift; sourceTree = "<group>"; };
 		151B0A1B267CE24B00FB49B8 /* 3DSConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = 3DSConstants.swift; sourceTree = "<group>"; };
 		15300DB8267A1211009A1B9C /* Vault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vault.swift; sourceTree = "<group>"; };
@@ -109,22 +110,22 @@
 		15F5BFFE25FBAFDB00426B1C /* PrimerSDK_Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PrimerSDK_Example.entitlements; sourceTree = "<group>"; };
 		15F5E2FE26982B21003AFF8A /* CardComponentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponentManagerTests.swift; sourceTree = "<group>"; };
 		15F97C622624480500DCB3BA /* AppViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppViewController.swift; sourceTree = "<group>"; };
-		15F97C672624488700DCB3BA /* MerchantCheckoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantCheckoutViewController.swift; sourceTree = "<group>"; };
+		15F97C672624488700DCB3BA /* MerchantCheckoutViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantCheckoutViewController.swift; sourceTree = "<group>"; tabWidth = 5; };
 		15F97C6C26246FD300DCB3BA /* MerchantCheckoutViewController+Primer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MerchantCheckoutViewController+Primer.swift"; sourceTree = "<group>"; };
 		15F97C71262470CB00DCB3BA /* MerchantCheckoutViewController+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MerchantCheckoutViewController+Helpers.swift"; sourceTree = "<group>"; };
 		15F97C762624718800DCB3BA /* PaymentMethodCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodCell.swift; sourceTree = "<group>"; };
 		15F97C7C2624730800DCB3BA /* UIViewController+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+API.swift"; sourceTree = "<group>"; };
 		15F9E67C2678C88000F6B6C1 /* UniversalCheckout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalCheckout.swift; sourceTree = "<group>"; };
+		172D98ADA686446B4F681B7B /* Pods-PrimerSDK_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Tests.release.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Tests/Pods-PrimerSDK_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		17C5DC4D957ECF53E0ACA5CA /* Pods_PrimerSDK_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrimerSDK_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1D0B17C1274528BD0050A89C /* Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Actions.swift; sourceTree = "<group>"; };
 		1D3922C9270DEC2F001BDCCA /* WebViewUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewUtilTests.swift; sourceTree = "<group>"; };
 		1DC7EE0B261FA39200BCBFFC /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		1DC7EE13261FA3D400BCBFFC /* CreateClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateClientToken.swift; sourceTree = "<group>"; };
 		1DEBE0DE26B6FD06004E3064 /* ApayaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApayaTests.swift; sourceTree = "<group>"; };
-		230AED131BB79CE6CA9EB05D /* Pods_PrimerSDK_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrimerSDK_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		386109E34FE905F69A810682 /* Pods-PrimerSDK_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Example.debug.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		3B55FBF1D40BE6B25F29A5D9 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
-		42F5EEFEBB58DEBB1800AA22 /* Pods-PrimerSDK_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Example.release.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example.release.xcconfig"; sourceTree = "<group>"; };
 		45CA532A34F52954A21835C5 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
-		5903211547877C65257C1F52 /* Pods_PrimerSDK_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrimerSDK_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD01AFB9204008FA782 /* PrimerSDK_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PrimerSDK_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACD51AFB9204008FA782 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -132,9 +133,8 @@
 		607FACDC1AFB9204008FA782 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		607FACDF1AFB9204008FA782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		607FACE51AFB9204008FA782 /* PrimerSDK_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrimerSDK_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		64F771B13433E562EA7CD6E0 /* Pods-PrimerSDK_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Tests.release.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Tests/Pods-PrimerSDK_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		88C0BE13BA9ECBC36AD5E81D /* Pods-PrimerSDK_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Tests.debug.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Tests/Pods-PrimerSDK_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		A428C8ED157F1E4DE41DBA8E /* Pods-PrimerSDK_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Example.debug.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		86EA0BA148120A6746E22690 /* Pods-PrimerSDK_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrimerSDK_Example.release.xcconfig"; path = "Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example.release.xcconfig"; sourceTree = "<group>"; };
+		AD4124170A31FCF520CD1DA5 /* Pods_PrimerSDK_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PrimerSDK_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -149,7 +149,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7EE85B0BA7C92DC04C7EA4C5 /* Pods_PrimerSDK_Example.framework in Frameworks */,
+				19C41222FAA61EC18D929589 /* Pods_PrimerSDK_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,22 +157,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA7A6FA0E893B746B631F273 /* Pods_PrimerSDK_Tests.framework in Frameworks */,
+				62BC56C0A16E6DB831961B3C /* Pods_PrimerSDK_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1414C0DDDD93C2D575AD1133 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				230AED131BB79CE6CA9EB05D /* Pods_PrimerSDK_Example.framework */,
-				5903211547877C65257C1F52 /* Pods_PrimerSDK_Tests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		151219E426E5F4EC007EFEA1 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
@@ -366,7 +357,7 @@
 				607FACD11AFB9204008FA782 /* Products */,
 				714FB3DC2580A763B394EB27 /* Pods */,
 				151219E426E5F4EC007EFEA1 /* Recovered References */,
-				1414C0DDDD93C2D575AD1133 /* Frameworks */,
+				C1739B4E7C69A29CA253738A /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -407,12 +398,21 @@
 		714FB3DC2580A763B394EB27 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				A428C8ED157F1E4DE41DBA8E /* Pods-PrimerSDK_Example.debug.xcconfig */,
-				42F5EEFEBB58DEBB1800AA22 /* Pods-PrimerSDK_Example.release.xcconfig */,
-				88C0BE13BA9ECBC36AD5E81D /* Pods-PrimerSDK_Tests.debug.xcconfig */,
-				64F771B13433E562EA7CD6E0 /* Pods-PrimerSDK_Tests.release.xcconfig */,
+				386109E34FE905F69A810682 /* Pods-PrimerSDK_Example.debug.xcconfig */,
+				86EA0BA148120A6746E22690 /* Pods-PrimerSDK_Example.release.xcconfig */,
+				1140A1BC7FE73D274C87C325 /* Pods-PrimerSDK_Tests.debug.xcconfig */,
+				172D98ADA686446B4F681B7B /* Pods-PrimerSDK_Tests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		C1739B4E7C69A29CA253738A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				17C5DC4D957ECF53E0ACA5CA /* Pods_PrimerSDK_Example.framework */,
+				AD4124170A31FCF520CD1DA5 /* Pods_PrimerSDK_Tests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -440,11 +440,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACEF1AFB9204008FA782 /* Build configuration list for PBXNativeTarget "PrimerSDK_Example" */;
 			buildPhases = (
-				CB54074EDC3D7AC67A15EDA7 /* [CP] Check Pods Manifest.lock */,
+				E104AD6CFDAAD9A38C69BE29 /* [CP] Check Pods Manifest.lock */,
 				607FACCC1AFB9204008FA782 /* Sources */,
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
-				5BA1DD106C58854B4A75AC36 /* [CP] Embed Pods Frameworks */,
+				2535AF1BC01DF942743ECAB7 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -459,7 +459,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 607FACF21AFB9204008FA782 /* Build configuration list for PBXNativeTarget "PrimerSDK_Tests" */;
 			buildPhases = (
-				19216BBF0030389D4A41B322 /* [CP] Check Pods Manifest.lock */,
+				9714C7AD1EB90D3FBDDD7E8C /* [CP] Check Pods Manifest.lock */,
 				607FACE11AFB9204008FA782 /* Sources */,
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
@@ -559,29 +559,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		19216BBF0030389D4A41B322 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-PrimerSDK_Tests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5BA1DD106C58854B4A75AC36 /* [CP] Embed Pods Frameworks */ = {
+		2535AF1BC01DF942743ECAB7 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -603,7 +581,29 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PrimerSDK_Example/Pods-PrimerSDK_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CB54074EDC3D7AC67A15EDA7 /* [CP] Check Pods Manifest.lock */ = {
+		9714C7AD1EB90D3FBDDD7E8C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-PrimerSDK_Tests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E104AD6CFDAAD9A38C69BE29 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -902,7 +902,7 @@
 		};
 		607FACF01AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A428C8ED157F1E4DE41DBA8E /* Pods-PrimerSDK_Example.debug.xcconfig */;
+			baseConfigurationReference = 386109E34FE905F69A810682 /* Pods-PrimerSDK_Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = PrimerSDK_Example.entitlements;
@@ -926,7 +926,7 @@
 		};
 		607FACF11AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 42F5EEFEBB58DEBB1800AA22 /* Pods-PrimerSDK_Example.release.xcconfig */;
+			baseConfigurationReference = 86EA0BA148120A6746E22690 /* Pods-PrimerSDK_Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = PrimerSDK_Example.entitlements;
@@ -950,7 +950,7 @@
 		};
 		607FACF31AFB9204008FA782 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 88C0BE13BA9ECBC36AD5E81D /* Pods-PrimerSDK_Tests.debug.xcconfig */;
+			baseConfigurationReference = 1140A1BC7FE73D274C87C325 /* Pods-PrimerSDK_Tests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
@@ -979,7 +979,7 @@
 		};
 		607FACF41AFB9204008FA782 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 64F771B13433E562EA7CD6E0 /* Pods-PrimerSDK_Tests.release.xcconfig */;
+			baseConfigurationReference = 172D98ADA686446B4F681B7B /* Pods-PrimerSDK_Tests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";

--- a/Example/PrimerSDK.xcodeproj/project.pbxproj
+++ b/Example/PrimerSDK.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		15F97C772624718800DCB3BA /* PaymentMethodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F97C762624718800DCB3BA /* PaymentMethodCell.swift */; };
 		15F97C7D2624730800DCB3BA /* UIViewController+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F97C7C2624730800DCB3BA /* UIViewController+API.swift */; };
 		15F9E67D2678C88000F6B6C1 /* UniversalCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F9E67C2678C88000F6B6C1 /* UniversalCheckout.swift */; };
+		1D0B17C2274528BE0050A89C /* Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0B17C1274528BD0050A89C /* Actions.swift */; };
 		1DC7EE0C261FA39200BCBFFC /* SpinnerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC7EE0B261FA39200BCBFFC /* SpinnerViewController.swift */; };
 		1DC7EE14261FA3D400BCBFFC /* CreateClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC7EE13261FA3D400BCBFFC /* CreateClientToken.swift */; };
 		1DEBE0DF26B6FD06004E3064 /* ApayaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEBE0DE26B6FD06004E3064 /* ApayaTests.swift */; };
@@ -114,6 +115,7 @@
 		15F97C762624718800DCB3BA /* PaymentMethodCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodCell.swift; sourceTree = "<group>"; };
 		15F97C7C2624730800DCB3BA /* UIViewController+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+API.swift"; sourceTree = "<group>"; };
 		15F9E67C2678C88000F6B6C1 /* UniversalCheckout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalCheckout.swift; sourceTree = "<group>"; };
+		1D0B17C1274528BD0050A89C /* Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Actions.swift; sourceTree = "<group>"; };
 		1D3922C9270DEC2F001BDCCA /* WebViewUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewUtilTests.swift; sourceTree = "<group>"; };
 		1DC7EE0B261FA39200BCBFFC /* SpinnerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerViewController.swift; sourceTree = "<group>"; };
 		1DC7EE13261FA3D400BCBFFC /* CreateClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateClientToken.swift; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 			children = (
 				1DC7EE13261FA3D400BCBFFC /* CreateClientToken.swift */,
 				15B2E64726F8A9EE005B8343 /* Apaya.swift */,
+				1D0B17C1274528BD0050A89C /* Actions.swift */,
 			);
 			name = "Data Models";
 			sourceTree = "<group>";
@@ -646,6 +649,7 @@
 				15F97C7D2624730800DCB3BA /* UIViewController+API.swift in Sources */,
 				15F97C772624718800DCB3BA /* PaymentMethodCell.swift in Sources */,
 				15B2E64826F8A9EE005B8343 /* Apaya.swift in Sources */,
+				1D0B17C2274528BE0050A89C /* Actions.swift in Sources */,
 				15F97C6D26246FD300DCB3BA /* MerchantCheckoutViewController+Primer.swift in Sources */,
 				1DC7EE0C261FA39200BCBFFC /* SpinnerViewController.swift in Sources */,
 				15F97C72262470CB00DCB3BA /* MerchantCheckoutViewController+Helpers.swift in Sources */,

--- a/Example/PrimerSDK/Actions.swift
+++ b/Example/PrimerSDK/Actions.swift
@@ -1,0 +1,33 @@
+//
+//  Actions.swift
+//  PrimerSDK_Example
+//
+//  Created by Carl Eriksson on 17/11/2021.
+//  Copyright © 2021 CocoaPods. All rights reserved.
+//
+
+import Foundation
+
+
+struct CaptureData: Encodable {
+    let capture: Bool
+    let required: Bool
+}
+
+struct SetInputAction: Encodable {
+    let type: String
+    let params: Array<Param>
+    
+    struct Param: Encodable {
+        var cardInformation: CardInformation? = nil
+        var billingAddress: BillingAddress? = nil
+    }
+    
+    struct CardInformation: Encodable {
+        var cardholderName: CaptureData
+    }
+    
+    struct BillingAddress: Encodable {
+        var postalCode: CaptureData
+    }
+}

--- a/Example/PrimerSDK/CreateClientToken.swift
+++ b/Example/PrimerSDK/CreateClientToken.swift
@@ -162,6 +162,7 @@ struct ClientSessionRequestBody {
     let customer: ClientSessionRequestBody.Customer?
     let order: ClientSessionRequestBody.Order?
     let paymentMethod: ClientSessionRequestBody.PaymentMethod?
+    let inputOptions: InputOptions?
     
     var dictionaryValue: [String: Any]? {
         var dic: [String: Any] = [:]
@@ -194,6 +195,10 @@ struct ClientSessionRequestBody {
         
         if let paymentMethod = paymentMethod {
             dic["paymentMethod"] = paymentMethod.dictionaryValue
+        }
+        
+        if let inputOptions = inputOptions {
+            dic["inputOptions"] = inputOptions.dictionaryValue
         }
 
         return dic.keys.count == 0 ? nil : dic
@@ -277,6 +282,46 @@ struct ClientSessionRequestBody {
             }
             
             return dic.keys.count == 0 ? nil : dic
+        }
+    }
+    
+    struct InputOptions {
+        let cardInformation: CardInformation
+        let billingAddress: BillingAddress
+        
+        var dictionaryValue: [String: Any] {
+            [
+                "cardInformation": cardInformation.dictionaryValue,
+                "billingAddress": billingAddress.dictionaryValue
+            ]
+        }
+        
+        struct CardInformation {
+            let cardholderName: CaptureData
+            
+            var dictionaryValue: [String: Any] {
+                [ "cardholderName": cardholderName.dictionaryValue ]
+            }
+        }
+        
+        struct BillingAddress {
+            let postalCode: CaptureData
+            let addressLine1: CaptureData
+            
+            var dictionaryValue: [String: Any] {
+                [
+                    "postalCode": postalCode.dictionaryValue,
+                    "addressLine1": addressLine1.dictionaryValue
+                ]
+            }
+        }
+        
+        struct CaptureData {
+            let capture, required: Bool
+            
+            var dictionaryValue: [String: Bool] {
+                ["capture": capture, "required": required]
+            }
         }
     }
 

--- a/Example/PrimerSDK/MerchantCheckoutViewController.swift
+++ b/Example/PrimerSDK/MerchantCheckoutViewController.swift
@@ -373,8 +373,20 @@ class MerchantCheckoutViewController: UIViewController {
         using actions: [PrimerSDK.ClientSession.Action],
         completion: @escaping (String?, Error?) -> Void
     ) {
+        print(actions[0].type)
+        let isNotSetPaymentMethod = actions[0].type != "SELECT_PAYMENT_METHOD"
+        
+        let binData = actions[0].params?["binData"] as? NSDictionary
+        let network = binData?["network"] as? String
+        let isNotVisa = network != "VISA"
+        
         guard let clientToken = clientToken else {
             completion(nil, NetworkError.missingParams)
+            return
+        }
+        
+        if (isNotSetPaymentMethod) {
+            completion(clientToken, nil)
             return
         }
         
@@ -398,7 +410,7 @@ class MerchantCheckoutViewController: UIViewController {
                     ),
                     SetInputAction.Param(
                         billingAddress: SetInputAction.BillingAddress(
-                            postalCode: CaptureData(capture: false, required: false)
+                            postalCode: CaptureData(capture: isNotVisa, required: isNotVisa)
                         )
                     )
                 ]

--- a/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
@@ -13,9 +13,10 @@ public class ClientSession: Codable {
     let paymentMethod: ClientSession.PaymentMethod?
     let order: ClientSession.Order?
     let customer: Customer?
+    let inputOptions: InputOptions?
     
     enum CodingKeys: String, CodingKey {
-        case metadata, paymentMethod, order, customer
+        case metadata, paymentMethod, order, customer, inputOptions
     }
     
     required public init(from decoder: Decoder) throws {
@@ -32,6 +33,7 @@ public class ClientSession: Codable {
         self.paymentMethod = (try? container.decode(ClientSession.PaymentMethod?.self, forKey: .paymentMethod)) ?? nil
         self.order = (try? container.decode(Order?.self, forKey: .order)) ?? nil
         self.customer = (try? container.decode(Customer?.self, forKey: .customer)) ?? nil
+        self.inputOptions = (try? container.decode(InputOptions?.self, forKey: .inputOptions)) ?? nil
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -190,6 +192,28 @@ public class ClientSession: Codable {
         }
     }
     
+    // MARK: - ClientSession.InputOptions
+    
+    public struct InputOptions: Codable {
+        let cardInformation: CardInformation?
+        let billingAddress: BillingAddress?
+        
+        
+        struct CardInformation: Codable {
+            let cardholderName: CaptureData
+        }
+        
+        struct BillingAddress: Codable {
+            let postalCode: CaptureData
+        }
+        
+        struct CaptureData: Codable {
+            let capture: Bool
+            let required: Bool
+        }
+        
+        var captureZip: Bool { billingAddress?.postalCode.capture ?? false }
+    }
 }
 
 internal extension Encodable {

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
@@ -30,9 +30,6 @@ struct PrimerConfiguration: Codable {
     let paymentMethods: [PaymentMethodConfig]?
     let keys: ThreeDS.Keys?
     
-    // todo: refactor once agreed
-    let requireZipCodeForCards: Bool = true
-    
     var isSetByClientSession: Bool {
         return clientSession != nil
     }

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
@@ -30,6 +30,9 @@ struct PrimerConfiguration: Codable {
     let paymentMethods: [PaymentMethodConfig]?
     let keys: ThreeDS.Keys?
     
+    // todo: refactor once agreed
+    let requireZipCodeForCards: Bool = true
+    
     var isSetByClientSession: Bool {
         return clientSession != nil
     }

--- a/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
@@ -398,7 +398,7 @@ enum PrimerError: PrimerErrorProtocol {
     case directDebitSessionFailed
     case intentNotSupported(intent: PrimerSessionIntent, paymentMethodType: PaymentMethodConfigType)
     
-    case invalidCardnumber, invalidExpiryDate, invalidCVV, invalidCardholderName
+    case invalidCardnumber, invalidExpiryDate, invalidCVV, invalidCardholderName, invalidZipCode
 
     static var errorDomain: String = "primer"
 
@@ -512,6 +512,8 @@ enum PrimerError: PrimerErrorProtocol {
             return 3102
         case .invalidCardholderName:
             return 3103
+        case .invalidZipCode:
+            return 3104
 
         case .intentNotSupported:
             return 3300
@@ -841,6 +843,13 @@ enum PrimerError: PrimerErrorProtocol {
                                      bundle: Bundle.primerResources,
                                      value: "Invalid cardholder name",
                                      comment: "Invalid cardholder name - Primer error message")
+            
+        case .invalidZipCode:
+            return NSLocalizedString("primer-error-message-invalid-zip-code",
+                                     tableName: nil,
+                                     bundle: Bundle.primerResources,
+                                     value: "Invalid zip code",
+                                     comment: "Invalid zip code - Primer error message")
             
         case .currencyMissing:
             return NSLocalizedString("primer-error-message-currency-missing",

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
@@ -143,6 +143,17 @@ internal extension String {
         let set = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ '`~.-")
         return !(self.rangeOfCharacter(from: set.inverted) != nil)
     }
+    
+    var isTypingValidZipCode: Bool? {
+        if isValidZipCode { return true }
+        return nil
+    }
+    
+    var isValidZipCode: Bool {
+        if isEmpty { return false }
+        let set = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLKMNOPQRSTUVWXYZ '`~.-1234567890")
+        return !(self.rangeOfCharacter(from: set.inverted) != nil)
+    }
 
     var isValidEmail: Bool {
         let emailRegEx = "(?:[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}~-]+(?:\\.[\\p{L}0-9!#$%\\&'*+/=?\\^_`{|}" +

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
@@ -55,6 +55,10 @@ class PrimerCardFormViewController: PrimerFormViewController {
         
         verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.cardholderNameContainerView)
         
+        if (formPaymentMethodTokenizationViewModel.requireZipCode) {
+            verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.zipCodeContainerView)
+        }
+        
         if !Primer.shared.flow.internalSessionFlow.vaulted {
             let saveCardSwitchContainerStackView = UIStackView()
             saveCardSwitchContainerStackView.axis = .horizontal

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
@@ -16,7 +16,17 @@ class PrimerCardFormViewController: PrimerFormViewController {
     
     private let cardholderNameContainerView = PrimerCustomFieldView()
     private let submitButton = PrimerOldButton()
-    private let secondHorizontalStackView = UIStackView()
+    private lazy var firstRow = row
+    private lazy var secondRow = row
+    
+    private var row: UIStackView {
+        let horizontalStackView = UIStackView()
+        horizontalStackView.axis = .horizontal
+        horizontalStackView.alignment = .fill
+        horizontalStackView.distribution = .fillEqually
+        horizontalStackView.spacing = 16
+        return horizontalStackView
+    }
     
     private let formPaymentMethodTokenizationViewModel: CardFormPaymentMethodTokenizationViewModel
     
@@ -32,38 +42,7 @@ class PrimerCardFormViewController: PrimerFormViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.secondHorizontalStackView.axis = .horizontal
-        self.secondHorizontalStackView.alignment = .fill
-        self.secondHorizontalStackView.distribution = .fillEqually
-        
-        formPaymentMethodTokenizationViewModel.zipCodeContainerView.tag = 1005
-        
-        formPaymentMethodTokenizationViewModel.onConfigurationFetched = { [weak self] (showZip) in
-            
-            guard
-                let zipView = self?.formPaymentMethodTokenizationViewModel.zipCodeContainerView,
-                let containsZipCode: Bool = self?.secondHorizontalStackView.arrangedSubviews.contains(zipView)
-            else {
-                return
-            }
-            
-            if (showZip && !containsZipCode) {
-                (self?.parent as? PrimerContainerViewController)?.layoutContainerViewControllerIfNeeded {
-                    
-                    self?.secondHorizontalStackView.insertArrangedSubview(zipView, at: 0)
-                }
-            }
-            
-            if (!showZip && containsZipCode) {
-                zipView.removeFromSuperview();
-                (self?.parent as? PrimerContainerViewController)?.layoutContainerViewControllerIfNeeded {
-                    self?.secondHorizontalStackView.removeArrangedSubview(zipView)
-                }
-            }
-            
-            self?.view.updateConstraints()
-            
-        }
+        formPaymentMethodTokenizationViewModel.onConfigurationFetched = onConfigurationFetched
                 
         title = NSLocalizedString("primer-form-type-main-title-card-form",
                                   tableName: nil,
@@ -75,20 +54,16 @@ class PrimerCardFormViewController: PrimerFormViewController {
         
         verticalStackView.spacing = 6
         verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.cardNumberContainerView)
-
-        let horizontalStackView = generateRow()
         
-        horizontalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.expiryDateContainerView)
-        
-        horizontalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.cvvContainerView)
-        horizontalStackView.spacing = 16
-        verticalStackView.addArrangedSubview(horizontalStackView)
+        firstRow.addArrangedSubview(formPaymentMethodTokenizationViewModel.expiryDateContainerView)
+        firstRow.addArrangedSubview(formPaymentMethodTokenizationViewModel.cvvContainerView)
+        verticalStackView.addArrangedSubview(firstRow)
         
         verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.cardholderNameContainerView)
         
-        secondHorizontalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.zipCodeContainerView)
-        secondHorizontalStackView.addArrangedSubview(UIView())
-        verticalStackView.addArrangedSubview(secondHorizontalStackView)
+        secondRow.addArrangedSubview(formPaymentMethodTokenizationViewModel.zipCodeContainerView)
+        secondRow.addArrangedSubview(UIView())
+        verticalStackView.addArrangedSubview(secondRow)
         
         if !Primer.shared.flow.internalSessionFlow.vaulted {
             let saveCardSwitchContainerStackView = UIStackView()
@@ -119,14 +94,26 @@ class PrimerCardFormViewController: PrimerFormViewController {
         formPaymentMethodTokenizationViewModel.cardNumberField.becomeFirstResponder()
     }
     
-    private func generateRow() -> UIStackView {
-        let horizontalStackView = UIStackView()
-        horizontalStackView.axis = .horizontal
-        horizontalStackView.alignment = .fill
-        horizontalStackView.distribution = .fillEqually
-        return horizontalStackView
+    private func onConfigurationFetched(_ showZip: Bool) {
+        let zipView = formPaymentMethodTokenizationViewModel.zipCodeContainerView
+        let containsZipCode: Bool = secondRow.arrangedSubviews.contains(zipView)
+        let parentVC = parent as? PrimerContainerViewController
+        
+        if (showZip && !containsZipCode) {
+            parentVC?.layoutContainerViewControllerIfNeeded { [weak self] in
+                self?.secondRow.insertArrangedSubview(zipView, at: 0)
+            }
+        }
+        
+        if (!showZip && containsZipCode) {
+            zipView.removeFromSuperview()
+            parentVC?.layoutContainerViewControllerIfNeeded { [weak self] in
+                self?.secondRow.removeArrangedSubview(zipView)
+            }
+        }
+        
+        view.updateConstraints()
     }
-    
 }
 
 #endif

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
@@ -30,6 +30,29 @@ class PrimerCardFormViewController: PrimerFormViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        formPaymentMethodTokenizationViewModel.zipCodeContainerView.tag = 1005
+        
+        formPaymentMethodTokenizationViewModel.onConfigurationFetched = { [weak self] (showZip) in
+            
+            guard
+                let zipView = self?.formPaymentMethodTokenizationViewModel.zipCodeContainerView,
+                let containsZipCode: Bool = self?.verticalStackView.arrangedSubviews.contains(zipView)
+            else {
+                return
+            }
+            
+            if (showZip && !containsZipCode) {
+                self?.verticalStackView.addArrangedSubview(zipView)
+            }
+            
+            if (!showZip && containsZipCode) {
+                zipView.removeFromSuperview();
+            }
+            
+            self?.view.updateConstraints()
+            
+        }
                 
         title = NSLocalizedString("primer-form-type-main-title-card-form",
                                   tableName: nil,
@@ -55,9 +78,7 @@ class PrimerCardFormViewController: PrimerFormViewController {
         
         verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.cardholderNameContainerView)
         
-        if (formPaymentMethodTokenizationViewModel.requireZipCode) {
-            verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.zipCodeContainerView)
-        }
+        verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.zipCodeContainerView)
         
         if !Primer.shared.flow.internalSessionFlow.vaulted {
             let saveCardSwitchContainerStackView = UIStackView()

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
@@ -16,6 +16,7 @@ class PrimerCardFormViewController: PrimerFormViewController {
     
     private let cardholderNameContainerView = PrimerCustomFieldView()
     private let submitButton = PrimerOldButton()
+    private let secondHorizontalStackView = UIStackView()
     
     private let formPaymentMethodTokenizationViewModel: CardFormPaymentMethodTokenizationViewModel
     
@@ -31,23 +32,33 @@ class PrimerCardFormViewController: PrimerFormViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.secondHorizontalStackView.axis = .horizontal
+        self.secondHorizontalStackView.alignment = .fill
+        self.secondHorizontalStackView.distribution = .fillEqually
+        
         formPaymentMethodTokenizationViewModel.zipCodeContainerView.tag = 1005
         
         formPaymentMethodTokenizationViewModel.onConfigurationFetched = { [weak self] (showZip) in
             
             guard
                 let zipView = self?.formPaymentMethodTokenizationViewModel.zipCodeContainerView,
-                let containsZipCode: Bool = self?.verticalStackView.arrangedSubviews.contains(zipView)
+                let containsZipCode: Bool = self?.secondHorizontalStackView.arrangedSubviews.contains(zipView)
             else {
                 return
             }
             
             if (showZip && !containsZipCode) {
-                self?.verticalStackView.addArrangedSubview(zipView)
+                (self?.parent as? PrimerContainerViewController)?.layoutContainerViewControllerIfNeeded {
+                    
+                    self?.secondHorizontalStackView.insertArrangedSubview(zipView, at: 0)
+                }
             }
             
             if (!showZip && containsZipCode) {
                 zipView.removeFromSuperview();
+                (self?.parent as? PrimerContainerViewController)?.layoutContainerViewControllerIfNeeded {
+                    self?.secondHorizontalStackView.removeArrangedSubview(zipView)
+                }
             }
             
             self?.view.updateConstraints()
@@ -65,10 +76,7 @@ class PrimerCardFormViewController: PrimerFormViewController {
         verticalStackView.spacing = 6
         verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.cardNumberContainerView)
 
-        let horizontalStackView = UIStackView()
-        horizontalStackView.axis = .horizontal
-        horizontalStackView.alignment = .fill
-        horizontalStackView.distribution = .fillEqually
+        let horizontalStackView = generateRow()
         
         horizontalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.expiryDateContainerView)
         
@@ -78,7 +86,9 @@ class PrimerCardFormViewController: PrimerFormViewController {
         
         verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.cardholderNameContainerView)
         
-        verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.zipCodeContainerView)
+        secondHorizontalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.zipCodeContainerView)
+        secondHorizontalStackView.addArrangedSubview(UIView())
+        verticalStackView.addArrangedSubview(secondHorizontalStackView)
         
         if !Primer.shared.flow.internalSessionFlow.vaulted {
             let saveCardSwitchContainerStackView = UIStackView()
@@ -105,6 +115,16 @@ class PrimerCardFormViewController: PrimerFormViewController {
         verticalStackView.addArrangedSubview(separatorView)
         
         verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.submitButton)
+        
+        formPaymentMethodTokenizationViewModel.cardNumberField.becomeFirstResponder()
+    }
+    
+    private func generateRow() -> UIStackView {
+        let horizontalStackView = UIStackView()
+        horizontalStackView.axis = .horizontal
+        horizontalStackView.alignment = .fill
+        horizontalStackView.distribution = .fillEqually
+        return horizontalStackView
     }
     
 }

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerContainerViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerContainerViewController.swift
@@ -71,6 +71,20 @@ class PrimerContainerViewController: PrimerViewController {
         childViewController.didMove(toParent: self)
     }
     
+    func layoutContainerViewControllerIfNeeded(block: (() -> Void)?) {
+         self.childViewHeightConstraint?.isActive = false
+         self.childViewHeightConstraint = nil
+
+         block?()
+
+         self.view.layoutIfNeeded()
+         self.childViewHeightConstraint?.isActive = false
+         self.childViewHeightConstraint = nil
+         childViewHeightConstraint = childView.heightAnchor.constraint(equalToConstant: childViewController.view.bounds.size.height)
+         childViewHeightConstraint?.isActive = true
+         Primer.shared.primerRootVC?.resetConstraint(for: childViewController)
+         view.layoutIfNeeded()
+     }
 }
 
 extension UIView {

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
@@ -310,6 +310,19 @@ internal class PrimerRootViewController: PrimerViewController {
         }
     }
     
+    func resetConstraint(for viewController: UIViewController) {
+         let navigationControllerHeight: CGFloat = (viewController.view.bounds.size.height + self.nc.navigationBar.bounds.height) > self.availableScreenHeight ? self.availableScreenHeight : (viewController.view.bounds.size.height + self.nc.navigationBar.bounds.height)
+         self.childViewHeightConstraint.isActive = false
+         self.childViewHeightConstraint?.constant = navigationControllerHeight + self.bottomPadding
+         self.childViewHeightConstraint.isActive = true
+
+         UIView.animate(withDuration: self.presentationDuration, delay: 0, options: .curveEaseInOut) {
+             self.view.layoutIfNeeded()
+         } completion: { _ in
+
+         }
+     }
+    
     internal func popViewController() {
         guard nc.viewControllers.count > 1,
               let viewController = (nc.viewControllers[nc.viewControllers.count-2] as? PrimerContainerViewController)?.childViewController else {

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerUniversalCheckoutViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerUniversalCheckoutViewController.swift
@@ -205,7 +205,9 @@ internal class PrimerUniversalCheckoutViewController: PrimerFormViewController {
             }
         }
         
-        verticalStackView.layoutIfNeeded()
+        (self.parent as? PrimerContainerViewController)?.layoutContainerViewControllerIfNeeded {
+            self.verticalStackView.layoutIfNeeded()
+        }
         
         Primer.shared.primerRootVC?.layoutIfNeeded()
     }

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/CardComponentsManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/CardComponentsManager.swift
@@ -30,6 +30,7 @@ protocol CardComponentsManagerProtocol {
     var expiryDateField: PrimerExpiryDateFieldView { get }
     var cvvField: PrimerCVVFieldView { get }
     var cardholderField: PrimerCardholderNameFieldView? { get }
+    var zipCodeField: PrimerZipCodeFieldView? { get }
     var flow: PaymentFlow { get }
     var delegate: CardComponentsManagerDelegate? { get }
     var customerId: String? { get }
@@ -49,6 +50,7 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
     public var expiryDateField: PrimerExpiryDateFieldView
     public var cvvField: PrimerCVVFieldView
     public var cardholderField: PrimerCardholderNameFieldView?
+    public var zipCodeField: PrimerZipCodeFieldView?
     
     private(set) public var flow: PaymentFlow
     public var delegate: CardComponentsManagerDelegate?
@@ -69,11 +71,20 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
     }
     
     /// The CardComponentsManager can be initialized with/out an access token. In the case that is initialized without an access token, the delegate function cardComponentsManager(_:clientTokenCallback:) will be called. You can initialize an instance (representing a session) by providing the flow (checkout or vault) and registering the necessary PrimerTextFieldViews
-    public init(clientToken: String? = nil, flow: PaymentFlow, cardnumberField: PrimerCardNumberFieldView, expiryDateField: PrimerExpiryDateFieldView, cvvField: PrimerCVVFieldView, cardholderNameField: PrimerCardholderNameFieldView?) {
+    public init(
+        clientToken: String? = nil,
+        flow: PaymentFlow,
+        cardnumberField: PrimerCardNumberFieldView,
+        expiryDateField: PrimerExpiryDateFieldView,
+        cvvField: PrimerCVVFieldView,
+        cardholderNameField: PrimerCardholderNameFieldView?,
+        zipCodeField: PrimerZipCodeFieldView?
+    ) {
         self.flow = flow
         self.cardnumberField = cardnumberField
         self.expiryDateField = expiryDateField
         self.cvvField = cvvField
+        self.zipCodeField = zipCodeField
         
         super.init()
         DependencyContainer.register(PrimerAPIClient() as PrimerAPIClientProtocol)
@@ -212,6 +223,12 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
             }
         }
         
+        if let zipCodeField = zipCodeField {
+            if !zipCodeField.zipCode.isValidZipCode {
+                errors.append(PrimerError.invalidZipCode)
+            }
+        }
+        
         if !errors.isEmpty {
             throw PrimerError.containerError(errors: errors)
         }
@@ -346,6 +363,8 @@ internal class MockCardComponentsManager: CardComponentsManagerProtocol {
     
     var cardholderField: PrimerCardholderNameFieldView?
     
+    var zipCodeField: PrimerZipCodeFieldView?
+    
     var flow: PaymentFlow
     
     var delegate: CardComponentsManagerDelegate?
@@ -365,13 +384,22 @@ internal class MockCardComponentsManager: CardComponentsManagerProtocol {
     
     var paymentMethodsConfig: PrimerConfiguration?
     
-    public init(clientToken: String? = nil, flow: PaymentFlow, cardnumberField: PrimerCardNumberFieldView, expiryDateField: PrimerExpiryDateFieldView, cvvField: PrimerCVVFieldView, cardholderNameField: PrimerCardholderNameFieldView?) {
+    public init(
+        clientToken: String? = nil,
+        flow: PaymentFlow,
+        cardnumberField: PrimerCardNumberFieldView,
+        expiryDateField: PrimerExpiryDateFieldView,
+        cvvField: PrimerCVVFieldView,
+        cardholderNameField: PrimerCardholderNameFieldView?,
+        zipCodeField: PrimerZipCodeFieldView
+    ) {
         DependencyContainer.register(PrimerAPIClient() as PrimerAPIClientProtocol)
         self.flow = flow
         self.cardnumberField = cardnumberField
         self.expiryDateField = expiryDateField
         self.cvvField = cvvField
         self.cardholderField = cardholderNameField
+        self.zipCodeField = zipCodeField
         
         if let clientToken = clientToken {
             try? ClientTokenService.storeClientToken(clientToken)
@@ -384,7 +412,15 @@ internal class MockCardComponentsManager: CardComponentsManagerProtocol {
     ) {
         let cardnumberFieldView = PrimerCardNumberFieldView()
         cardnumberFieldView.textField._text = cardnumber
-        self.init(clientToken: clientToken, flow: .checkout, cardnumberField: cardnumberFieldView, expiryDateField: PrimerExpiryDateFieldView(), cvvField: PrimerCVVFieldView(), cardholderNameField: PrimerCardholderNameFieldView())
+        self.init(
+            clientToken: clientToken,
+            flow: .checkout,
+            cardnumberField: cardnumberFieldView,
+            expiryDateField: PrimerExpiryDateFieldView(),
+            cvvField: PrimerCVVFieldView(),
+            cardholderNameField: PrimerCardholderNameFieldView(),
+            zipCodeField: PrimerZipCodeFieldView()
+        )
         
         try? ClientTokenService.storeClientToken(clientToken)
     }

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerNibView.swift
@@ -56,7 +56,9 @@ internal extension PrimerNibView {
         } else if nibName == "PrimerCVVFieldView" {
             nibName = "PrimerTextFieldView"
         } else if nibName == "PrimerCardholderNameFieldView" {
-           nibName = "PrimerTextFieldView"
+            nibName = "PrimerTextFieldView"
+        } else if nibName == "PrimerZipCodeFieldView" {
+            nibName = "PrimerTextFieldView"
         }
         
         let nib = UINib(nibName: nibName, bundle: bundle)

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.swift
@@ -17,6 +17,9 @@ public protocol PrimerTextFieldViewDelegate {
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?)
     /// Will return the card network (e.g. Visa) detected, unknown if the network cannot be detected. Only applies on PrimerCardNumberFieldView
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, didDetectCardNetwork cardNetwork: CardNetwork?)
+    
+    func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, didDetectZipCode zipCode: String?)
+    
     /// Will return a the validation error on the text input.
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, validationDidFailWithError error: Error)
     
@@ -32,6 +35,7 @@ public protocol PrimerTextFieldViewDelegate {
 public extension PrimerTextFieldViewDelegate {
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {}
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, didDetectCardNetwork cardNetwork: CardNetwork?) {}
+    func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, didDetectZipCode zipCode: String?) {}
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, validationDidFailWithError error: Error) {}
     func primerTextFieldViewDidBeginEditing(_ primerTextFieldView: PrimerTextFieldView) {}
     func primerTextFieldDidEndEditing(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {}

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView.swift
@@ -22,6 +22,8 @@ public protocol PrimerTextFieldViewDelegate {
     
     func primerTextFieldViewDidBeginEditing(_ primerTextFieldView: PrimerTextFieldView)
     
+    func primerTextFieldDidEndEditing(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?)
+    
     func primerTextFieldViewShouldBeginEditing(_ primerTextFieldView: PrimerTextFieldView) -> Bool
     
     func primerTextFieldViewShouldEndEditing(_ primerTextFieldView: PrimerTextFieldView) -> Bool
@@ -32,6 +34,7 @@ public extension PrimerTextFieldViewDelegate {
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, didDetectCardNetwork cardNetwork: CardNetwork?) {}
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, validationDidFailWithError error: Error) {}
     func primerTextFieldViewDidBeginEditing(_ primerTextFieldView: PrimerTextFieldView) {}
+    func primerTextFieldDidEndEditing(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {}
     func primerTextFieldViewShouldBeginEditing(_ primerTextFieldView: PrimerTextFieldView) -> Bool { return true }
     func primerTextFieldViewShouldEndEditing(_ primerTextFieldView: PrimerTextFieldView) -> Bool { return true}
 }
@@ -179,16 +182,17 @@ public class PrimerTextFieldView: PrimerNibView, UITextFieldDelegate {
         switch validation {
         case .valid:
             delegate?.primerTextFieldView(self, isValid: true)
-
+            delegate?.primerTextFieldDidEndEditing(self, isValid: true)
         case .invalid(let err):
             delegate?.primerTextFieldView(self, isValid: false)
-            
+            delegate?.primerTextFieldDidEndEditing(self, isValid: false)
             if let err = err {
                 delegate?.primerTextFieldView(self, validationDidFailWithError: err)
             }
     
         case .notAvailable:
             delegate?.primerTextFieldView(self, isValid: nil)
+            delegate?.primerTextFieldDidEndEditing(self, isValid: nil)
         }
     }
     

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerZipCodeFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerZipCodeFieldView.swift
@@ -37,6 +37,12 @@ public final class PrimerZipCodeFieldView: PrimerTextFieldView {
         let currentText = primerTextField._text ?? ""
         let newText = (currentText as NSString).replacingCharacters(in: range, with: string) as String
         
+        if newText.isEmpty {
+            delegate?.primerTextFieldView(self, didDetectZipCode: nil)
+        } else {
+            delegate?.primerTextFieldView(self, didDetectZipCode: newText)
+        }
+        
         switch self.isValid?(newText) {
         case true:
             validation = .valid

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerZipCodeFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerZipCodeFieldView.swift
@@ -1,0 +1,68 @@
+//
+//  PrimerZipCodeFieldView.swift
+//  PrimerSDK
+//
+//  Created by Carl Eriksson on 10/11/2021.
+//
+
+#if canImport(UIKit)
+
+import UIKit
+
+public final class PrimerZipCodeFieldView: PrimerTextFieldView {
+    
+    internal var zipCode: String {
+        return textField._text ?? ""
+    }
+    
+    override func xibSetup() {
+        super.xibSetup()
+        
+        textField.keyboardType = .namePhonePad
+        textField.isAccessibilityElement = true
+        textField.accessibilityIdentifier = "zip_code_txt_fld"
+        textField.delegate = self
+        isValid = { text in
+            // todo: look into more sophisticated zip code validation, ascii check for now
+            return text.isTypingValidZipCode
+        }
+    }
+    
+    // todo: refactor into separate functions somewhere
+    public override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        let positionOriginal = textField.beginningOfDocument
+        let cursorLocation = textField.position(from: positionOriginal, offset: (range.location + NSString(string: string).length))
+        
+        guard let primerTextField = textField as? PrimerTextField else { return true }
+        let currentText = primerTextField._text ?? ""
+        let newText = (currentText as NSString).replacingCharacters(in: range, with: string) as String
+        
+        switch self.isValid?(newText) {
+        case true:
+            validation = .valid
+        case false:
+            validation = .invalid(PrimerError.invalidZipCode)
+        default:
+            validation = .notAvailable
+        }
+        
+        switch validation {
+        case .valid:
+            delegate?.primerTextFieldView(self, isValid: true)
+        default:
+            delegate?.primerTextFieldView(self, isValid: nil)
+        }
+        
+        primerTextField._text = newText
+        primerTextField.text = newText
+        
+        if let cursorLoc = cursorLocation {
+            textField.selectedTextRange = textField.textRange(from: cursorLoc, to: cursorLoc)
+        }
+        
+        return false
+    }
+    
+}
+
+#endif

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
@@ -406,18 +406,7 @@ extension CardFormPaymentMethodTokenizationViewModel: PrimerTextFieldViewDelegat
         }
     }
     
-    func primerTextFieldDidEndEditing(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {
-        // if requireZipCode, primerTextFieldView is PrimerZipCodeFieldView, isValid == true  {
-        //     guard let zipCode = primerTextFieldView.text else { return }
-        //     let actions = [ClientSession.Action(type: "SET_ZIP_CODE", params: ["zipCode": zipCode])]
-        //     Primer.shared.delegate?.onClientSessionActions?(actions) { [weak self] (clientToken, err) in
-        //         if let clientToken = clientToken {
-        //             try? ClientTokenService.storeClientToken(clientToken)
-        //         }
-        //         self?.fetchConfiguration()
-        //     }
-        // }
-    }
+    func primerTextFieldDidEndEditing(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?) { }
     
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {
         if primerTextFieldView is PrimerCardNumberFieldView, isValid == false {

--- a/Tests/PrimerSDK_Tests/Services/CardComponentManagerTests.swift
+++ b/Tests/PrimerSDK_Tests/Services/CardComponentManagerTests.swift
@@ -118,4 +118,11 @@ class CardComponentManagerTests: XCTestCase {
         }
     }
     
+    func test_is_valid_zip_code() throws {
+        XCTAssertTrue("12345".isValidZipCode)
+    }
+    
+    func test_is_invalid_zip_code() throws {
+        XCTAssertFalse("".isValidZipCode)
+    }
 }


### PR DESCRIPTION
DEX-796

# What this PR does

Adds dynamic zip code functionality to card form view. Only displayed if toggle is set true in configuration received from backend. Typing in the input triggers function that is used to send a client session action telling the developer a zip code was detected.

# Notable decisions & other stuff

List & explain ...

# Instructions on how to test this

Let other reviewers know how they can test this.

# Before merging

_QA_

- [ ] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
