### PR TITLE
Run unit tests during pipeline build

### DIFF
--- a/.github/workflows/build_test_upload.yml
+++ b/.github/workflows/build_test_upload.yml
@@ -74,6 +74,10 @@ jobs:
       - name: Create the Xcode project and workspace
         run: sh ./Internal/Debug\ App/tuist-generate.sh is_ci
 
+      - name: Run Unit Tests
+        run: |
+          bundle exec fastlane tests
+
       - name: Distribute app to Appetize 🚀
         run: |
           bundle exec fastlane appetize_build_and_upload

--- a/.github/workflows/build_test_upload.yml
+++ b/.github/workflows/build_test_upload.yml
@@ -74,11 +74,7 @@ jobs:
       - name: Create the Xcode project and workspace
         run: sh ./Internal/Debug\ App/tuist-generate.sh is_ci
 
-      - name: Run Unit Tests
-        run: |
-          bundle exec fastlane tests
-
-      - name: Distribute app to Appetize 🚀
+      - name: Test, Build, and Distribute app to Appetize 🚀
         run: |
           bundle exec fastlane appetize_build_and_upload
         env:

--- a/Internal/Debug App/Tests/Unit Tests/Primer/PrimerBancontactCardDataManagerTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Primer/PrimerBancontactCardDataManagerTests.swift
@@ -13,6 +13,8 @@ import XCTest
 
 class PrimerBancontactCardDataManagerTests: XCTestCase {
     
+    private static let expectationTimeout = 1.0
+    
     func test_valid_raw_bancontact_card_data() throws {
         let exp = expectation(description: "Await validation")
         
@@ -34,7 +36,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
     }
     
     // We are making the below tests as well to make sure that the standards validation of simple card data passes
@@ -60,7 +62,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
     }
     
     func test_invalid_cardnumber_in_raw_card_data() throws {
@@ -85,7 +87,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -100,7 +102,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -115,7 +117,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -130,7 +132,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
     }
     
     func test_invalid_expiry_date_in_raw_card_data() throws {
@@ -154,7 +156,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -169,7 +171,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -184,7 +186,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -199,7 +201,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -214,7 +216,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -229,7 +231,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -244,7 +246,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -259,7 +261,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -274,7 +276,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -289,7 +291,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -304,7 +306,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -319,7 +321,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -334,7 +336,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -349,7 +351,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -364,7 +366,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
     }
 }
 

--- a/Internal/Debug App/Tests/Unit Tests/Primer/PrimerBancontactCardDataManagerTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Primer/PrimerBancontactCardDataManagerTests.swift
@@ -36,7 +36,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
     }
     
     // We are making the below tests as well to make sure that the standards validation of simple card data passes
@@ -62,7 +62,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
     }
     
     func test_invalid_cardnumber_in_raw_card_data() throws {
@@ -87,7 +87,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -102,7 +102,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -117,7 +117,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -132,7 +132,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
     }
     
     func test_invalid_expiry_date_in_raw_card_data() throws {
@@ -156,7 +156,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -171,7 +171,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -186,7 +186,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -201,7 +201,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -216,7 +216,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -231,7 +231,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -246,7 +246,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -261,7 +261,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -276,7 +276,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -291,7 +291,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -306,7 +306,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -321,7 +321,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -336,7 +336,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -351,7 +351,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -366,7 +366,7 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
     }
 }
 

--- a/Internal/Debug App/Tests/Unit Tests/Primer/PrimerRawCardDataManagerTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Primer/PrimerRawCardDataManagerTests.swift
@@ -13,6 +13,8 @@ import XCTest
 
 class PrimerRawCardDataManagerTests: XCTestCase {
     
+    static let validationTimeout = 1.0
+    
     func test_invalid_cardnumber_in_raw_card_data() throws {
         var exp = expectation(description: "Await validation")
         
@@ -36,7 +38,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -51,7 +53,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -66,7 +68,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -81,7 +83,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
     }
     
     func test_invalid_expiry_date_in_raw_card_data() throws {
@@ -106,7 +108,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -121,7 +123,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -136,7 +138,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -151,7 +153,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -166,7 +168,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -181,7 +183,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -196,7 +198,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -211,7 +213,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -226,7 +228,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -241,7 +243,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
     }
     
     func test_invalid_cvv_in_raw_card_data() throws {
@@ -266,7 +268,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -282,7 +284,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
 
         firstly { () -> Promise<Void> in
@@ -298,7 +300,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -314,7 +316,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
 
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
         exp = expectation(description: "Await validation")
         
         firstly { () -> Promise<Void> in
@@ -330,7 +332,7 @@ class PrimerRawCardDataManagerTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.4)
+        wait(for: [exp], timeout: Self.validationTimeout)
     }
 }
 

--- a/Internal/Debug App/Tests/Unit Tests/Primer/PrimerRawRetailerDataTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Primer/PrimerRawRetailerDataTests.swift
@@ -33,7 +33,7 @@ class PrimerRawRetailerDataTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
     }
     
     func test_valid_raw_retail_data() throws {
@@ -54,7 +54,7 @@ class PrimerRawRetailerDataTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: expectationTimeout)
+        wait(for: [exp], timeout: Self.expectationTimeout)
     }
 
 }

--- a/Internal/Debug App/Tests/Unit Tests/Primer/PrimerRawRetailerDataTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Primer/PrimerRawRetailerDataTests.swift
@@ -13,6 +13,8 @@ import XCTest
 
 class PrimerRawRetailerDataTests: XCTestCase {
     
+    private static let expectationTimeout = 1.0
+    
     func test_invalid_raw_retail_data() throws {
         let exp = expectation(description: "Await validation")
         
@@ -31,7 +33,7 @@ class PrimerRawRetailerDataTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
     }
     
     func test_valid_raw_retail_data() throws {
@@ -52,7 +54,7 @@ class PrimerRawRetailerDataTests: XCTestCase {
             exp.fulfill()
         }
         
-        wait(for: [exp], timeout: 0.1)
+        wait(for: [exp], timeout: expectationTimeout)
     }
 
 }

--- a/Internal/Debug App/Tests/Unit Tests/v2/HeadlessVaultManagerTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/v2/HeadlessVaultManagerTests.swift
@@ -335,7 +335,8 @@ final class HeadlessVaultManagerTests: XCTestCase {
                                         XCTAssert(true, "Failed with error \(err.localizedDescription)")
                                         
                                     } else if let updatedVaultedPaymentMethods = updatedVaultedPaymentMethods {
-                                        XCTAssert(!updatedVaultedPaymentMethods.isEmpty, "Failed to delete vaulted payment method")
+                                        XCTAssert(updatedVaultedPaymentMethods.isEmpty, "Failed to delete vaulted payment method")
+                                        exp.fulfill()
                                     } else {
                                         XCTAssert(true, "Should have received vaulted payment methods or error")
                                     }
@@ -349,10 +350,7 @@ final class HeadlessVaultManagerTests: XCTestCase {
                 } else {
                     XCTAssert(true, "Should have received vaulted payment methods or error")
                 }
-                
-                exp.fulfill()
             }
-
         }
         
         wait(for: [exp], timeout: 30)

--- a/Internal/Debug App/Tests/Unit Tests/v2/RawDataManagerTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/v2/RawDataManagerTests.swift
@@ -11,6 +11,8 @@ import XCTest
 
 class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataManagerDelegate {
     
+    private static let validationTimeout = 1.0
+    
     var rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager!
     
     func test_validation_callback() throws {
@@ -112,7 +114,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid data
         var cardData = PrimerCardData(cardNumber: "", expiryDate: "", cvv: "", cardholderName: nil)
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -134,7 +136,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Valid data
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "03/2030", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -156,7 +158,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid cardnumber
         cardData = PrimerCardData(cardNumber: "424242424242424", expiryDate: "03/2030", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -178,7 +180,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid cardnumber
         cardData = PrimerCardData(cardNumber: "42424242424242424242", expiryDate: "03/2030", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -200,7 +202,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid cardnumber
         cardData = PrimerCardData(cardNumber: "", expiryDate: "03/2030", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -222,7 +224,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid cardnumber
         cardData = PrimerCardData(cardNumber: "4242424242424243", expiryDate: "03/2030", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -244,7 +246,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "0/2030", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -266,7 +268,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "/2030", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -288,7 +290,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "2030", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -310,7 +312,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "/", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -332,7 +334,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "01/2022", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -354,7 +356,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "05/2022", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -376,7 +378,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "02", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -398,7 +400,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "aa", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -420,7 +422,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "2030/03", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -442,7 +444,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "03/30", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -464,7 +466,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid expiry date
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "03/203030", cvv: "123", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -486,7 +488,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid CVV
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "03/2030", cvv: "12", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -508,7 +510,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid CVV
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "03/2030", cvv: "12345", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -530,7 +532,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid CVV
         cardData = PrimerCardData(cardNumber: "4242424242424242", expiryDate: "03/2030", cvv: "abc", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -552,7 +554,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid CVV
         cardData = PrimerCardData(cardNumber: "9120000000000006", expiryDate: "03/2030", cvv: "12345", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
         
         // -------------------
         
@@ -574,7 +576,7 @@ class RawDataManagerTests: XCTestCase, PrimerHeadlessUniversalCheckoutRawDataMan
         // Invalid CVV
         cardData = PrimerCardData(cardNumber: "9120000000000006", expiryDate: "03/2030", cvv: "1", cardholderName: "Test")
         self.rawDataManager.rawData = cardData
-        wait(for: [validation], timeout: 0.4)
+        wait(for: [validation], timeout: Self.validationTimeout)
     }
     
     func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager, dataIsValid isValid: Bool, errors: [Error]?) {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,7 +91,7 @@ platform :ios do
 
   end
 
-  desc 'This action builds the app and uplads it to Appetize'
+  desc 'This action runs Unit Tests, builds the app and uploads it to Appetize'
   lane :appetize_build_and_upload do
 
     common_pre_build_action
@@ -101,6 +101,9 @@ platform :ios do
       use_bundle_exec: true,
       podfile: "Internal/Debug App/Appetize Podfile/Podfile"
     )
+
+    # Run Unit Tests
+    run_tests
 
     # Build for appetize
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -99,6 +99,8 @@ platform :ios do
       podfile: "Internal/Debug App/Appetize Podfile/Podfile"
     )
 
+    tests
+
     # Build for appetize
 
     build_app(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,10 @@ platform :ios do
 ###################### PUBLIC LANES #######################
 
   lane :tests do
-    run_tests(workspace: app_workspace)
+    run_tests(workspace: app_workspace, 
+              scheme: "Debug App Tests",
+              destination: "platform=iOS Simulator,name=iPhone 14 Pro",
+              xcargs: "EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64")
   end
 
   lane :ui_tests do
@@ -98,8 +101,6 @@ platform :ios do
       use_bundle_exec: true,
       podfile: "Internal/Debug App/Appetize Podfile/Podfile"
     )
-
-    tests
 
     # Build for appetize
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -103,7 +103,7 @@ platform :ios do
     )
 
     # Run Unit Tests
-    run_tests
+    tests
 
     # Build for appetize
 


### PR DESCRIPTION
This PR adds running of the Debug App's Unit Test target before the Appetize build step.

Changes made to the unit tests:
- Moved an incorrectly placed expectation fulfill in `HeadlessVaultManager.test_headless_delete_vaulted_payment_method`
- Flipped an assertion (see comment in file)
- Updated expectation timeouts where the value was too low for the slower build machine