### PR TITLE
Feature/dex 1238 fix apm redirect

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ExternalPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ExternalPaymentMethodTokenizationViewModel.swift
@@ -599,14 +599,10 @@ class ExternalPaymentMethodTokenizationViewModel: PaymentMethodTokenizationViewM
                     fatalError()
                 }
             case .failure(let err):
-                let nsErr = err as NSError
-                if nsErr.domain == NSURLErrorDomain && nsErr.code == -1001 {
-                    // Retry
-                    Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { _ in
-                        self.startPolling(on: url, completion: completion)
-                    }
-                } else {
-                    completion(nil, err)
+                ErrorHandler.handle(error: err)
+                // Retry
+                Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { _ in
+                    self.startPolling(on: url, completion: completion)
                 }
             }
         }

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ExternalPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ExternalPaymentMethodTokenizationViewModel.swift
@@ -595,8 +595,8 @@ class ExternalPaymentMethodTokenizationViewModel: PaymentMethodTokenizationViewM
                 } else if res.status == .complete {
                     completion(res.id, nil)
                 } else {
-                    // Do what here?
-                    fatalError()
+                    let err = PrimerError.generic(message: "Should never end up here", userInfo: ["file": #file, "class": "\(Self.self)", "function": #function, "line": "\(#line)"])
+                    ErrorHandler.handle(error: err)
                 }
             case .failure(let err):
                 ErrorHandler.handle(error: err)


### PR DESCRIPTION
DEX-1238

# What this PR does

Temp fix on some polling failures, which resulted on showing a failure screen, while the payment was successful

# Notable decisions & other stuff

List & explain ...

# Instructions on how to test this

Let other reviewers know how they can test this.

# Before merging

_QA_

- [ ] I manually tested this with a demo application (simulator)
- [ ] I manually tested this with a demo application (real device)
- [ ] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
