### PR TITLE
Remove PollingURLs from PollingResponse

### DIFF
--- a/Internal/Debug App/Tests/Unit Tests/Modules/HUC_TokenizationViewModelTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Modules/HUC_TokenizationViewModelTests.swift
@@ -268,9 +268,9 @@ class HUC_TokenizationViewModelTests: XCTestCase {
         let mockApiClient = MockPrimerAPIClient()
         mockApiClient.validateClientTokenResult = (SuccessResponse(success: true), nil)
         mockApiClient.pollingResults = [
-            (PollingResponse(status: .pending, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil),
+            (PollingResponse(status: .pending, id: "0", source: "src"), nil),
             (nil, NSError(domain: "dummy-network-error", code: 100)),
-            (PollingResponse(status: .complete, id: "resume_token", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil)
+            (PollingResponse(status: .complete, id: "resume_token", source: "src"), nil)
         ]
         mockApiClient.tokenizePaymentMethodResult = (Mocks.primerPaymentMethodTokenData, nil)
         mockApiClient.paymentResult = (Mocks.payment, nil)

--- a/Internal/Debug App/Tests/Unit Tests/Modules/PollingModuleTests.swift
+++ b/Internal/Debug App/Tests/Unit Tests/Modules/PollingModuleTests.swift
@@ -20,9 +20,9 @@ class PollingModuleTests: XCTestCase {
         
         let mockApiClient = MockPrimerAPIClient()
         mockApiClient.pollingResults = [
-            (PollingResponse(status: .pending, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil),
-            (PollingResponse(status: .pending, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil),
-            (PollingResponse(status: .complete, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil)
+            (PollingResponse(status: .pending, id: "0", source: "src"), nil),
+            (PollingResponse(status: .pending, id: "0", source: "src"), nil),
+            (PollingResponse(status: .complete, id: "0", source: "src"), nil)
         ]
         
         PollingModule.apiClient = mockApiClient
@@ -50,9 +50,9 @@ class PollingModuleTests: XCTestCase {
         
         let mockApiClient = MockPrimerAPIClient()
         mockApiClient.pollingResults = [
-            (PollingResponse(status: .pending, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil),
+            (PollingResponse(status: .pending, id: "0", source: "src"), nil),
             (nil, NSError(domain: "dummy-network-error", code: 100)),
-            (PollingResponse(status: .complete, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil)
+            (PollingResponse(status: .complete, id: "0", source: "src"), nil)
         ]
         
         PollingModule.apiClient = mockApiClient
@@ -78,9 +78,9 @@ class PollingModuleTests: XCTestCase {
                 
         let mockApiClient = MockPrimerAPIClient()
         mockApiClient.pollingResults = [
-            (PollingResponse(status: .pending, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil),
-            (PollingResponse(status: .pending, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil),
-            (PollingResponse(status: .complete, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil)
+            (PollingResponse(status: .pending, id: "0", source: "src"), nil),
+            (PollingResponse(status: .pending, id: "0", source: "src"), nil),
+            (PollingResponse(status: .complete, id: "0", source: "src"), nil)
         ]
         
         PollingModule.apiClient = mockApiClient

--- a/Internal/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
+++ b/Internal/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
@@ -768,9 +768,9 @@ extension MockPrimerAPIClient {
                     type: "Visa",
                     expiryDate: "03/2030")))
         static let mockPollingResults: [(PollingResponse?, Error?)] = [
-            (PollingResponse(status: .pending, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil),
-            (PollingResponse(status: .pending, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil),
-            (PollingResponse(status: .complete, id: "0", source: "src", urls: PollingURLs(status: "", redirect: "", complete: "")), nil)
+            (PollingResponse(status: .pending, id: "0", source: "src"), nil),
+            (PollingResponse(status: .pending, id: "0", source: "src"), nil),
+            (PollingResponse(status: .complete, id: "0", source: "src"), nil)
         ]
         static let mockTokenizePaymentMethod = PrimerPaymentMethodTokenData(
             analyticsId: "mock_analytics_id",

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/WebRedirectPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/WebRedirectPaymentMethodTokenizationViewModel.swift
@@ -387,25 +387,21 @@ struct PollingResponse: Decodable {
     let status: PollingStatus
     let id: String
     let source: String
-    let urls: PollingURLs
     
     enum CodingKeys: CodingKey {
         case status
         case id
         case source
-        case urls
     }
     
     init(
         status: PollingStatus,
         id: String,
-        source: String,
-        urls: PollingURLs
+        source: String
     ) {
         self.status = status
         self.id = id
         self.source = source
-        self.urls = urls
     }
     
     init(from decoder: Decoder) throws {
@@ -414,32 +410,11 @@ struct PollingResponse: Decodable {
             self.status = try container.decode(PollingStatus.self, forKey: .status)
             self.id = try container.decode(String.self, forKey: .id)
             self.source = try container.decode(String.self, forKey: .source)
-            self.urls = try container.decode(PollingURLs.self, forKey: .urls)
         } catch {
             throw error
         }
         
     }
-}
-
-struct PollingURLs: Decodable {
-    let status: String
-    lazy var statusUrl: URL? = {
-        return URL(string: status)
-    }()
-    let redirect: String
-    lazy var redirectUrl: URL? = {
-        return URL(string: redirect)
-    }()
-    let complete: String?
-}
-
-struct QRCodePollingURLs: Decodable {
-    let status: String
-    lazy var statusUrl: URL? = {
-        return URL(string: status)
-    }()
-    let complete: String?
 }
 
 #endif


### PR DESCRIPTION
CHKT-1636

Removes `PollingURLs` from `PollingResponse` per conversation with @xevious78.

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
