### PR TITLE
Passing correct screen type to result screen

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
@@ -525,7 +525,7 @@ extension PrimerRootViewController {
 extension PrimerRootViewController {
     
     private func showResultScreenForResultType(type: PrimerResultViewController.ScreenType, message: String? = nil) {
-        let resultViewController = PrimerResultViewController(screenType: .success, message: message)
+        let resultViewController = PrimerResultViewController(screenType: type, message: message)
         resultViewController.view.translatesAutoresizingMaskIntoConstraints = false
         resultViewController.view.heightAnchor.constraint(equalToConstant: 300).isActive = true
         Primer.shared.primerRootVC?.show(viewController: resultViewController)


### PR DESCRIPTION
# What this PR does

There was an issue in the result view always showing the success screen I spotted while running tests.
This PR addresses the issue.