### PR TITLE
Remove canImport(UIKit) from all files

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -31,18 +31,6 @@ let swiftFilesWithCopyright = sdkEditedFiles.filter {
 //    warn("In Danger we don't include copyright headers, found them in: \(files)")
 //}
 
-// MARK: - Check UIKit import
-
-let swiftFilesNotContainingUIKitImport = sdkEditedFiles.filter {
-    $0.fileType == .swift &&
-    danger.utils.readFile($0).contains("#if canImport(UIKit)") == false
-}
-
-if swiftFilesNotContainingUIKitImport.count > 0 {
-    let files = swiftFilesNotContainingUIKitImport.joined(separator: ", ")
-    warn("Please check your 'canImport(UIKit)` in the following files: \(files)")
-}
-
 // MARK: - PR Contains Tests
 
 // Raw check based on created / updated files containing `import XCTest`

--- a/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
+++ b/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 17/6/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -693,4 +693,4 @@ internal class MockPrimer3DSCompletion: Primer3DSCompletion {
 }
 #endif
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/3DS/Data Models/3DS.swift
+++ b/Sources/PrimerSDK/Classes/Core/3DS/Data Models/3DS.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 1/4/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 #if canImport(Primer3DS)
@@ -611,4 +611,4 @@ public class ThreeDS {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/3DS/Networking/PrimerAPIClient+3DS.swift
+++ b/Sources/PrimerSDK/Classes/Core/3DS/Networking/PrimerAPIClient+3DS.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 2/4/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -42,4 +42,4 @@ extension PrimerAPIClient {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 13/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -181,4 +181,4 @@ class Analytics {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 13/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -594,4 +594,4 @@ struct SDKProperties: Codable {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 13/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -403,4 +403,4 @@ extension Analytics {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Analytics/Device.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/Device.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 13/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -86,4 +86,4 @@ struct Device: Codable {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Connectivity/Connectivity.swift
+++ b/Sources/PrimerSDK/Classes/Core/Connectivity/Connectivity.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 15/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import SystemConfiguration
@@ -50,4 +50,4 @@ internal class Connectivity {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Constants/Colors.swift
+++ b/Sources/PrimerSDK/Classes/Core/Constants/Colors.swift
@@ -1,6 +1,6 @@
 // MARK: Light
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -39,4 +39,4 @@ public struct PrimerColors {
     static let blurredBackground = UIColor.black.withAlphaComponent(0.4)
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Constants/Content.swift
+++ b/Sources/PrimerSDK/Classes/Core/Constants/Content.swift
@@ -5,9 +5,9 @@
 //  Created by Carl Eriksson on 12/10/2021.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Constants/Dimensions.swift
+++ b/Sources/PrimerSDK/Classes/Core/Constants/Dimensions.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -33,4 +33,4 @@ public struct PrimerDimensions {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Constants/Strings.swift
+++ b/Sources/PrimerSDK/Classes/Core/Constants/Strings.swift
@@ -6,7 +6,7 @@
 //
 
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -1037,4 +1037,4 @@ extension Strings {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Crypto/AES256.swift
+++ b/Sources/PrimerSDK/Classes/Core/Crypto/AES256.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 13/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import CommonCrypto
 import Foundation
@@ -169,4 +169,4 @@ internal struct AES256 {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Keychain/Keychain.swift
+++ b/Sources/PrimerSDK/Classes/Core/Keychain/Keychain.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 13/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -131,4 +131,4 @@ class Keychain {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 24/02/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -63,4 +63,4 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/PayPalService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/PayPalService.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -257,4 +257,4 @@ internal class PayPalService: PayPalServiceProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/PrimerAPIConfigurationModule.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/PrimerAPIConfigurationModule.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -290,4 +290,4 @@ internal class PrimerAPIConfigurationModule: PrimerAPIConfigurationModuleProtoco
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/VaultService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/VaultService.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -77,4 +77,4 @@ internal class VaultService: VaultServiceProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Primer/AppState.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/AppState.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 16/01/2021.
 //
 
-#if canImport(UIKit)
+
 
 internal protocol AppStateProtocol: AnyObject {
     
@@ -48,4 +48,4 @@ internal class AppState: AppStateProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Primer/Decision Handlers/Decisions.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/Decision Handlers/Decisions.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 02/05/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -123,4 +123,4 @@ public extension PrimerPaymentCreationDecision {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Primer/DependencyInjection.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/DependencyInjection.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 10/02/2021.
 //
 
-#if canImport(UIKit)
+
 
 @propertyWrapper
 struct Dependency<T> {
@@ -75,4 +75,4 @@ final internal class DependencyContainer {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Primer/Primer.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/Primer.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 import UIKit
 
 // swiftlint:disable identifier_name
@@ -84,4 +84,4 @@ public class Primer {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -273,4 +273,4 @@ internal class PrimerDelegateProxy {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 20/9/22.
 //
 
-#if canImport(UIKit)
+
 import UIKit
 
 #if canImport(Primer3DS)
@@ -317,4 +317,4 @@ internal class PrimerInternal {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerSource.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerSource.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 25/04/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -27,4 +27,4 @@ extension PrimerSource {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/Primer/ResumeHandlerProtocol.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/ResumeHandlerProtocol.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 15/9/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -16,4 +16,4 @@ public protocol ResumeHandlerProtocol {
     func handleSuccess()
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/AssetsManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/AssetsManager.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 26/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -182,4 +182,4 @@ public enum PrimerUserInterfaceStyle: CaseIterable, Hashable {
     case dark, light
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/CardComponentsManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/CardComponentsManager.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 9/2/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import SafariServices
@@ -1095,4 +1095,4 @@ extension PrimerHeadlessUniversalCheckout.CardComponentsManager: SFSafariViewCon
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/NativeUIManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/NativeUIManager.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 4/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -123,5 +123,5 @@ extension PrimerHeadlessUniversalCheckout {
 
 
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/PrimerPaymentMethodManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/PrimerPaymentMethodManager.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 26/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -23,4 +23,4 @@ internal protocol PrimerPaymentMethodManager {
     func showPaymentMethod(intent: PrimerSessionIntent) throws
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/RawDataManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/RawDataManager.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 12/7/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import SafariServices
@@ -933,4 +933,4 @@ extension PrimerHeadlessUniversalCheckout.RawDataManager {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 17/08/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -150,4 +150,4 @@ class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizationBuil
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawRetailerDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawRetailerDataTokenizationBuilder.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 18/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -149,4 +149,4 @@ class PrimerRawRetailerDataTokenizationBuilder: PrimerRawDataTokenizationBuilder
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/VaultManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/VaultManager.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 13/6/23.
 //
 
-#if canImport(UIKit)
+
 
 import SafariServices
 import UIKit
@@ -937,4 +937,4 @@ extension PrimerPaymentMethodTokenData {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutInputElement.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutInputElement.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 4/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -193,5 +193,5 @@ public protocol PrimerHeadlessUniversalCheckoutInputElement {
     var isValid: Bool { get }
 }
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutInputElementDelegate.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutInputElementDelegate.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 4/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -106,5 +106,5 @@ extension PrimerHeadlessUniversalCheckout {
     }
 }
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 27/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -55,4 +55,4 @@ extension PrimerHeadlessUniversalCheckout {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerRetailerData.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerRetailerData.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 15/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -32,4 +32,4 @@ public class PrimerRetailerData: PrimerRawData {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 28/1/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -260,4 +260,4 @@ public class PrimerHeadlessUniversalCheckout {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckoutProtocols.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckoutProtocols.swift
@@ -6,7 +6,7 @@
 //
 
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -47,4 +47,4 @@ public protocol PrimerInputElementDelegate: AnyObject {
     @objc optional func inputElementDidDetectType(_ sender: PrimerHeadlessUniversalCheckoutInputElement, type: Any?)
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/API/ClientSessionAPIModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/API/ClientSessionAPIModel.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 5/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -180,4 +180,4 @@ public struct ClientSessionUpdateRequest: Encodable {
     let actions: ClientSessionAction
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/API/PaymentAPIModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/API/PaymentAPIModel.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -368,4 +368,4 @@ extension PrimerCheckoutDataPayment {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/API/Request.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/API/Request.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 5/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -14,4 +14,4 @@ public class Request {
     internal class URLParameters {}
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/API/Response.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/API/Response.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 5/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -13,4 +13,4 @@ public class Response {
     public class Body {}
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/API/VaultedPaymentMethods.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/API/VaultedPaymentMethods.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 5/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -16,4 +16,4 @@ extension Response.Body {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/AdyenDotPay.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/AdyenDotPay.swift
@@ -5,7 +5,7 @@
 //  Created by Admin on 8/11/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -59,4 +59,4 @@ internal struct BanksListSessionResponse: Decodable {
     let result: [Response.Body.Adyen.Bank]
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Apaya.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Apaya.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 27/07/2021.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -221,4 +221,4 @@ public struct Apaya {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/ApplePay.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ApplePay.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 public enum MerchantCapability {
     case capability3DS
@@ -38,4 +38,4 @@ struct ApplePayTokenPaymentDataHeader: Codable {
     let transactionId: String
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/CardButtonViewModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CardButtonViewModel.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -16,4 +16,4 @@ struct CardButtonViewModel {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 29/6/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import PassKit
@@ -523,4 +523,4 @@ public enum PaymentNetwork: String {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/CheckoutModule.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CheckoutModule.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 internal class CheckoutModule: Codable {
     let type: String
@@ -12,4 +12,4 @@ internal class CheckoutModule: Codable {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 22/11/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -371,4 +371,4 @@ internal extension Encodable {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/ClientToken.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ClientToken.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -266,4 +266,4 @@ extension DecodedJWTToken {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Consolable.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Consolable.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 19/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -25,4 +25,4 @@ struct Consolable<T> {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/CountryCode.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CountryCode.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -356,4 +356,4 @@ extension CountryCode {
     }()
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Currency.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Currency.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 internal struct CurrencyElement: Codable {
     let name: String
@@ -204,4 +204,4 @@ public enum Currency: String, Codable, CaseIterable {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/ImageName.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ImageName.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 29/12/2020.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -43,4 +43,4 @@ public enum ImageName: String {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Klarna.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Klarna.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 24/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -144,4 +144,4 @@ extension Response.Body.Klarna {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Notification.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Notification.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 7/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -15,4 +15,4 @@ internal extension Notification.Name {
     static let receivedUrlSchemeCancellation    = Notification.Name(rawValue: "PrimerURLSchemeCancellation")
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/OrderItem.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/OrderItem.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 24/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import PassKit
@@ -72,4 +72,4 @@ internal struct OrderItem: Codable {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PCI/FormType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PCI/FormType.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 24/01/2021.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -18,4 +18,4 @@ public enum PrimerFormType: String, CaseIterable {
     case cardForm
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PayPal.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PayPal.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 extension Request.Body {
     public class PayPal {}
@@ -80,4 +80,4 @@ extension Response.Body.Tokenization {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethod.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -550,5 +550,5 @@ extension PrimerTheme {
     }
 }
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfigurationOptions.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfigurationOptions.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 28/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -45,5 +45,5 @@ extension PrimerTestPaymentMethodSessionInfo.FlowDecision {
     
 }
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentResponse.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentResponse.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 3/9/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -65,4 +65,4 @@ internal protocol RequiredActionProtocol {
     var clientToken: String? { get }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerCheckoutAdditionalInfo.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerCheckoutAdditionalInfo.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -13,4 +13,4 @@ import Foundation
 
 @objc public class PrimerCheckoutAdditionalInfo: NSObject, Codable {}
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerCheckoutQRCodeInfo.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerCheckoutQRCodeInfo.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 18/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -51,4 +51,4 @@ import Foundation
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerCheckoutVoucherAdditionalInfo.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerCheckoutVoucherAdditionalInfo.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 18/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -46,4 +46,4 @@ import Foundation
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerConfiguration.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerConfiguration.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 28/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import PassKit
@@ -415,5 +415,5 @@ extension Response.Body.Configuration {
     }
 }
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerFlowEnums.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerFlowEnums.swift
@@ -5,11 +5,11 @@
 //  Created by Carl Eriksson on 13/01/2021.
 //
 
-#if canImport(UIKit)
+
 
 public enum PrimerSessionIntent: String, Codable {
     case checkout = "CHECKOUT"
     case vault = "VAULT"
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerInitializationData.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerInitializationData.swift
@@ -5,10 +5,10 @@
 //  Created by Dario Carlomagno on 15/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
 @objc public class PrimerInitializationData: NSObject, Codable {}
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerIntegrationOptions.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerIntegrationOptions.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/11/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -18,4 +18,4 @@ public class PrimerIntegrationOptions: NSObject {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerLocaleData.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerLocaleData.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 2/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -27,4 +27,4 @@ public struct PrimerLocaleData: Codable {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerMultibancoCheckoutAdditionalInfo.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerMultibancoCheckoutAdditionalInfo.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 18/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -44,4 +44,4 @@ import Foundation
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -154,4 +154,4 @@ internal enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable,
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSDKIntegrationType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSDKIntegrationType.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 19/12/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -14,4 +14,4 @@ internal enum PrimerSDKIntegrationType: String, Codable {
     case headless   = "HEADLESS"
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 // MARK: - PRIMER SETTINGS
 
@@ -208,4 +208,4 @@ public class PrimerThreeDsOptions: PrimerThreeDsOptionsProtocol, Codable {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerVaultedCardAdditionalData.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerVaultedCardAdditionalData.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 22/6/23.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -18,4 +18,4 @@ public class PrimerVaultedCardAdditionalData: PrimerVaultedPaymentMethodAddition
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerVaultedPaymentMethodAdditionalData.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerVaultedPaymentMethodAdditionalData.swift
@@ -5,10 +5,10 @@
 //  Created by Evangelos Pittas on 22/6/23.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
 public protocol PrimerVaultedPaymentMethodAdditionalData: Codable {}
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/RetailOutletsRetail.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/RetailOutletsRetail.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 18/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -59,4 +59,4 @@ import Foundation
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/SuccessMessage.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/SuccessMessage.swift
@@ -5,11 +5,11 @@
 //  Created by Carl Eriksson on 13/01/2021.
 //
 
-#if canImport(UIKit)
+
 
 enum SuccessMessage: String {
     case paymentSuccessful
     case paymentMethodSavedSuccessfully
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Borders.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Borders.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -16,4 +16,4 @@ internal class BorderTheme {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Buttons.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Buttons.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -32,4 +32,4 @@ internal class ButtonTheme {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Colors.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Colors.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -43,4 +43,4 @@ internal class ColorSwatch {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Inputs.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Inputs.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -34,4 +34,4 @@ internal class InputTheme {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+TextStyles.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+TextStyles.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -36,4 +36,4 @@ internal class TextTheme {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Views.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/Internal/PrimerTheme+Views.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -22,4 +22,4 @@ internal struct ViewTheme {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/PrimerTheme.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/PrimerTheme.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 04/01/2021.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -79,4 +79,4 @@ public class PrimerTheme: PrimerThemeProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/Public/PrimerThemeData+Deprecated.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/Public/PrimerThemeData+Deprecated.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -222,4 +222,4 @@ public struct PrimerDarkTheme: ColorTheme {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/Public/PrimerThemeData.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/Public/PrimerThemeData.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -330,4 +330,4 @@ public class PrimerThemeData {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/Throwable.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Throwable.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 22/11/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -32,4 +32,4 @@ enum Throwable<T: Decodable>: Decodable {
         }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/TokenizationRequestBody.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/TokenizationRequestBody.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -59,4 +59,4 @@ extension Request.Body {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/TokenizationRequestPaymentInstrument.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/TokenizationRequestPaymentInstrument.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 29/8/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -198,4 +198,4 @@ public struct BinData: Codable {
     public var productName: String?
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/TokenizationRequestPaymentSessionInfo.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/TokenizationRequestPaymentSessionInfo.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 29/8/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -65,4 +65,4 @@ struct IPay88SessionInfo: OffSessionPaymentSessionInfo {
     var redirectionUrl: String? = PrimerSettings.current.paymentMethodOptions.urlScheme
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/TokenizationResponse.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/TokenizationResponse.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 2/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -166,4 +166,4 @@ extension Response.Body.Tokenization {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/UniversalCheckoutViewModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/UniversalCheckoutViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 6/8/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -41,4 +41,4 @@ internal class UniversalCheckoutViewModel: UniversalCheckoutViewModelProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/VoucherValue.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/VoucherValue.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -80,4 +80,4 @@ extension VoucherValue {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/XenditRetailOutlets.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/XenditRetailOutlets.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 18/10/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -56,4 +56,4 @@ internal struct RetailOutletTokenizationSessionRequestParameters: OffSessionPaym
 }
 
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Data Models/_PaymentAPIModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/_PaymentAPIModel.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 28/02/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -61,4 +61,4 @@ extension PrimerClientSession {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Error Handler/ErrorHandler.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/ErrorHandler.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 16/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -98,4 +98,4 @@ internal class ErrorHandler {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Error Handler/Primer3DSErrorContainer.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/Primer3DSErrorContainer.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 12/5/23.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -203,4 +203,4 @@ public enum Primer3DSErrorContainer: PrimerErrorProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 16/3/21.
 //
 
-#if canImport(UIKit)
+
 
 // swiftlint:disable file_length
 import Foundation
@@ -956,4 +956,4 @@ internal extension Error {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/AlertController.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/AlertController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 17/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -52,4 +52,4 @@ internal class ClearViewController: UIViewController {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/ArrayExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/ArrayExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 13/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -33,4 +33,4 @@ extension Array where Element:Weak<AnyObject> {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/BundleExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/BundleExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 18/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -42,4 +42,4 @@ internal extension Bundle {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/DataExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/DataExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 13/12/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -19,4 +19,4 @@ internal extension Data {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/DateExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/DateExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 10/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -90,4 +90,4 @@ internal extension Date {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/DateFormatter+Extensions.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/DateFormatter+Extensions.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 28/08/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -41,4 +41,4 @@ internal extension DateFormatter {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/EncodingDecodingContainerExtensions.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/EncodingDecodingContainerExtensions.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 4/3/23.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -144,4 +144,4 @@ extension UnkeyedDecodingContainer {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/IntExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/IntExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 14/09/2021.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -40,4 +40,4 @@ internal extension Int {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/Logger.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/Logger.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 16/01/2021.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -135,4 +135,4 @@ internal func logJSON(obj: Any) {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/Mask.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/Mask.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -71,4 +71,4 @@ internal class Mask {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/NSObject+ClassName.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/NSObject+ClassName.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Dario Carlomagno on 07/06/22.
 //
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -46,4 +46,4 @@ extension NSObject {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/Optional+Extensions.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/Optional+Extensions.swift
@@ -5,10 +5,10 @@
 //  Created by Carl Eriksson on 07/03/2021.
 //
 
-#if canImport(UIKit)
+
 
 internal extension Optional {
     var exists: Bool { return self != nil }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PostalCode.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PostalCode.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 class PostalCode {
     
@@ -17,4 +17,4 @@ class PostalCode {
     }    
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PresentationController.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PresentationController.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -72,4 +72,4 @@ internal extension UIView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerButton.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerButton.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 18/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -201,4 +201,4 @@ extension PrimerButton {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerCustomStyleTextField.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerCustomStyleTextField.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -151,4 +151,4 @@ internal class PrimerCustomStyleTextField: UITextField {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerImage.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerImage.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 20/10/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -71,4 +71,4 @@ internal enum PrimerImage {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerImageView.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerImageView.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -36,4 +36,4 @@ extension PrimerImageView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerScrollView.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerScrollView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 18/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -23,4 +23,4 @@ internal class PrimerScrollView: UIScrollView {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerStackVIew.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerStackVIew.swift
@@ -6,7 +6,7 @@
 //
 
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -33,5 +33,5 @@ extension PrimerStackView {
     }
 }
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerTableViewCell.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerTableViewCell.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 23/01/2021.
 //
 
-#if canImport(UIKit)
+
 import UIKit
 
 internal class PrimerTableViewCell: UITableViewCell {
@@ -35,4 +35,4 @@ internal class PrimerTableViewCell: UITableViewCell {
     }
     
 }
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerUIImage.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerUIImage.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -30,4 +30,4 @@ extension PrimerUIImage {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerViewController.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerViewController.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -32,4 +32,4 @@ internal class PrimerViewController: UIViewController {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerViewExtensions.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/PrimerViewExtensions.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 29/11/2020.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -137,4 +137,4 @@ internal class PrimerView: UIView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 10/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -413,4 +413,4 @@ internal extension String {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/TimerExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/TimerExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 20/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -20,4 +20,4 @@ internal extension Timer {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/UIColorExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/UIColorExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 2/8/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -113,4 +113,4 @@ public extension UIColor {
     static let gray700  = #colorLiteral(red: 0.2666399777, green: 0.2666836977, blue: 0.2666304708, alpha: 1)
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/UIDeviceExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/UIDeviceExtension.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -319,4 +319,4 @@ internal extension UIDevice {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/UILocalizableUtil.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/UILocalizableUtil.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 16/02/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -14,4 +14,4 @@ internal struct UILocalizableUtil {
     static var isRightToLeftLocale =  UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/UINavigationController+Extensions.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/UINavigationController+Extensions.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 29/4/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -47,4 +47,4 @@ extension UINavigationController {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/UIScreenExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/UIScreenExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 03/07/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -20,4 +20,4 @@ extension UIScreen {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/URLExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/URLExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 18/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -32,4 +32,4 @@ internal extension URL {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/UserAgent.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/UserAgent.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -51,4 +51,4 @@ extension UserAgent {
     static var userAgentAsString: String = "\(appNameAndVersion()) \(deviceName()) \(deviceVersion()) \(CFNetworkVersion()) \(DarwinVersion())"
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/UserDefaultsExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/UserDefaultsExtension.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 18/3/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -26,4 +26,4 @@ internal extension UserDefaults {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/Weak.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/Weak.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 23/2/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -16,4 +16,4 @@ internal class Weak<T: AnyObject> {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Modules/ClientSessionActionsModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/ClientSessionActionsModule.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 11/7/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -118,4 +118,4 @@ class ClientSessionActionsModule: ClientSessionActionsProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Modules/Downloader.swift
+++ b/Sources/PrimerSDK/Classes/Modules/Downloader.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 14/7/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -250,4 +250,4 @@ extension Downloader: FileManagerDelegate {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
+++ b/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 15/7/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -248,5 +248,5 @@ internal class ImageManager {
     }
 }
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/Modules/PollingModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/PollingModule.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 30/6/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -102,4 +102,4 @@ class PollingModule: Module {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -6,7 +6,7 @@
 //
 
 
-#if canImport(UIKit)
+
 
 protocol UserInterfaceModuleProtocol {
     
@@ -1076,4 +1076,4 @@ class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerCardData.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerCardData.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 27/09/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -58,4 +58,4 @@ public class PrimerCardData: PrimerRawData {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerCardRedirectData.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerCardRedirectData.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 27/09/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -50,4 +50,4 @@ public class PrimerBancontactCardData: PrimerRawData {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerInputElements.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerInputElements.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 28/1/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -132,4 +132,4 @@ public class PrimerPostalCodeInputElement: PrimerInputTextField {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerPhoneNumberData.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerPhoneNumberData.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 27/09/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -34,4 +34,4 @@ public class PrimerPhoneNumberData: PrimerRawData {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataRedirectTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataRedirectTokenizationBuilder.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 27/09/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -258,4 +258,4 @@ class PrimerBancontactRawCardDataRedirectTokenizationBuilder: PrimerRawDataToken
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 18/08/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -267,4 +267,4 @@ class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuilderProt
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawData.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawData.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 12/7/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -22,4 +22,4 @@ public class PrimerRawData: NSObject, PrimerRawDataProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 26/2/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -411,4 +411,4 @@ internal extension PrimerAPI {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPIClient+PCI.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPIClient+PCI.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 26/2/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -24,4 +24,4 @@ extension PrimerAPIClient {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Services/Network/URLSessionStack.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/Network/URLSessionStack.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 26/2/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -352,7 +352,7 @@ internal extension URLSessionStack {
     }
 }
 
-#endif
+
 
 
 let mockedConfigResponse = """

--- a/Sources/PrimerSDK/Classes/PCI/Services/Parser/JSON/JSONParser.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/Parser/JSON/JSONParser.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 26/2/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -38,4 +38,4 @@ extension JSONParser {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/CardFormPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/CardFormPaymentMethodTokenizationViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 11/10/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import SafariServices
@@ -946,4 +946,4 @@ extension CardFormPaymentMethodTokenizationViewModel: UITextFieldDelegate {
 }
 
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/AddressField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/AddressField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -57,4 +57,4 @@ class PrimerAddressLine2Field: PrimerAddressField {
 }
 
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CVVField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CVVField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -32,4 +32,4 @@ class PrimerCVVField: PrimerCardFormFieldProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CardNumberField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CardNumberField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -33,4 +33,4 @@ class PrimerCardNumberField: PrimerCardFormFieldProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CardholderNameField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CardholderNameField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -46,4 +46,4 @@ extension PrimerCardholderNameField {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CityField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CityField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -32,4 +32,4 @@ class PrimerCityField: PrimerCardFormFieldProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CountryField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/CountryField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -36,4 +36,4 @@ class PrimerCountryField: PrimerCardFormFieldProtocol {
 }
 
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/ExpiryDateField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/ExpiryDateField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -32,4 +32,4 @@ class PrimerEpiryDateField: PrimerCardFormFieldProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/Field.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/Field.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 09/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -14,4 +14,4 @@ protocol PrimerCardFormFieldProtocol {
     // Declare a view with its delegate
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/FirstNameField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/FirstNameField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -32,4 +32,4 @@ class PrimerFirstNameField: PrimerCardFormFieldProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/LastNameField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/LastNameField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -32,4 +32,4 @@ class PrimerLastNameField: PrimerCardFormFieldProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/PostalCodeField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/PostalCodeField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -40,4 +40,4 @@ extension PrimerPostalCodeField {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/StateField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/Fields/StateField.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 08/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -32,4 +32,4 @@ class PrimerStateField: PrimerCardFormFieldProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel+FormViews.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel+FormViews.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -430,4 +430,4 @@ extension FormPaymentMethodTokenizationViewModel {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -960,4 +960,4 @@ extension FormPaymentMethodTokenizationViewModel: UITextFieldDelegate {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/TokenizationService.swift
+++ b/Sources/PrimerSDK/Classes/PCI/TokenizationService.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -97,4 +97,4 @@ internal class TokenizationService: TokenizationServiceProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/User Interface/InternalCardComponentsManager.swift
+++ b/Sources/PrimerSDK/Classes/PCI/User Interface/InternalCardComponentsManager.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 6/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -418,4 +418,4 @@ internal class MockCardComponentsManager: InternalCardComponentsManagerProtocol 
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/User Interface/Root/PrimerCardFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/PCI/User Interface/Root/PrimerCardFormViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 30/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -81,4 +81,4 @@ class PrimerCardFormViewController: PrimerFormViewController {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerCVVFieldView.swift
+++ b/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerCVVFieldView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 5/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -97,4 +97,4 @@ public final class PrimerCVVFieldView: PrimerTextFieldView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerCardNumberFieldView.swift
+++ b/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerCardNumberFieldView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 29/6/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -104,4 +104,4 @@ public final class PrimerCardNumberFieldView: PrimerTextFieldView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerCardholderNameFieldView.swift
+++ b/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerCardholderNameFieldView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 5/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -42,4 +42,4 @@ public final class PrimerCardholderNameFieldView: PrimerSimpleCardFormTextFieldV
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerExpiryDateFieldView.swift
+++ b/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerExpiryDateFieldView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 5/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -92,4 +92,4 @@ public final class PrimerExpiryDateFieldView: PrimerTextFieldView {
     }    
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerTextField.swift
+++ b/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerTextField.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 29/6/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -59,4 +59,4 @@ internal class PrimerTextField: UITextField {
         
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerTextFieldView.swift
+++ b/Sources/PrimerSDK/Classes/PCI/User Interface/Text Fields/PrimerTextFieldView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 29/6/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -349,4 +349,4 @@ internal class PaddedImageView: PrimerImageView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Services/Network/Endpoint.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/Endpoint.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 26/2/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -28,4 +28,4 @@ enum HTTPMethod: String, Codable {
     case delete = "DELETE"
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Services/Network/NetworkService.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/NetworkService.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 26/2/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -15,4 +15,4 @@ internal protocol NetworkService {
     func request<T: Decodable>(_ endpoint: Endpoint, completion: @escaping ResultCallback<T>)
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient+Promises.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient+Promises.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 15/6/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -26,4 +26,4 @@ extension PrimerAPIClient {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 26/2/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -532,4 +532,4 @@ internal class PrimerAPIClient: PrimerAPIClientProtocol {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Services/Network/SuccessResponse.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/SuccessResponse.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 13/1/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -15,4 +15,4 @@ internal struct SuccessResponse: Codable {
     let success: Bool
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/Services/Parser/Parser.swift
+++ b/Sources/PrimerSDK/Classes/Services/Parser/Parser.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 26/2/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -13,4 +13,4 @@ internal protocol Parser {
     func parse<T: Decodable>(_ type: T.Type, from data: Data) throws -> T
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Banks/BankSelectorViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Banks/BankSelectorViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 25/10/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -97,4 +97,4 @@ internal class BankSelectorViewController: PrimerFormViewController {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Banks/BankTableViewCell.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Banks/BankTableViewCell.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 25/10/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -95,4 +95,4 @@ fileprivate extension UIImageView {
         }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Components/HeaderFooterLabelView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Components/HeaderFooterLabelView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -40,4 +40,4 @@ extension HeaderFooterLabelView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Components/PrimerFormView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Components/PrimerFormView.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 09/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -96,4 +96,4 @@ extension PrimerFormView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Components/PrimerNibView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Components/PrimerNibView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 29/6/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -51,4 +51,4 @@ public class PrimerNibView: UIView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Components/PrimerResultComponentView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Components/PrimerResultComponentView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 3/2/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -70,4 +70,4 @@ class PrimerResultComponentView: PrimerView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Components/PrimerResultViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Components/PrimerResultViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 3/2/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -80,4 +80,4 @@ internal class PrimerResultViewController: PrimerViewController {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Components/PrimerSearchTextField.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Components/PrimerSearchTextField.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 26/10/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -117,4 +117,4 @@ internal class PrimerSearchTextField: UITextField, UITextFieldDelegate {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Countries/CountrySelectorViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Countries/CountrySelectorViewController.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -78,4 +78,4 @@ internal class CountrySelectorViewController: PrimerFormViewController {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Countries/CountryTableViewCell.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Countries/CountryTableViewCell.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -55,4 +55,4 @@ class CountryTableViewCell: UITableViewCell {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Identifiable.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Identifiable.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -19,4 +19,4 @@ protocol Identifiable where Self: UIView {
     var id: String? { get set }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/PrimerWebViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/PrimerWebViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 28/07/2021.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 import WebKit
@@ -63,4 +63,4 @@ internal class PrimerWebViewController: PrimerViewController {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/PaymentMethodsGroupView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/PaymentMethodsGroupView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 4/10/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -73,4 +73,4 @@ class PaymentMethodsGroupView: PrimerView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Primer/CardButton.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Primer/CardButton.swift
@@ -5,7 +5,7 @@
 //  Created by Carl Eriksson on 26/01/2021.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -240,4 +240,4 @@ internal class CardButton: PrimerButton {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/PrimerDemo3DSViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/PrimerDemo3DSViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 7/12/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -152,4 +152,4 @@ class PrimerThirdPartySDKViewController: UIViewController {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/PrimerUIManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/PrimerUIManager.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 9/9/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -255,4 +255,4 @@ internal class PrimerUIManager {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerAccountInfoPaymentViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerAccountInfoPaymentViewController.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -43,4 +43,4 @@ internal class PrimerAccountInfoPaymentViewController: PrimerFormViewController 
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerContainerViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerContainerViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 30/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -107,4 +107,4 @@ extension UIView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerFormViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 27/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -118,4 +118,4 @@ class PrimerFormViewController: PrimerViewController {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerInputViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerInputViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 11/11/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -45,4 +45,4 @@ internal class PrimerInputViewController: PrimerFormViewController {
 
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerLoadingViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerLoadingViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 30/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -65,4 +65,4 @@ class PrimerLoadingViewController: PrimerViewController {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerNavigationBar.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerNavigationBar.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 31/8/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -201,4 +201,4 @@ extension PrimerNavigationBar {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerNavigationController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerNavigationController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 30/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -82,4 +82,4 @@ internal final class DissolveAnimator: NSObject, UIViewControllerAnimatedTransit
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerPaymentPendingInfoViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerPaymentPendingInfoViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 22/08/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -34,4 +34,4 @@ internal class PrimerPaymentPendingInfoViewController: PrimerFormViewController 
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerRootViewController.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -448,4 +448,4 @@ extension PrimerRootViewController: UIGestureRecognizerDelegate {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerUniversalCheckoutViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerUniversalCheckoutViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 31/7/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -340,4 +340,4 @@ extension PrimerUniversalCheckoutViewController: ReloadDelegate {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerVaultManagerViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerVaultManagerViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 2/8/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -51,4 +51,4 @@ internal class PrimerVaultManagerViewController: PrimerFormViewController {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerVoucherInfoPaymentViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerVoucherInfoPaymentViewController.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -76,4 +76,4 @@ extension PrimerVoucherInfoPaymentViewController {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TestPaymentMethods/FlowDecisionTableViewCell.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TestPaymentMethods/FlowDecisionTableViewCell.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 29/05/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -67,4 +67,4 @@ extension FlowDecisionTableViewCell {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TestPaymentMethods/PrimerTestPaymentMethodViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TestPaymentMethods/PrimerTestPaymentMethodViewController.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Dario Carlomagno on 24/05/22.
 //
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -64,4 +64,4 @@ extension PrimerTestPaymentMethodViewController {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/Generic/PrimerGenericTextFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/Generic/PrimerGenericTextFieldView.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 12/11/21.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -72,4 +72,4 @@ public final class PrimerGenericFieldView: PrimerTextFieldView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/Generic/PrimerSimpleCardFormTextFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/Generic/PrimerSimpleCardFormTextFieldView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -65,4 +65,4 @@ public class PrimerSimpleCardFormTextFieldView: PrimerTextFieldView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerAddressLineFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerAddressLineFieldView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -51,4 +51,4 @@ public final class PrimerAddressLine2FieldView: PrimerSimpleCardFormTextFieldVie
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCityFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCityFieldView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -30,4 +30,4 @@ public final class PrimerCityFieldView: PrimerSimpleCardFormTextFieldView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCountryFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerCountryFieldView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -61,4 +61,4 @@ extension PrimerCountryFieldView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerFirstNameFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerFirstNameFieldView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -35,4 +35,4 @@ public final class PrimerFirstNameFieldView: PrimerSimpleCardFormTextFieldView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerLastNameFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerLastNameFieldView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -35,4 +35,4 @@ public final class PrimerLastNameFieldView: PrimerSimpleCardFormTextFieldView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerPostalCodeFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerPostalCodeFieldView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -83,4 +83,4 @@ public final class PrimerPostalCodeFieldView: PrimerTextFieldView {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerStateFieldView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerStateFieldView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -35,4 +35,4 @@ public final class PrimerStateFieldView: PrimerSimpleCardFormTextFieldView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView+Analytics.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView+Analytics.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 07/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -41,4 +41,4 @@ extension PrimerTextFieldView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView+CardFormFieldsAnalytics.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Text Fields/PrimerTextFieldView+CardFormFieldsAnalytics.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 07/06/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -45,4 +45,4 @@ extension PrimerTextFieldView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewControllers/QRCodeViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewControllers/QRCodeViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 11/1/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -161,5 +161,5 @@ internal class QRCodeViewController: PrimerFormViewController {
     }
 }
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApayaTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApayaTokenizationViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 12/10/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -310,4 +310,4 @@ extension ApayaTokenizationViewModel: WKNavigationDelegate {
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 import PassKit
@@ -525,4 +525,4 @@ extension ApplePayTokenizationViewModel: PKPaymentAuthorizationViewControllerDel
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/BankSelectorTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/BankSelectorTokenizationViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Admin on 8/11/21.
 //
 
-#if canImport(UIKit)
+
 
 import SafariServices
 import UIKit
@@ -334,4 +334,4 @@ extension BankSelectorTokenizationViewModel: UITextFieldDelegate {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/CheckoutWithVaultedPaymentMethodViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/CheckoutWithVaultedPaymentMethodViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 9/5/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 
@@ -595,4 +595,4 @@ class CheckoutWithVaultedPaymentMethodViewModel {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/IPay88TokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/IPay88TokenizationViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 12/12/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -631,5 +631,5 @@ extension IPay88TokenizationViewModel: PrimerIPay88ViewControllerDelegate {
 }
 #endif
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/KlarnaTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/KlarnaTokenizationViewModel.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -507,4 +507,4 @@ extension KlarnaTokenizationViewModel: PrimerKlarnaViewControllerDelegate {
 }
 #endif
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PayPalTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PayPalTokenizationViewModel.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 import AuthenticationServices
@@ -447,4 +447,4 @@ extension PayPalTokenizationViewModel: ASWebAuthenticationPresentationContextPro
     
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos on 6/5/22.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -598,4 +598,4 @@ extension PaymentMethodTokenizationViewModel {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 7/10/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import UIKit
@@ -195,4 +195,4 @@ class PaymentMethodTokenizationViewModel: NSObject, PaymentMethodTokenizationVie
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PrimerTestPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PrimerTestPaymentMethodTokenizationViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Dario Carlomagno on 25/05/22.
 //
 
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -372,4 +372,4 @@ extension PrimerTestPaymentMethodTokenizationViewModel: UITableViewDataSource, U
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/QRCodeTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/QRCodeTokenizationViewModel.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2022 Primer API ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
+
 
 import SafariServices
 import UIKit
@@ -329,5 +329,5 @@ extension QRCodeTokenizationViewModel {
     }
 }
 
-#endif
+
 

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/WebRedirectPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/WebRedirectPaymentMethodTokenizationViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Evangelos Pittas on 11/10/21.
 //
 
-#if canImport(UIKit)
+
 
 import Foundation
 import SafariServices
@@ -442,4 +442,4 @@ struct QRCodePollingURLs: Decodable {
     let complete: String?
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/UI Delegates/ReloadDelegate.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/UI Delegates/ReloadDelegate.swift
@@ -5,10 +5,10 @@
 //  Created by Carl Eriksson on 06/01/2021.
 //
 
-#if canImport(UIKit)
+
 
 internal protocol ReloadDelegate: AnyObject {
     func reload()
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodView.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodView.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -67,4 +67,4 @@ internal extension VaultPaymentMethodView {
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 import UIKit
 
@@ -346,4 +346,4 @@ extension VaultedPaymentInstrumentsViewController: UITableViewDataSource, UITabl
     }
 }
 
-#endif
+

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewModel.swift
@@ -1,4 +1,4 @@
-#if canImport(UIKit)
+
 
 internal protocol VaultPaymentMethodViewModelProtocol: AnyObject {
     var paymentMethods: [PrimerPaymentMethodTokenData] { get }
@@ -75,4 +75,4 @@ internal class MockVaultPaymentMethodViewModel: VaultPaymentMethodViewModelProto
     
 }
 
-#endif
+


### PR DESCRIPTION
CHKT-1638

# What this PR does

Removes the `canImport(UIKit)` wrapper from all files. 

This was once needed to support SPM but isn't any longer.

# Notable decisions & other stuff

Automation of a regular expression was used to modify all files

# Instructions on how to test this

Integrate this branch using SPM into a SwiftUI or UIKit app project

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
