### PR TITLE
fix: Remove deinits + logs inside relevant deinits

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
+++ b/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
@@ -38,10 +38,6 @@ class ThreeDSService: ThreeDSServiceProtocol {
     private var primer3DS: Primer3DS!
 #endif
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     internal func perform3DS(
         paymentMethodTokenData: PrimerPaymentMethodTokenData,
         sdkDismissed: (() -> Void)?,

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
@@ -18,10 +18,6 @@ internal protocol CreateResumePaymentServiceProtocol {
 internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
     
     static var apiClient: PrimerAPIClientProtocol?
-    
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
 
     func createPayment(paymentRequest: Request.Body.Payment.Create, completion: @escaping (Response.Body.Payment?, Error?) -> Void) {
         guard let clientToken = PrimerAPIConfigurationModule.decodedJWTToken else {

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/PayPalService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/PayPalService.swift
@@ -15,10 +15,6 @@ internal class PayPalService: PayPalServiceProtocol {
     static var apiClient: PrimerAPIClientProtocol?
     
     private var paypalTokenId: String?
-    
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
 
     private func prepareUrlAndTokenAndId(path: String) -> (DecodedJWTToken, URL, String)? {
         guard let decodedJWTToken = PrimerAPIConfigurationModule.decodedJWTToken else {

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/VaultService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/VaultService.swift
@@ -11,10 +11,6 @@ internal protocol VaultServiceProtocol {
 internal class VaultService: VaultServiceProtocol {
     
     static var apiClient: PrimerAPIClientProtocol?
-    
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
 
     func fetchVaultedPaymentMethods() -> Promise<Void> {
         return Promise { seal in

--- a/Sources/PrimerSDK/Classes/Core/Primer/AppState.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/AppState.swift
@@ -42,10 +42,6 @@ internal class AppState: AppStateProtocol {
         guard let selectedPaymentMethodToken = selectedPaymentMethodId else { return nil }
         return paymentMethods.first(where: { $0.id == selectedPaymentMethodToken })
     }
-
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
 }
 
 

--- a/Sources/PrimerSDK/Classes/Core/Primer/DependencyInjection.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/DependencyInjection.swift
@@ -21,9 +21,6 @@ private let _DependencyContainer = DependencyContainer()
 // swiftlint:enable identifier_name
 
 final internal class DependencyContainer {
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
     
     private var dependencies = [String: AnyObject]()
 

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/CardComponentsManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/CardComponentsManager.swift
@@ -89,11 +89,7 @@ extension PrimerHeadlessUniversalCheckout {
         private(set) public var paymentCheckoutData: PrimerCheckoutData?
         private var webViewController: SFSafariViewController?
         private var webViewCompletion: ((_ authorizationToken: String?, _ error: PrimerError?) -> Void)?
-        
-        deinit {
-            log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-        }
-        
+                
         public init(paymentMethodType: String) throws {
             let sdkEvent = Analytics.Event(
                 eventType: .sdkEvent,

--- a/Sources/PrimerSDK/Classes/Data Models/UniversalCheckoutViewModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/UniversalCheckoutViewModel.swift
@@ -35,10 +35,6 @@ internal class UniversalCheckoutViewModel: UniversalCheckoutViewModelProtocol {
     var selectedPaymentMethod: PrimerPaymentMethodTokenData? {
         return AppState.current.selectedPaymentMethod
     }
-
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
 }
 
 

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel.swift
@@ -448,11 +448,7 @@ class FormPaymentMethodTokenizationViewModel: PaymentMethodTokenizationViewModel
     /// Input completion block callback
     var userInputCompletion: (() -> Void)?
     
-    // MARK: - Init
-    
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
+    // MARK: - Payment Flow
     
     override func validate() throws {
         guard let decodedJWTToken = PrimerAPIConfigurationModule.decodedJWTToken else {

--- a/Sources/PrimerSDK/Classes/PCI/TokenizationService.swift
+++ b/Sources/PrimerSDK/Classes/PCI/TokenizationService.swift
@@ -17,10 +17,6 @@ internal class TokenizationService: TokenizationServiceProtocol {
     static var apiClient: PrimerAPIClientProtocol?
     
     var paymentMethodTokenData: PrimerPaymentMethodTokenData?
-    
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
 
     func tokenize(requestBody: Request.Body.Tokenization) -> Promise<PrimerPaymentMethodTokenData> {
         return Promise { seal in

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
@@ -124,10 +124,6 @@ internal class PrimerAPIClient: PrimerAPIClientProtocol {
     internal let networkService: NetworkService
 
     // MARK: - Object lifecycle
-    
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
 
     init(networkService: NetworkService = URLSessionStack()) {
         self.networkService = networkService

--- a/Sources/PrimerSDK/Classes/User Interface/Banks/BankSelectorViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Banks/BankSelectorViewController.swift
@@ -19,7 +19,6 @@ internal class BankSelectorViewController: PrimerFormViewController {
     deinit {
         viewModel.cancel()
         viewModel = nil
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
     }
     
     init(viewModel: BankSelectorTokenizationViewModel) {

--- a/Sources/PrimerSDK/Classes/User Interface/Countries/CountrySelectorViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Countries/CountrySelectorViewController.swift
@@ -13,7 +13,6 @@ internal class CountrySelectorViewController: PrimerFormViewController {
     deinit {
         viewModel.cancel()
         viewModel = nil
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
     }
     
     init(viewModel: SearchableItemsPaymentMethodTokenizationViewModelProtocol) {

--- a/Sources/PrimerSDK/Classes/User Interface/OAuth/PrimerWebViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/OAuth/PrimerWebViewController.swift
@@ -23,10 +23,6 @@ internal class PrimerWebViewController: PrimerViewController {
         "primer.io",
         "livedemostore.primer.io"
     ]
-
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self.self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
     
     init(with url: URL) {
         self.url = url

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerAccountInfoPaymentViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerAccountInfoPaymentViewController.swift
@@ -13,10 +13,6 @@ internal class PrimerAccountInfoPaymentViewController: PrimerFormViewController 
         
     let formPaymentMethodTokenizationViewModel: FormPaymentMethodTokenizationViewModel
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     init(navigationBarLogo: UIImage?, formPaymentMethodTokenizationViewModel: FormPaymentMethodTokenizationViewModel) {
         self.formPaymentMethodTokenizationViewModel = formPaymentMethodTokenizationViewModel
         super.init(nibName: nil, bundle: nil)

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerInputViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerInputViewController.swift
@@ -13,10 +13,6 @@ internal class PrimerInputViewController: PrimerFormViewController {
         
     let formPaymentMethodTokenizationViewModel: FormPaymentMethodTokenizationViewModel
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     init(navigationBarLogo: UIImage?,
          formPaymentMethodTokenizationViewModel: FormPaymentMethodTokenizationViewModel,
          inputsDistribution: NSLayoutConstraint.Axis = .vertical) {

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerPaymentPendingInfoViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerPaymentPendingInfoViewController.swift
@@ -14,10 +14,6 @@ internal class PrimerPaymentPendingInfoViewController: PrimerFormViewController 
     private let formPaymentMethodTokenizationViewModel: FormPaymentMethodTokenizationViewModel
     private let infoView: PrimerFormView
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     init(formPaymentMethodTokenizationViewModel: FormPaymentMethodTokenizationViewModel, infoView: PrimerFormView) {
         self.formPaymentMethodTokenizationViewModel = formPaymentMethodTokenizationViewModel
         self.infoView = infoView

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerVoucherInfoPaymentViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerVoucherInfoPaymentViewController.swift
@@ -25,10 +25,6 @@ internal class PrimerVoucherInfoPaymentViewController: PrimerFormViewController 
         lazyShareButton.addTarget(self, action: #selector(shareVoucherInfoTapped(_:)), for: .touchUpInside)
         return lazyShareButton
     }()
-
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
     
     init(navigationBarLogo: UIImage?, formPaymentMethodTokenizationViewModel: FormPaymentMethodTokenizationViewModel, shouldShareVoucherInfoWithText textToShare: String? = nil) {
         self.formPaymentMethodTokenizationViewModel = formPaymentMethodTokenizationViewModel

--- a/Sources/PrimerSDK/Classes/User Interface/TestPaymentMethods/PrimerTestPaymentMethodViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TestPaymentMethods/PrimerTestPaymentMethodViewController.swift
@@ -14,8 +14,8 @@ class PrimerTestPaymentMethodViewController: PrimerFormViewController {
     private var viewModel: PrimerTestPaymentMethodTokenizationViewModel!
     
     deinit {
+        viewModel.cancel()
         viewModel = nil
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
     }
     
     init(viewModel: PrimerTestPaymentMethodTokenizationViewModel) {

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewControllers/QRCodeViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewControllers/QRCodeViewController.swift
@@ -20,7 +20,6 @@ internal class QRCodeViewController: PrimerFormViewController {
     deinit {
         viewModel.cancel()
         viewModel = nil
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
     }
     
     init(viewModel: QRCodeTokenizationViewModel) {

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApayaTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApayaTokenizationViewModel.swift
@@ -18,10 +18,6 @@ class ApayaTokenizationViewModel: PaymentMethodTokenizationViewModel {
     private var webViewCompletion: ((_ res: Apaya.WebViewResponse?, _ error: Error?) -> Void)?
     private var apayaWebViewResponse: Apaya.WebViewResponse!
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     override func validate() throws {
         guard let decodedJWTToken = PrimerAPIConfigurationModule.decodedJWTToken, decodedJWTToken.isValid else {
             let err = PrimerError.invalidClientToken(userInfo: ["file": #file, "class": "\(Self.self)", "function": #function, "line": "\(#line)"], diagnosticsId: UUID().uuidString)

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -31,10 +31,6 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
     private var applePayControllerCompletion: ((PKPaymentAuthorizationResult) -> Void)?
     private var didTimeout: Bool = false
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     override func validate() throws {
         guard let decodedJWTToken = PrimerAPIConfigurationModule.decodedJWTToken, decodedJWTToken.isValid else {
             let err = PrimerError.invalidClientToken(userInfo: ["file": #file, "class": "\(Self.self)", "function": #function, "line": "\(#line)"], diagnosticsId: UUID().uuidString)

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/BankSelectorTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/BankSelectorTokenizationViewModel.swift
@@ -63,10 +63,6 @@ class BankSelectorTokenizationViewModel: WebRedirectPaymentMethodTokenizationVie
     
     private var selectedBank: AdyenBank?
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     override func cancel() {
         self.webViewController = nil
         self.webViewCompletion = nil

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/IPay88TokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/IPay88TokenizationViewModel.swift
@@ -16,10 +16,6 @@ import PrimerIPay88MYSDK
 
 class IPay88TokenizationViewModel: PaymentMethodTokenizationViewModel {
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self.self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
 #if canImport(PrimerIPay88MYSDK)
     private var backendCallbackUrl: URL!
     private var primerTransactionId: String!

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/KlarnaTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/KlarnaTokenizationViewModel.swift
@@ -26,10 +26,6 @@ class KlarnaTokenizationViewModel: PaymentMethodTokenizationViewModel {
     private var klarnaPaymentSessionCompletion: ((_ authorizationToken: String?, _ error: Error?) -> Void)?
     private var authorizationToken: String?
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self.self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     override func validate() throws {
         guard let decodedJWTToken = PrimerAPIConfigurationModule.decodedJWTToken, decodedJWTToken.isValid else {
             let err = PrimerError.invalidClientToken(userInfo: ["file": #file, "class": "\(Self.self)", "function": #function, "line": "\(#line)"], diagnosticsId: UUID().uuidString)

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PayPalTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PayPalTokenizationViewModel.swift
@@ -20,10 +20,6 @@ class PayPalTokenizationViewModel: PaymentMethodTokenizationViewModel {
         PayPalService()
     }()
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     override func validate() throws {
         guard let decodedJWTToken = PrimerAPIConfigurationModule.decodedJWTToken else {
             let err = PrimerError.invalidClientToken(userInfo: ["file": #file, "class": "\(Self.self)", "function": #function, "line": "\(#line)"], diagnosticsId: UUID().uuidString)

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel.swift
@@ -89,7 +89,6 @@ class PaymentMethodTokenizationViewModel: NSObject, PaymentMethodTokenizationVie
     var uiModule: UserInterfaceModule!
     
     deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
         NotificationCenter.default.removeObserver(self)
     }
     

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PrimerTestPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PrimerTestPaymentMethodTokenizationViewModel.swift
@@ -41,13 +41,7 @@ class PrimerTestPaymentMethodTokenizationViewModel: PaymentMethodTokenizationVie
         tableView.delegate = self
         return tableView
     }()
-    
-    // MARK: - Deinit
-    
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
+        
     // MARK: - Overrides
     
     override func start() {

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/QRCodeTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/QRCodeTokenizationViewModel.swift
@@ -21,7 +21,6 @@ class QRCodeTokenizationViewModel: WebRedirectPaymentMethodTokenizationViewModel
     deinit {
         tokenizationService = nil
         qrCode = nil
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
     }
     
     override func validate() throws {

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/WebRedirectPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/WebRedirectPaymentMethodTokenizationViewModel.swift
@@ -27,10 +27,6 @@ class WebRedirectPaymentMethodTokenizationViewModel: PaymentMethodTokenizationVi
     private var redirectUrlRequestId: String?
     private var redirectUrlComponents: URLComponents?
     
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-    
     @objc
     override func receivedNotification(_ notification: Notification) {
         switch notification.name.rawValue {

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewModel.swift
@@ -21,10 +21,6 @@ internal class VaultPaymentMethodViewModel: VaultPaymentMethodViewModelProtocol 
         }
     }
 
-    deinit {
-        log(logLevel: .debug, message: "🧨 deinit: \(self) \(Unmanaged.passUnretained(self).toOpaque())")
-    }
-
     func reloadVault(with completion: @escaping (Error?) -> Void) {
         let vaultService: VaultServiceProtocol = VaultService()
         firstly {


### PR DESCRIPTION
CHKT-1685

# What this PR does

* Removes `deinit` declarations that only include logs for checking memory locations
* Remove logs for checking memory locations from `deinit` declarations that contain other logic
* Bonus: added missing call to `viewModel.cancel()` in one of the `deinit` declarations

# Notable decisions & other stuff

A bit of git archaeology suggests that these were used to debug issues with a dependency injection bug. This bug was resolved some time ago ([reference](https://github.com/primer-io/primer-sdk-ios/commit/927dae43adf598801b4afdcbee4f6a587b473365)) and so they no longer serve a purpose.

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)