### PR TITLE
Feature/dex 618 card form fields autofocus

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCVVFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCVVFieldView.swift
@@ -50,7 +50,11 @@ public final class PrimerCVVFieldView: PrimerTextFieldView {
         
         switch validation {
         case .valid:
-            delegate?.primerTextFieldView(self, isValid: true)
+            if let cvvLength = cardNetwork.validation?.code.length, newText.count == cvvLength {
+                delegate?.primerTextFieldView(self, isValid: true)
+            } else {
+                delegate?.primerTextFieldView(self, isValid: nil)
+            }
         case .invalid:
             if let cvvLength = cardNetwork.validation?.code.length, newText.count == cvvLength {
                 delegate?.primerTextFieldView(self, isValid: false)

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCVVFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCVVFieldView.swift
@@ -45,15 +45,22 @@ public final class PrimerCVVFieldView: PrimerTextFieldView {
             validation = .notAvailable
         }
         
+        primerTextField._text = newText
+        primerTextField.text = newText
+        
         switch validation {
         case .valid:
             delegate?.primerTextFieldView(self, isValid: true)
+        case .invalid:
+            if let cvvLength = cardNetwork.validation?.code.length, newText.count == cvvLength {
+                delegate?.primerTextFieldView(self, isValid: false)
+            } else {
+                delegate?.primerTextFieldView(self, isValid: nil)
+            }
         default:
             delegate?.primerTextFieldView(self, isValid: nil)
         }
         
-        primerTextField._text = newText
-        primerTextField.text = newText
         return false
     }
     

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCardNumberFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCardNumberFieldView.swift
@@ -52,7 +52,17 @@ public final class PrimerCardNumberFieldView: PrimerTextFieldView {
             DispatchQueue.main.async {
                 switch self.validation {
                 case .valid:
-                    self.delegate?.primerTextFieldView(self, isValid: true)
+                    if let maxLength = self.cardNetwork.validation?.lengths.max(), newText.withoutWhiteSpace.count == maxLength {
+                        self.delegate?.primerTextFieldView(self, isValid: true)
+                    } else {
+                        self.delegate?.primerTextFieldView(self, isValid: nil)
+                    }
+                case .invalid:
+                    if let maxLength = self.cardNetwork.validation?.lengths.max(), newText.withoutWhiteSpace.count == maxLength {
+                        self.delegate?.primerTextFieldView(self, isValid: false)
+                    } else {
+                        self.delegate?.primerTextFieldView(self, isValid: nil)
+                    }
                 default:
                     self.delegate?.primerTextFieldView(self, isValid: nil)
                 }

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerExpiryDateFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerExpiryDateFieldView.swift
@@ -37,13 +37,6 @@ public final class PrimerExpiryDateFieldView: PrimerTextFieldView {
         
         validation = (self.isValid?(newText) ?? false) ? .valid : .invalid(PrimerError.invalidExpiryDate)
         
-        switch validation {
-        case .valid:
-            delegate?.primerTextFieldView(self, isValid: true)
-        default:
-            delegate?.primerTextFieldView(self, isValid: nil)
-        }
-        
         if string != "" {   // Typing
             if newText.count == 2 {
                 newText += "/"
@@ -69,6 +62,18 @@ public final class PrimerExpiryDateFieldView: PrimerTextFieldView {
             expiryMonth = nil
             expiryYear = nil
         }
+        
+        if newText.count == 5, !newText.isValidExpiryDate {
+            delegate?.primerTextFieldView(self, isValid: false)
+        } else {
+            switch validation {
+            case .valid:
+                delegate?.primerTextFieldView(self, isValid: true)
+            default:
+                delegate?.primerTextFieldView(self, isValid: nil)
+            }
+        }
+        
         return false
     }
     

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
@@ -436,14 +436,41 @@ extension CardFormPaymentMethodTokenizationViewModel: PrimerTextFieldViewDelegat
     }
     
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {
-        if primerTextFieldView is PrimerCardNumberFieldView, isValid == false {
-            cardNumberContainerView.errorText = "Invalid card number"
-        } else if primerTextFieldView is PrimerExpiryDateFieldView, isValid == false {
-            expiryDateContainerView.errorText = "Invalid date"
-        } else if primerTextFieldView is PrimerCVVFieldView, isValid == false {
-            cvvContainerView.errorText = "Invalid CVV"
-        } else if primerTextFieldView is PrimerCardholderNameFieldView, isValid == false {
-            cardholderNameContainerView.errorText = "Invalid name"
+        if isValid == false {
+            // We know for sure that the text is not valid, even if the user hasn't finished typing.
+            if primerTextFieldView is PrimerCardNumberFieldView {
+                cardNumberContainerView.errorText = !primerTextFieldView.isEmpty ? "Invalid card number" : nil
+            } else if primerTextFieldView is PrimerExpiryDateFieldView {
+                expiryDateContainerView.errorText = !primerTextFieldView.isEmpty ? "Invalid date" : nil
+            } else if primerTextFieldView is PrimerCVVFieldView {
+                cvvContainerView.errorText = !primerTextFieldView.isEmpty ? "Invalid CVV" : nil
+            } else if primerTextFieldView is PrimerCardholderNameFieldView {
+                cardholderNameContainerView.errorText = !primerTextFieldView.isEmpty ? "Invalid name" : nil
+            }
+        } else if isValid == true {
+            // We know for sure that the text is valid, but could change to invalid if the user continues typing.
+            if primerTextFieldView is PrimerCardNumberFieldView {
+                cardNumberContainerView.errorText = nil
+                _ = expiryDateField.becomeFirstResponder()
+            } else if primerTextFieldView is PrimerExpiryDateFieldView {
+                expiryDateContainerView.errorText = nil
+                _ = cvvField.becomeFirstResponder()
+            } else if primerTextFieldView is PrimerCVVFieldView {
+                cvvContainerView.errorText = nil
+                _ = cardholderNameField.becomeFirstResponder()
+            } else if primerTextFieldView is PrimerCardholderNameFieldView {
+                cardholderNameContainerView.errorText = nil
+            }
+        } else {
+            // We don't know for sure if the text is valid
+            if primerTextFieldView is PrimerCardNumberFieldView {
+                cardNumberContainerView.errorText = nil
+            } else if primerTextFieldView is PrimerExpiryDateFieldView {
+                expiryDateContainerView.errorText = nil
+            } else if primerTextFieldView is PrimerCVVFieldView {
+                cvvContainerView.errorText = nil
+            } else if primerTextFieldView is PrimerCardholderNameFieldView {
+            }
         }
         
         if cardNumberField.isTextValid,

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
@@ -210,7 +210,11 @@ class CardFormPaymentMethodTokenizationViewModel: PaymentMethodTokenizationViewM
         return submitButton
     }()
     
-    var cardNetwork: CardNetwork?
+    var cardNetwork: CardNetwork? {
+        didSet {
+            cvvField.cardNetwork = cardNetwork ?? .unknown
+        }
+    }
     
     required init(config: PaymentMethodConfig) {
         self.flow = Primer.shared.flow.internalSessionFlow.vaulted ? .vault : .checkout

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/FormTokenizationViewModel.swift
@@ -423,6 +423,58 @@ extension CardFormPaymentMethodTokenizationViewModel: CardComponentsManagerDeleg
         Primer.shared.primerRootVC?.view.isUserInteractionEnabled = !isLoading
     }
     
+    fileprivate func autofocusToNextFieldIfNeeded(for primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {
+        if isValid == true {
+            if primerTextFieldView is PrimerCardNumberFieldView {
+                _ = expiryDateField.becomeFirstResponder()
+            } else if primerTextFieldView is PrimerExpiryDateFieldView {
+                _ = cvvField.becomeFirstResponder()
+            } else if primerTextFieldView is PrimerCVVFieldView {
+                _ = cardholderNameField.becomeFirstResponder()
+            }
+        }
+    }
+    
+    fileprivate func showTexfieldViewErrorIfNeeded(for primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {
+        if isValid == false, !primerTextFieldView.isEmpty {
+            // We know for sure that the text is not valid, even if the user hasn't finished typing.
+            if primerTextFieldView is PrimerCardNumberFieldView {
+                cardNumberContainerView.errorText = "Invalid card number"
+            } else if primerTextFieldView is PrimerExpiryDateFieldView {
+                expiryDateContainerView.errorText = "Invalid date"
+            } else if primerTextFieldView is PrimerCVVFieldView {
+                cvvContainerView.errorText = "Invalid CVV"
+            } else if primerTextFieldView is PrimerCardholderNameFieldView {
+                cardholderNameContainerView.errorText = "Invalid name"
+            }
+        } else {
+            // We don't know for sure if the text is valid
+            if primerTextFieldView is PrimerCardNumberFieldView {
+                cardNumberContainerView.errorText = nil
+            } else if primerTextFieldView is PrimerExpiryDateFieldView {
+                expiryDateContainerView.errorText = nil
+            } else if primerTextFieldView is PrimerCVVFieldView {
+                cvvContainerView.errorText = nil
+            } else if primerTextFieldView is PrimerCardholderNameFieldView {
+                cardholderNameContainerView.errorText = nil
+            }
+        }
+    }
+    
+    fileprivate func enableSubmitButtonIfNeeded() {
+        if cardNumberField.isTextValid,
+           expiryDateField.isTextValid,
+           cvvField.isTextValid,
+           cardholderNameField.isTextValid
+        {
+            submitButton.isEnabled = true
+            submitButton.backgroundColor = theme.mainButton.color(for: .enabled)
+        } else {
+            submitButton.isEnabled = false
+            submitButton.backgroundColor = theme.mainButton.color(for: .disabled)
+        }
+    }
+    
 }
 
 extension CardFormPaymentMethodTokenizationViewModel: PrimerTextFieldViewDelegate {
@@ -440,58 +492,9 @@ extension CardFormPaymentMethodTokenizationViewModel: PrimerTextFieldViewDelegat
     }
     
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, isValid: Bool?) {
-        if isValid == false {
-            // We know for sure that the text is not valid, even if the user hasn't finished typing.
-            if primerTextFieldView is PrimerCardNumberFieldView {
-                cardNumberContainerView.errorText = !primerTextFieldView.isEmpty ? "Invalid card number" : nil
-            } else if primerTextFieldView is PrimerExpiryDateFieldView {
-                expiryDateContainerView.errorText = !primerTextFieldView.isEmpty ? "Invalid date" : nil
-            } else if primerTextFieldView is PrimerCVVFieldView {
-                cvvContainerView.errorText = !primerTextFieldView.isEmpty ? "Invalid CVV" : nil
-            } else if primerTextFieldView is PrimerCardholderNameFieldView {
-                cardholderNameContainerView.errorText = !primerTextFieldView.isEmpty ? "Invalid name" : nil
-            }
-        } else if isValid == true {
-            // We know for sure that the text is valid, but could change to invalid if the user continues typing.
-            if primerTextFieldView is PrimerCardNumberFieldView {
-                cardNumberContainerView.errorText = nil
-                _ = expiryDateField.becomeFirstResponder()
-            } else if primerTextFieldView is PrimerExpiryDateFieldView {
-                expiryDateContainerView.errorText = nil
-                _ = cvvField.becomeFirstResponder()
-            } else if primerTextFieldView is PrimerCVVFieldView {
-                cvvContainerView.errorText = nil
-                _ = cardholderNameField.becomeFirstResponder()
-            } else if primerTextFieldView is PrimerCardholderNameFieldView {
-                cardholderNameContainerView.errorText = nil
-            }
-        } else {
-            // We don't know for sure if the text is valid
-            if primerTextFieldView is PrimerCardNumberFieldView {
-                cardNumberContainerView.errorText = nil
-            } else if primerTextFieldView is PrimerExpiryDateFieldView {
-                expiryDateContainerView.errorText = nil
-            } else if primerTextFieldView is PrimerCVVFieldView {
-                cvvContainerView.errorText = nil
-            } else if primerTextFieldView is PrimerCardholderNameFieldView {
-            }
-        }
-        
-        if cardNumberField.isTextValid,
-           expiryDateField.isTextValid,
-           cvvField.isTextValid,
-           cardholderNameField.isTextValid
-        {
-            submitButton.isEnabled = true
-            submitButton.backgroundColor = theme.mainButton.color(for: .enabled)
-        } else {
-            submitButton.isEnabled = false
-            submitButton.backgroundColor = theme.mainButton.color(for: .disabled)
-        }
-    }
-    
-    func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, validationDidFailWithError error: Error) {
-        
+        autofocusToNextFieldIfNeeded(for: primerTextFieldView, isValid: isValid)
+        showTexfieldViewErrorIfNeeded(for: primerTextFieldView, isValid: isValid)
+        enableSubmitButtonIfNeeded()
     }
     
     func primerTextFieldView(_ primerTextFieldView: PrimerTextFieldView, didDetectCardNetwork cardNetwork: CardNetwork?) {


### PR DESCRIPTION
DEX-618

# What this PR does

- Autofocuses on the next card form field if user has arrived on the max length, and also text has passed validation.
- Removes error text when field is empty

# Notable decisions & other stuff

List & explain ...

# Instructions on how to test this

Let other reviewers know how they can test this.

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
