### PR TITLE
CHKT-266 Improvements on the Bank and Country selector

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/CountryCode.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CountryCode.swift
@@ -287,7 +287,7 @@ extension CountryCode {
         Locale.current.languageCode ?? "en"
     }
     
-    private struct LocalizedCountries: Decodable {
+    struct DecodableLocalizedCountries: Decodable {
         let locale: String
         var countries: [CountryCode.RawValue: String]
         
@@ -314,16 +314,19 @@ extension CountryCode {
         }
     }
     
-    private var loadedCountriesBasedOnLocale: LocalizedCountries? {
-        let jsonParser = JSONParser()
-        guard let localizedCountriesData = jsonParser.loadJsonData(fileName: CountryCode.languageCode) else {
-            return nil
-        }
-        return try? jsonParser.parse(LocalizedCountries.self, from: localizedCountriesData)
-    }
+    struct LocalizedCountries {
+        
+        static var loadedCountriesBasedOnLocale: DecodableLocalizedCountries? = {
+            let jsonParser = JSONParser()
+            guard let localizedCountriesData = jsonParser.loadJsonData(fileName: CountryCode.languageCode) else {
+                return nil
+            }
+            return try? jsonParser.parse(DecodableLocalizedCountries.self, from: localizedCountriesData)
+        }()
+    }    
     
     private var localizedCountryName: String {
-        return loadedCountriesBasedOnLocale?.countries.first { $0.key == self.rawValue }?.value ?? "N/A"
+        return LocalizedCountries.loadedCountriesBasedOnLocale?.countries.first { $0.key == self.rawValue }?.value ?? "N/A"
     }
 }
 

--- a/Sources/PrimerSDK/Classes/User Interface/Banks/BankSelectorViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Banks/BankSelectorViewController.swift
@@ -87,14 +87,11 @@ internal class BankSelectorViewController: PrimerFormViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
-        Timer.scheduledTimer(withTimeInterval: 0.3, repeats: false) { _ in
-            if self.viewModel.tableView.superview == nil {
-                let lastView = self.verticalStackView.arrangedSubviews.last!
-                self.verticalStackView.removeArrangedSubview(lastView)
-                self.verticalStackView.addArrangedSubview(self.viewModel.tableView)
-                self.viewModel.tableView.translatesAutoresizingMaskIntoConstraints = false
-            }
+        if self.viewModel.tableView.superview == nil {
+            let lastView = self.verticalStackView.arrangedSubviews.last!
+            self.verticalStackView.removeArrangedSubview(lastView)
+            self.verticalStackView.addArrangedSubview(self.viewModel.tableView)
+            self.viewModel.tableView.translatesAutoresizingMaskIntoConstraints = false
         }
     }
     

--- a/Sources/PrimerSDK/Classes/User Interface/Countries/CountrySelectorViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Countries/CountrySelectorViewController.swift
@@ -52,11 +52,11 @@ internal class CountrySelectorViewController: PrimerFormViewController {
         
         let theme: PrimerThemeProtocol = DependencyContainer.resolve()
         
-        let bankTitleLabel = UILabel()
-        bankTitleLabel.text = Strings.CountrySelector.selectCountryTitle
-        bankTitleLabel.font = UIFont.systemFont(ofSize: 20)
-        bankTitleLabel.textColor = theme.text.title.color
-        verticalStackView.addArrangedSubview(bankTitleLabel)
+        let countryTitleLabel = UILabel()
+        countryTitleLabel.text = Strings.CountrySelector.selectCountryTitle
+        countryTitleLabel.font = UIFont.systemFont(ofSize: 20)
+        countryTitleLabel.textColor = theme.text.title.color
+        verticalStackView.addArrangedSubview(countryTitleLabel)
         
         verticalStackView.addArrangedSubview(viewModel.searchableTextField)
                 
@@ -65,8 +65,16 @@ internal class CountrySelectorViewController: PrimerFormViewController {
         separator.heightAnchor.constraint(equalToConstant: 5).isActive = true
         verticalStackView.addArrangedSubview(separator)
         
-        self.verticalStackView.addArrangedSubview(self.viewModel.tableView)
-        self.viewModel.tableView.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if self.viewModel.tableView.superview == nil {
+            let lastView = self.verticalStackView.arrangedSubviews.last!
+            self.verticalStackView.removeArrangedSubview(lastView)
+            self.verticalStackView.addArrangedSubview(self.viewModel.tableView)
+            self.viewModel.tableView.translatesAutoresizingMaskIntoConstraints = false
+        }
     }
 }
 


### PR DESCRIPTION
# What this PR does

Improvements in the Banks and Countries selector.
As you can navigate back and forth in Banks, we don't want a new object added to memory every time we present the list.
We have removed the warning in the console attempting to present the countries list.