### PR TITLE
Bugfix/chkt 1591 cardholdername spaces

### DIFF
--- a/Internal/Debug App/Appetize Podfile/Podfile
+++ b/Internal/Debug App/Appetize Podfile/Podfile
@@ -9,7 +9,7 @@ target 'Debug App' do
 
   # Pods for Debug App
   pod 'PrimerSDK', :path => '../../../'
-  pod 'Primer3DS', "~> 1.2.0"
+  pod 'Primer3DS', "~> 1.2.1"
   pod 'PrimerKlarnaSDK'
   # pod 'PrimerIPay88MYSDK' -> fails on arm64
   

--- a/Internal/Debug App/Tests/Unit Tests/Primer/PrimerInputElementTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Primer/PrimerInputElementTests.swift
@@ -1,0 +1,33 @@
+//
+//  PrimerHeadlessValidationTests.swift
+//  Debug App Tests
+//
+//  Created by Niall Quinn on 21/08/23.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+final class PrimerInputElementTests: XCTestCase {
+
+    override func setUpWithError() throws {}
+
+    override func tearDownWithError() throws {}
+
+    func test_validate_cardholderName() throws {
+        let sut = PrimerInputElementType.cardholderName
+        
+        XCTAssertTrue(sut.validate(value: "Joe Bloggs", detectedValueType: nil))
+        XCTAssertTrue(sut.validate(value: "JoeBloggs", detectedValueType: nil))
+        XCTAssertTrue(sut.validate(value: "Joe Bloggs Jr.", detectedValueType: nil))
+       
+        let allTheLetters = CharacterSet.letters.characters().reduce("", { $0 + "\($1)"})
+        XCTAssertTrue(sut.validate(value: allTheLetters, detectedValueType: nil))
+        
+        XCTAssertFalse(sut.validate(value: "123", detectedValueType: nil))
+        XCTAssertFalse(sut.validate(value: "Joe Bloggs the 3rd", detectedValueType: nil))
+        
+    }
+
+}

--- a/Internal/Debug App/Tests/Unit Tests/Primer/PrimerInputElementTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Primer/PrimerInputElementTests.swift
@@ -22,12 +22,15 @@ final class PrimerInputElementTests: XCTestCase {
         XCTAssertTrue(sut.validate(value: "JoeBloggs", detectedValueType: nil))
         XCTAssertTrue(sut.validate(value: "Joe Bloggs Jr.", detectedValueType: nil))
        
-        let allTheLetters = CharacterSet.letters.characters().reduce("", { $0 + "\($1)"})
+        let allTheLetters = CharacterSet.letters.union(.whitespaces).characters().reduce("", { $0 + "\($1)"})
         XCTAssertTrue(sut.validate(value: allTheLetters, detectedValueType: nil))
         
+        // Test strings with numerics. Logic states these should fail
         XCTAssertFalse(sut.validate(value: "123", detectedValueType: nil))
         XCTAssertFalse(sut.validate(value: "Joe Bloggs the 3rd", detectedValueType: nil))
         
+        // Test non-string entry
+        XCTAssertFalse(sut.validate(value: 123, detectedValueType: nil))
     }
 
 }

--- a/Internal/Debug App/Tests/Unit Tests/Primer/PrimerInputElementTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Primer/PrimerInputElementTests.swift
@@ -11,10 +11,6 @@ import XCTest
 
 final class PrimerInputElementTests: XCTestCase {
 
-    override func setUpWithError() throws {}
-
-    override func tearDownWithError() throws {}
-
     func test_validate_cardholderName() throws {
         let sut = PrimerInputElementType.cardholderName
         
@@ -33,4 +29,101 @@ final class PrimerInputElementTests: XCTestCase {
         XCTAssertFalse(sut.validate(value: 123, detectedValueType: nil))
     }
 
+    func test_validate_cardNumber() throws {
+        let cardNumbers = Constants.testCardNumbers.values.flatMap { $0 }
+        let sut = PrimerInputElementType.cardNumber
+        
+        // Use existing test cards to test
+        for cardNumber in cardNumbers {
+            XCTAssertTrue(sut.validate(value: cardNumber, detectedValueType: nil))
+        }
+        
+        // Failure cases
+        XCTAssertFalse(sut.validate(value: "12", detectedValueType: nil))
+        XCTAssertFalse(sut.validate(value: "notanumber", detectedValueType: nil))
+        XCTAssertFalse(sut.validate(value: 4242424242424242, detectedValueType: nil))
+    }
+    
+    func test_validate_phoneNumber() {
+        let sut = PrimerInputElementType.phoneNumber
+        
+        XCTAssertTrue(sut.validate(value: "1234567890", detectedValueType: nil))
+        
+        // Current logic states purely numeric phone number. This should fail
+        XCTAssertFalse(sut.validate(value: "+1234567890", detectedValueType: nil))
+    }
+    
+    func test_validate_postalCode() {
+        let sut = PrimerInputElementType.postalCode
+        
+        XCTAssertTrue(sut.validate(value: "X82-RJ29", detectedValueType: nil))
+        XCTAssertTrue(sut.validate(value: "90210", detectedValueType: nil))
+        XCTAssertTrue(sut.validate(value: "SW1A 0RS", detectedValueType: nil))
+        
+        XCTAssertFalse(sut.validate(value: "Ké5", detectedValueType: nil))
+        XCTAssertFalse(sut.validate(value: "", detectedValueType: nil))
+    }
+    
+    func test_validate_otp() throws {
+        let sut = PrimerInputElementType.otp
+        
+        XCTAssertTrue(sut.validate(value: "123456", detectedValueType: nil))
+        
+        // Current logic states spaces or dashes are not allowed
+        XCTAssertFalse(sut.validate(value: "123-456", detectedValueType: nil))
+        XCTAssertFalse(sut.validate(value: "123 456", detectedValueType: nil))
+    }
+    
+    func test_validate_cvv() throws {
+        // Testing without cardNetwork
+        let sut = PrimerInputElementType.cvv
+        
+        XCTAssertTrue(sut.validate(value: "123", detectedValueType: nil))
+        XCTAssertTrue(sut.validate(value: "1234", detectedValueType: nil))
+        XCTAssertTrue(sut.validate(value: "12345", detectedValueType: nil))
+        
+        XCTAssertFalse(sut.validate(value: "12", detectedValueType: nil))
+        XCTAssertFalse(sut.validate(value: "123456", detectedValueType: nil))
+        
+        // Test with CardNetwork
+        for network in CardNetwork.allCases {
+            for code in network.testCvvCodes {
+                XCTAssertTrue(sut.validate(value: code, detectedValueType: network))
+            }
+        }
+    }
+    
+    func test_validate_expiryDate() throws {
+        let sut = PrimerInputElementType.expiryDate
+        
+        XCTAssertTrue(sut.validate(value: "12/24", detectedValueType: nil))
+        XCTAssertTrue(sut.validate(value: "1224", detectedValueType: nil))
+        
+        // Current logic says the string stripped of "/" should be exactly 4 digits
+        // note: this seems to be at odds with CardComponents validation
+        XCTAssertFalse(sut.validate(value: "12/2024", detectedValueType: nil))
+    }
+}
+
+private extension CardNetwork {
+    var testCvvCodes: [String] {
+        switch self {
+        case .amex:
+            return ["1234", "4567", "8901"]
+        case .bancontact,
+                .diners,
+                .discover,
+                .elo,
+                .hiper,
+                .hipercard,
+                .jcb,
+                .maestro,
+                .masterCard,
+                .mir,
+                .visa,
+                .unionpay,
+                .unknown:
+            return ["123", "345", "456"]
+        }
+    }
 }

--- a/Internal/Debug App/Tests/Unit Tests/Utils/CharacterSet+Utils.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Utils/CharacterSet+Utils.swift
@@ -1,0 +1,35 @@
+//
+//  CharacterSet+Utils.swift
+//  Debug App Tests
+//
+//  Created by Niall Quinn on 21/08/23.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import Foundation
+
+extension CharacterSet {
+    func characters() -> [Character] {
+        // A Unicode scalar is any Unicode code point in the range U+0000 to U+D7FF inclusive or U+E000 to U+10FFFF inclusive.
+        return codePoints().compactMap { UnicodeScalar($0) }.map { Character($0) }
+    }
+    
+    func codePoints() -> [Int] {
+        var result: [Int] = []
+        var plane = 0
+        // following documentation at https://developer.apple.com/documentation/foundation/nscharacterset/1417719-bitmaprepresentation
+        for (i, w) in bitmapRepresentation.enumerated() {
+            let k = i % 0x2001
+            if k == 0x2000 {
+                // plane index byte
+                plane = Int(w) << 13
+                continue
+            }
+            let base = (plane + k) << 3
+            for j in 0 ..< 8 where w & 1 << j != 0 {
+                result.append(base + j)
+            }
+        }
+        return result
+    }
+}

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutInputElement.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutInputElement.swift
@@ -159,7 +159,7 @@ public enum PrimerInputElementType: Int {
             return CharacterSet(charactersIn: "0123456789")
             
         case .cardholderName:
-            return CharacterSet.letters
+            return CharacterSet.letters.union(.whitespaces)
             
         default:
             return nil


### PR DESCRIPTION
# What this PR does

This fixes an issue where PrimerInputElement validation was blocking insertion of spaces in cardholdername

# Instructions on how to test this

In Headless->CardComponents, it should now be possible to enter spaces in the cardholdername field

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [x] I manually tested this with a demo application (real device)
- [x] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [ ] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
