### PR TITLE
Add logic to hide surcharge boxes if no surcharge is applied

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfig.swift
@@ -48,6 +48,8 @@ struct PrimerConfiguration: Codable {
         self.paymentMethods = throwables.compactMap({ $0.value })
         self.keys = (try? container.decode(ThreeDS.Keys?.self, forKey: .keys)) ?? nil
         
+        var hasSetCardPaymentSurcharge: Bool = false
+        
         if let options = clientSession?.paymentMethod?.options, !options.isEmpty {
             for paymentMethodOption in options {
                 if let type = paymentMethodOption["type"] as? String {
@@ -59,7 +61,7 @@ struct PrimerConfiguration: Codable {
                             guard let type = network["type"] as? String,
                             let surcharge = network["surcharge"] as? Int
                             else { continue }
-                            
+                            hasSetCardPaymentSurcharge = true
                         }
                     } else if let surcharge = paymentMethodOption["surcharge"] as? Int,
                               let paymentMethod = self.paymentMethods?.filter({ $0.type.rawValue == type }).first
@@ -72,7 +74,7 @@ struct PrimerConfiguration: Codable {
         }
         
         if let paymentMethod = self.paymentMethods?.filter({ $0.type == PaymentMethodConfigType.paymentCard }).first {
-            paymentMethod.hasUnknownSurcharge = true
+            paymentMethod.hasUnknownSurcharge = hasSetCardPaymentSurcharge
             paymentMethod.surcharge = nil
         }
     }


### PR DESCRIPTION
DEX-1038

# What this PR does

- Hide surcharge boxes if not enabled

# Notable decisions & other stuff

List & explain ...

# Instructions on how to test this

Let other reviewers know how they can test this.

# Before merging

_QA_

- [ ] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
