### PR TITLE
DEX-855 Make cardnumber field the first responder

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerCardFormViewController.swift
@@ -82,6 +82,8 @@ class PrimerCardFormViewController: PrimerFormViewController {
         verticalStackView.addArrangedSubview(separatorView)
         
         verticalStackView.addArrangedSubview(formPaymentMethodTokenizationViewModel.submitButton)
+        
+        formPaymentMethodTokenizationViewModel.cardNumberField.becomeFirstResponder()
     }
     
 }


### PR DESCRIPTION
DEX-855

# What this PR does

Present keyboard when card form gets presented.

# Notable decisions & other stuff

List & explain ...

# Instructions on how to test this

Let other reviewers know how they can test this.

# Before merging

_QA_

- [ ] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
