### PR TITLE
DEX-855 Throw error when trying to present payment method that hasn't been configured on the dashboard.

### DIFF
--- a/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
@@ -353,6 +353,7 @@ public enum PrimerError: PrimerErrorProtocol {
     case delegateNotSet
     case userCancelled
     case invalidValue(key: String)
+    case misconfiguredPaymentMethod
     
     case clientTokenNull
     case clientTokenExpirationMissing
@@ -415,6 +416,8 @@ public enum PrimerError: PrimerErrorProtocol {
             return 500
         case .userCancelled:
             return 1500
+        case .misconfiguredPaymentMethod:
+            return 1600
             
         // Settings
         case .clientTokenNull:
@@ -450,8 +453,6 @@ public enum PrimerError: PrimerErrorProtocol {
             return 2000
         case .dataMissing:
             return 2010
-        case .orderIdMissing:
-            return 2022
         case .userDetailsMissing:
             return 2030
         case .userDetailsAddressMissing:
@@ -684,6 +685,13 @@ public enum PrimerError: PrimerErrorProtocol {
                                      bundle: Bundle.primerResources,
                                      value: "User cancelled",
                                      comment: "User cancelled. - Primer error message")
+            
+        case .misconfiguredPaymentMethod:
+            return NSLocalizedString("primer-error-message-misconfigured-payment-method",
+                                     tableName: nil,
+                                     bundle: Bundle.primerResources,
+                                     value: "Failed to initialize due to missing configuration. Please ensure the requested payment method has been configured in Primer's dashboard.",
+                                     comment: "Failed to initialize due to missing configuration. Please ensure the requested payment method has been configured in Primer's dashboard. - Primer error message")
             
         case .amountShouldBeNullForPendingOrderItems:
             return NSLocalizedString("primer-error-message-amount-should-be-null-for-pending-order-items",

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
@@ -424,7 +424,12 @@ internal class PrimerRootViewController: PrimerViewController {
 extension PrimerRootViewController {
     
     func presentPaymentMethod(type: PaymentMethodConfigType) {
-        guard let paymentMethodTokenizationViewModel = PrimerConfiguration.paymentMethodConfigViewModels.filter({ $0.config.type == type }).first else { return }
+        guard let paymentMethodTokenizationViewModel = PrimerConfiguration.paymentMethodConfigViewModels.filter({ $0.config.type == type }).first else {
+            let err = PrimerError.misconfiguredPaymentMethod
+            Primer.shared.delegate?.checkoutFailed?(with: err)
+            return
+        }
+        
         paymentMethodTokenizationViewModel.didStartTokenization = {
             Primer.shared.primerRootVC?.showLoadingScreenIfNeeded()
         }


### PR DESCRIPTION
DEX-855 Throw error when trying to present payment method that hasn't been configured on the dashboard.

# What this PR does

Describe ... (Features / UI / logic changes)

# Notable decisions & other stuff

List & explain ...

# Instructions on how to test this

Let other reviewers know how they can test this.

# Before merging

_QA_

- [ ] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
