### PR TITLE
DEX-449 Refactor

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/PCI/TokenizationService.swift
+++ b/Sources/PrimerSDK/Classes/Core/PCI/TokenizationService.swift
@@ -23,15 +23,13 @@ internal class TokenizationService: TokenizationServiceProtocol {
         request: TokenizationRequest,
         onTokenizeSuccess: @escaping (Result<PaymentMethodToken, PrimerError>) -> Void
     ) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return onTokenizeSuccess(.failure(PrimerError.tokenizationPreRequestFailed))
         }
 
-        log(logLevel: .verbose, title: nil, message: "Client Token: \(clientToken)", prefix: nil, suffix: nil, bundle: nil, file: #file, className: String(describing: Self.self), function: #function, line: #line)
+        log(logLevel: .verbose, title: nil, message: "Client Token: \(decodedClientToken)", prefix: nil, suffix: nil, bundle: nil, file: #file, className: String(describing: Self.self), function: #function, line: #line)
 
-        guard let pciURL = clientToken.pciUrl else {
+        guard let pciURL = decodedClientToken.pciUrl else {
             return onTokenizeSuccess(.failure(PrimerError.tokenizationPreRequestFailed))
         }
 
@@ -45,7 +43,7 @@ internal class TokenizationService: TokenizationServiceProtocol {
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
         
-        api.tokenizePaymentMethod(clientToken: clientToken, paymentMethodTokenizationRequest: request) { (result) in
+        api.tokenizePaymentMethod(clientToken: decodedClientToken, paymentMethodTokenizationRequest: request) { (result) in
             switch result {
             case .failure:
                 DispatchQueue.main.async {

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/DirectDebitService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/DirectDebitService.swift
@@ -20,7 +20,7 @@ internal class DirectDebitService: DirectDebitServiceProtocol {
     func createMandate(_ completion: @escaping (Error?) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(PrimerError.directDebitSessionFailed)
         }
 
@@ -47,7 +47,7 @@ internal class DirectDebitService: DirectDebitServiceProtocol {
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
 
-        api.directDebitCreateMandate(clientToken: clientToken, mandateRequest: body) { [weak self] result in
+        api.directDebitCreateMandate(clientToken: clientToken, mandateRequest: body) { result in
             switch result {
             case .failure:
                 completion(PrimerError.directDebitSessionFailed)

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/PayPalService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/PayPalService.swift
@@ -17,7 +17,7 @@ internal class PayPalService: PayPalServiceProtocol {
     private func prepareUrlAndTokenAndId(path: String) -> (DecodedClientToken, URL, String)? {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return nil
         }
 
@@ -25,7 +25,7 @@ internal class PayPalService: PayPalServiceProtocol {
             return nil
         }
 
-        guard let coreURL = clientToken.coreUrl else {
+        guard let coreURL = decodedClientToken.coreUrl else {
             return nil
         }
 
@@ -33,13 +33,13 @@ internal class PayPalService: PayPalServiceProtocol {
             return nil
         }
 
-        return (clientToken, url, configId)
+        return (decodedClientToken, url, configId)
     }
 
     func startOrderSession(_ completion: @escaping (Result<String, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.clientTokenNull))
         }
 
@@ -75,7 +75,7 @@ internal class PayPalService: PayPalServiceProtocol {
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
 
-        api.payPalStartOrderSession(clientToken: clientToken, payPalCreateOrderRequest: body) { [weak self] (result) in
+        api.payPalStartOrderSession(clientToken: decodedClientToken, payPalCreateOrderRequest: body) { [weak self] (result) in
             switch result {
             case .failure:
                 completion(.failure(PrimerError.payPalSessionFailed))
@@ -89,7 +89,7 @@ internal class PayPalService: PayPalServiceProtocol {
     func startBillingAgreementSession(_ completion: @escaping (Result<String, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.payPalSessionFailed))
         }
 
@@ -129,7 +129,7 @@ internal class PayPalService: PayPalServiceProtocol {
     func confirmBillingAgreement(_ completion: @escaping (Result<PayPalConfirmBillingAgreementResponse, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             return completion(.failure(PrimerError.payPalSessionFailed))
         }
 
@@ -145,7 +145,7 @@ internal class PayPalService: PayPalServiceProtocol {
         
         let api: PrimerAPIClientProtocol = DependencyContainer.resolve()
 
-        api.payPalConfirmBillingAgreement(clientToken: clientToken, payPalConfirmBillingAgreementRequest: body) { [weak self] (result) in
+        api.payPalConfirmBillingAgreement(clientToken: decodedClientToken, payPalConfirmBillingAgreementRequest: body) { (result) in
             switch result {
             case .failure:
                 completion(.failure(PrimerError.payPalSessionFailed))

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/PaymentMethodConfigService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/PaymentMethodConfigService.swift
@@ -13,9 +13,7 @@ internal class PaymentMethodConfigService: PaymentMethodConfigServiceProtocol {
     }
 
     func fetchConfig(_ completion: @escaping (Error?) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
-        guard let clientToken = state.decodedClientToken else {
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(PrimerError.configFetchFailed)
         }
         
@@ -26,6 +24,7 @@ internal class PaymentMethodConfigService: PaymentMethodConfigServiceProtocol {
             case .failure(let error):
                 completion(error)
             case .success(let config):
+                let state: AppStateProtocol = DependencyContainer.resolve()
                 state.paymentMethodConfig = config
                 completion(nil)
             }

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/VaultService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/VaultService.swift
@@ -13,11 +13,10 @@ internal class VaultService: VaultServiceProtocol {
         log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
     }
 
-    // swiftlint:disable cyclomatic_complexity
     func loadVaultedPaymentMethods(_ completion: @escaping (Error?) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(PrimerError.vaultFetchFailed)
         }
         
@@ -43,10 +42,8 @@ internal class VaultService: VaultServiceProtocol {
         }
     }
 
-    func deleteVaultedPaymentMethod(with id: String, _ completion: @escaping (Error?) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
-        guard let clientToken = state.decodedClientToken else {
+    func deleteVaultedPaymentMethod(with id: String, _ completion: @escaping (Error?) -> Void) {        
+        guard let clientToken = ClientTokenService.decodedClientToken else {
             return completion(PrimerError.vaultDeleteFailed)
         }
         

--- a/Sources/PrimerSDK/Classes/Core/Primer/AppState.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/AppState.swift
@@ -10,9 +10,8 @@
 internal protocol AppStateProtocol: AnyObject {
     var paymentMethods: [PaymentMethodToken] { get set }
     var selectedPaymentMethod: String { get set }
-    var decodedClientToken: DecodedClientToken? { get set }
     var paymentMethodConfig: PrimerConfiguration? { get set }
-    var accessToken: String? { get set }
+    var clientToken: String? { get set }
     var billingAgreementToken: String? { get set }
     var orderId: String? { get set }
     var confirmedBillingAgreement: PayPalConfirmBillingAgreementResponse? { get set }
@@ -29,9 +28,8 @@ internal protocol AppStateProtocol: AnyObject {
 internal class AppState: AppStateProtocol {
     var paymentMethods: [PaymentMethodToken] = []
     var selectedPaymentMethod: String = ""
-    var decodedClientToken: DecodedClientToken?
     var paymentMethodConfig: PrimerConfiguration?
-    var accessToken: String?
+    var clientToken: String?
     var billingAgreementToken: String?
     var orderId: String?
     var confirmedBillingAgreement: PayPalConfirmBillingAgreementResponse?

--- a/Sources/PrimerSDK/Classes/Data Models/Apaya.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Apaya.swift
@@ -43,7 +43,6 @@ public struct Apaya {
         let status: String
         let success: String
         
-        
         init(url: URL) throws {
             guard
                 url.queryParameterValue(for: "success") != nil,
@@ -70,7 +69,7 @@ public struct Apaya {
             }
             
             let state: AppStateProtocol = DependencyContainer.resolve()
-            guard state.decodedClientToken != nil,
+            guard ClientTokenService.decodedClientToken != nil,
                   let merchantAccountId = state.paymentMethodConfig?.getProductId(for: .apaya)
             else {
                 throw ApayaException.invalidWebViewResult

--- a/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
@@ -104,7 +104,7 @@ public enum CardNetwork: String, CaseIterable {
                     [650901, 650978],
                     [651652, 651679],
                     [655000, 655019],
-                    [655021, 655058],
+                    [655021, 655058]
                 ],
                 gaps: [4, 8, 12],
                 lengths: [16],
@@ -163,7 +163,7 @@ public enum CardNetwork: String, CaseIterable {
                     [56, 59],
                     [63],
                     [67],
-                    [6],
+                    [6]
                   ],
                 gaps: [4, 8, 12],
                 lengths: [16, 17, 18, 19],
@@ -219,7 +219,7 @@ public enum CardNetwork: String, CaseIterable {
               [8110, 8131],
               [8132, 8151],
               [8152, 8163],
-              [8164, 8171],
+              [8164, 8171]
             ],
                 gaps: [4, 8, 12],
                 lengths: [14, 15, 16, 17, 18, 19],
@@ -265,8 +265,6 @@ public enum CardNetwork: String, CaseIterable {
     }
     
     var directoryServerId: String? {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
         switch self {
         case .visa:
             return "A000000003"
@@ -281,8 +279,8 @@ public enum CardNetwork: String, CaseIterable {
         case .unionpay:
             return "A000000333"
         default:
-            if let clientToken = state.decodedClientToken,
-               let env = clientToken.env {
+            if let decodedClientToken = ClientTokenService.decodedClientToken,
+               let env = decodedClientToken.env {
                 if env.uppercased() == "PRODUCTION" {
                     return nil
                 } else {
@@ -458,18 +456,14 @@ public enum PaymentNetwork: String {
         ]
         
         if #available(iOS 11.2, *) {
-//            @available(iOS 11.2, *)
             supportedNetworks.append(.cartesBancaires)
         } else if #available(iOS 11.0, *) {
-//            @available(iOS, introduced: 11.0, deprecated: 11.2, message: "Use PKPaymentNetworkCartesBancaires instead.")
             supportedNetworks.append(.carteBancaires)
         } else if #available(iOS 10.3, *) {
-//            @available(iOS, introduced: 10.3, deprecated: 11.0, message: "Use PKPaymentNetworkCartesBancaires instead.")
             supportedNetworks.append(.carteBancaire)
         }
 
         if #available(iOS 12.0, *) {
-//            @available(iOS 12.0, *)
             supportedNetworks.append(.eftpos)
             supportedNetworks.append(.electron)
             supportedNetworks.append(.maestro)
@@ -477,30 +471,24 @@ public enum PaymentNetwork: String {
         }
 
         if #available(iOS 12.1.1, *) {
-//            @available(iOS 12.1.1, *)
             supportedNetworks.append(.elo)
             supportedNetworks.append(.mada)
         }
         
         if #available(iOS 10.3.1, *) {
-//            @available(iOS 10.3, *)
             supportedNetworks.append(.idCredit)
         }
         
         if #available(iOS 10.1, *) {
-//            @available(iOS 10.1, *)
             supportedNetworks.append(.JCB)
             supportedNetworks.append(.suica)
         }
         
         if #available(iOS 10.3, *) {
-//            @available(iOS 10.3, *)
             supportedNetworks.append(.quicPay)
         }
         
         if #available(iOS 14.0, *) {
-//            @available(iOS 14.0, *)
-//            supportedNetworks.append(.barcode)
             supportedNetworks.append(.girocard)
         }
         

--- a/Sources/PrimerSDK/Classes/Data Models/PayPal.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PayPal.swift
@@ -50,7 +50,7 @@ struct PayPalCreateBillingAgreementResponse: Codable {
 }
 
 struct PayPalAccessTokenResponse: Codable {
-    let accessToken: String?
+    let clientToken: String?
 }
 
 struct PayPalOrderLink: Decodable {

--- a/Sources/PrimerSDK/Classes/Data Models/VaultCheckoutViewModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/VaultCheckoutViewModel.swift
@@ -71,8 +71,7 @@ internal class VaultCheckoutViewModel: VaultCheckoutViewModelProtocol {
     }
 
     func loadConfig(_ completion: @escaping (Error?) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        if state.decodedClientToken.exists {
+        if ClientTokenService.decodedClientToken.exists {
             let paymentMethodConfigService: PaymentMethodConfigServiceProtocol = DependencyContainer.resolve()
             paymentMethodConfigService.fetchConfig({ err in
                 if let err = err {
@@ -153,4 +152,3 @@ extension VaultCheckoutViewModel: ResumeHandlerProtocol {
 }
 
 #endif
-

--- a/Sources/PrimerSDK/Classes/User Interface/Primer/ExternalViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Primer/ExternalViewModel.swift
@@ -22,7 +22,7 @@ internal class ExternalViewModel: ExternalViewModelProtocol {
     func fetchVaultedPaymentMethods(_ completion: @escaping (Result<[PaymentMethodToken], Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        if state.decodedClientToken.exists {
+        if ClientTokenService.decodedClientToken.exists {
             let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
             vaultService.loadVaultedPaymentMethods({ err in
                 if let err = err {

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/CardComponentsManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/CardComponentsManager.swift
@@ -57,8 +57,7 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
     public var amount: Int?
     public var currency: Currency?
     internal var decodedClientToken: DecodedClientToken? {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        return state.decodedClientToken
+        return ClientTokenService.decodedClientToken
     }
     internal var paymentMethodsConfig: PrimerConfiguration?
     private(set) public var isLoading: Bool = false
@@ -80,7 +79,7 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
         
         self.cardholderField = cardholderNameField
         
-        if let clientToken = clientToken, let decodedClientToken = clientToken.jwtTokenPayload {
+        if let clientToken = clientToken {
             try? ClientTokenService.storeClientToken(clientToken)
         }
     }
@@ -105,8 +104,7 @@ public class CardComponentsManager: NSObject, CardComponentsManagerProtocol {
                 } else if let clientToken = clientToken {
                     do {
                         try ClientTokenService.storeClientToken(clientToken)
-                        let state: AppStateProtocol = DependencyContainer.resolve()
-                        if let decodedClientToken = state.decodedClientToken {
+                        if let decodedClientToken = ClientTokenService.decodedClientToken {
                             seal.fulfill(decodedClientToken)
                         } else {
                             seal.reject(PrimerError.clientTokenNull)
@@ -359,8 +357,7 @@ internal class MockCardComponentsManager: CardComponentsManagerProtocol {
     var currency: Currency?
     
     var decodedClientToken: DecodedClientToken? {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        return state.decodedClientToken
+        return ClientTokenService.decodedClientToken
     }
     
     var paymentMethodsConfig: PrimerConfiguration?

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApayaTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApayaTokenizationViewModel.swift
@@ -115,7 +115,7 @@ class ApayaTokenizationViewModel: PaymentMethodTokenizationViewModel, ExternalPa
         let state: AppStateProtocol = DependencyContainer.resolve()
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken, decodedClientToken.isValid else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken, decodedClientToken.isValid else {
             let err = PaymentException.missingClientToken
             _ = ErrorHandler.shared.handle(error: err)
             throw err
@@ -200,7 +200,7 @@ class ApayaTokenizationViewModel: PaymentMethodTokenizationViewModel, ExternalPa
     
     private func generateWebViewUrl(_ completion: @escaping (Result<String, Error>) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
-        guard let clientToken = state.decodedClientToken,
+        guard let clientToken = ClientTokenService.decodedClientToken,
               let merchantAccountId = state.paymentMethodConfig?.getProductId(for: .apaya)
         else {
             return completion(.failure(ApayaException.noToken))
@@ -303,14 +303,14 @@ class ApayaTokenizationViewModel: PaymentMethodTokenizationViewModel, ExternalPa
             state: state
         )
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             completion(nil, PrimerError.clientTokenNull)
             return
         }
         
         let apiClient: PrimerAPIClientProtocol = DependencyContainer.resolve()
         apiClient.tokenizePaymentMethod(
-            clientToken: clientToken,
+            clientToken: decodedClientToken,
             paymentMethodTokenizationRequest: request) { result in
                 switch result {
                 case .success(let paymentMethod):

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -122,10 +122,9 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel, Externa
     }
     
     override func validate() throws {
-        let state: AppStateProtocol = DependencyContainer.resolve()
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken, decodedClientToken.isValid else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken, decodedClientToken.isValid else {
             let err = PaymentException.missingClientToken
             _ = ErrorHandler.shared.handle(error: err)
             throw err
@@ -234,10 +233,9 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel, Externa
     }
     
     private func payWithApple(completion: @escaping (PaymentMethodToken?, Error?) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        let decodedClientToken = state.decodedClientToken!
+        let decodedClientToken = ClientTokenService.decodedClientToken!
         let countryCode = settings.countryCode!
         let currency = settings.currency!
         let merchantIdentifier = settings.merchantIdentifier!
@@ -249,7 +247,6 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel, Externa
             countryCode: countryCode,
             items: (orderItems ?? [])
         )
-        
         
         let supportedNetworks = PaymentNetwork.iOSSupportedPKPaymentNetworks
         if PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: supportedNetworks) {

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/BankSelectorTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/BankSelectorTokenizationViewModel.swift
@@ -125,7 +125,7 @@ class BankSelectorTokenizationViewModel: ExternalPaymentMethodTokenizationViewMo
     override func validate() throws {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken, decodedClientToken.isValid else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken, decodedClientToken.isValid else {
             let err = PaymentException.missingClientToken
             _ = ErrorHandler.shared.handle(error: err)
             throw err
@@ -247,8 +247,7 @@ class BankSelectorTokenizationViewModel: ExternalPaymentMethodTokenizationViewMo
     
     private func fetchBanks() -> Promise<[Bank]> {
         return Promise { seal in
-            let state: AppStateProtocol = DependencyContainer.resolve()
-            let decodedClientToken = state.decodedClientToken!
+            let decodedClientToken = ClientTokenService.decodedClientToken!
             
             var paymentMethodRequestValue: String = ""
             switch self.config.type {
@@ -309,8 +308,6 @@ class BankSelectorTokenizationViewModel: ExternalPaymentMethodTokenizationViewMo
     }
 
     private func tokenize(bank: Bank, completion: @escaping (_ paymentMethod: PaymentMethodToken?, _ err: Error?) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-
         let req = BankSelectorTokenizationRequest(
             paymentInstrument: PaymentInstrument(
                 paymentMethodConfigId: self.config.id!,
@@ -318,14 +315,14 @@ class BankSelectorTokenizationViewModel: ExternalPaymentMethodTokenizationViewMo
                 type: "OFF_SESSION_PAYMENT",
                 paymentMethodType: config.type.rawValue))
         
-        guard let clientToken = state.decodedClientToken else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken else {
             completion(nil, PrimerError.clientTokenNull)
             return
         }
         
         let apiClient: PrimerAPIClientProtocol = DependencyContainer.resolve()
         apiClient.tokenizePaymentMethod(
-            clientToken: clientToken,
+            clientToken: decodedClientToken,
             paymentMethodTokenizationRequest: req) { result in
                 switch result {
                 case .success(let paymentMethod):

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ExternalPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ExternalPaymentMethodTokenizationViewModel.swift
@@ -303,10 +303,8 @@ class ExternalPaymentMethodTokenizationViewModel: PaymentMethodTokenizationViewM
         log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
     }
     
-    override func validate() throws {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        
-        if state.decodedClientToken?.isValid != true {
+    override func validate() throws {        
+        if ClientTokenService.decodedClientToken?.isValid != true {
             throw PrimerError.clientTokenNull
         }
     }
@@ -462,19 +460,24 @@ class ExternalPaymentMethodTokenizationViewModel: PaymentMethodTokenizationViewM
                 if let err = err {
                     seal.reject(err)
                 } else if let clientToken = clientToken {
-                    let state: AppStateProtocol = DependencyContainer.resolve()
-                    if let decodedClientToken = state.decodedClientToken {
-                        if let intent = decodedClientToken.intent {
+                    do {
+                        try ClientTokenService.storeClientToken(clientToken)
+                    } catch {
+                        seal.reject(error)
+                        return
+                    }
+                    
+                    if let decodedClientToken = ClientTokenService.decodedClientToken {
+                        if let _ = decodedClientToken.intent {
                             if let redirectUrl = decodedClientToken.redirectUrl,
                                let statusUrl = decodedClientToken.statusUrl {
                                 seal.fulfill(PollingURLs(status: statusUrl, redirect: redirectUrl, complete: nil))
                                 return
                             }
                         }
-                        
                     }
                     
-                    let err = PrimerError.invalidValue(key: "polling params")
+                    let err = PrimerError.invalidValue(key: "polling parameters")
                     seal.reject(err)
                 } else {
                     assert(true, "Should have received one parameter")
@@ -525,9 +528,8 @@ class ExternalPaymentMethodTokenizationViewModel: PaymentMethodTokenizationViewM
     }
     
     fileprivate func startPolling(on url: URL, completion: @escaping (_ id: String?, _ err: Error?) -> Void) {
-        let state: AppStateProtocol = DependencyContainer.resolve()
         let client: PrimerAPIClientProtocol = DependencyContainer.resolve()
-        client.poll(clientToken: state.decodedClientToken, url: url.absoluteString) { result in
+        client.poll(clientToken: ClientTokenService.decodedClientToken, url: url.absoluteString) { result in
             if self.webViewCompletion == nil {
                 completion(nil, PrimerError.userCancelled)
                 return
@@ -652,7 +654,7 @@ class MockAsyncPaymentMethodTokenizationViewModel: ExternalPaymentMethodTokeniza
     var failValidation: Bool = false {
         didSet {
             let state: AppStateProtocol = DependencyContainer.resolve()
-            state.decodedClientToken = nil
+            state.clientToken = nil
         }
     }
     var returnedPaymentMethodJson: String?

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
@@ -224,10 +224,9 @@ class CardFormPaymentMethodTokenizationViewModel: PaymentMethodTokenizationViewM
     }
     
     override func validate() throws {
-        let state: AppStateProtocol = DependencyContainer.resolve()
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken, decodedClientToken.isValid else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken, decodedClientToken.isValid else {
             let err = PaymentException.missingClientToken
             _ = ErrorHandler.shared.handle(error: err)
             throw err
@@ -305,7 +304,7 @@ extension CardFormPaymentMethodTokenizationViewModel: CardComponentsManagerDeleg
     func cardComponentsManager(_ cardComponentsManager: CardComponentsManager, clientTokenCallback completion: @escaping (String?, Error?) -> Void) {
         let state: AppStateProtocol = DependencyContainer.resolve()
         
-        if let clientToken = state.accessToken {
+        if let clientToken = state.clientToken {
             completion(clientToken, nil)
         } else {
             completion(nil, PrimerError.clientTokenNull)
@@ -388,7 +387,7 @@ extension CardFormPaymentMethodTokenizationViewModel {
     
     override func handle(newClientToken clientToken: String) {
         let state: AppStateProtocol = DependencyContainer.resolve()
-        if state.accessToken == clientToken {
+        if state.clientToken == clientToken {
             let err = PrimerError.invalidValue(key: "clientToken")
             handle(error: err)
             DispatchQueue.main.async {
@@ -400,8 +399,7 @@ extension CardFormPaymentMethodTokenizationViewModel {
         do {
             try ClientTokenService.storeClientToken(clientToken)
            
-            let state: AppStateProtocol = DependencyContainer.resolve()
-            let decodedClientToken = state.decodedClientToken!
+            let decodedClientToken = ClientTokenService.decodedClientToken!
             
             guard let paymentMethod = paymentMethod else {
                 let err = PrimerError.invalidValue(key: "paymentMethod")

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PayPalTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PayPalTokenizationViewModel.swift
@@ -102,7 +102,7 @@ class PayPalTokenizationViewModel: PaymentMethodTokenizationViewModel, ExternalP
         let state: AppStateProtocol = DependencyContainer.resolve()
 //        let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         
-        guard let decodedClientToken = state.decodedClientToken, decodedClientToken.isValid else {
+        guard let decodedClientToken = ClientTokenService.decodedClientToken, decodedClientToken.isValid else {
             let err = PaymentException.missingClientToken
             _ = ErrorHandler.shared.handle(error: err)
             throw err

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewModel.swift
@@ -23,10 +23,6 @@ internal class VaultPaymentMethodViewModel: VaultPaymentMethodViewModelProtocol 
             state.selectedPaymentMethod = newValue
         }
     }
-    private var clientToken: DecodedClientToken? {
-        let state: AppStateProtocol = DependencyContainer.resolve()
-        return state.decodedClientToken
-    }
 
     deinit {
         log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
@@ -39,7 +35,7 @@ internal class VaultPaymentMethodViewModel: VaultPaymentMethodViewModelProtocol 
 
     func deletePaymentMethod(with id: String, and completion: @escaping (Error?) -> Void) {
         let vaultService: VaultServiceProtocol = DependencyContainer.resolve()
-        vaultService.deleteVaultedPaymentMethod(with: id) { [weak self] _ in
+        vaultService.deleteVaultedPaymentMethod(with: id) { _ in
             let state: AppStateProtocol = DependencyContainer.resolve()
             
             // reset selected payment method if that has been deleted

--- a/Tests/PrimerSDK_Tests/Data Models/ApayaTests.swift
+++ b/Tests/PrimerSDK_Tests/Data Models/ApayaTests.swift
@@ -18,7 +18,9 @@ class ApayaDataModelTests: XCTestCase {
     func test_apaya_web_view_result_created_from_correct_url() throws {
         let url = URL(string: rootUrl + "token=A9IotQFdJBSYjth7h)hGWmFAgzVjxU6xeGGT)AaAbB=&pt=ExamplePTValue&success=1&status=SETUP_SUCCESS&HashedIdentifier=602&MX=MX&MCC=208&MNC=91&success=1")
         
-        let state: AppStateProtocol = MockAppState()
+        let clientToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjI2MjA0NTI2MDksImFjY2Vzc1Rva2VuIjoiZGNjNGI1NjUtZmM2Mi00NDVmLWEzNzktYTdmMDdkYzkwOTM3IiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9hbmFseXRpY3MuYXBpLnNhbmRib3guY29yZS5wcmltZXIuaW8vbWl4cGFuZWwiLCJpbnRlbnQiOiJDSEVDS09VVCIsImNvbmZpZ3VyYXRpb25VcmwiOiJodHRwczovL2FwaS5zYW5kYm94LnByaW1lci5pby9jbGllbnQtc2RrL2NvbmZpZ3VyYXRpb24iLCJjb3JlVXJsIjoiaHR0cHM6Ly9hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJwY2lVcmwiOiJodHRwczovL3Nkay5hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJlbnYiOiJTQU5EQk9YIiwidGhyZWVEU2VjdXJlSW5pdFVybCI6Imh0dHBzOi8vc29uZ2JpcmRzdGFnLmNhcmRpbmFsY29tbWVyY2UuY29tL2NhcmRpbmFsY3J1aXNlL3YxL3NvbmdiaXJkLmpzIiwidGhyZWVEU2VjdXJlVG9rZW4iOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKcWRHa2lPaUpoWlRSaVltRTRNUzFqTm1WakxUUTJZVGt0WVdRell5MWhNV0V3T1RJMk1UYzBPVEVpTENKcFlYUWlPakUyTWpBek5qWXlNRGtzSW1semN5STZJalZsWWpWaVlXVmpaVFpsWXpjeU5tVmhOV1ppWVRkbE5TSXNJazl5WjFWdWFYUkpaQ0k2SWpWbFlqVmlZVFF4WkRRNFptSmtOakE0T0RoaU9HVTBOQ0o5LmlIbGhjbWRMVE1sVURKMXREY0hFVkhjT01hZUstUUJTTGFXczJVVVJnOGsiLCJwYXltZW50RmxvdyI6IlBSRUZFUl9WQVVMVCJ9.RMqc8MjYhltrlfNmXK3R0IZOaHQvIzhJdNL_nScy08Y"
+        
+        let state: AppStateProtocol = MockAppState(clientToken: clientToken)
         state.paymentMethodConfig = mockPaymentMethodConfig
         DependencyContainer.register(state as AppStateProtocol)
         let settings = PrimerSettings(currency: .GBP)

--- a/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
+++ b/Tests/PrimerSDK_Tests/Mocks/Mocks.swift
@@ -194,11 +194,9 @@ class MockAppState: AppStateProtocol {
 
     var selectedPaymentMethod: String = ""
 
-    var decodedClientToken: DecodedClientToken? = mockClientToken
-
     var paymentMethodConfig: PrimerConfiguration?
 
-    var accessToken: String? = "accessToken"
+    var clientToken: String? = "accessToken"
 
     var billingAgreementToken: String? = "token"
 
@@ -209,7 +207,7 @@ class MockAppState: AppStateProtocol {
     var approveURL: String? = "approveUrl"
 
     init(
-        decodedClientToken: DecodedClientToken? = mockClientToken,
+        clientToken: String? = "accessToken",
         paymentMethodConfig: PrimerConfiguration? = PrimerConfiguration(
             coreUrl: "url",
             pciUrl: "url",
@@ -222,7 +220,7 @@ class MockAppState: AppStateProtocol {
             keys: nil
         )
     ) {
-        self.decodedClientToken = decodedClientToken
+        self.clientToken = clientToken
         self.paymentMethodConfig = paymentMethodConfig
     }
 }

--- a/Tests/PrimerSDK_Tests/Services/ClientTokenServiceTests.swift
+++ b/Tests/PrimerSDK_Tests/Services/ClientTokenServiceTests.swift
@@ -12,14 +12,13 @@ import XCTest
 
 class ClientTokenServiceTests: XCTestCase {
     
-    let clientToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2MjA0NTI2MDksImFjY2Vzc1Rva2VuIjoiZGNjNGI1NjUtZmM2Mi00NDVmLWEzNzktYTdmMDdkYzkwOTM3IiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9hbmFseXRpY3MuYXBpLnNhbmRib3guY29yZS5wcmltZXIuaW8vbWl4cGFuZWwiLCJpbnRlbnQiOiJDSEVDS09VVCIsImNvbmZpZ3VyYXRpb25VcmwiOiJodHRwczovL2FwaS5zYW5kYm94LnByaW1lci5pby9jbGllbnQtc2RrL2NvbmZpZ3VyYXRpb24iLCJjb3JlVXJsIjoiaHR0cHM6Ly9hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJwY2lVcmwiOiJodHRwczovL3Nkay5hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJlbnYiOiJTQU5EQk9YIiwidGhyZWVEU2VjdXJlSW5pdFVybCI6Imh0dHBzOi8vc29uZ2JpcmRzdGFnLmNhcmRpbmFsY29tbWVyY2UuY29tL2NhcmRpbmFsY3J1aXNlL3YxL3NvbmdiaXJkLmpzIiwidGhyZWVEU2VjdXJlVG9rZW4iOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKcWRHa2lPaUpoWlRSaVltRTRNUzFqTm1WakxUUTJZVGt0WVdRell5MWhNV0V3T1RJMk1UYzBPVEVpTENKcFlYUWlPakUyTWpBek5qWXlNRGtzSW1semN5STZJalZsWWpWaVlXVmpaVFpsWXpjeU5tVmhOV1ppWVRkbE5TSXNJazl5WjFWdWFYUkpaQ0k2SWpWbFlqVmlZVFF4WkRRNFptSmtOakE0T0RoaU9HVTBOQ0o5LmlIbGhjbWRMVE1sVURKMXREY0hFVkhjT01hZUstUUJTTGFXczJVVVJnOGsiLCJwYXltZW50RmxvdyI6IlBSRUZFUl9WQVVMVCJ9.7v55XlO8zpIjsKTtMDtowdT2nfyULuLNTaw-B1qEi2I"
+    let clientToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjI2MjA0NTI2MDksImFjY2Vzc1Rva2VuIjoiZGNjNGI1NjUtZmM2Mi00NDVmLWEzNzktYTdmMDdkYzkwOTM3IiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9hbmFseXRpY3MuYXBpLnNhbmRib3guY29yZS5wcmltZXIuaW8vbWl4cGFuZWwiLCJpbnRlbnQiOiJDSEVDS09VVCIsImNvbmZpZ3VyYXRpb25VcmwiOiJodHRwczovL2FwaS5zYW5kYm94LnByaW1lci5pby9jbGllbnQtc2RrL2NvbmZpZ3VyYXRpb24iLCJjb3JlVXJsIjoiaHR0cHM6Ly9hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJwY2lVcmwiOiJodHRwczovL3Nkay5hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJlbnYiOiJTQU5EQk9YIiwidGhyZWVEU2VjdXJlSW5pdFVybCI6Imh0dHBzOi8vc29uZ2JpcmRzdGFnLmNhcmRpbmFsY29tbWVyY2UuY29tL2NhcmRpbmFsY3J1aXNlL3YxL3NvbmdiaXJkLmpzIiwidGhyZWVEU2VjdXJlVG9rZW4iOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKcWRHa2lPaUpoWlRSaVltRTRNUzFqTm1WakxUUTJZVGt0WVdRell5MWhNV0V3T1RJMk1UYzBPVEVpTENKcFlYUWlPakUyTWpBek5qWXlNRGtzSW1semN5STZJalZsWWpWaVlXVmpaVFpsWXpjeU5tVmhOV1ppWVRkbE5TSXNJazl5WjFWdWFYUkpaQ0k2SWpWbFlqVmlZVFF4WkRRNFptSmtOakE0T0RoaU9HVTBOQ0o5LmlIbGhjbWRMVE1sVURKMXREY0hFVkhjT01hZUstUUJTTGFXczJVVVJnOGsiLCJwYXltZW50RmxvdyI6IlBSRUZFUl9WQVVMVCJ9.RMqc8MjYhltrlfNmXK3R0IZOaHQvIzhJdNL_nScy08Y"
 
     func test_loadCheckoutConfig_calls_clientTokenRequestCallback() throws {
         let expectation = XCTestExpectation(description: "Load checkout config")
 
         let accessToken = "dcc4b565-fc62-445f-a379-a7f07dc90937"
         
-
         Primer.shared.delegate = self
 
         MockLocator.registerDependencies()
@@ -35,7 +34,7 @@ class ClientTokenServiceTests: XCTestCase {
                     XCTAssert(false, err.localizedDescription)
                 }
             } else {
-                XCTAssertEqual(state.decodedClientToken?.accessToken, accessToken)
+                XCTAssertEqual(ClientTokenService.decodedClientToken?.accessToken, accessToken)
             }
             
             expectation.fulfill()

--- a/Tests/PrimerSDK_Tests/Services/PayPalServiceTests.swift
+++ b/Tests/PrimerSDK_Tests/Services/PayPalServiceTests.swift
@@ -19,10 +19,13 @@ class PayPalServiceTests: XCTestCase {
         let response = PayPalCreateOrderResponse(orderId: "oid", approvalUrl: "primer.io")
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: false)
-        let state = MockAppState()
+        let state = MockAppState(clientToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjI2MjA0NTI2MDksImFjY2Vzc1Rva2VuIjoiZGNjNGI1NjUtZmM2Mi00NDVmLWEzNzktYTdmMDdkYzkwOTM3IiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9hbmFseXRpY3MuYXBpLnNhbmRib3guY29yZS5wcmltZXIuaW8vbWl4cGFuZWwiLCJpbnRlbnQiOiJDSEVDS09VVCIsImNvbmZpZ3VyYXRpb25VcmwiOiJodHRwczovL2FwaS5zYW5kYm94LnByaW1lci5pby9jbGllbnQtc2RrL2NvbmZpZ3VyYXRpb24iLCJjb3JlVXJsIjoiaHR0cHM6Ly9hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJwY2lVcmwiOiJodHRwczovL3Nkay5hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJlbnYiOiJTQU5EQk9YIiwidGhyZWVEU2VjdXJlSW5pdFVybCI6Imh0dHBzOi8vc29uZ2JpcmRzdGFnLmNhcmRpbmFsY29tbWVyY2UuY29tL2NhcmRpbmFsY3J1aXNlL3YxL3NvbmdiaXJkLmpzIiwidGhyZWVEU2VjdXJlVG9rZW4iOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKcWRHa2lPaUpoWlRSaVltRTRNUzFqTm1WakxUUTJZVGt0WVdRell5MWhNV0V3T1RJMk1UYzBPVEVpTENKcFlYUWlPakUyTWpBek5qWXlNRGtzSW1semN5STZJalZsWWpWaVlXVmpaVFpsWXpjeU5tVmhOV1ppWVRkbE5TSXNJazl5WjFWdWFYUkpaQ0k2SWpWbFlqVmlZVFF4WkRRNFptSmtOakE0T0RoaU9HVTBOQ0o5LmlIbGhjbWRMVE1sVURKMXREY0hFVkhjT01hZUstUUJTTGFXczJVVVJnOGsiLCJwYXltZW50RmxvdyI6IlBSRUZFUl9WQVVMVCJ9.RMqc8MjYhltrlfNmXK3R0IZOaHQvIzhJdNL_nScy08Y")
+
+        let settings = MockPrimerSettings()
 
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         DependencyContainer.register(state as AppStateProtocol)
+        DependencyContainer.register(settings as PrimerSettingsProtocol)
 
         let service = PayPalService()
 
@@ -51,7 +54,7 @@ class PayPalServiceTests: XCTestCase {
         let response = PayPalCreateOrderResponse(orderId: "oid", approvalUrl: "primer.io")
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: true)
-        let state = MockAppState(decodedClientToken: nil)
+        let state = MockAppState(clientToken: nil)
 
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         DependencyContainer.register(state as AppStateProtocol)
@@ -112,10 +115,12 @@ class PayPalServiceTests: XCTestCase {
         let response = PayPalCreateBillingAgreementResponse(tokenId: "tid", approvalUrl: "https://primer.io")
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: false)
-        let state = MockAppState()
+        let state = MockAppState(clientToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjI2MjA0NTI2MDksImFjY2Vzc1Rva2VuIjoiZGNjNGI1NjUtZmM2Mi00NDVmLWEzNzktYTdmMDdkYzkwOTM3IiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9hbmFseXRpY3MuYXBpLnNhbmRib3guY29yZS5wcmltZXIuaW8vbWl4cGFuZWwiLCJpbnRlbnQiOiJDSEVDS09VVCIsImNvbmZpZ3VyYXRpb25VcmwiOiJodHRwczovL2FwaS5zYW5kYm94LnByaW1lci5pby9jbGllbnQtc2RrL2NvbmZpZ3VyYXRpb24iLCJjb3JlVXJsIjoiaHR0cHM6Ly9hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJwY2lVcmwiOiJodHRwczovL3Nkay5hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJlbnYiOiJTQU5EQk9YIiwidGhyZWVEU2VjdXJlSW5pdFVybCI6Imh0dHBzOi8vc29uZ2JpcmRzdGFnLmNhcmRpbmFsY29tbWVyY2UuY29tL2NhcmRpbmFsY3J1aXNlL3YxL3NvbmdiaXJkLmpzIiwidGhyZWVEU2VjdXJlVG9rZW4iOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKcWRHa2lPaUpoWlRSaVltRTRNUzFqTm1WakxUUTJZVGt0WVdRell5MWhNV0V3T1RJMk1UYzBPVEVpTENKcFlYUWlPakUyTWpBek5qWXlNRGtzSW1semN5STZJalZsWWpWaVlXVmpaVFpsWXpjeU5tVmhOV1ppWVRkbE5TSXNJazl5WjFWdWFYUkpaQ0k2SWpWbFlqVmlZVFF4WkRRNFptSmtOakE0T0RoaU9HVTBOQ0o5LmlIbGhjbWRMVE1sVURKMXREY0hFVkhjT01hZUstUUJTTGFXczJVVVJnOGsiLCJwYXltZW50RmxvdyI6IlBSRUZFUl9WQVVMVCJ9.RMqc8MjYhltrlfNmXK3R0IZOaHQvIzhJdNL_nScy08Y")
+        let settings = MockPrimerSettings()
 
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         DependencyContainer.register(state as AppStateProtocol)
+        DependencyContainer.register(settings as PrimerSettingsProtocol)
 
         let service = PayPalService()
 
@@ -141,7 +146,7 @@ class PayPalServiceTests: XCTestCase {
         let response = PayPalCreateBillingAgreementResponse(tokenId: "tid", approvalUrl: "https://primer.io")
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: false)
-        let state = MockAppState(decodedClientToken: nil)
+        let state = MockAppState(clientToken: nil)
 
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         DependencyContainer.register(state as AppStateProtocol)
@@ -201,7 +206,7 @@ class PayPalServiceTests: XCTestCase {
         let response = mockPayPalBillingAgreement
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: false)
-        let state = MockAppState()
+        let state = MockAppState(clientToken: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjI2MjA0NTI2MDksImFjY2Vzc1Rva2VuIjoiZGNjNGI1NjUtZmM2Mi00NDVmLWEzNzktYTdmMDdkYzkwOTM3IiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9hbmFseXRpY3MuYXBpLnNhbmRib3guY29yZS5wcmltZXIuaW8vbWl4cGFuZWwiLCJpbnRlbnQiOiJDSEVDS09VVCIsImNvbmZpZ3VyYXRpb25VcmwiOiJodHRwczovL2FwaS5zYW5kYm94LnByaW1lci5pby9jbGllbnQtc2RrL2NvbmZpZ3VyYXRpb24iLCJjb3JlVXJsIjoiaHR0cHM6Ly9hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJwY2lVcmwiOiJodHRwczovL3Nkay5hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJlbnYiOiJTQU5EQk9YIiwidGhyZWVEU2VjdXJlSW5pdFVybCI6Imh0dHBzOi8vc29uZ2JpcmRzdGFnLmNhcmRpbmFsY29tbWVyY2UuY29tL2NhcmRpbmFsY3J1aXNlL3YxL3NvbmdiaXJkLmpzIiwidGhyZWVEU2VjdXJlVG9rZW4iOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKcWRHa2lPaUpoWlRSaVltRTRNUzFqTm1WakxUUTJZVGt0WVdRell5MWhNV0V3T1RJMk1UYzBPVEVpTENKcFlYUWlPakUyTWpBek5qWXlNRGtzSW1semN5STZJalZsWWpWaVlXVmpaVFpsWXpjeU5tVmhOV1ppWVRkbE5TSXNJazl5WjFWdWFYUkpaQ0k2SWpWbFlqVmlZVFF4WkRRNFptSmtOakE0T0RoaU9HVTBOQ0o5LmlIbGhjbWRMVE1sVURKMXREY0hFVkhjT01hZUstUUJTTGFXczJVVVJnOGsiLCJwYXltZW50RmxvdyI6IlBSRUZFUl9WQVVMVCJ9.RMqc8MjYhltrlfNmXK3R0IZOaHQvIzhJdNL_nScy08Y")
 
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         DependencyContainer.register(state as AppStateProtocol)
@@ -230,7 +235,7 @@ class PayPalServiceTests: XCTestCase {
         let response = mockPayPalBillingAgreement
         let data = try JSONEncoder().encode(response)
         let api = MockPrimerAPIClient(with: data, throwsError: false)
-        let state = MockAppState(decodedClientToken: nil)
+        let state = MockAppState(clientToken: nil)
 
         DependencyContainer.register(api as PrimerAPIClientProtocol)
         DependencyContainer.register(state as AppStateProtocol)

--- a/Tests/PrimerSDK_Tests/ViewModels/VaultCheckoutViewModelTests.swift
+++ b/Tests/PrimerSDK_Tests/ViewModels/VaultCheckoutViewModelTests.swift
@@ -14,7 +14,7 @@ class VaultCheckoutViewModelTests: XCTestCase {
 
     func test_loadConfig_calls_clientTokenService_if_client_token_nil() throws {
         let clientTokenService = MockClientTokenService()
-        let state = MockAppState(decodedClientToken: nil)
+        let state = MockAppState(clientToken: nil)
 
         MockLocator.registerDependencies()
         DependencyContainer.register(clientTokenService as ClientTokenServiceProtocol)


### PR DESCRIPTION
DEX-449 Refactor

# What this PR does

Remove decodedClientToken from state. Fetch decodedClientToken as static var from ClientTokenService. Fix warnings. Fix tests.

# Notable decisions & other stuff

List & explain ...

# Instructions on how to test this

Let other reviewers know how they can test this.

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [x] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
