### PR TITLE
Release 1.35.0

### DIFF
--- a/PrimerSDK.podspec
+++ b/PrimerSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerSDK"
-    s.version      = "1.34.2"
+    s.version      = "1.35.0"
     s.summary      = "Official iOS SDK for Primer"
     s.description  = <<-DESC
     This library contains the official iOS SDK for Primer. Install this Cocoapod to seemlessly integrate the Primer Checkout & API platform in your app.

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethodTokenizationRequest.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethodTokenizationRequest.swift
@@ -7,21 +7,18 @@ struct PaymentMethodTokenizationRequest: TokenizationRequest {
     let paymentInstrument: PaymentInstrument
     let tokenType: TokenType
     let paymentFlow: PaymentFlow?
-    let customerId: String?
 
     init(paymentInstrument: PaymentInstrument, state: AppStateProtocol?) {
         let settings: PrimerSettingsProtocol = DependencyContainer.resolve()
         self.paymentInstrument = paymentInstrument
         self.tokenType = Primer.shared.flow.internalSessionFlow.vaulted ? .multiUse : .singleUse
         self.paymentFlow = Primer.shared.flow.internalSessionFlow.vaulted ? .vault : nil
-        self.customerId = Primer.shared.flow.internalSessionFlow.vaulted ? settings.customerId : nil
     }
     
     init(paymentInstrument: PaymentInstrument, paymentFlow: PaymentFlow?, customerId: String?) {
         self.paymentInstrument = paymentInstrument
         self.paymentFlow = (paymentFlow == .vault) ? .vault : nil
         self.tokenType = (paymentFlow == .vault) ? .multiUse : .singleUse
-        self.customerId = customerId
     }
 
 }

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
@@ -134,6 +134,16 @@ internal class PrimerRootViewController: PrimerViewController {
                     return
                 }
                 
+                let state: AppStateProtocol = DependencyContainer.resolve()
+                
+                if Primer.shared.flow.internalSessionFlow.vaulted, state.primerConfiguration?.clientSession?.customer?.id == nil {
+                    let err = PrimerError.invalidValue(key: "customer.id", value: nil, userInfo: [NSLocalizedDescriptionKey: "Make sure you have set a customerId in the client session"])
+                    ErrorHandler.handle(error: err)
+                    Primer.shared.primerRootVC?.handle(error: err)
+                    return
+                    
+                }
+                
                 switch self?.flow {
                 case .`default`:
                     self?.blurBackground()


### PR DESCRIPTION
Release 1.35.0

- Fix vaulting with PayPal
- Remove `customerId` on tokenization API call on latest API version
- Return an error when vaulting if `customerId` doesn't exist in the client session