### PR TITLE
Hotfix Fallback to standard user defaults in case of RN

### DIFF
--- a/PrimerSDK.podspec
+++ b/PrimerSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerSDK"
-    s.version      = "1.28.0-beta.5"
+    s.version      = "1.29.2"
     s.summary      = "Official iOS SDK for Primer"
     s.description  = <<-DESC
     This library contains the official iOS SDK for Primer. Install this Cocoapod to seemlessly integrate the Primer Checkout & API platform in your app.

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/UserDefaultsExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/UserDefaultsExtension.swift
@@ -12,7 +12,7 @@ import Foundation
 internal extension UserDefaults {
 
     static var primerFramework: UserDefaults {
-        return UserDefaults(suiteName: Bundle.primerFrameworkIdentifier)!
+        return UserDefaults(suiteName: Bundle.primerFrameworkIdentifier) ?? UserDefaults.standard
     }
 
     func clearPrimerFramework() {


### PR DESCRIPTION
- React Native uses its own bundle, fallback to standard user defaults if the SDK bundle is not found