### PR TITLE
DEX-2494 Card holder name fix

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Checkout Components/PrimerHeadlessUniversalCheckout.swift
+++ b/Sources/PrimerSDK/Classes/Core/Checkout Components/PrimerHeadlessUniversalCheckout.swift
@@ -163,11 +163,9 @@ public class PrimerHeadlessUniversalCheckout {
         switch paymentMethodType {
         case PrimerPaymentMethodType.paymentCard.rawValue:
             var requiredFields: [PrimerInputElementType] = [.cardNumber, .expiryDate, .cvv]
-            if let checkoutModule = PrimerAPIConfigurationModule.apiConfiguration?.checkoutModules?.filter({ $0.type == "CARD_INFORMATION" }).first,
-               let options = checkoutModule.options as? PrimerAPIConfiguration.CheckoutModule.CardInformationOptions {
-                if options.cardHolderName == true {
-                    requiredFields.append(.cardholderName)
-                }
+            let cardInfoOptions = PrimerAPIConfigurationModule.apiConfiguration?.checkoutModules?.filter({ $0.type == "CARD_INFORMATION" }).first?.options as? PrimerAPIConfiguration.CheckoutModule.CardInformationOptions
+            if cardInfoOptions?.cardHolderName != false {
+                requiredFields.append(.cardholderName)
             }
             return requiredFields
         case PrimerPaymentMethodType.adyenBancontactCard.rawValue:

--- a/Sources/PrimerSDK/Classes/Core/Checkout Components/PrimerHeadlessUniversalCheckout.swift
+++ b/Sources/PrimerSDK/Classes/Core/Checkout Components/PrimerHeadlessUniversalCheckout.swift
@@ -170,6 +170,10 @@ public class PrimerHeadlessUniversalCheckout {
             return requiredFields
         case PrimerPaymentMethodType.adyenBancontactCard.rawValue:
             return [.cardNumber, .expiryDate, .cardholderName]
+        case PrimerPaymentMethodType.xenditOvo.rawValue:
+            return [.phoneNumber]
+        case PrimerPaymentMethodType.xenditRetailOutlets.rawValue:
+            return [.retailer]
         default:
             return []
         }

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
@@ -63,14 +63,10 @@ class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuilderProt
     var requiredInputElementTypes: [PrimerInputElementType] {
         
         var mutableRequiredInputElementTypes: [PrimerInputElementType] = [.cardNumber, .expiryDate, .cvv]
-        
-        if let checkoutModule = PrimerAPIConfigurationModule.apiConfiguration?.checkoutModules?.filter({ $0.type == "CARD_INFORMATION" }).first,
-           let options = checkoutModule.options as? PrimerAPIConfiguration.CheckoutModule.CardInformationOptions {
-            if options.cardHolderName == true {
-                mutableRequiredInputElementTypes.append(.cardholderName)
-            }
-        }
-        
+        let cardInfoOptions = PrimerAPIConfigurationModule.apiConfiguration?.checkoutModules?.filter({ $0.type == "CARD_INFORMATION" }).first?.options as? PrimerAPIConfiguration.CheckoutModule.CardInformationOptions
+        if cardInfoOptions?.cardHolderName != false {
+            mutableRequiredInputElementTypes.append(.cardholderName)
+        }        
         return mutableRequiredInputElementTypes
     }
     


### PR DESCRIPTION
# What this PR does

This PR fixes the issue on the cardholder name check against the checkout module configuration.
In the case of a non-present checkout module, by default, it adds the cardholder name among the required fields.

The PR also fixes the required fields array not returned out of the `public func listRequiredInputElementTypes(for paymentMethodType: String) -> [PrimerInputElementType]?`