### PR TITLE
chore: Use version.swift for version reporting

### DIFF
--- a/Debug App/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Debug App/Pods/Pods.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 		EDB2A4C62E16581A08CF3385841E4BF8 /* CoreDataDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8BFB4BF6C1343B4ACB13ACA968F483 /* CoreDataDispatcher.swift */; };
 		EE0CCE61EE1909ECEF6F204B278CCD6C /* PrimerAddressLineFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4F824F61AB7ED19B472516A3E9C8D /* PrimerAddressLineFieldView.swift */; };
 		EEB8C49A72E04185A67A9D7E9F8B6014 /* sk.json in Resources */ = {isa = PBXBuildFile; fileRef = 56B368F810A2AB543CC374D7AC273A20 /* sk.json */; };
+		F03699532AC2DB5700E4179D /* VersionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03699522AC2DB5700E4179D /* VersionUtils.swift */; };
 		F0436570ADD72DF65293A1A25FA25F30 /* PrimerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE3CDE2B9BE96DC251CEB6FC68EC6E4 /* PrimerConfiguration.swift */; };
 		F097A00591647AE1226DA32369F0D4E6 /* PrimerInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D90FB6A5D795F4049AE61499E72F81 /* PrimerInputViewController.swift */; };
 		F219167FF3FE3C20BD85C39A075903FF /* PrimerRetailerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C1D9987D0E6274C876388CD7B764E /* PrimerRetailerData.swift */; };
@@ -484,37 +485,37 @@
 
 /* Begin PBXFileReference section */
 		016508A0C946E61AFD1324092F7F4475 /* KlarnaMobileSDK-xcframeworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "KlarnaMobileSDK-xcframeworks.sh"; sourceTree = "<group>"; };
-		01DCCECEF6DE0816459294F7D4E380B3 /* pt.json */ = {isa = PBXFileReference; includeInIndex = 1; path = pt.json; sourceTree = "<group>"; };
+		01DCCECEF6DE0816459294F7D4E380B3 /* pt.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = pt.json; sourceTree = "<group>"; };
 		025655E2356AE6CED57CD52291D755CE /* PrimerCardData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardData.swift; sourceTree = "<group>"; };
 		0292748EAA0F59FF63A048594369AFB0 /* PrimerVaultedPaymentMethodAdditionalData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultedPaymentMethodAdditionalData.swift; sourceTree = "<group>"; };
 		02E4F824F61AB7ED19B472516A3E9C8D /* PrimerAddressLineFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAddressLineFieldView.swift; sourceTree = "<group>"; };
 		0432C455D98AF72FD6864C01E3E06BE5 /* PrimerSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerSDK.release.xcconfig; sourceTree = "<group>"; };
 		04CA368E1040DCDB874CFD05EB959664 /* BankTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BankTableViewCell.swift; sourceTree = "<group>"; };
-		04DE2790F4BA934C8B330CE4A023A484 /* hy.json */ = {isa = PBXFileReference; includeInIndex = 1; path = hy.json; sourceTree = "<group>"; };
-		059A44FD4398BD3ECD3A33D1571C4CA0 /* so.json */ = {isa = PBXFileReference; includeInIndex = 1; path = so.json; sourceTree = "<group>"; };
+		04DE2790F4BA934C8B330CE4A023A484 /* hy.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = hy.json; sourceTree = "<group>"; };
+		059A44FD4398BD3ECD3A33D1571C4CA0 /* so.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = so.json; sourceTree = "<group>"; };
 		066A1F71DBE9D14ACDB2A63D48ADDF68 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		06EFDD6B847899803CDD6CEC7D495774 /* InternalCardComponentsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InternalCardComponentsManager.swift; sourceTree = "<group>"; };
 		0828534D079454FFFF543D9866AA1AE1 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
 		08B07423AA82A0FE4FA4CCA0106C9DE4 /* PrimerCardFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardFormViewController.swift; sourceTree = "<group>"; };
 		08D90FB6A5D795F4049AE61499E72F81 /* PrimerInputViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInputViewController.swift; sourceTree = "<group>"; };
-		091C52DB4E0BF544AAB20BF31610BE30 /* bg.json */ = {isa = PBXFileReference; includeInIndex = 1; path = bg.json; sourceTree = "<group>"; };
+		091C52DB4E0BF544AAB20BF31610BE30 /* bg.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = bg.json; sourceTree = "<group>"; };
 		0924D8D07A2B8717AEE1B845A2907C21 /* PrimerThemeData+Deprecated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerThemeData+Deprecated.swift"; sourceTree = "<group>"; };
-		09A090A65E85F0E260BBBC518FAFDD22 /* ko.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ko.json; sourceTree = "<group>"; };
+		09A090A65E85F0E260BBBC518FAFDD22 /* ko.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ko.json; sourceTree = "<group>"; };
 		0A9B45FE4B61770CD32006E3F49CCBFB /* RawDataManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RawDataManager.swift; sourceTree = "<group>"; };
 		0A9BFD6F8F465F8A708FE03A17414427 /* PrimerWebViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerWebViewController.swift; sourceTree = "<group>"; };
 		0CEA1480749C8D81B0FFB635BDEB4705 /* PrimerResultComponentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerResultComponentView.swift; sourceTree = "<group>"; };
-		0CFE031BD7589055BFCEEB1119F8C153 /* sr.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sr.json; sourceTree = "<group>"; };
-		0D50B801A56ACD5BC022CAA60F462518 /* ThreeDS_SDK.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = ThreeDS_SDK.xcframework; path = Sources/Frameworks/ThreeDS_SDK.xcframework; sourceTree = "<group>"; };
+		0CFE031BD7589055BFCEEB1119F8C153 /* sr.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sr.json; sourceTree = "<group>"; };
+		0D50B801A56ACD5BC022CAA60F462518 /* ThreeDS_SDK.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = ThreeDS_SDK.xcframework; path = Sources/Frameworks/ThreeDS_SDK.xcframework; sourceTree = "<group>"; };
 		0D67E38AE53D2DD65A16AF5CDC8AB67F /* PrimerSDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PrimerSDK-dummy.m"; sourceTree = "<group>"; };
 		0DB7F2D5BB97649A588DE3F579C41081 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		0E27177B7CCF2DA6BEAA61936C53BA02 /* TokenizationResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationResponse.swift; sourceTree = "<group>"; };
 		0EC45ABAE4CC9173E7137A76536C5003 /* PrimerKlarnaSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerKlarnaSDK.release.xcconfig; sourceTree = "<group>"; };
-		0FBDA3A3F35DC75334856E3135A512A3 /* ar.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ar.json; sourceTree = "<group>"; };
+		0FBDA3A3F35DC75334856E3135A512A3 /* ar.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ar.json; sourceTree = "<group>"; };
 		100E01528D455CA7428CDF87A1F9DCE1 /* TokenizationRequestBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationRequestBody.swift; sourceTree = "<group>"; };
 		10526B5EF46C2F86753394A25C7D0445 /* PrimerFlowEnums.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFlowEnums.swift; sourceTree = "<group>"; };
 		105344FCAA5C83C80B929CC49544A9CE /* TokenizationRequestPaymentInstrument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationRequestPaymentInstrument.swift; sourceTree = "<group>"; };
 		12C71BBF27B01BBE5B854B2CC1B4A651 /* PaymentMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethod.swift; sourceTree = "<group>"; };
-		12F049D553385B220511DA5324E73CAC /* kk.json */ = {isa = PBXFileReference; includeInIndex = 1; path = kk.json; sourceTree = "<group>"; };
+		12F049D553385B220511DA5324E73CAC /* kk.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = kk.json; sourceTree = "<group>"; };
 		139D45FF1CFA7B8C5CE600B027FAB52E /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		13E57A9033664934BB815C9ABE12CB43 /* Pods-Debug App Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Debug App Tests-dummy.m"; sourceTree = "<group>"; };
 		1437FAD4E45E8929285D343D53E42338 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawPhoneNumberDataTokenizationBuilder.swift; sourceTree = "<group>"; };
@@ -522,19 +523,19 @@
 		1547B16E14281179C5FE685621B67B38 /* Analytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		158FA9B9DBF1A80235CBB6C292AD3822 /* Currency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
 		167D824DCDED21787986848B8C99950E /* PrimerAccountInfoPaymentViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAccountInfoPaymentViewController.swift; sourceTree = "<group>"; };
-		16A13FF37400C98AB78552A82F345D3C /* ru.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ru.json; sourceTree = "<group>"; };
+		16A13FF37400C98AB78552A82F345D3C /* ru.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ru.json; sourceTree = "<group>"; };
 		16DB0A2C906E424C429F09EE8F4236C1 /* ApplePayTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePayTokenizationViewModel.swift; sourceTree = "<group>"; };
 		1701C2BA9780B96815CB6F6C83AA7974 /* PrimerAPIClient+Promises.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+Promises.swift"; sourceTree = "<group>"; };
 		18234F9225DD0A2D3272048CD6BE9FFA /* PrimerStackVIew.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerStackVIew.swift; sourceTree = "<group>"; };
 		185C900448A65C8F0C6739A8080914DB /* _PaymentAPIModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = _PaymentAPIModel.swift; sourceTree = "<group>"; };
 		18A9C0DF1386999EC3DF0E2399A99778 /* AnyEncodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
-		19DF40448DACEAE8218A622C7ACADE84 /* be.json */ = {isa = PBXFileReference; includeInIndex = 1; path = be.json; sourceTree = "<group>"; };
+		19DF40448DACEAE8218A622C7ACADE84 /* be.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = be.json; sourceTree = "<group>"; };
 		19E148415476719682D2C8368A32882D /* PrimerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerDelegate.swift; sourceTree = "<group>"; };
 		1A02E51F9DDD9CBB429D9AC7629F987E /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = race.swift; sourceTree = "<group>"; };
 		1AC0D5435EBA802F72AAD2E73D6F67D8 /* PrimerGenericTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerGenericTextFieldView.swift; sourceTree = "<group>"; };
 		1CDD75F8BD3124D3057BDBC8548F8B7F /* PrimerTextFieldView+CardFormFieldsAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTextFieldView+CardFormFieldsAnalytics.swift"; sourceTree = "<group>"; };
 		1D7F5643FEC6A897A8B48171D8D0AFD6 /* PrimerIPay88MYSDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PrimerIPay88MYSDK.modulemap; sourceTree = "<group>"; };
-		1DA399A7CEC10284AA5DFF7087AB1606 /* no.json */ = {isa = PBXFileReference; includeInIndex = 1; path = no.json; sourceTree = "<group>"; };
+		1DA399A7CEC10284AA5DFF7087AB1606 /* no.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = no.json; sourceTree = "<group>"; };
 		1E110BB01B6F3D4258B22B7B95A9777A /* PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PrimerSDK-Info.plist"; sourceTree = "<group>"; };
 		1EA4574401EEB535ABC2ECC64430D181 /* Throwable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Throwable.swift; sourceTree = "<group>"; };
 		1FEC86D93BAC13455F163218A9C1D20D /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -543,7 +544,7 @@
 		2151B899A62EE15E2483007A778E8E7C /* IpayPayment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IpayPayment.h; path = PrimerIPay88SDK/Frameworks/IpayPayment.h; sourceTree = "<group>"; };
 		22B89EDEC387A04C17D485DA9DBA096E /* OrderItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrderItem.swift; sourceTree = "<group>"; };
 		22E3B6E2350EC9C8A4FB2AB0DF81D119 /* CountryField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryField.swift; sourceTree = "<group>"; };
-		23008DCE30635C2A48179C8955173D36 /* af.json */ = {isa = PBXFileReference; includeInIndex = 1; path = af.json; sourceTree = "<group>"; };
+		23008DCE30635C2A48179C8955173D36 /* af.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = af.json; sourceTree = "<group>"; };
 		24D6FA47A795B7308C0D55A653CC3104 /* PrimerSDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PrimerSDK.modulemap; sourceTree = "<group>"; };
 		25C166BF577DFC28F1BF4A07FA174775 /* CheckoutWithVaultedPaymentMethodViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckoutWithVaultedPaymentMethodViewModel.swift; sourceTree = "<group>"; };
 		26238DDBA62CD3748B820A6A1EDE9B01 /* CountryTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryTableViewCell.swift; sourceTree = "<group>"; };
@@ -561,7 +562,7 @@
 		2B8E34C5AB81858E000094E1562BFE13 /* Icons.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = Sources/PrimerSDK/Resources/Icons.xcassets; sourceTree = "<group>"; };
 		2BDB1A39669149DDD85D9C2D48ACE042 /* 3DSService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = 3DSService.swift; sourceTree = "<group>"; };
 		2CB46A21DBAC34A6131F27F401CAD3D4 /* Pods-Debug App Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Debug App Tests.release.xcconfig"; sourceTree = "<group>"; };
-		2D222B2A5D57E2055C9EF12BCAE26F26 /* hu.json */ = {isa = PBXFileReference; includeInIndex = 1; path = hu.json; sourceTree = "<group>"; };
+		2D222B2A5D57E2055C9EF12BCAE26F26 /* hu.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = hu.json; sourceTree = "<group>"; };
 		2E7E40195DF13E27C66AAAFB4107A989 /* UIDeviceExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIDeviceExtension.swift; sourceTree = "<group>"; };
 		2E94D787E8A251544ECBAA995DA1E9DD /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		2EA913A90FFF849E790BF1C22831A3E2 /* PrimerLoadingViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerLoadingViewController.swift; sourceTree = "<group>"; };
@@ -571,7 +572,7 @@
 		30424A15FF625421E63F306D4DCA634A /* PrimerTheme+Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Colors.swift"; sourceTree = "<group>"; };
 		306C952ED493894150536F8CD8BECB6D /* Pods-Debug App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Debug App.debug.xcconfig"; sourceTree = "<group>"; };
 		30D818DA62200FE99F17329E4AD45DDC /* CardComponentsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardComponentsManager.swift; sourceTree = "<group>"; };
-		30E5D8C43EE6F0E901F1F460DB736C49 /* sq.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sq.json; sourceTree = "<group>"; };
+		30E5D8C43EE6F0E901F1F460DB736C49 /* sq.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sq.json; sourceTree = "<group>"; };
 		318BA5A624F10FCFF9BD9A70E71E6C4C /* PrimerTheme+Buttons.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Buttons.swift"; sourceTree = "<group>"; };
 		323D8195FE7CB72DDEA0EBBF57E27D47 /* Device.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
 		3378FDE7CF6756B16256FFBF993DA91A /* AES256.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AES256.swift; sourceTree = "<group>"; };
@@ -583,7 +584,7 @@
 		36B00EB0B836D5100D8906245B8B9661 /* PrimerAPIClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPIClient.swift; sourceTree = "<group>"; };
 		37C4A9E16F4E2DAB60510F9F8C696597 /* PaymentResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentResponse.swift; sourceTree = "<group>"; };
 		38135FC951FDE8E3032F3CC26C45B06D /* PostalCodeField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostalCodeField.swift; sourceTree = "<group>"; };
-		3830E414F3EB4A0C9C40924BC94F52B5 /* ja.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ja.json; sourceTree = "<group>"; };
+		3830E414F3EB4A0C9C40924BC94F52B5 /* ja.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ja.json; sourceTree = "<group>"; };
 		38F0A1B7C84315DFF960C70DB61CA8B4 /* NetworkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		39397A68F8DB8974205E95E52C42B4B3 /* Pods-Debug App Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Debug App Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		39747BEC69572C1757907F113F6B19C5 /* Connectivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Connectivity.swift; sourceTree = "<group>"; };
@@ -595,17 +596,17 @@
 		3BCDD17220E89326943E0B5A24F8505F /* TokenizationRequestPaymentSessionInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationRequestPaymentSessionInfo.swift; sourceTree = "<group>"; };
 		3C8B1D6DD39AFB383F44343B08D4575F /* PrimerIPay88Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimerIPay88Error.swift; path = PrimerIPay88SDK/Classes/PrimerIPay88Error.swift; sourceTree = "<group>"; };
 		3CCCFF6ACD3423689A805F7A41F456C6 /* PrimerViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerViewExtensions.swift; sourceTree = "<group>"; };
-		3D5DD3A443EAFA64A6728D9623C32711 /* de.json */ = {isa = PBXFileReference; includeInIndex = 1; path = de.json; sourceTree = "<group>"; };
+		3D5DD3A443EAFA64A6728D9623C32711 /* de.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = de.json; sourceTree = "<group>"; };
 		3D6C93E9B8E12ADD7F2EAC90F253F50B /* WebRedirectPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebRedirectPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
 		3D803FB62A01F2DB010435FC0D6B72FE /* CountrySelectorViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewController.swift; sourceTree = "<group>"; };
 		3DB1E4A809AB5A63367A70A754CF2CE0 /* PrimerKlarnaSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerKlarnaSDK.debug.xcconfig; sourceTree = "<group>"; };
-		3DCE173F1CCAF4B0D75CB8CC7AA5F677 /* hi.json */ = {isa = PBXFileReference; includeInIndex = 1; path = hi.json; sourceTree = "<group>"; };
+		3DCE173F1CCAF4B0D75CB8CC7AA5F677 /* hi.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = hi.json; sourceTree = "<group>"; };
 		3E83B8F8F0ECE8ECEDC17E44428515C7 /* PrimerStateFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerStateFieldView.swift; sourceTree = "<group>"; };
-		3E85F286365CE24446B8414E7519ABDA /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		3E85F286365CE24446B8414E7519ABDA /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3ECCC38DA7558D2053B8F5633AAAAF79 /* Mask.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Mask.swift; sourceTree = "<group>"; };
 		3ED1DCCC3BE7EDEB962787A8E30A6F96 /* AnyCodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
-		3EE5B0DBF4ADCE0BC50EFA7DCA887F8D /* et.json */ = {isa = PBXFileReference; includeInIndex = 1; path = et.json; sourceTree = "<group>"; };
-		3F61EEC23B1A888114C4C1ADF4A86673 /* ms.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ms.json; sourceTree = "<group>"; };
+		3EE5B0DBF4ADCE0BC50EFA7DCA887F8D /* et.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = et.json; sourceTree = "<group>"; };
+		3F61EEC23B1A888114C4C1ADF4A86673 /* ms.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ms.json; sourceTree = "<group>"; };
 		3F972271981C552CAC86D444BA3DE791 /* PrimerThemeData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerThemeData.swift; sourceTree = "<group>"; };
 		41597C1A733DB1BD5944A6326180453D /* SuccessResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuccessResponse.swift; sourceTree = "<group>"; };
 		416909675AF7DE52F724EDD75BDE04E8 /* Primer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Primer.swift; sourceTree = "<group>"; };
@@ -614,13 +615,13 @@
 		435935B2F316A11311905DAD68C8DDAC /* PrimerSDK-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerSDK-prefix.pch"; sourceTree = "<group>"; };
 		43AEB5A843B70ED85E8FF9395AD90F72 /* PrimerHeadlessUniversalCheckoutInputElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutInputElement.swift; sourceTree = "<group>"; };
 		43C681726407CC7178476F02DD75F944 /* Primer3DSProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSProtocols.swift; path = Sources/Primer3DS/Classes/Primer3DSProtocols.swift; sourceTree = "<group>"; };
-		442C27AA6E002EB3C377B9C4198AFAF3 /* eu.json */ = {isa = PBXFileReference; includeInIndex = 1; path = eu.json; sourceTree = "<group>"; };
+		442C27AA6E002EB3C377B9C4198AFAF3 /* eu.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = eu.json; sourceTree = "<group>"; };
 		44C586906ABD4A1190735F29E3788C85 /* VaultPaymentMethodViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodViewController.swift; sourceTree = "<group>"; };
 		45B781E11A79C388D813B06730D8D4DD /* PrimerMultibancoCheckoutAdditionalInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerMultibancoCheckoutAdditionalInfo.swift; sourceTree = "<group>"; };
 		466113CEF6EAC19D866900CCB282BEC2 /* PrimerTheme+Views.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Views.swift"; sourceTree = "<group>"; };
 		46BE40CF3D522E23F0A1AC4996C89EB1 /* PrimerFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFormViewController.swift; sourceTree = "<group>"; };
 		46C178A25FF859EF537327E90C69CE3F /* ResumeHandlerProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResumeHandlerProtocol.swift; sourceTree = "<group>"; };
-		46DF979C091AAEB2188A67A4E60973E0 /* az.json */ = {isa = PBXFileReference; includeInIndex = 1; path = az.json; sourceTree = "<group>"; };
+		46DF979C091AAEB2188A67A4E60973E0 /* az.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = az.json; sourceTree = "<group>"; };
 		4763244FE4EDBBEBBE0F08E1A504653A /* PrimerCardholderNameFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardholderNameFieldView.swift; sourceTree = "<group>"; };
 		4904C99F7D4BCDF5793E01B9EB59BA89 /* Content.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Content.swift; sourceTree = "<group>"; };
 		4AA5F22D270953E5CEAD29BE54F6F305 /* ApayaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApayaTokenizationViewModel.swift; sourceTree = "<group>"; };
@@ -634,27 +635,27 @@
 		4F6618008B201E5110B04678DF9385E9 /* PrimerRootViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRootViewController.swift; sourceTree = "<group>"; };
 		4FD32028FD5BF0AEA431D16151440339 /* Identifiable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		4FDC593A82D77E5EF706A60594B1B94C /* Primer3DS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Primer3DS-prefix.pch"; sourceTree = "<group>"; };
-		5183A3A34BBBB945AE29667C7553B603 /* el.json */ = {isa = PBXFileReference; includeInIndex = 1; path = el.json; sourceTree = "<group>"; };
+		5183A3A34BBBB945AE29667C7553B603 /* el.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = el.json; sourceTree = "<group>"; };
 		5241D5AB36F0290E407D6A25D1058C04 /* Notification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 		529B61E5B348E049881C610F2A08C40F /* KlarnaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KlarnaTokenizationViewModel.swift; sourceTree = "<group>"; };
-		5329A0B8367E43F6DE39ABE055E9D040 /* tt.json */ = {isa = PBXFileReference; includeInIndex = 1; path = tt.json; sourceTree = "<group>"; };
+		5329A0B8367E43F6DE39ABE055E9D040 /* tt.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = tt.json; sourceTree = "<group>"; };
 		5335514016E0A6B50E5A03D318A7CC71 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		540DEED9BBAEB1E131517E332CA97BF0 /* PaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
-		54AB737F3043554978BCE0BD76000729 /* phone_number_country_codes.json */ = {isa = PBXFileReference; includeInIndex = 1; path = phone_number_country_codes.json; sourceTree = "<group>"; };
-		5536D76A02FB86E84689A5D3B051CBDA /* zh-KH.json */ = {isa = PBXFileReference; includeInIndex = 1; path = "zh-KH.json"; sourceTree = "<group>"; };
-		559CE23A5F2B394A14101BA2F258C75A /* ta.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ta.json; sourceTree = "<group>"; };
-		5602C99E5A9BBF31FEE8709F61A81EF8 /* vi.json */ = {isa = PBXFileReference; includeInIndex = 1; path = vi.json; sourceTree = "<group>"; };
-		56B368F810A2AB543CC374D7AC273A20 /* sk.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sk.json; sourceTree = "<group>"; };
+		54AB737F3043554978BCE0BD76000729 /* phone_number_country_codes.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = phone_number_country_codes.json; sourceTree = "<group>"; };
+		5536D76A02FB86E84689A5D3B051CBDA /* zh-KH.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = "zh-KH.json"; sourceTree = "<group>"; };
+		559CE23A5F2B394A14101BA2F258C75A /* ta.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ta.json; sourceTree = "<group>"; };
+		5602C99E5A9BBF31FEE8709F61A81EF8 /* vi.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = vi.json; sourceTree = "<group>"; };
+		56B368F810A2AB543CC374D7AC273A20 /* sk.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sk.json; sourceTree = "<group>"; };
 		56CB9647CC8CDA9763FAE921DACC3E1F /* PrimerSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSource.swift; sourceTree = "<group>"; };
 		5707CA8EF477DEEB8CB41B18726CB8E5 /* RateLimitedDispatcherBase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RateLimitedDispatcherBase.swift; sourceTree = "<group>"; };
 		571542B6D7831B459B37FF0196AC9727 /* Field.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Field.swift; sourceTree = "<group>"; };
 		5765DC8F588CF473C2FFA0F6182C0D8A /* PrimerIPay88MYSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PrimerIPay88MYSDK-Info.plist"; sourceTree = "<group>"; };
 		576918A6C15D07BD412AAF448EA54616 /* PrimerTheme+Borders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Borders.swift"; sourceTree = "<group>"; };
 		57F087DB1B37A42AFDE479741B0685DB /* UIScreenExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIScreenExtension.swift; sourceTree = "<group>"; };
-		5857FE9CD25823EAB3D2A307A82BE32A /* ml.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ml.json; sourceTree = "<group>"; };
-		58D0B252742894B8F436E2D6226EE52E /* th.json */ = {isa = PBXFileReference; includeInIndex = 1; path = th.json; sourceTree = "<group>"; };
-		5B0FE5BEF2FD855A8FF77C7511E26F6D /* tg.json */ = {isa = PBXFileReference; includeInIndex = 1; path = tg.json; sourceTree = "<group>"; };
-		5B711EB42C8FFABADACBF36D08837634 /* sw.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sw.json; sourceTree = "<group>"; };
+		5857FE9CD25823EAB3D2A307A82BE32A /* ml.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ml.json; sourceTree = "<group>"; };
+		58D0B252742894B8F436E2D6226EE52E /* th.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = th.json; sourceTree = "<group>"; };
+		5B0FE5BEF2FD855A8FF77C7511E26F6D /* tg.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = tg.json; sourceTree = "<group>"; };
+		5B711EB42C8FFABADACBF36D08837634 /* sw.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sw.json; sourceTree = "<group>"; };
 		5C7DE3C637C159DD04B51F8624B44624 /* PrimerDemo3DSViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerDemo3DSViewController.swift; sourceTree = "<group>"; };
 		5CDA794A6B5D0DDDEC3CDCA3E9C09451 /* version.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = version.swift; path = Sources/PrimerSDK/Classes/version.swift; sourceTree = "<group>"; };
 		5D7A695188A525A8B0AB1A92A82EAE48 /* BankSelectorTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BankSelectorTokenizationViewModel.swift; sourceTree = "<group>"; };
@@ -663,11 +664,11 @@
 		5EB4E9AA4460DB6E3B6C1B7BF6D21C53 /* PrimerPhoneNumberData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPhoneNumberData.swift; sourceTree = "<group>"; };
 		6098CE9116BFC3845DD96AD652C04E36 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		61E7AFAA58AAFA31C00BACCCF8559AC5 /* QRCodeViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeViewController.swift; sourceTree = "<group>"; };
-		626D728BC82242ED9E4EC34D4ABC2559 /* KlarnaMobileSDK.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = KlarnaMobileSDK.xcframework; path = ios/XCFramework/full/universal/KlarnaMobileSDK.xcframework; sourceTree = "<group>"; };
+		626D728BC82242ED9E4EC34D4ABC2559 /* KlarnaMobileSDK.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = KlarnaMobileSDK.xcframework; path = ios/XCFramework/full/universal/KlarnaMobileSDK.xcframework; sourceTree = "<group>"; };
 		626ED1D07DD4BE16F1861F5747FECFEA /* PrimerKlarnaSDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PrimerKlarnaSDK-dummy.m"; sourceTree = "<group>"; };
 		62A18C33E8EA3177FFB8E9F460AA11C3 /* PayPal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPal.swift; sourceTree = "<group>"; };
 		62C19D32F3F0BAF184A5959FDA7AD8BA /* PrimerCardRedirectData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardRedirectData.swift; sourceTree = "<group>"; };
-		63C72E6699818410EB0A9F8081A9EC1E /* zh-TW.json */ = {isa = PBXFileReference; includeInIndex = 1; path = "zh-TW.json"; sourceTree = "<group>"; };
+		63C72E6699818410EB0A9F8081A9EC1E /* zh-TW.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = "zh-TW.json"; sourceTree = "<group>"; };
 		64B6B05ABD3E84D51BBFF140D357117F /* URLExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLExtension.swift; sourceTree = "<group>"; };
 		64C256376B658E0EEEAD460E6A30370D /* Pods-Debug App Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Debug App Tests.modulemap"; sourceTree = "<group>"; };
 		64CB452411D8A47E63F1EBD0B6DE437B /* Primer3DS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Primer3DS.modulemap; sourceTree = "<group>"; };
@@ -675,9 +676,9 @@
 		651FF45F7CE8B91761113CF106217967 /* PrimerScrollView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerScrollView.swift; sourceTree = "<group>"; };
 		65B624EBF5412516975BDAF22E1D53D9 /* Pods-Debug App-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Debug App-umbrella.h"; sourceTree = "<group>"; };
 		65EEC09164AC46A490D889A4B3A4E875 /* BundleExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
-		661B567C4810A935CFBA7E116438230C /* tr.json */ = {isa = PBXFileReference; includeInIndex = 1; path = tr.json; sourceTree = "<group>"; };
+		661B567C4810A935CFBA7E116438230C /* tr.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = tr.json; sourceTree = "<group>"; };
 		666D95E8D4302FED5DF81F797FFBB301 /* PrimerTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTableViewCell.swift; sourceTree = "<group>"; };
-		67D4FB0F9B75B23896A5A80E46D02369 /* lv.json */ = {isa = PBXFileReference; includeInIndex = 1; path = lv.json; sourceTree = "<group>"; };
+		67D4FB0F9B75B23896A5A80E46D02369 /* lv.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = lv.json; sourceTree = "<group>"; };
 		67F9DF091B832A01099152CA0D21E5E2 /* PrimerKlarnaError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimerKlarnaError.swift; path = PrimerKlarnaSDK/Classes/PrimerKlarnaError.swift; sourceTree = "<group>"; };
 		6813F8F686CB86F947CFCA3AA6A59FD5 /* ErrorHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
 		6942EEB75589F8096F31A852E985DC5A /* PrimerTextFieldView+Analytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTextFieldView+Analytics.swift"; sourceTree = "<group>"; };
@@ -691,7 +692,7 @@
 		6CAF284EDC26FEF7841A7544FE7A32BF /* SequenceWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SequenceWrappers.swift; sourceTree = "<group>"; };
 		6DA2540D3BC7689BF9C7C5B4C5D639DD /* Primer3DS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Primer3DS.release.xcconfig; sourceTree = "<group>"; };
 		6E2D380EA6458429CFE29C01BD613DA1 /* ClientSessionAPIModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientSessionAPIModel.swift; sourceTree = "<group>"; };
-		70248D6685AE5AFEA64D59F62D4A16C8 /* zh.json */ = {isa = PBXFileReference; includeInIndex = 1; path = zh.json; sourceTree = "<group>"; };
+		70248D6685AE5AFEA64D59F62D4A16C8 /* zh.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = zh.json; sourceTree = "<group>"; };
 		703B7306E142EC188CB5862A3386412B /* UserInterfaceModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserInterfaceModule.swift; sourceTree = "<group>"; };
 		70D18DEBD3D9202B61D938D18A963228 /* Pods-Debug App-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Debug App-Info.plist"; sourceTree = "<group>"; };
 		70DE611C78184781092429D859F017EB /* PrimerAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPI.swift; sourceTree = "<group>"; };
@@ -703,29 +704,29 @@
 		75802316C029BB1D2F3FA33D0890975A /* UserAgent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
 		768DFADB4567BC5D42C0BE71D3D87CCA /* PrimerTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTheme.swift; sourceTree = "<group>"; };
 		76E3578E4B628CC91F9BC1B6C5C4FC73 /* ExpiryDateField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExpiryDateField.swift; sourceTree = "<group>"; };
-		7731D330DFFDE5BDB7262CBFE75CFA39 /* ku.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ku.json; sourceTree = "<group>"; };
+		7731D330DFFDE5BDB7262CBFE75CFA39 /* ku.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ku.json; sourceTree = "<group>"; };
 		77D77D924D9D8A4F3B31A8DC78BC7214 /* PrimerSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSettings.swift; sourceTree = "<group>"; };
 		783C2198F3C3B9492F9BE43E191B8507 /* CardNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardNetwork.swift; sourceTree = "<group>"; };
 		7851B1E6D972B53FDD5C84DEA2B2BA94 /* PrimerCustomStyleTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCustomStyleTextField.swift; sourceTree = "<group>"; };
 		788823208848A5A159A527490F431C70 /* PrimerKlarnaViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimerKlarnaViewController.swift; path = PrimerKlarnaSDK/Classes/PrimerKlarnaViewController.swift; sourceTree = "<group>"; };
-		79B5FDC0D811DD22D438C8299147D10B /* km.json */ = {isa = PBXFileReference; includeInIndex = 1; path = km.json; sourceTree = "<group>"; };
+		79B5FDC0D811DD22D438C8299147D10B /* km.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = km.json; sourceTree = "<group>"; };
 		7CEAFB01FBCF6405EEA41A57F47836BB /* Primer3DS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Primer3DS-umbrella.h"; sourceTree = "<group>"; };
 		7DFB82FC49735A1C87A9ADAF73EBD766 /* PrimerIPay88MYSDK-xcframeworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "PrimerIPay88MYSDK-xcframeworks.sh"; sourceTree = "<group>"; };
 		7E576BDDB4E79A57CE3045FD25A4E450 /* VaultManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultManager.swift; sourceTree = "<group>"; };
 		7E63F745E427E987E09670C63FFB0AAD /* PrimerNavigationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationController.swift; sourceTree = "<group>"; };
-		7E9EF19EBB79EF723BE66B549F0964B7 /* gl.json */ = {isa = PBXFileReference; includeInIndex = 1; path = gl.json; sourceTree = "<group>"; };
+		7E9EF19EBB79EF723BE66B549F0964B7 /* gl.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = gl.json; sourceTree = "<group>"; };
 		7EC9E7DF45F1F430B386960FC32F8DE4 /* ImageManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
 		8065232778925761294C43BC52D3166A /* ArrayExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
 		80CA37C2FE6FB9EFDFFDD60DE151158B /* Queue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
-		810EAC7B6BF98765F2675614D2007FF5 /* sv.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sv.json; sourceTree = "<group>"; };
+		810EAC7B6BF98765F2675614D2007FF5 /* sv.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sv.json; sourceTree = "<group>"; };
 		812E080E981922506FDB77AB628466A0 /* ConcurrencyLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConcurrencyLimitedDispatcher.swift; sourceTree = "<group>"; };
 		816A780D0C2C1EFA953A2F9344D73E85 /* PayPalService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalService.swift; sourceTree = "<group>"; };
 		81AE82A628E72F5492DD077308038416 /* Primer3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DS.swift; path = Sources/Primer3DS/Classes/Primer3DS.swift; sourceTree = "<group>"; };
-		827092588059F50742C1CF6F40847E91 /* nb.json */ = {isa = PBXFileReference; includeInIndex = 1; path = nb.json; sourceTree = "<group>"; };
+		827092588059F50742C1CF6F40847E91 /* nb.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = nb.json; sourceTree = "<group>"; };
 		8332AEB6F0EF946984EC5330A3BD7049 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = "zh-TW.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		83C62C92B25C4DD650DB6D989A3638B7 /* Dimensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dimensions.swift; sourceTree = "<group>"; };
 		84515E13647664B38A39E91DD35FBCAD /* PrimerSDKIntegrationType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSDKIntegrationType.swift; sourceTree = "<group>"; };
-		8504B12C19D5BE4EC28864CDA892D4EB /* da.json */ = {isa = PBXFileReference; includeInIndex = 1; path = da.json; sourceTree = "<group>"; };
+		8504B12C19D5BE4EC28864CDA892D4EB /* da.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = da.json; sourceTree = "<group>"; };
 		8553901DF5E05FEE1FD261595F9EA449 /* UINavigationController+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Extensions.swift"; sourceTree = "<group>"; };
 		8773AEACAE4EA5CB563B2BE3205E04D9 /* AnalyticsService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		883415DFDF218C8F2FB7036E78A986FE /* PrimerKlarnaSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PrimerKlarnaSDK-Info.plist"; sourceTree = "<group>"; };
@@ -733,8 +734,8 @@
 		88BBFB31782058675116A1EF8DF9BD73 /* ReloadDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReloadDelegate.swift; sourceTree = "<group>"; };
 		8B18397CD1BFAF65AECB88E78BAC0ADD /* StateField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StateField.swift; sourceTree = "<group>"; };
 		8B91C4014A12B7961AD63B9CB1618597 /* PaymentMethodConfigurationOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodConfigurationOptions.swift; sourceTree = "<group>"; };
-		8CE87FB7342A874BC723C9F2B2ED8AB3 /* id.json */ = {isa = PBXFileReference; includeInIndex = 1; path = id.json; sourceTree = "<group>"; };
-		8E982532F5FBC7DEB03C0F6F70AC0AB7 /* hr.json */ = {isa = PBXFileReference; includeInIndex = 1; path = hr.json; sourceTree = "<group>"; };
+		8CE87FB7342A874BC723C9F2B2ED8AB3 /* id.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = id.json; sourceTree = "<group>"; };
+		8E982532F5FBC7DEB03C0F6F70AC0AB7 /* hr.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = hr.json; sourceTree = "<group>"; };
 		8F42F8ED46021BBDDAE4541C3E02327C /* RateLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RateLimitedDispatcher.swift; sourceTree = "<group>"; };
 		8F8BFB4BF6C1343B4ACB13ACA968F483 /* CoreDataDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoreDataDispatcher.swift; sourceTree = "<group>"; };
 		8FB0823F6509EFDB7D3DD9F61B99EDF8 /* DependencyInjection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependencyInjection.swift; sourceTree = "<group>"; };
@@ -748,28 +749,28 @@
 		93A25D32A132A902D0DCB08F3A936C0D /* Pods-Debug App.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Debug App.modulemap"; sourceTree = "<group>"; };
 		940D103C6AB77833ADB6DD2AED6ABE4D /* PayPalTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalTokenizationViewModel.swift; sourceTree = "<group>"; };
 		949CE6E65977A51E812ED6A48E8401C9 /* PrimerTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextFieldView.swift; sourceTree = "<group>"; };
-		958DF5DC676C76B87FD38B6C4BE484F3 /* it.json */ = {isa = PBXFileReference; includeInIndex = 1; path = it.json; sourceTree = "<group>"; };
+		958DF5DC676C76B87FD38B6C4BE484F3 /* it.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = it.json; sourceTree = "<group>"; };
 		96245C913D414469B1B055FE759BCE36 /* Downloader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
 		967B58577CC95960D03E88A8367394BB /* KlarnaMobileSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = KlarnaMobileSDK.debug.xcconfig; sourceTree = "<group>"; };
-		96E5CD74C7CEF13F144389B9A7954C9C /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
-		971A091B046B3E3D91DE2A49AD38C415 /* ha.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ha.json; sourceTree = "<group>"; };
+		96E5CD74C7CEF13F144389B9A7954C9C /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		971A091B046B3E3D91DE2A49AD38C415 /* ha.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ha.json; sourceTree = "<group>"; };
 		97797B3A826695B50126CEBA1DF3D1C4 /* StrictRateLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StrictRateLimitedDispatcher.swift; sourceTree = "<group>"; };
-		980024E63BCCDC799A4FB8E643F4B7EE /* bs.json */ = {isa = PBXFileReference; includeInIndex = 1; path = bs.json; sourceTree = "<group>"; };
+		980024E63BCCDC799A4FB8E643F4B7EE /* bs.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = bs.json; sourceTree = "<group>"; };
 		99342384F60ADE69EAEC663468C5BA21 /* Apaya.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Apaya.swift; sourceTree = "<group>"; };
 		999B0869695391000743FA8993417DE1 /* PrimerImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerImageView.swift; sourceTree = "<group>"; };
 		9A959FADE6100F477E9A88FBF7BE17B5 /* Logger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		9AAB7DA46BCC03ACEFF4CDD2153279AE /* PrimerSDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerSDK-umbrella.h"; sourceTree = "<group>"; };
 		9ABC4030035F85290FD763D2D6531134 /* Pods-Debug App Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Debug App Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9B1F3303C4C025BE383B9236FF4CCA51 /* currencies.json */ = {isa = PBXFileReference; includeInIndex = 1; path = currencies.json; sourceTree = "<group>"; };
+		9B1F3303C4C025BE383B9236FF4CCA51 /* currencies.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = currencies.json; sourceTree = "<group>"; };
 		9C062FCDF5BFF61AE88C845C637AB4D3 /* Pods-Debug App Tests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-Debug App Tests"; path = Pods_Debug_App_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9CEDC7C2CEA211E2F43BE2A99F644487 /* PrimerFormView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFormView.swift; sourceTree = "<group>"; };
 		9D06A2CDE452ACD10D1C7D44B64CB297 /* PrimerUniversalCheckoutViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUniversalCheckoutViewController.swift; sourceTree = "<group>"; };
 		9D78288C113DF70776B53F4AEE36AA99 /* RecoverWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecoverWrappers.swift; sourceTree = "<group>"; };
 		9D7C958BD41FAEE38C857055F4768929 /* Pods-Debug App-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Debug App-acknowledgements.plist"; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9DA99FE5EE965E84DBF481F457B7FBB8 /* fa.json */ = {isa = PBXFileReference; includeInIndex = 1; path = fa.json; sourceTree = "<group>"; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9DA99FE5EE965E84DBF481F457B7FBB8 /* fa.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = fa.json; sourceTree = "<group>"; };
 		9DF67D061C1A24B3FCA790F0F1686FEC /* PrimerError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerError.swift; sourceTree = "<group>"; };
-		9E30A8643A102CCE33849AEF658FA34B /* ps.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ps.json; sourceTree = "<group>"; };
+		9E30A8643A102CCE33849AEF658FA34B /* ps.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ps.json; sourceTree = "<group>"; };
 		9EA4A71D94958A6D770D8022282CF78E /* Pods-Debug App Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Debug App Tests-acknowledgements.plist"; sourceTree = "<group>"; };
 		9FD9839D3A21F0287751A379E0C7A708 /* PrimerRawData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawData.swift; sourceTree = "<group>"; };
 		A02784547B176EA2ACAAD8AC90276D48 /* AnyDecodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
@@ -784,16 +785,16 @@
 		A572AB697E2F05A71DD3D8B2776AD7DC /* TokenizationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationService.swift; sourceTree = "<group>"; };
 		A5AAD964478E927406E375C8674D47C4 /* PaymentMethodsGroupView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodsGroupView.swift; sourceTree = "<group>"; };
 		A61E7B7CCD27CE3F5AFAF67768319512 /* CardholderNameField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardholderNameField.swift; sourceTree = "<group>"; };
-		A6210190AB0CCA765D073F0650BDB241 /* fr.json */ = {isa = PBXFileReference; includeInIndex = 1; path = fr.json; sourceTree = "<group>"; };
+		A6210190AB0CCA765D073F0650BDB241 /* fr.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = fr.json; sourceTree = "<group>"; };
 		A6411C49128C3CFB8AA377695C2104AE /* UIColorExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
-		A6EB9488B303B043EBC9D2CFC453B832 /* ro.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ro.json; sourceTree = "<group>"; };
+		A6EB9488B303B043EBC9D2CFC453B832 /* ro.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ro.json; sourceTree = "<group>"; };
 		A737E9A220CDE88BDFAFFDFCBB3E6FC8 /* CancellablePromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellablePromise.swift; sourceTree = "<group>"; };
 		A7E7C922FA3D5E9F00F096D43C00BE9D /* Pods-Debug App-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Debug App-frameworks.sh"; sourceTree = "<group>"; };
 		A868F8F8AE186AD14381696AF523D3E1 /* Keychain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		A889FF4523F520564912A3FDA3C91182 /* PrimerIPay88MYSDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerIPay88MYSDK-umbrella.h"; sourceTree = "<group>"; };
 		A8B3BC107C2BDC3C03D961866F721265 /* PrimerSDK-PrimerResources */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "PrimerSDK-PrimerResources"; path = PrimerResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		A96C1C2310EE6FE1A26F847E3F502237 /* CancellableCatchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellableCatchable.swift; sourceTree = "<group>"; };
-		AA9C05DD563B3DC1156264E53846CC54 /* ur.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ur.json; sourceTree = "<group>"; };
+		AA9C05DD563B3DC1156264E53846CC54 /* ur.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ur.json; sourceTree = "<group>"; };
 		AC15F60DD4F3F7665ED569E4AE16ED4C /* 3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = 3DS.swift; sourceTree = "<group>"; };
 		AC2FF4FF9CA6622553575894E48FF1AB /* VaultedPaymentMethods.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultedPaymentMethods.swift; sourceTree = "<group>"; };
 		ACE756423ACD98DA2114EA9F928D956A /* Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
@@ -801,7 +802,7 @@
 		AD7653830962AC27B8ACE623177ABA58 /* CardButtonViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardButtonViewModel.swift; sourceTree = "<group>"; };
 		AE74B9F2D48722B979E0F7CCB0D926CC /* CountryCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryCode.swift; sourceTree = "<group>"; };
 		AE871E7A7628A6EDCB416299F7D5C312 /* WrapperProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WrapperProtocols.swift; sourceTree = "<group>"; };
-		AFED0419F58810B094B045A94F42778F /* pl.json */ = {isa = PBXFileReference; includeInIndex = 1; path = pl.json; sourceTree = "<group>"; };
+		AFED0419F58810B094B045A94F42778F /* pl.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = pl.json; sourceTree = "<group>"; };
 		B070035BEF45F872802D2C617B7BEE8F /* Weak.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Weak.swift; sourceTree = "<group>"; };
 		B0BD9C15AD36B10902A3BE3A8FD99FE7 /* PrimerKlarnaSDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PrimerKlarnaSDK.modulemap; sourceTree = "<group>"; };
 		B17DF89D13BDE22B8A4D2168769C4E48 /* PrimerRawCardDataTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawCardDataTokenizationBuilder.swift; sourceTree = "<group>"; };
@@ -811,11 +812,11 @@
 		B41878BCFFB2F0774673FAF76C845093 /* PrimerNavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationBar.swift; sourceTree = "<group>"; };
 		B4A4CE6F1CC363A481904B25055BD090 /* LogEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogEvent.swift; sourceTree = "<group>"; };
 		B5C4ED515E094C4A43320B79DF8524FB /* Guarantee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Guarantee.swift; sourceTree = "<group>"; };
-		B61DC9B4534E5B21A28E037B2A53A371 /* mn.json */ = {isa = PBXFileReference; includeInIndex = 1; path = mn.json; sourceTree = "<group>"; };
+		B61DC9B4534E5B21A28E037B2A53A371 /* mn.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = mn.json; sourceTree = "<group>"; };
 		B6BD7F4864DA4F3847A569AE1AC6892C /* PrimerSearchTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSearchTextField.swift; sourceTree = "<group>"; };
 		B6F06C6C20AF0AFB2E34E54D37EB61B9 /* Thenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Thenable.swift; sourceTree = "<group>"; };
-		B72E54D3874156D1405A9599AAAD83E9 /* es.json */ = {isa = PBXFileReference; includeInIndex = 1; path = es.json; sourceTree = "<group>"; };
-		B79C83472C36ACC8CA5F9E1B0014E4A4 /* uk.json */ = {isa = PBXFileReference; includeInIndex = 1; path = uk.json; sourceTree = "<group>"; };
+		B72E54D3874156D1405A9599AAAD83E9 /* es.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = es.json; sourceTree = "<group>"; };
+		B79C83472C36ACC8CA5F9E1B0014E4A4 /* uk.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = uk.json; sourceTree = "<group>"; };
 		B7F1D9613A2366B3F5224FB667DD56DE /* PrimerCityFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCityFieldView.swift; sourceTree = "<group>"; };
 		B7F35FC28E43595B3B10E170BB27463E /* UIUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIUtils.swift; sourceTree = "<group>"; };
 		B847413264FC8E4DE2484CEC473289CB /* PrimerSimpleCardFormTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSimpleCardFormTextFieldView.swift; sourceTree = "<group>"; };
@@ -828,7 +829,7 @@
 		BBD82A811F119463D9AFE8CF7713F31E /* HeaderFooterLabelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HeaderFooterLabelView.swift; sourceTree = "<group>"; };
 		BC112EEE2F4BA17EEC9EFEFADF148540 /* FinallyWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FinallyWrappers.swift; sourceTree = "<group>"; };
 		BC639942D4366A5AA567E6912B6C66C3 /* PrimerCVVFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCVVFieldView.swift; sourceTree = "<group>"; };
-		BC6E909C3027887A486C44600B79E2C4 /* en.json */ = {isa = PBXFileReference; includeInIndex = 1; path = en.json; sourceTree = "<group>"; };
+		BC6E909C3027887A486C44600B79E2C4 /* en.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = en.json; sourceTree = "<group>"; };
 		BD1AC8628545D02AF110941128880271 /* CancellableThenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellableThenable.swift; sourceTree = "<group>"; };
 		BD241F41F82B185EBCCAE78E790C9528 /* WebViewUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewUtil.swift; sourceTree = "<group>"; };
 		BD91667428047551AF217B76A0AA3019 /* StringExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
@@ -840,14 +841,14 @@
 		BF7DE13FF2DF199E58D9F85F4BB36999 /* PrimerPaymentMethodManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPaymentMethodManager.swift; sourceTree = "<group>"; };
 		BFE3CDE2B9BE96DC251CEB6FC68EC6E4 /* PrimerConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerConfiguration.swift; sourceTree = "<group>"; };
 		C15924FCA59DFA2A8C5A284117050AAC /* Primer3DSError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSError.swift; path = Sources/Primer3DS/Classes/Primer3DSError.swift; sourceTree = "<group>"; };
-		C15FF3302B2650F6B206E8C98C61B6A4 /* uz.json */ = {isa = PBXFileReference; includeInIndex = 1; path = uz.json; sourceTree = "<group>"; };
+		C15FF3302B2650F6B206E8C98C61B6A4 /* uz.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = uz.json; sourceTree = "<group>"; };
 		C261F7EADFA6BAC30B19D15FC9DD783E /* CustomStringConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomStringConvertible.swift; sourceTree = "<group>"; };
 		C29E21010341A1863EABED0426192B0C /* PrimerAPIClient+PCI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+PCI.swift"; sourceTree = "<group>"; };
-		C2B4A5EC72F45CCBD072612DD8D0FFD8 /* cy.json */ = {isa = PBXFileReference; includeInIndex = 1; path = cy.json; sourceTree = "<group>"; };
-		C2E84F0E6CADC0D66E56DE50C04D9C1B /* sl.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sl.json; sourceTree = "<group>"; };
+		C2B4A5EC72F45CCBD072612DD8D0FFD8 /* cy.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = cy.json; sourceTree = "<group>"; };
+		C2E84F0E6CADC0D66E56DE50C04D9C1B /* sl.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sl.json; sourceTree = "<group>"; };
 		C47EC51E5F91302F731C24E676785A2E /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
 		C55F57D8EB2561C31E768A27EAE77E37 /* Primer3DSStructures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSStructures.swift; path = Sources/Primer3DS/Classes/Primer3DSStructures.swift; sourceTree = "<group>"; };
-		C5892FD01BAD8F04E4AA744ED4E8DCD7 /* ka.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ka.json; sourceTree = "<group>"; };
+		C5892FD01BAD8F04E4AA744ED4E8DCD7 /* ka.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ka.json; sourceTree = "<group>"; };
 		C5D152F5C198FFCC1BADCADFEE4A9DBB /* DataExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
 		C69E70953DB1701A8251042C30D374FD /* PrimerCountryFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCountryFieldView.swift; sourceTree = "<group>"; };
 		C71C344CC918ADCA293407831E1C5025 /* VaultPaymentMethodView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodView.swift; sourceTree = "<group>"; };
@@ -856,10 +857,10 @@
 		C9A892EA6945752EE41ED16A748E8593 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C9F9D0BE575001BCCB6589A9BC14F891 /* PrimerTestPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTestPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
 		CAAC1DC0B5F5979EF3D8E6494A9E5713 /* PrimerAPIClient+3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+3DS.swift"; sourceTree = "<group>"; };
-		CAFD03D52BC86E04D48749A8276E6435 /* bn.json */ = {isa = PBXFileReference; includeInIndex = 1; path = bn.json; sourceTree = "<group>"; };
+		CAFD03D52BC86E04D48749A8276E6435 /* bn.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = bn.json; sourceTree = "<group>"; };
 		CB2D76BD1B8AC84CA2D9720E5345DF1D /* PrimerButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerButton.swift; sourceTree = "<group>"; };
 		CB83F002475DA8C34F8A8E93D336C3C4 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = "zh-HK.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		CDACA4B200F86A610702409F061A2342 /* he.json */ = {isa = PBXFileReference; includeInIndex = 1; path = he.json; sourceTree = "<group>"; };
+		CDACA4B200F86A610702409F061A2342 /* he.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = he.json; sourceTree = "<group>"; };
 		CF62A4EBA4EDBA912B5ACEB9B84BA64A /* PrimerVaultManagerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultManagerViewController.swift; sourceTree = "<group>"; };
 		CF92DE9C2024A0DCE5088E1DC761A8A5 /* IntExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntExtension.swift; sourceTree = "<group>"; };
 		D03FF889913EE3797E582422BEFFC4E3 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -867,22 +868,22 @@
 		D24CD24F268D7252CA8F3E99D6CAC1D2 /* PrimerNibView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNibView.swift; sourceTree = "<group>"; };
 		D258EE2578C0D3E4396FE13FE69516DD /* PrimerHeadlessUniversalCheckout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckout.swift; sourceTree = "<group>"; };
 		D3A7E9C2363E309FB79C2CD38C041213 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		D3D99E723F3EFB3D2C3BE3BD7D65A31E /* nn.json */ = {isa = PBXFileReference; includeInIndex = 1; path = nn.json; sourceTree = "<group>"; };
+		D3D99E723F3EFB3D2C3BE3BD7D65A31E /* nn.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = nn.json; sourceTree = "<group>"; };
 		D54B45F9C5D3FD0C7451109D6DD7C14F /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		D54FA7720C78342B5439459172907A60 /* PrimerVaultedCardAdditionalData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultedCardAdditionalData.swift; sourceTree = "<group>"; };
-		D5AA7F2B319372A3BCC38F1C1FA73FD2 /* dv.json */ = {isa = PBXFileReference; includeInIndex = 1; path = dv.json; sourceTree = "<group>"; };
-		D5E82976D4CF476DD8CD1853E13FE271 /* lt.json */ = {isa = PBXFileReference; includeInIndex = 1; path = lt.json; sourceTree = "<group>"; };
+		D5AA7F2B319372A3BCC38F1C1FA73FD2 /* dv.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = dv.json; sourceTree = "<group>"; };
+		D5E82976D4CF476DD8CD1853E13FE271 /* lt.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = lt.json; sourceTree = "<group>"; };
 		D64EE816E96456BBED6752EF8A36E8FE /* PrimerCheckoutVoucherAdditionalInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCheckoutVoucherAdditionalInfo.swift; sourceTree = "<group>"; };
 		D6B512BDDA31559E37688AEDA591FA63 /* ApplePay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePay.swift; sourceTree = "<group>"; };
-		D7216679FBF84EF0B6A60C80BEE735FA /* cs.json */ = {isa = PBXFileReference; includeInIndex = 1; path = cs.json; sourceTree = "<group>"; };
+		D7216679FBF84EF0B6A60C80BEE735FA /* cs.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = cs.json; sourceTree = "<group>"; };
 		D7D904908A5EC60003EC3C0C7137DBBF /* PaymentAPIModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentAPIModel.swift; sourceTree = "<group>"; };
 		D81C1DB85FAF3F49403DF67E2C7D8A5E /* LastNameField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LastNameField.swift; sourceTree = "<group>"; };
 		D86DD8C26E739EFE60DD76F302B92D95 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = el.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D8A42D0CFF172D36E04B660BDEA23C9C /* FormType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormType.swift; sourceTree = "<group>"; };
-		D9D7EA565E96F5A5809133ED8B30E4D3 /* fi.json */ = {isa = PBXFileReference; includeInIndex = 1; path = fi.json; sourceTree = "<group>"; };
+		D9D7EA565E96F5A5809133ED8B30E4D3 /* fi.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = fi.json; sourceTree = "<group>"; };
 		DA52BDA0E27F4AC98488EEB595A22985 /* AssetsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetsManager.swift; sourceTree = "<group>"; };
 		DBC487EDD403A3B04E9CE4657D379494 /* PrimerRawRetailerDataTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawRetailerDataTokenizationBuilder.swift; sourceTree = "<group>"; };
-		DC4D8F2C4DC84A5D2246A81EF8201817 /* mk.json */ = {isa = PBXFileReference; includeInIndex = 1; path = mk.json; sourceTree = "<group>"; };
+		DC4D8F2C4DC84A5D2246A81EF8201817 /* mk.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = mk.json; sourceTree = "<group>"; };
 		DD562A76991139BF0C87B8B2B6A9280C /* XenditRetailOutlets.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = XenditRetailOutlets.swift; sourceTree = "<group>"; };
 		DE2740CE0C1C407E24C98CDD0225339C /* PrimerKlarnaSDK-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerKlarnaSDK-prefix.pch"; sourceTree = "<group>"; };
 		DE4CA17ABBC956DFB5EBCB1FC341FEF2 /* Cancellable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
@@ -897,11 +898,11 @@
 		E5655E627608AFA927330EA4F085DC1E /* Consolable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Consolable.swift; sourceTree = "<group>"; };
 		E57599F7963C47B5B97E6FD223D67623 /* PrimerIPay88MYSDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PrimerIPay88MYSDK-dummy.m"; sourceTree = "<group>"; };
 		E644D1C56D1D4998DED55F15CB97E65E /* PrimerTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
-		E6E126C004CE794EDFA7032CF6351974 /* ca.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ca.json; sourceTree = "<group>"; };
+		E6E126C004CE794EDFA7032CF6351974 /* ca.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ca.json; sourceTree = "<group>"; };
 		E701688A7539F7F476C08E5EFDB6E654 /* Box.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
-		E748D2D45994BFBE4E57575B230B0427 /* is.json */ = {isa = PBXFileReference; includeInIndex = 1; path = is.json; sourceTree = "<group>"; };
+		E748D2D45994BFBE4E57575B230B0427 /* is.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = is.json; sourceTree = "<group>"; };
 		E7ED812FA013CBAC09A203CFBA13CBDC /* PrimerIPay88MYSDK */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PrimerIPay88MYSDK; path = PrimerIPay88MYSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E906FBDA07229BAB789B1402FE3C3585 /* libipay88sdk.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = libipay88sdk.xcframework; path = PrimerIPay88SDK/Frameworks/libipay88sdk.xcframework; sourceTree = "<group>"; };
+		E906FBDA07229BAB789B1402FE3C3585 /* libipay88sdk.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = libipay88sdk.xcframework; path = PrimerIPay88SDK/Frameworks/libipay88sdk.xcframework; sourceTree = "<group>"; };
 		E90F653BB74E42ECC1D505557700C4F1 /* CheckoutModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckoutModule.swift; sourceTree = "<group>"; };
 		E92EE860BD6063D1EE4ACE39842D2A82 /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		EA3E2B044C716428041F1D0811B3020A /* PrimerIntegrationOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerIntegrationOptions.swift; sourceTree = "<group>"; };
@@ -912,13 +913,14 @@
 		ED316D11AA35ACCF831DB7531099B3A4 /* PrimerHeadlessUniversalCheckoutProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutProtocols.swift; sourceTree = "<group>"; };
 		EE90A0AF7BD80B38DC3402043B60F5CD /* PrimerPaymentPendingInfoViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPaymentPendingInfoViewController.swift; sourceTree = "<group>"; };
 		F0237EB57F7AD1A4F815C165E0EFB038 /* FormPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
+		F03699522AC2DB5700E4179D /* VersionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionUtils.swift; sourceTree = "<group>"; };
 		F06F82B7CB435921C318E2F65F16D86F /* Pods-Debug App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Debug App.release.xcconfig"; sourceTree = "<group>"; };
 		F0D277A20A55FD3777A8DB8968C43D82 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
-		F106E4972B36125362E0E9C48D144360 /* ky.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ky.json; sourceTree = "<group>"; };
+		F106E4972B36125362E0E9C48D144360 /* ky.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ky.json; sourceTree = "<group>"; };
 		F1188C3FC901946A1FDBE86766A5B95C /* PrimerSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerSDK.debug.xcconfig; sourceTree = "<group>"; };
 		F18BCB868F3724D32521D544D38E81FF /* PrimerKlarnaSDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerKlarnaSDK-umbrella.h"; sourceTree = "<group>"; };
-		F1E339730CCE3ED7B776D477C2269C47 /* am.json */ = {isa = PBXFileReference; includeInIndex = 1; path = am.json; sourceTree = "<group>"; };
-		F28575A74077FCF39A3210CFB2F4AE85 /* PrimerSDK.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = PrimerSDK.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		F1E339730CCE3ED7B776D477C2269C47 /* am.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = am.json; sourceTree = "<group>"; };
+		F28575A74077FCF39A3210CFB2F4AE85 /* PrimerSDK.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = PrimerSDK.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		F3813836067E9031CA7259B38E484389 /* NativeUIManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NativeUIManager.swift; sourceTree = "<group>"; };
 		F3D88D9E2B7D011FB604E94CDF53ACAC /* Primer3DSSDKProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSSDKProvider.swift; path = Sources/Primer3DS/Classes/Primer3DSSDKProvider.swift; sourceTree = "<group>"; };
 		F44E15C725A433194F568EA0DF915951 /* Sequence+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Sequence+Helpers.swift"; path = "Sources/Primer3DS/Classes/Sequence+Helpers.swift"; sourceTree = "<group>"; };
@@ -926,7 +928,7 @@
 		F4BA008515B6E5DB751DCD7290E712B4 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F4F8BF23E74B8A9811AF0145DDF82D00 /* PrimerUIManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUIManager.swift; sourceTree = "<group>"; };
 		F52B6F5E14121C09C0A1D067D35D33C2 /* PollingModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PollingModule.swift; sourceTree = "<group>"; };
-		F7443D3024DCD2FF2616FBE671774A2C /* ug.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ug.json; sourceTree = "<group>"; };
+		F7443D3024DCD2FF2616FBE671774A2C /* ug.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ug.json; sourceTree = "<group>"; };
 		F794734B826005672CB694B77118C250 /* Primer3DS-xcframeworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Primer3DS-xcframeworks.sh"; sourceTree = "<group>"; };
 		F7C8B8D5DF70EDE81CC29CD5256B05DC /* Pods-Debug App Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Debug App Tests-umbrella.h"; sourceTree = "<group>"; };
 		F80AB2877BC6D8647D57A95FBA70289E /* ClientSessionActionsModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientSessionActionsModule.swift; sourceTree = "<group>"; };
@@ -937,11 +939,11 @@
 		F9320FDCA77DBA0E62C540F6DE339266 /* Dispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
 		F9BC26CC87B45CB05FEACEF3F0AA3520 /* PrimerInitializationData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInitializationData.swift; sourceTree = "<group>"; };
 		FA0C1D9987D0E6274C876388CD7B764E /* PrimerRetailerData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRetailerData.swift; sourceTree = "<group>"; };
-		FA140C6F6C4E7C0563354CB048666AAD /* nl.json */ = {isa = PBXFileReference; includeInIndex = 1; path = nl.json; sourceTree = "<group>"; };
+		FA140C6F6C4E7C0563354CB048666AAD /* nl.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = nl.json; sourceTree = "<group>"; };
 		FA236D6CCC7FE519C6A4A34148702342 /* CancelContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancelContext.swift; sourceTree = "<group>"; };
 		FAD89B0D3B0B712AE738025E0B73D538 /* Optional+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		FC3AEB607A42E7813FA5CC05C2E22893 /* FirstNameField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirstNameField.swift; sourceTree = "<group>"; };
-		FCDF6C3A22A8FF7C96EEF514CD7A64D0 /* sd.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sd.json; sourceTree = "<group>"; };
+		FCDF6C3A22A8FF7C96EEF514CD7A64D0 /* sd.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sd.json; sourceTree = "<group>"; };
 		FD0935E4B2588CB2DA6A40F62D00F08D /* PrimerInputElements.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInputElements.swift; sourceTree = "<group>"; };
 		FD1E076A29F1C07267338334E92B48A9 /* PrimerIPay88.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimerIPay88.swift; path = PrimerIPay88SDK/Classes/PrimerIPay88.swift; sourceTree = "<group>"; };
 		FE0C1FD24F7ECFA7B9140F323CE3E83D /* PrimerKlarnaSDK */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PrimerKlarnaSDK; path = PrimerKlarnaSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1016,7 +1018,6 @@
 			children = (
 				C5F9EF159569E8D0D992ACC9346871A0 /* Primer */,
 			);
-			name = API;
 			path = API;
 			sourceTree = "<group>";
 		};
@@ -1043,7 +1044,6 @@
 				B1BB7587E588AB3D40D39783F44D8DCF /* Dispatchers */,
 				160266FC42F0DDC4BDB933101AF1BD60 /* Wrappers */,
 			);
-			name = PromiseKit;
 			path = PromiseKit;
 			sourceTree = "<group>";
 		};
@@ -1053,7 +1053,6 @@
 				1AC0D5435EBA802F72AAD2E73D6F67D8 /* PrimerGenericTextFieldView.swift */,
 				B847413264FC8E4DE2484CEC473289CB /* PrimerSimpleCardFormTextFieldView.swift */,
 			);
-			name = Generic;
 			path = Generic;
 			sourceTree = "<group>";
 		};
@@ -1065,7 +1064,6 @@
 				83C62C92B25C4DD650DB6D989A3638B7 /* Dimensions.swift */,
 				74175679E2F8D1320AF2DCCF0D19A0C1 /* Strings.swift */,
 			);
-			name = Constants;
 			path = Constants;
 			sourceTree = "<group>";
 		};
@@ -1075,7 +1073,6 @@
 				3F972271981C552CAC86D444BA3DE791 /* PrimerThemeData.swift */,
 				0924D8D07A2B8717AEE1B845A2907C21 /* PrimerThemeData+Deprecated.swift */,
 			);
-			name = Public;
 			path = Public;
 			sourceTree = "<group>";
 		};
@@ -1087,7 +1084,6 @@
 				8773AEACAE4EA5CB563B2BE3205E04D9 /* AnalyticsService.swift */,
 				323D8195FE7CB72DDEA0EBBF57E27D47 /* Device.swift */,
 			);
-			name = Analytics;
 			path = Analytics;
 			sourceTree = "<group>";
 		};
@@ -1114,7 +1110,6 @@
 				6BDE2DE281F0EABFABF487C99974EC99 /* ThenableWrappers.swift */,
 				AE871E7A7628A6EDCB416299F7D5C312 /* WrapperProtocols.swift */,
 			);
-			name = Wrappers;
 			path = Wrappers;
 			sourceTree = "<group>";
 		};
@@ -1132,7 +1127,6 @@
 				E59AE524338A66D328434373B5ECC4BD /* full */,
 				B3770BD74A9165DBC013AC1357AEE513 /* Support Files */,
 			);
-			name = KlarnaMobileSDK;
 			path = KlarnaMobileSDK;
 			sourceTree = "<group>";
 		};
@@ -1168,7 +1162,6 @@
 				E8986BCA747D691F5B00D6934671BC95 /* Frameworks */,
 				B3B6248A3659FFE79D1FF5FF0278D0EF /* Support Files */,
 			);
-			name = PrimerIPay88MYSDK;
 			path = PrimerIPay88MYSDK;
 			sourceTree = "<group>";
 		};
@@ -1241,7 +1234,6 @@
 			children = (
 				39747BEC69572C1757907F113F6B19C5 /* Connectivity.swift */,
 			);
-			name = Connectivity;
 			path = Connectivity;
 			sourceTree = "<group>";
 		};
@@ -1265,7 +1257,6 @@
 			children = (
 				E92EE860BD6063D1EE4ACE39842D2A82 /* Parser.swift */,
 			);
-			name = Parser;
 			path = Parser;
 			sourceTree = "<group>";
 		};
@@ -1276,7 +1267,6 @@
 				F183F4030364A6D6AA087BA35BB1A61F /* Network */,
 				4A6950B7CC56CC38FEC802F75E2A77BC /* Parser */,
 			);
-			name = Services;
 			path = Services;
 			sourceTree = "<group>";
 		};
@@ -1285,7 +1275,6 @@
 			children = (
 				ACEBE3BDAA2D803EC20D1C7BF48D6671 /* JSONParser.swift */,
 			);
-			name = JSON;
 			path = JSON;
 			sourceTree = "<group>";
 		};
@@ -1317,7 +1306,6 @@
 				46C178A25FF859EF537327E90C69CE3F /* ResumeHandlerProtocol.swift */,
 				4D29753161FB67C76BB309AC671DD565 /* Decision Handlers */,
 			);
-			name = Primer;
 			path = Primer;
 			sourceTree = "<group>";
 		};
@@ -1329,7 +1317,6 @@
 				A110D9DDF6D23AC5B92C9F94D65B5F84 /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift */,
 				FA0C1D9987D0E6274C876388CD7B764E /* PrimerRetailerData.swift */,
 			);
-			name = Models;
 			path = Models;
 			sourceTree = "<group>";
 		};
@@ -1341,7 +1328,6 @@
 				BF7DE13FF2DF199E58D9F85F4BB36999 /* PrimerPaymentMethodManager.swift */,
 				0A9B45FE4B61770CD32006E3F49CCBFB /* RawDataManager.swift */,
 			);
-			name = "Payment Method Managers";
 			path = "Payment Method Managers";
 			sourceTree = "<group>";
 		};
@@ -1353,7 +1339,6 @@
 				A0BB1A8B295DFB412F3F87C014FDB0D1 /* Mock */,
 				BBB9D1FE04554DB9AC20289D7535AED5 /* Networking */,
 			);
-			name = 3DS;
 			path = 3DS;
 			sourceTree = "<group>";
 		};
@@ -1389,7 +1374,6 @@
 				BEC2D85A6C68596EFED767F643DE8B23 /* QRCodeTokenizationViewModel.swift */,
 				3D6C93E9B8E12ADD7F2EAC90F253F50B /* WebRedirectPaymentMethodTokenizationViewModel.swift */,
 			);
-			name = TokenizationViewModels;
 			path = TokenizationViewModels;
 			sourceTree = "<group>";
 		};
@@ -1415,7 +1399,6 @@
 			children = (
 				31D53FA7E09A790E7EEB0B4240A2B6E2 /* JSON */,
 			);
-			name = Parser;
 			path = Parser;
 			sourceTree = "<group>";
 		};
@@ -1424,7 +1407,6 @@
 			children = (
 				BF50BA2C098F8594D41E91FF6C94A457 /* Decisions.swift */,
 			);
-			name = "Decision Handlers";
 			path = "Decision Handlers";
 			sourceTree = "<group>";
 		};
@@ -1438,7 +1420,6 @@
 				E644D1C56D1D4998DED55F15CB97E65E /* PrimerTextField.swift */,
 				949CE6E65977A51E812ED6A48E8401C9 /* PrimerTextFieldView.swift */,
 			);
-			name = "Text Fields";
 			path = "Text Fields";
 			sourceTree = "<group>";
 		};
@@ -1451,7 +1432,6 @@
 				FF0CB5F76D1C29AF189A924DB990AA56 /* Response.swift */,
 				AC2FF4FF9CA6622553575894E48FF1AB /* VaultedPaymentMethods.swift */,
 			);
-			name = API;
 			path = API;
 			sourceTree = "<group>";
 		};
@@ -1460,7 +1440,6 @@
 			children = (
 				A868F8F8AE186AD14381696AF523D3E1 /* Keychain.swift */,
 			);
-			name = Keychain;
 			path = Keychain;
 			sourceTree = "<group>";
 		};
@@ -1484,7 +1463,6 @@
 				B17DF89D13BDE22B8A4D2168769C4E48 /* PrimerRawCardDataTokenizationBuilder.swift */,
 				9FD9839D3A21F0287751A379E0C7A708 /* PrimerRawData.swift */,
 			);
-			name = "Checkout Components";
 			path = "Checkout Components";
 			sourceTree = "<group>";
 		};
@@ -1514,7 +1492,6 @@
 				44C586906ABD4A1190735F29E3788C85 /* VaultPaymentMethodViewController.swift */,
 				8FE1F56967A901690D1F1C9ADE944D2F /* VaultPaymentMethodViewModel.swift */,
 			);
-			name = Vault;
 			path = Vault;
 			sourceTree = "<group>";
 		};
@@ -1545,7 +1522,6 @@
 			children = (
 				84B550C489920745A7B99D0AB780D467 /* FormsTokenizationViewModel */,
 			);
-			name = "Tokenization View Models";
 			path = "Tokenization View Models";
 			sourceTree = "<group>";
 		};
@@ -1558,7 +1534,6 @@
 				1701C2BA9780B96815CB6F6C83AA7974 /* PrimerAPIClient+Promises.swift */,
 				41597C1A733DB1BD5944A6326180453D /* SuccessResponse.swift */,
 			);
-			name = Network;
 			path = Network;
 			sourceTree = "<group>";
 		};
@@ -1572,7 +1547,6 @@
 				BB21E1376352DE378AADDC08EFEF7AC3 /* PrimerTheme+TextStyles.swift */,
 				466113CEF6EAC19D866900CCB282BEC2 /* PrimerTheme+Views.swift */,
 			);
-			name = Internal;
 			path = Internal;
 			sourceTree = "<group>";
 		};
@@ -1592,7 +1566,6 @@
 				76D63374FF815E04E0862E4533FE06D9 /* Managers */,
 				3657ECFC9B1AA39BA364A60C4F9D2BFB /* Models */,
 			);
-			name = PrimerHeadlessUniversalCheckout;
 			path = PrimerHeadlessUniversalCheckout;
 			sourceTree = "<group>";
 		};
@@ -1602,7 +1575,6 @@
 				20B0427E8C854C706F85DF8529F099FD /* BankSelectorViewController.swift */,
 				04CA368E1040DCDB874CFD05EB959664 /* BankTableViewCell.swift */,
 			);
-			name = Banks;
 			path = Banks;
 			sourceTree = "<group>";
 		};
@@ -1615,7 +1587,6 @@
 				7E576BDDB4E79A57CE3045FD25A4E450 /* VaultManager.swift */,
 				3A70404AA616BFD28BAC5A79415EAA24 /* Payment Method Managers */,
 			);
-			name = Managers;
 			path = Managers;
 			sourceTree = "<group>";
 		};
@@ -1625,7 +1596,6 @@
 				27ADB4294EBF96BDDC56D895E9C695F0 /* FlowDecisionTableViewCell.swift */,
 				2B2F07CE5498831C6E3A6EB73C38EE5E /* PrimerTestPaymentMethodViewController.swift */,
 			);
-			name = TestPaymentMethods;
 			path = TestPaymentMethods;
 			sourceTree = "<group>";
 		};
@@ -1637,7 +1607,6 @@
 				26B15B62F11C383393F1DECF26A5DFF6 /* FormPaymentMethodTokenizationViewModel+FormViews.swift */,
 				F1D28C317BB17486018978978A329936 /* Fields */,
 			);
-			name = FormsTokenizationViewModel;
 			path = FormsTokenizationViewModel;
 			sourceTree = "<group>";
 		};
@@ -1646,7 +1615,6 @@
 			children = (
 				3378FDE7CF6756B16256FFBF993DA91A /* AES256.swift */,
 			);
-			name = Crypto;
 			path = Crypto;
 			sourceTree = "<group>";
 		};
@@ -1659,7 +1627,6 @@
 				A737E9A220CDE88BDFAFFDFCBB3E6FC8 /* CancellablePromise.swift */,
 				BD1AC8628545D02AF110941128880271 /* CancellableThenable.swift */,
 			);
-			name = Cancellation;
 			path = Cancellation;
 			sourceTree = "<group>";
 		};
@@ -1676,7 +1643,6 @@
 			children = (
 				BF5AB512118494BC502B5323CFA02BF0 /* CardButton.swift */,
 			);
-			name = Primer;
 			path = Primer;
 			sourceTree = "<group>";
 		};
@@ -1759,7 +1725,6 @@
 				5536D76A02FB86E84689A5D3B051CBDA /* zh-KH.json */,
 				63C72E6699818410EB0A9F8081A9EC1E /* zh-TW.json */,
 			);
-			name = localized_countries;
 			path = localized_countries;
 			sourceTree = "<group>";
 		};
@@ -1794,7 +1759,6 @@
 				A0FAE966BC79B9B16334FAED9F133131 /* Root */,
 				4EC1BD9CC6162D39D51B8D2310C702FA /* Text Fields */,
 			);
-			name = "User Interface";
 			path = "User Interface";
 			sourceTree = "<group>";
 		};
@@ -1803,7 +1767,6 @@
 			children = (
 				BF39310D7B33FA69131E4875E4A13290 /* Mock3DSService.swift */,
 			);
-			name = Mock;
 			path = Mock;
 			sourceTree = "<group>";
 		};
@@ -1812,7 +1775,6 @@
 			children = (
 				08B07423AA82A0FE4FA4CCA0106C9DE4 /* PrimerCardFormViewController.swift */,
 			);
-			name = Root;
 			path = Root;
 			sourceTree = "<group>";
 		};
@@ -1826,7 +1788,6 @@
 				E559541AB9C303C0205C05EBBD2103B9 /* PrimerResultViewController.swift */,
 				B6BD7F4864DA4F3847A569AE1AC6892C /* PrimerSearchTextField.swift */,
 			);
-			name = Components;
 			path = Components;
 			sourceTree = "<group>";
 		};
@@ -1838,7 +1799,6 @@
 				BB51DD55C93705722B61C0C1C641F20C /* PrimerAPIConfigurationModule.swift */,
 				4DDCF00E3E0AD992D1C7DBDE77038D7C /* VaultService.swift */,
 			);
-			name = "Payment Services";
 			path = "Payment Services";
 			sourceTree = "<group>";
 		};
@@ -1847,7 +1807,6 @@
 			children = (
 				D8A42D0CFF172D36E04B660BDEA23C9C /* FormType.swift */,
 			);
-			name = PCI;
 			path = PCI;
 			sourceTree = "<group>";
 		};
@@ -1875,7 +1834,6 @@
 				5707CA8EF477DEEB8CB41B18726CB8E5 /* RateLimitedDispatcherBase.swift */,
 				97797B3A826695B50126CEBA1DF3D1C4 /* StrictRateLimitedDispatcher.swift */,
 			);
-			name = Dispatchers;
 			path = Dispatchers;
 			sourceTree = "<group>";
 		};
@@ -1931,7 +1889,6 @@
 			children = (
 				88BBFB31782058675116A1EF8DF9BD73 /* ReloadDelegate.swift */,
 			);
-			name = "UI Delegates";
 			path = "UI Delegates";
 			sourceTree = "<group>";
 		};
@@ -1978,6 +1935,7 @@
 				E43836F7676956C6AE724F137B96A47F /* UserDefaultsExtension.swift */,
 				B070035BEF45F872802D2C617B7BEE8F /* Weak.swift */,
 				BD241F41F82B185EBCCAE78E790C9528 /* WebViewUtil.swift */,
+				F03699522AC2DB5700E4179D /* VersionUtils.swift */,
 			);
 			name = "Extensions & Utilities";
 			path = "Sources/PrimerSDK/Classes/Extensions & Utilities";
@@ -1988,7 +1946,6 @@
 			children = (
 				CAAC1DC0B5F5979EF3D8E6494A9E5713 /* PrimerAPIClient+3DS.swift */,
 			);
-			name = Networking;
 			path = Networking;
 			sourceTree = "<group>";
 		};
@@ -2007,7 +1964,6 @@
 				70DE611C78184781092429D859F017EB /* PrimerAPI.swift */,
 				C29E21010341A1863EABED0426192B0C /* PrimerAPIClient+PCI.swift */,
 			);
-			name = Primer;
 			path = Primer;
 			sourceTree = "<group>";
 		};
@@ -2053,7 +2009,6 @@
 				680359D66F46C2951A78C19ED2AC9FD9 /* Internal */,
 				0C30A86041FA6C60519939331CCE5008 /* Public */,
 			);
-			name = Theme;
 			path = Theme;
 			sourceTree = "<group>";
 		};
@@ -2087,7 +2042,6 @@
 			children = (
 				AC15F60DD4F3F7665ED569E4AE16ED4C /* 3DS.swift */,
 			);
-			name = "Data Models";
 			path = "Data Models";
 			sourceTree = "<group>";
 		};
@@ -2119,7 +2073,6 @@
 				1CDD75F8BD3124D3057BDBC8548F8B7F /* PrimerTextFieldView+CardFormFieldsAnalytics.swift */,
 				0680F97659B4FEEABFECADE8CF824132 /* Generic */,
 			);
-			name = "Text Fields";
 			path = "Text Fields";
 			sourceTree = "<group>";
 		};
@@ -2137,7 +2090,6 @@
 				3D803FB62A01F2DB010435FC0D6B72FE /* CountrySelectorViewController.swift */,
 				26238DDBA62CD3748B820A6A1EDE9B01 /* CountryTableViewCell.swift */,
 			);
-			name = Countries;
 			path = Countries;
 			sourceTree = "<group>";
 		};
@@ -2157,7 +2109,6 @@
 				CF62A4EBA4EDBA912B5ACEB9B84BA64A /* PrimerVaultManagerViewController.swift */,
 				3613D9723544DFCA6CB7871DA72A105D /* PrimerVoucherInfoPaymentViewController.swift */,
 			);
-			name = Root;
 			path = Root;
 			sourceTree = "<group>";
 		};
@@ -2191,7 +2142,6 @@
 			children = (
 				E13D715A28E38B1A41D9B3671C0F90CF /* URLSessionStack.swift */,
 			);
-			name = Network;
 			path = Network;
 			sourceTree = "<group>";
 		};
@@ -2211,7 +2161,6 @@
 				38135FC951FDE8E3032F3CC26C45B06D /* PostalCodeField.swift */,
 				8B18397CD1BFAF65AECB88E78BAC0ADD /* StateField.swift */,
 			);
-			name = Fields;
 			path = Fields;
 			sourceTree = "<group>";
 		};
@@ -2220,7 +2169,6 @@
 			children = (
 				0A9BFD6F8F465F8A708FE03A17414427 /* PrimerWebViewController.swift */,
 			);
-			name = OAuth;
 			path = OAuth;
 			sourceTree = "<group>";
 		};
@@ -2231,7 +2179,6 @@
 				788823208848A5A159A527490F431C70 /* PrimerKlarnaViewController.swift */,
 				28CBDFB3C4CF4B13FFC4A89754308FEB /* Support Files */,
 			);
-			name = PrimerKlarnaSDK;
 			path = PrimerKlarnaSDK;
 			sourceTree = "<group>";
 		};
@@ -2240,7 +2187,6 @@
 			children = (
 				61E7AFAA58AAFA31C00BACCCF8559AC5 /* QRCodeViewController.swift */,
 			);
-			name = TokenizationViewControllers;
 			path = TokenizationViewControllers;
 			sourceTree = "<group>";
 		};
@@ -2258,7 +2204,6 @@
 				987BBF73787C38018601EDE014539D37 /* Frameworks */,
 				91D9ECEEBE4B18617FCB1A4D8F79C8CA /* Support Files */,
 			);
-			name = Primer3DS;
 			path = Primer3DS;
 			sourceTree = "<group>";
 		};
@@ -2752,6 +2697,7 @@
 				4F9C98C798275B4809F824CD1E0B5CFF /* Cancellable.swift in Sources */,
 				D7EACE861C11D105F007A281BA538B0C /* CancellableCatchable.swift in Sources */,
 				99373AEFC79F35130A5278872B48AFFB /* CancellablePromise.swift in Sources */,
+				F03699532AC2DB5700E4179D /* VersionUtils.swift in Sources */,
 				4A9E857059A73B4DE144ECF8569C17FE /* CancellableThenable.swift in Sources */,
 				A11411FF83DE56C6B4C61144E1F865CB /* CardButton.swift in Sources */,
 				0A4DFBDD664FEA2FC5641A638FB281E6 /* CardButtonViewModel.swift in Sources */,

--- a/Debug App/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Debug App/Pods/Pods.xcodeproj/project.pbxproj
@@ -20,935 +20,935 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		0063DDF5EF039CCEF448CD2AED360274 /* ClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269943DFE2671D1E4DB4BA0ADAC42F3F /* ClientToken.swift */; };
-		014C524E29C473BFEDAE3AD78F5AAC3C /* ps.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E30A8643A102CCE33849AEF658FA34B /* ps.json */; };
+		0047C55A24CDD0CCE0A0235D6688A894 /* TokenizationRequestPaymentSessionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0247110EB538C01C77850CA1CFF0D9F5 /* TokenizationRequestPaymentSessionInfo.swift */; };
+		00D28CB035C060FC6264205886F77664 /* PrimerSearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4FE78145CB0E3CE9CA10F5B57E721B /* PrimerSearchTextField.swift */; };
+		00DC67712DC2F3FCADB3E78C98D20453 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697F562017C7745AC1D8B516C087C7BE /* PaymentMethod.swift */; };
+		01266976EABD22087B74AD1088FD2E2A /* Field.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A6FCB18ED6D61CB1B602B5C540367D /* Field.swift */; };
+		017854BE0483AC2B14F3508368CEE9F2 /* fr.json in Resources */ = {isa = PBXBuildFile; fileRef = F887E16271844B36888D936B3045E36D /* fr.json */; };
 		01D7B28E622457AAE0D14F338B5F0578 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B0F5B516F1F27FB337A11ED5BB3CAD /* String+Helpers.swift */; };
-		0416D0FB3FEC7A0564562E58EA704252 /* VoucherValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FD99B3B52E4F690CAB441EDBA07126 /* VoucherValue.swift */; };
-		04AB8A1739E637B8937E370536B2D6EE /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FEC86D93BAC13455F163218A9C1D20D /* Configuration.swift */; };
-		06239314163E8B9A998CF74E64C0A0B7 /* Decisions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF50BA2C098F8594D41E91FF6C94A457 /* Decisions.swift */; };
-		0875C63487274992CBEF00E157525A9D /* PrimerCardNumberFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301374484CD143E215F45C43DD6875D7 /* PrimerCardNumberFieldView.swift */; };
-		09319A1F89C2ECE4FEB39CE24DCAF0D9 /* PrimerPaymentMethodManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7DE13FF2DF199E58D9F85F4BB36999 /* PrimerPaymentMethodManager.swift */; };
-		0997BA5898D28DF3D707169207F523CE /* ClientSessionAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E2D380EA6458429CFE29C01BD613DA1 /* ClientSessionAPIModel.swift */; };
-		0A4DFBDD664FEA2FC5641A638FB281E6 /* CardButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7653830962AC27B8ACE623177ABA58 /* CardButtonViewModel.swift */; };
-		0AC10349CDBDADC11503633C2E5B6602 /* mk.json in Resources */ = {isa = PBXBuildFile; fileRef = DC4D8F2C4DC84A5D2246A81EF8201817 /* mk.json */; };
+		0230FD67B5771625664B73D962E2C74A /* tr.json in Resources */ = {isa = PBXBuildFile; fileRef = BBE9A4BD522623C67BCCB016D50A9029 /* tr.json */; };
+		026D9A82E011E1344A2BFDAFCBDD4965 /* QRCodeTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEAE956392261FC2FEF850F716750641 /* QRCodeTokenizationViewModel.swift */; };
+		048BD37DFCDEB8637C9F29D6AF4536D6 /* uk.json in Resources */ = {isa = PBXBuildFile; fileRef = 4A976165D788F0CD483FCDE40AFD93D6 /* uk.json */; };
+		04DDA0CB6CB772E6B0B620695F65A746 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0DE56B2DF2205BD309227E499DAC80 /* Analytics.swift */; };
+		054526B68E9339989D17B8FCF531C8A9 /* PrimerStateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1B8D416406FEAA3A9068980F70516F /* PrimerStateFieldView.swift */; };
+		0582675A4147315A319BE9067D2C5AA4 /* PrimerAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5FF4C72E7E2C6ADD0AA37002B72A81 /* PrimerAPIClient.swift */; };
+		068D511A2D5AF97B73207AF444117599 /* PrimerHeadlessUniversalCheckoutInputElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09BC433DAF546E65AF30911F263AE73 /* PrimerHeadlessUniversalCheckoutInputElement.swift */; };
+		069044A430CED2722377537410FB0C49 /* am.json in Resources */ = {isa = PBXBuildFile; fileRef = C15B03C6068D04B239AB92399510FEB5 /* am.json */; };
+		0853A7ED996225D3A9303B8D70CC424C /* PrimerContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0BDB02350A2F210BF098C93DAD877DB /* PrimerContainerViewController.swift */; };
+		0855FC2FA594BC4FA6A25C95E55AEC3A /* PaymentMethodConfigurationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35194EC2E6CDD5B61472DDC6541EA89 /* PaymentMethodConfigurationOptions.swift */; };
+		0AA18B7E79D56919F0E67ED2F3D4FCA5 /* ka.json in Resources */ = {isa = PBXBuildFile; fileRef = 3F4D40A84A2FD64608BF069DDCFB78B8 /* ka.json */; };
 		0ADBA3AA0DA66C25D48230135C0721B2 /* PrimerIPay88.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD1E076A29F1C07267338334E92B48A9 /* PrimerIPay88.swift */; };
-		0B2D0F1F5A2D4BAE523E216BD2A1F8CF /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54B45F9C5D3FD0C7451109D6DD7C14F /* AppState.swift */; };
+		0AE4507010624BD53BFE57DC8D58AD15 /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16ADD8E6E4EC877AC44728F26B1DEBB /* hang.swift */; };
+		0B4554175AD2C3AB8A7EA399DBD0FCAF /* PrimerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929B7338F092F3735EFE03928AF9FD3D /* PrimerImageView.swift */; };
+		0B7481462DB080AE7289E28332EBDAC3 /* ms.json in Resources */ = {isa = PBXBuildFile; fileRef = 4E530B50E3299919F005E3567B4CA23E /* ms.json */; };
 		0BA32CC65B041E67103CC872C8F5472B /* PrimerKlarnaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788823208848A5A159A527490F431C70 /* PrimerKlarnaViewController.swift */; };
-		0BB0E1196DFC9F551A9B59FAB6B08766 /* QRCodeTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC2D85A6C68596EFED767F643DE8B23 /* QRCodeTokenizationViewModel.swift */; };
-		0C4F2A0575B460737338609780C51401 /* PrimerHeadlessUniversalCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D258EE2578C0D3E4396FE13FE69516DD /* PrimerHeadlessUniversalCheckout.swift */; };
-		0CB5F72EEB51A1E60599A4429C955DFD /* ha.json in Resources */ = {isa = PBXBuildFile; fileRef = 971A091B046B3E3D91DE2A49AD38C415 /* ha.json */; };
-		0DCB89E913FCA27A0BC821857F28E1FD /* UniversalCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E54933A4E92ADB9FFE676EAE0DF5E91 /* UniversalCheckoutViewModel.swift */; };
-		0FD069250A0316B0A6F03DE67A00D9F7 /* sd.json in Resources */ = {isa = PBXBuildFile; fileRef = FCDF6C3A22A8FF7C96EEF514CD7A64D0 /* sd.json */; };
-		11AADCBE699813B2BF3D1326D4E6C688 /* EncodingDecodingContainerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A8D570C8144D1E41B17235A8B0E377 /* EncodingDecodingContainerExtensions.swift */; };
-		122705E4F7AC7565303938843292B36E /* PrimerInitializationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9BC26CC87B45CB05FEACEF3F0AA3520 /* PrimerInitializationData.swift */; };
-		125B9A0D45C0ECA16BA4FD56E8A34D6D /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C4ED515E094C4A43320B79DF8524FB /* Guarantee.swift */; };
-		128C1BEE9B19ABDA88D26B4181072C72 /* mn.json in Resources */ = {isa = PBXBuildFile; fileRef = B61DC9B4534E5B21A28E037B2A53A371 /* mn.json */; };
-		12CF81BDA8626434B0942B8E448AD8D1 /* lv.json in Resources */ = {isa = PBXBuildFile; fileRef = 67D4FB0F9B75B23896A5A80E46D02369 /* lv.json */; };
-		14A47C330CAAF5A5DE0F22D98AFBB875 /* Mask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECCC38DA7558D2053B8F5633AAAAF79 /* Mask.swift */; };
+		0BB2717D4F0F9D3BAB28907C198F36AA /* InternalCardComponentsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A98A4CC4194D2E133E1A93105BECAA7 /* InternalCardComponentsManager.swift */; };
+		0E907F1ED25E8430D07F613B069DC69D /* hy.json in Resources */ = {isa = PBXBuildFile; fileRef = 213B5FDF3D6350724D0E3CB989DD6807 /* hy.json */; };
+		0EF5FB1C897C76FD7850DCB5852CC772 /* WebRedirectPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292F09167F7D41E75E311819BF0A00A9 /* WebRedirectPaymentMethodTokenizationViewModel.swift */; };
+		0F653D74B38A8BB3B885AF79ADCD6075 /* ha.json in Resources */ = {isa = PBXBuildFile; fileRef = 637B454A256CADC4D8EFD5280ED58548 /* ha.json */; };
+		106937FD9BAF7983249FBC5560D7706D /* fi.json in Resources */ = {isa = PBXBuildFile; fileRef = 3BE2983E904B9562D062C90EDB0F7369 /* fi.json */; };
+		108DAA60EC83C905F227A6C829CF70E7 /* Apaya.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79520503C17021C8D802355B38DBA688 /* Apaya.swift */; };
+		1103A16421D4EFB2DCAF49BD1DD35B95 /* PrimerHeadlessUniversalCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87394339D5F31F4ED7E321E376ACB274 /* PrimerHeadlessUniversalCheckout.swift */; };
+		111DCA97CF2A019D06D2D0CC50B0096E /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44162EBABABA5203CEA22C4AD66FDEA9 /* Cancellable.swift */; };
+		1140B0E9C7DAFC6131F04131BF2184EF /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = F528C392D992975CBA53BB67D7133282 /* Error.swift */; };
+		12F0B7F31E9C0CB055D964A743C4E218 /* PrimerInputElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9BE98AD0A498B74ABC35971CBB1EA3 /* PrimerInputElements.swift */; };
+		134855B0A05ABAEB971DDF30D199CBC6 /* ky.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EA5F939D4E2AE50BF6269EDDAA890A4 /* ky.json */; };
+		137A3093F17FE67B5FE0304311CF3E9E /* CancellablePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B53B2736E88AB8E197388914CF53DC8 /* CancellablePromise.swift */; };
+		13D25B5E61AF2EB068F96ACB661222C7 /* PrimerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C87A27D9176D689333D6F72470419B6 /* PrimerSource.swift */; };
+		14B35AF46143EDCAA071BDFCB9DDA13E /* is.json in Resources */ = {isa = PBXBuildFile; fileRef = 20F8C6339735F2D7EF116A79442C0A1C /* is.json */; };
+		155918B7996866F3D9DCDBD9704DA9F2 /* SuccessResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FCE2DA2B80A0F125D65996840608AA /* SuccessResponse.swift */; };
+		158DF5688F26F4313FDE615553B21DA0 /* PaymentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 887D600A945B48F43F00E7255BBE5D05 /* PaymentResponse.swift */; };
+		15BBA5C2D14D9F340528B2771E70F8B7 /* Throwable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3B5D594811C6D3791379596AE24942 /* Throwable.swift */; };
+		15E86FC99F9636F3A801993A83FCDEF6 /* mk.json in Resources */ = {isa = PBXBuildFile; fileRef = A4545C55DFE17BDBA7005AED27FF9E22 /* mk.json */; };
+		160BC5B64C58B0FCBEF6E9AED0DA0907 /* FormType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A8A6E0DF6DAFCAFAB8BC61C6252B63 /* FormType.swift */; };
+		160FF3F5E7D40DBD83C973F3D8799C45 /* PrimerCheckoutAdditionalInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A458D6481F4DE942B95A0A4A062F0A83 /* PrimerCheckoutAdditionalInfo.swift */; };
+		166B3214F3930A766A23765378F44712 /* be.json in Resources */ = {isa = PBXBuildFile; fileRef = E3DA91531A79C93FB543A72149CB5D0F /* be.json */; };
+		167DEBF94CED26FE6B9ED4DDE3B48698 /* SuccessMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914AEED83D36A581262868890D3DAA85 /* SuccessMessage.swift */; };
+		177FD231C69ACC3F2A6A909F4B3C92D3 /* LastNameField.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5BC25EC635A1BF75DD2781EE799554 /* LastNameField.swift */; };
+		17B2AFE0C21A5187A4FC01A38800D667 /* PrimerSDK-PrimerResources in Resources */ = {isa = PBXBuildFile; fileRef = A8B3BC107C2BDC3C03D961866F721265 /* PrimerSDK-PrimerResources */; };
 		18243B5E67A6DBB8EA0F68B95D23250F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		185B5CBD64C5DF783753A483A3E085E0 /* GuaranteeWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F9757ABA5220992213CD56B6C1A6E2 /* GuaranteeWrappers.swift */; };
-		187EFC88FD260D9577A5C423E2BD84DA /* ClientSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265216BCC916C3783AAD38C074BF98B7 /* ClientSession.swift */; };
-		18A170A1E091F4B100334BA1D56F470A /* no.json in Resources */ = {isa = PBXBuildFile; fileRef = 1DA399A7CEC10284AA5DFF7087AB1606 /* no.json */; };
-		19ADDFD87EFAEDE49E31344D273345E8 /* sq.json in Resources */ = {isa = PBXBuildFile; fileRef = 30E5D8C43EE6F0E901F1F460DB736C49 /* sq.json */; };
-		19E2AB62A71504DD0095A79CAD85F7C0 /* PrimerHeadlessUniversalCheckoutInputElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AEB5A843B70ED85E8FF9395AD90F72 /* PrimerHeadlessUniversalCheckoutInputElement.swift */; };
-		1A5EF02432234C27BD393DD2C5B83436 /* sv.json in Resources */ = {isa = PBXBuildFile; fileRef = 810EAC7B6BF98765F2675614D2007FF5 /* sv.json */; };
+		1879BFFE78BC1D5AEAAF27346CF5A92E /* _PaymentAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C82FF4240C6EBBC2703286D663E3FC /* _PaymentAPIModel.swift */; };
+		18CBF4097EC2AAAEF24A704ABCFF7013 /* PrimerCardholderNameFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A824B2812F36EF238ACDF467425101 /* PrimerCardholderNameFieldView.swift */; };
 		1AAD78165AE229ECE16D87491F3B2FDB /* Primer3DSProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C681726407CC7178476F02DD75F944 /* Primer3DSProtocols.swift */; };
-		1B7922891AB7A7893B74703078F1743F /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6411C49128C3CFB8AA377695C2104AE /* UIColorExtension.swift */; };
-		1B8B20E53F8C220776B76F67122367DF /* RecoverWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D78288C113DF70776B53F4AEE36AA99 /* RecoverWrappers.swift */; };
-		1BA14BE3A70732BD492CF0939060B0AB /* VaultPaymentMethodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE1F56967A901690D1F1C9ADE944D2F /* VaultPaymentMethodViewModel.swift */; };
-		1C9DC1876CEE43ECF100BC9C5F7D09E1 /* PrimerTestPaymentMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B2F07CE5498831C6E3A6EB73C38EE5E /* PrimerTestPaymentMethodViewController.swift */; };
-		1CDE557D6CB2436BB8161744B0DEEB94 /* InternalCardComponentsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EFDD6B847899803CDD6CEC7D495774 /* InternalCardComponentsManager.swift */; };
-		1E5D8E4DECCFB923EA11E82DA1615BA0 /* WebViewUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD241F41F82B185EBCCAE78E790C9528 /* WebViewUtil.swift */; };
-		1E7014216D3C80B146E4CF11B3276DF2 /* sw.json in Resources */ = {isa = PBXBuildFile; fileRef = 5B711EB42C8FFABADACBF36D08837634 /* sw.json */; };
-		1EB16A8D35751125308F7496BA3FFB85 /* PrimerTheme+Borders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576918A6C15D07BD412AAF448EA54616 /* PrimerTheme+Borders.swift */; };
-		1F94A232CA204C37C0427CD6145E8E91 /* en.json in Resources */ = {isa = PBXBuildFile; fileRef = BC6E909C3027887A486C44600B79E2C4 /* en.json */; };
-		211BCD0F16C3C01C852B8187FA257D1B /* OrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B89EDEC387A04C17D485DA9DBA096E /* OrderItem.swift */; };
-		2275211086B4218FFC05873534A8852F /* ta.json in Resources */ = {isa = PBXBuildFile; fileRef = 559CE23A5F2B394A14101BA2F258C75A /* ta.json */; };
-		238646B9826A9F6D4E81C6360AF08A25 /* TokenizationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E27177B7CCF2DA6BEAA61936C53BA02 /* TokenizationResponse.swift */; };
-		23BD510FA8AD2D6A773AFC4B870C4E10 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6813F8F686CB86F947CFCA3AA6A59FD5 /* ErrorHandler.swift */; };
-		240DB8AB800EB3D8F5FE12E339A19E7D /* PrimerPostalCodeFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E0ADF57D15D16B4B09330F015DAC41 /* PrimerPostalCodeFieldView.swift */; };
-		25274121CBE436BE5BD26B3937B43B9B /* ky.json in Resources */ = {isa = PBXBuildFile; fileRef = F106E4972B36125362E0E9C48D144360 /* ky.json */; };
+		1C6E791714F0E609B788E83AA6CBA03C /* sq.json in Resources */ = {isa = PBXBuildFile; fileRef = D9E3ED96959579BEEE7BAF7E4A95AF12 /* sq.json */; };
+		1C6F2D3FE87D0730CB21F682E11EDA3C /* RetailOutletsRetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A815CA108556A535E26386C83B8C39D /* RetailOutletsRetail.swift */; };
+		1C805B1E0817E26C3EA7CF89730B1301 /* ClientSessionActionsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F16846F426A104F596734101DA7B30 /* ClientSessionActionsModule.swift */; };
+		1E6491AE7451C22527030EC38E4A6EBA /* IPay88TokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F414173C1C3C202C11A4C20E0BB57ADD /* IPay88TokenizationViewModel.swift */; };
+		2021E3E6A9A27B2E76241E8ACCC60E4E /* UILocalizableUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3765E6101DD650B9FF36CD06892A83 /* UILocalizableUtil.swift */; };
+		20645148922EECD1763BF10979FB5AA0 /* VaultPaymentMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F038A4E81716AB1E8C552E2504CF13C /* VaultPaymentMethodViewController.swift */; };
+		207F743D2B6BD97FD11D6AD087C7D3FC /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318698473C98A0165F9B976398542408 /* PrimerTextField.swift */; };
+		22E01854198F40F0589161F0E5A9FC8B /* ur.json in Resources */ = {isa = PBXBuildFile; fileRef = 2E125144112EB19BFE978F77064D400C /* ur.json */; };
+		22EB3B80DC4632A9C3D8F39A8A8632F4 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1B3A54375C99482321E8D936194200 /* Keychain.swift */; };
+		232D2FB5A74E423D7F81356C87A407E8 /* EncodingDecodingContainerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA1ACC3B92AF5E7BA2BD4CC83D6BBEE /* EncodingDecodingContainerExtensions.swift */; };
+		239263C672FCEFFADABA2D4257682626 /* VoucherValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043F404DDFA27D969C50608A28EEB47B /* VoucherValue.swift */; };
+		246D7F69B91260D4B962C1B0182A760B /* nl.json in Resources */ = {isa = PBXBuildFile; fileRef = 6B0806BEFC9CC9998C48890016E52486 /* nl.json */; };
+		2482BA1CA254F97C3E399B63C9F65C54 /* PrimerRawData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3750940B2FA6D58AE93382E53D20C4 /* PrimerRawData.swift */; };
+		24E5571F00D7574C36FE672E2D6575C6 /* PrimerResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C00E0D3A4D85BDA30C8760990EE13C /* PrimerResultViewController.swift */; };
 		254FD733650956BEC9FADBC4B4AC0D5B /* Primer3DSStructures.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55F57D8EB2561C31E768A27EAE77E37 /* Primer3DSStructures.swift */; };
-		25A286907F09947F15B84606013518E3 /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACEBE3BDAA2D803EC20D1C7BF48D6671 /* JSONParser.swift */; };
-		25CCDBB8C347CAFBB8AD8B263B348E3F /* cy.json in Resources */ = {isa = PBXBuildFile; fileRef = C2B4A5EC72F45CCBD072612DD8D0FFD8 /* cy.json */; };
-		264FFDBC9CD2A52D0C36B73C78F6E356 /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE74B9F2D48722B979E0F7CCB0D926CC /* CountryCode.swift */; };
-		266CED9451AA8C03DCED9A3EBA68200B /* be.json in Resources */ = {isa = PBXBuildFile; fileRef = 19DF40448DACEAE8218A622C7ACADE84 /* be.json */; };
-		2711F8E08FDED2DA544FC5970F17FE7F /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3C63DD85A6A9E4C7DB5A148B98C37FE1 /* Localizable.strings */; };
-		2726A5AB70D3EC9A8F9A59B37CF4EAC8 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6281B16544CCC7823F456512C67B53 /* Promise.swift */; };
-		28FA3E1C3A4AD6A84E60F1F9BBC1C45C /* PrimerResultComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CEA1480749C8D81B0FFB635BDEB4705 /* PrimerResultComponentView.swift */; };
-		2967858E7576797276258A886262E8D4 /* UserDefaultsExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43836F7676956C6AE724F137B96A47F /* UserDefaultsExtension.swift */; };
-		2A34459350773A77479834CD960DCDD1 /* BankTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CA368E1040DCDB874CFD05EB959664 /* BankTableViewCell.swift */; };
-		2A958724141525BAEF326B49D4E07640 /* PaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 540DEED9BBAEB1E131517E332CA97BF0 /* PaymentMethodTokenizationViewModel.swift */; };
-		2C1D946C476290C7A21B0405873E4CF2 /* TimerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932B912B4240B649996034B90C5C83CA /* TimerExtension.swift */; };
-		2C4E730D919A7F3A88AFE37A349DCA63 /* PrimerExpiryDateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85C15F141C35AC1BAD8B8D3C74122F7 /* PrimerExpiryDateFieldView.swift */; };
-		2CAADB525BA5B3ABB8A715DB8A5848A0 /* PrimerAPIConfigurationModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB51DD55C93705722B61C0C1C641F20C /* PrimerAPIConfigurationModule.swift */; };
-		2D4BCBC60D6A9DA6E660BB5DD923BD31 /* PrimerSDK-PrimerResources in Resources */ = {isa = PBXBuildFile; fileRef = A8B3BC107C2BDC3C03D961866F721265 /* PrimerSDK-PrimerResources */; };
-		2D99BEE894D28B1FF73F4760A8337000 /* PrimerSDKIntegrationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84515E13647664B38A39E91DD35FBCAD /* PrimerSDKIntegrationType.swift */; };
+		2619F43D465820A75A94CD1A7312A25B /* IntExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA2A455CF52819239E4F86D36167A86 /* IntExtension.swift */; };
+		279CD4F2CBBA2D16C5A31B25649258CD /* sl.json in Resources */ = {isa = PBXBuildFile; fileRef = D4C1587E41FF1F893688589214A1F24D /* sl.json */; };
+		284E6C157330E4EE01FA454134B5B11C /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5B8121BE683E18C1BD5CA7EE3581141 /* ArrayExtension.swift */; };
+		28B4C72C9CABE7AA765936A41FFFEF6C /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60FE8FC3ABBE39B2E52060DF3AC064DC /* Endpoint.swift */; };
+		29922C5DC274B5DBD2E0AE32A1B72E04 /* PrimerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D5898376477D28E2A203F36651F59C /* PrimerButton.swift */; };
+		29B3C5276319AF781C5B071BFD91816E /* fa.json in Resources */ = {isa = PBXBuildFile; fileRef = 46B3EA56B0956E1AF30EDF2B734CE19C /* fa.json */; };
+		2A330F0C41AC4E4063E40BEF83B7127F /* tg.json in Resources */ = {isa = PBXBuildFile; fileRef = BAD688DF63876C2E1AE5B532F18C7D0D /* tg.json */; };
+		2A76C85858CC82770DB962B167EED755 /* ExpiryDateField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631718A3A98AB5B6B06E017715D36CE9 /* ExpiryDateField.swift */; };
+		2CA2EE76A731273A1AC977DA229C5AB7 /* PrimerRawRetailerDataTokenizationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565C2F154D3AF2C4CF0567D742493C93 /* PrimerRawRetailerDataTokenizationBuilder.swift */; };
+		2D6C3C0AE899231F313F2731B1F48EB0 /* RateLimitedDispatcherBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300244607D16CA9353D9E8A3BC84638D /* RateLimitedDispatcherBase.swift */; };
+		2D80F501AA10D68E6DB0EA622DAEE6F7 /* da.json in Resources */ = {isa = PBXBuildFile; fileRef = 973F4605FB509D06C59F6AB96ED9EDF0 /* da.json */; };
 		2DC5896F17C5D056B40D1D66EEE31036 /* PrimerIPay88MYSDK-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E57599F7963C47B5B97E6FD223D67623 /* PrimerIPay88MYSDK-dummy.m */; };
-		2DE94B5CAFA5D0A595AFF3CCA45C0D57 /* NSObject+ClassName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F862A072948ABE92A6870DD4AD7B0FD /* NSObject+ClassName.swift */; };
-		2DF278C9F5CC65A2A76B2265B6B043E8 /* Klarna.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752B234AD397FFDF2C3E7ABB54273544 /* Klarna.swift */; };
-		2F1643EABAF0D77D455206D2E1E59921 /* PostalCodeField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38135FC951FDE8E3032F3CC26C45B06D /* PostalCodeField.swift */; };
-		2F181CEC1B9E78FC9E8023EF2B3CF4E0 /* PrimerTestPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F9D0BE575001BCCB6589A9BC14F891 /* PrimerTestPaymentMethodTokenizationViewModel.swift */; };
-		2F80A714ACAE14E5EE60B937BCC9CDBD /* AddressField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80A02EA38330B87DF2A01E76DA99CF /* AddressField.swift */; };
-		2FB3CA07F8C08C808C4D69EA96350823 /* nb.json in Resources */ = {isa = PBXBuildFile; fileRef = 827092588059F50742C1CF6F40847E91 /* nb.json */; };
-		30FC34E9815ABDDFC082EC5F7A584498 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD91667428047551AF217B76A0AA3019 /* StringExtension.swift */; };
-		312C974250B49255DA79E2E3BFD87E15 /* PollingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B6F5E14121C09C0A1D067D35D33C2 /* PollingModule.swift */; };
-		319356506C1E7A4D390E46F53B6401BB /* PayPalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816A780D0C2C1EFA953A2F9344D73E85 /* PayPalService.swift */; };
-		323114E92AD7B249AFC7D7D12B24021D /* Content.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4904C99F7D4BCDF5793E01B9EB59BA89 /* Content.swift */; };
-		368300110598446595EC7467DFEB91BE /* PrimerCheckoutAdditionalInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9277A876AC31CA1290A688A1EDB7AB9E /* PrimerCheckoutAdditionalInfo.swift */; };
-		371EC33E8989AFCC8810B46216AE6801 /* TokenizationRequestPaymentSessionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCDD17220E89326943E0B5A24F8505F /* TokenizationRequestPaymentSessionInfo.swift */; };
-		380D48B7EDBF3209CFE15E69ABA9330A /* PrimerTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 768DFADB4567BC5D42C0BE71D3D87CCA /* PrimerTheme.swift */; };
-		3831698229FE103843982AA1218C3ADB /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD32028FD5BF0AEA431D16151440339 /* Identifiable.swift */; };
-		391D5CE37A29CA1D38CA59CD609E5A33 /* tg.json in Resources */ = {isa = PBXBuildFile; fileRef = 5B0FE5BEF2FD855A8FF77C7511E26F6D /* tg.json */; };
-		3969A93549D85A2FDD387538FFA999BA /* PrimerLastNameFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7BBE63AFAE496E1D588F9F8EE93954 /* PrimerLastNameFieldView.swift */; };
-		39E30C3D9D239DA34BAE4402CED7C903 /* PrimerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9376E09A9CF791A7E524DAE45024EE8D /* PrimerViewController.swift */; };
-		3B5A6B47B566362822E1EA34CE7A953D /* PrimerCountryFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C69E70953DB1701A8251042C30D374FD /* PrimerCountryFieldView.swift */; };
-		3CB900063BF1DF50D33DB6BFDCA10E5E /* NativeUIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3813836067E9031CA7259B38E484389 /* NativeUIManager.swift */; };
-		3D5F819E57B47ECCA17CDE0290F2054B /* KlarnaTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529B61E5B348E049881C610F2A08C40F /* KlarnaTokenizationViewModel.swift */; };
-		3D6F530D8331C9039FCA2E3D42365771 /* ApplePay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6B512BDDA31559E37688AEDA591FA63 /* ApplePay.swift */; };
-		3E2F20142F93D7731AD0FFBF0AB23CE5 /* DependencyInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB0823F6509EFDB7D3DD9F61B99EDF8 /* DependencyInjection.swift */; };
-		41202FE114E26F23AB27C1C1DFFD9ECE /* ug.json in Resources */ = {isa = PBXBuildFile; fileRef = F7443D3024DCD2FF2616FBE671774A2C /* ug.json */; };
-		42918D8C3EDA4381966EF347B2BDB5AD /* PaymentAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D904908A5EC60003EC3C0C7137DBBF /* PaymentAPIModel.swift */; };
-		42AD943772E9FEF6247E9A728D865240 /* cs.json in Resources */ = {isa = PBXBuildFile; fileRef = D7216679FBF84EF0B6A60C80BEE735FA /* cs.json */; };
-		42BCF68DB690C3AC2F2332505110B136 /* zh-TW.json in Resources */ = {isa = PBXBuildFile; fileRef = 63C72E6699818410EB0A9F8081A9EC1E /* zh-TW.json */; };
-		431F6F8F51B550EF3C8EA36797306F5B /* CheckoutEventsNotifierModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B221963E70220E6B3394DEF7763AB4 /* CheckoutEventsNotifierModule.swift */; };
-		4364A26809CFE3BFF6D1C387F1D4B869 /* az.json in Resources */ = {isa = PBXBuildFile; fileRef = 46DF979C091AAEB2188A67A4E60973E0 /* az.json */; };
-		44722AAA42E7AA57010A9C110571D8BF /* _PaymentAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 185C900448A65C8F0C6739A8080914DB /* _PaymentAPIModel.swift */; };
-		454CBAD1FBD8053E84D855AE0243A3A2 /* CardNumberField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F7C27DA3C1925E73955990BEF67E0A /* CardNumberField.swift */; };
+		2F84899923D7679832F1FBA28B2B9190 /* ClientSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B76A46C31B6739890DE6910AD4BF0EC /* ClientSession.swift */; };
+		2FA5A10DE6688A74B692CB69AF26E669 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0823CBC7355A73F7ED71C1AF4A115F82 /* Colors.swift */; };
+		2FCEADBC467212BBE7DE2FF3660A1452 /* NSErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2265FF9EA917CC753CDA43675489BBF9 /* NSErrorExtension.swift */; };
+		2FD7A5B737B87210A606E81A4D44BF32 /* AdyenDotPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDFEEE6924BE67058D42627DB539218 /* AdyenDotPay.swift */; };
+		307BF4B4DAD4C1ACC2BC36E0C368C3CB /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86DA92035CFB330FDA160250182919A /* Currency.swift */; };
+		30FE9E01D4020B25D8589108A668338A /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294457E6EC1065D042CE94502D6F82B3 /* CustomStringConvertible.swift */; };
+		311CA7B281D44CF7ED2B9EF5001D749C /* PrimerThemeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8EE2C72FA1F716181A3C2ED47540C02 /* PrimerThemeData.swift */; };
+		3179D5F9CCD483BC06E3AC4D00D6A23F /* CardButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1A622C0E32F4C7F85CBF2F78B95636 /* CardButtonViewModel.swift */; };
+		326AD2D6F55892152FD1E5F5D0E00DF3 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7152E639D865A2AB5D0E967175881AA7 /* firstly.swift */; };
+		32F5A3484817FDE0DB15C9A31553EEB6 /* PrimerScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5ABAA71946AE923EBDB4FB83DD4E012 /* PrimerScrollView.swift */; };
+		32FDB09865EB81F57C1635AC8E30ACD7 /* it.json in Resources */ = {isa = PBXBuildFile; fileRef = 79FEB8CEBD39C9AEB4C37603C20372C4 /* it.json */; };
+		33D80B332E429634DCE82884C67D256B /* BankSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524E15085489715E24AB2EEDFA319E33 /* BankSelectorViewController.swift */; };
+		35B0F46955D221BED20908E798CC1AC1 /* PrimerCountryFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2935E4B0A5808F755F54846BEE6AF5E9 /* PrimerCountryFieldView.swift */; };
+		365AD3F069149AC2DDC7BA04A42B42E8 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C187F5DFF3075C9D1790B79AA29905 /* AnyCodable.swift */; };
+		398BC07833BC44F18EE2AC8536ACFA39 /* PrimerCityFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8577639BB5E2ADF2D73E37E2D5645366 /* PrimerCityFieldView.swift */; };
+		39CB4A3E452C22D0F0EFB445941C4BD3 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 546760DB141F1C41C74B89B193EED62D /* NetworkService.swift */; };
+		39DEBF122D67CEC7F876D2067B5F17CE /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC965C17D86D28EEA7C1247831FB1B27 /* Request.swift */; };
+		3A6CC0C21C3BDEF6E33EB7272ED5D43B /* sr.json in Resources */ = {isa = PBXBuildFile; fileRef = C3E2546D6816E142BAD4DDA304274D32 /* sr.json */; };
+		3BA7704C8CE75E8D1D0FFB1B05C6F76D /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6971C4F3174907CE296FE18125901E /* AppState.swift */; };
+		3BDB0B2387E3F1C2523E355B60D1C636 /* lt.json in Resources */ = {isa = PBXBuildFile; fileRef = 2AB885AFB60EE0C6B39062DFE30176AC /* lt.json */; };
+		3C894DBAEC1E5425BC891FA99AD937EC /* th.json in Resources */ = {isa = PBXBuildFile; fileRef = FEE6C260E8DFD5CEB5C5BACDB1620BAB /* th.json */; };
+		3C8CF8C485E5FBB0591585904873E3A5 /* PrimerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747C2640DE0A63351A972AE55921A08F /* PrimerError.swift */; };
+		3D3BF04386CD7C7876F019E23472CD03 /* VaultService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D4869523FCF15EA32B37EC87DD6F19A /* VaultService.swift */; };
+		3DD29072DA7F2701E2DAC4174D061118 /* PrimerAPIClient+3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372BA201AC4938F7D167D5060203BB85 /* PrimerAPIClient+3DS.swift */; };
+		3E91783E8BE5E43164BD4ABB791DC06F /* PrimerPhoneNumberData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71CB22A248E6C3F8A502B7539BBCF73C /* PrimerPhoneNumberData.swift */; };
+		3E9B4605720345FBA68419D0074CF886 /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027EF89D51BC1409FF36F92A4B40695D /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift */; };
+		3EC500D7BAB81C3873E1DEA57BF966D5 /* PrimerVaultManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C68FFDC0DB7E31F13437D793D85EEA8 /* PrimerVaultManagerViewController.swift */; };
+		3FC830AD4C485F517E1ADBF2BDEB33EE /* PrimerTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01CB8FDA4F59661CDB4F887F79ED7B4 /* PrimerTheme.swift */; };
+		41BE82E48B02158234F9CC37428A95D0 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307663AD5935C039472F05A5DD7574B0 /* Resolver.swift */; };
+		41F99066672B4CB84CA9F81BC4B2215B /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543B41C5C2EDE9AA3BB42EB5694F0714 /* AnalyticsService.swift */; };
+		423D733401241A30AE19FD0682D47448 /* PrimerUniversalCheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CA8CA6BB86462451ED4D675CC1E279 /* PrimerUniversalCheckoutViewController.swift */; };
+		42D20B1E2F0D0C9455294CABB8FF7C7E /* CardComponentsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10518419B19F405054471079A3497216 /* CardComponentsManager.swift */; };
+		430128B993F1ED51292E2A837188AC72 /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F95A46947102FD5D1FF05FA25E6C3E59 /* LogEvent.swift */; };
 		4558FD758572BC2D0F018704E87C5B4A /* Pods-Debug App Tests-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C8B8D5DF70EDE81CC29CD5256B05DC /* Pods-Debug App Tests-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		45D0E33FCBC1A929D1FB3BACF4E513EA /* zh-KH.json in Resources */ = {isa = PBXBuildFile; fileRef = 5536D76A02FB86E84689A5D3B051CBDA /* zh-KH.json */; };
-		491A4225D2D223D0F7625F914F9E42E8 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F35FC28E43595B3B10E170BB27463E /* UIUtils.swift */; };
-		49406745B6BAAB7578B5856F1042CFFA /* CountryField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E3B6E2350EC9C8A4FB2AB0DF81D119 /* CountryField.swift */; };
+		46C0E408664E32E075A980113500F6C7 /* SequenceWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE8D111E172A4BCC76ACD0E62DB9972 /* SequenceWrappers.swift */; };
+		46E111D8A06C7A28D9C51CB99D309043 /* VaultManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89CD109AF48504DEE37CFC24F53DACD2 /* VaultManager.swift */; };
+		47CBA74E57F387AC617C78DDC0FECBED /* KlarnaTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D347F7C4C935764556D644C5440D140 /* KlarnaTokenizationViewModel.swift */; };
+		47D91F38A5E41383DCA4F11BAE34EFFF /* PrimerAPIClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374EFD57A0283E73FBB80FBF949DB664 /* PrimerAPIClient+Promises.swift */; };
+		49170C629B41B4B013B6307A549AB5BD /* PaymentAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5084423FF5D474B7098BAF76BCC636 /* PaymentAPIModel.swift */; };
+		49AE481684D585E4C8D6B6F2F3EA7BF9 /* UIUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7400A013AEDEF44A971F11CAD1BA407 /* UIUtils.swift */; };
 		49C5CF9C822A8D07D4F20F20CD88E340 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */; };
-		4A9E857059A73B4DE144ECF8569C17FE /* CancellableThenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1AC8628545D02AF110941128880271 /* CancellableThenable.swift */; };
-		4B37EAF151154CBB216977928324F816 /* ja.json in Resources */ = {isa = PBXBuildFile; fileRef = 3830E414F3EB4A0C9C40924BC94F52B5 /* ja.json */; };
-		4B3A306CBBFC00939662136388B5B575 /* RawDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9B45FE4B61770CD32006E3F49CCBFB /* RawDataManager.swift */; };
-		4DB4439507F12698585A300C026BABEE /* WebRedirectPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D6C93E9B8E12ADD7F2EAC90F253F50B /* WebRedirectPaymentMethodTokenizationViewModel.swift */; };
-		4F83FED6407EA397E86AD8B9806E2AB2 /* VaultPaymentMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C586906ABD4A1190735F29E3788C85 /* VaultPaymentMethodViewController.swift */; };
-		4F9AF0AC03CB91D2E6460A4C8D35AA1D /* PrimerFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEDC7C2CEA211E2F43BE2A99F644487 /* PrimerFormView.swift */; };
-		4F9C98C798275B4809F824CD1E0B5CFF /* Cancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE4CA17ABBC956DFB5EBCB1FC341FEF2 /* Cancellable.swift */; };
-		4FE8183A1E2DBC989A3B77719D547DCA /* ImageName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BB30024C6CE1D203C1A1ECB896CF5CC /* ImageName.swift */; };
+		4B852D34199682AD08222B044E8CB9E1 /* PrimerCustomStyleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001E05D511E77A6FA8C2963AC7FB50A5 /* PrimerCustomStyleTextField.swift */; };
+		4BCF555BB378319B84938A268583EE89 /* ThenableWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0317C27EC0D1EE81480B338605D14E /* ThenableWrappers.swift */; };
+		4C8EBC2302679848450315CF3E15B765 /* phone_number_country_codes.json in Resources */ = {isa = PBXBuildFile; fileRef = 123DE8A650ADC397D8B69D45F02E8575 /* phone_number_country_codes.json */; };
+		4FA9664093FFC69CBEFEAC86BB6F5053 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DD3ECFAF50DF47E3F4EBE777CEF518B /* Response.swift */; };
 		4FFD6169BD8ABAA83876DD393ED02964 /* PrimerIPay88Payment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3E74479A31CC9E74D03296171FE3E9 /* PrimerIPay88Payment.swift */; };
-		5204BAE23E4B036E1870B9BFC7B827A0 /* PrimerFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BE40CF3D522E23F0A1AC4996C89EB1 /* PrimerFormViewController.swift */; };
-		525DC99947F2605886DDF0875358D5FA /* PrimerTheme+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466113CEF6EAC19D866900CCB282BEC2 /* PrimerTheme+Views.swift */; };
-		527EFC230461EA5C15FA7962FF19AA84 /* PresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F76FB1A589EF365F1AEBAB99EBFA5F5 /* PresentationController.swift */; };
-		52F788E625802856465B4B2D5676CE07 /* hu.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D222B2A5D57E2055C9EF12BCAE26F26 /* hu.json */; };
-		535CDAABFDB80965A0DF264C2E4FD6FC /* PayPalTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 940D103C6AB77833ADB6DD2AED6ABE4D /* PayPalTokenizationViewModel.swift */; };
-		5385DE76B7F00F80033BAA6CDB1EFE45 /* sl.json in Resources */ = {isa = PBXBuildFile; fileRef = C2E84F0E6CADC0D66E56DE50C04D9C1B /* sl.json */; };
-		540AEE941275FB770AC5A5236FD36B11 /* so.json in Resources */ = {isa = PBXBuildFile; fileRef = 059A44FD4398BD3ECD3A33D1571C4CA0 /* so.json */; };
-		54912066C003D58A6EB95128BEF91991 /* PrimerCheckoutVoucherAdditionalInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D64EE816E96456BBED6752EF8A36E8FE /* PrimerCheckoutVoucherAdditionalInfo.swift */; };
-		555A59F7214CB9C907A8A975D2400430 /* PrimerVaultedPaymentMethodAdditionalData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0292748EAA0F59FF63A048594369AFB0 /* PrimerVaultedPaymentMethodAdditionalData.swift */; };
-		567000E6DA9A409C0F9EE94347135FF3 /* PrimerRawCardDataTokenizationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17DF89D13BDE22B8A4D2168769C4E48 /* PrimerRawCardDataTokenizationBuilder.swift */; };
-		56DA6251DE9EBB0BC6E29B6290C1432B /* PrimerAPIClient+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1701C2BA9780B96815CB6F6C83AA7974 /* PrimerAPIClient+Promises.swift */; };
-		5A97C78BEABC8CB8216E8D856F244B22 /* IPay88TokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED4F9C90B56C0E6349C4371D676C991 /* IPay88TokenizationViewModel.swift */; };
-		5BD49609BA3C39DCE430160E18CC510A /* PrimerTheme+TextStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB21E1376352DE378AADDC08EFEF7AC3 /* PrimerTheme+TextStyles.swift */; };
-		5BE3D708EBC970C282B673F4A4D8920E /* PrimerTheme+Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30424A15FF625421E63F306D4DCA634A /* PrimerTheme+Colors.swift */; };
-		5DEC6214C32D1DBFFBD611AEE8EC5BB2 /* th.json in Resources */ = {isa = PBXBuildFile; fileRef = 58D0B252742894B8F436E2D6226EE52E /* th.json */; };
-		5E7431ECF9C516E46206F6B8183DE3FE /* CardholderNameField.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61E7B7CCD27CE3F5AFAF67768319512 /* CardholderNameField.swift */; };
-		5F66DDE8DB124E3CD2C81AF820B25C98 /* PrimerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DF67D061C1A24B3FCA790F0F1686FEC /* PrimerError.swift */; };
-		5F836E2EE4C4A059FB93E2AD183EC7C8 /* PrimerSDK-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D67E38AE53D2DD65A16AF5CDC8AB67F /* PrimerSDK-dummy.m */; };
-		601008AD15B07A3502754F7905AD07BF /* vi.json in Resources */ = {isa = PBXBuildFile; fileRef = 5602C99E5A9BBF31FEE8709F61A81EF8 /* vi.json */; };
-		60166F35DB9B5FEC0F970EDEE04611D9 /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96245C913D414469B1B055FE759BCE36 /* Downloader.swift */; };
-		60503B86EEE1AFD14CBF990E5E60F944 /* hi.json in Resources */ = {isa = PBXBuildFile; fileRef = 3DCE173F1CCAF4B0D75CB8CC7AA5F677 /* hi.json */; };
-		6075CB00D12E3CB83A6B4471F2898483 /* ru.json in Resources */ = {isa = PBXBuildFile; fileRef = 16A13FF37400C98AB78552A82F345D3C /* ru.json */; };
-		60986774826B581EC079F37AC10AC96E /* CancelContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA236D6CCC7FE519C6A4A34148702342 /* CancelContext.swift */; };
-		60994BCB481CA73588524AA590E08126 /* PrimerLocaleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BACB9741092B773E390ABBF54027853F /* PrimerLocaleData.swift */; };
-		610672125FB39E76DB8392133A1DEC63 /* PrimerPaymentMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E5897C9ECB8AC1D141436435B05A6F /* PrimerPaymentMethodType.swift */; };
-		6108382731B4A9CD2F7E240B404D09B4 /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D152F5C198FFCC1BADCADFEE4A9DBB /* DataExtension.swift */; };
-		61AB2516BA25047CF79BCE3DB4A684E2 /* RetailOutletsRetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8026BB771C9833F41AE8BDFDA671FE /* RetailOutletsRetail.swift */; };
-		62DEF38F2A78274B2E28FAA523AF2F2C /* AES256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3378FDE7CF6756B16256FFBF993DA91A /* AES256.swift */; };
-		62EBE6572803AE2D7B4286B21F1EF6BA /* QRCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E7AFAA58AAFA31C00BACCCF8559AC5 /* QRCodeViewController.swift */; };
-		63E8656535F70CB23091FF23064835C5 /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F06C6C20AF0AFB2E34E54D37EB61B9 /* Thenable.swift */; };
-		63F37738C45B82C6F97456589D11F8EA /* FormPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0237EB57F7AD1A4F815C165E0EFB038 /* FormPaymentMethodTokenizationViewModel.swift */; };
-		651C6737EB0BA2A743C23F7CC33DF460 /* ExpiryDateField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76E3578E4B628CC91F9BC1B6C5C4FC73 /* ExpiryDateField.swift */; };
-		66481EA2CBF7AFC8590263121AD7B1A4 /* PrimerGenericTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC0D5435EBA802F72AAD2E73D6F67D8 /* PrimerGenericTextFieldView.swift */; };
-		669300183A9A0B6C31F1B5BAE80D6E4F /* da.json in Resources */ = {isa = PBXBuildFile; fileRef = 8504B12C19D5BE4EC28864CDA892D4EB /* da.json */; };
-		67482175C339F66B108C5710090BC5E6 /* lt.json in Resources */ = {isa = PBXBuildFile; fileRef = D5E82976D4CF476DD8CD1853E13FE271 /* lt.json */; };
-		67B2CA1A7AD4D2F09E5E36479E2D40D3 /* fr.json in Resources */ = {isa = PBXBuildFile; fileRef = A6210190AB0CCA765D073F0650BDB241 /* fr.json */; };
+		505F38FBD69611077DF0A5515E281EA1 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0DE4CDFEDDADC6C799DCF98FA4027D /* Identifiable.swift */; };
+		5085F457670F7774BDA18C7EE2FE326E /* PollingModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31878C04FDEA377DA4D75BACEDA06152 /* PollingModule.swift */; };
+		5142CC524F7DB55C500E378D3D3B56B5 /* NativeUIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517718981FB204D4344CF16DA72C1765 /* NativeUIManager.swift */; };
+		517CD4047125CEAAC7232631C78418F8 /* Dimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7C836C26AC3E7BB20F867B3EAF13164 /* Dimensions.swift */; };
+		523B2D8586C398B62CAFACD182558E32 /* PrimerNibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715B7A9737972FC4CFF322C9D09BA162 /* PrimerNibView.swift */; };
+		52513ADEC23A6FDADDCE6B4D8541AC54 /* PayPalTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44864A6EC767509F172A34423DCDB50 /* PayPalTokenizationViewModel.swift */; };
+		534940DA47CE2B00A9498B25017B886E /* PrimerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1938219645ECD7444E7368C7AE41EC /* PrimerViewController.swift */; };
+		5379DE83ECE0F20EE0E8EEEB2C5BEFBE /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A025D9F91E2FF89B8464E303E74DB9 /* after.swift */; };
+		55E378081852352525DC1017A401CCF1 /* PaymentMethodsGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31FE9C6312D13374285B21F2E910631C /* PaymentMethodsGroupView.swift */; };
+		56833A8FCF855324404168991E37CEDF /* ClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82383F3DEAFBE1C349DFE724310C8181 /* ClientToken.swift */; };
+		57F73A2311AF02C4DC5A6CC60684C5E4 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDC3243C2E4F76161D1FD8B607AB018 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift */; };
+		5BFC2FB36F5C2887C11A9F8151E28A86 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C51AE115C965E7B9FD010CCFF9695A /* Device.swift */; };
+		5C678B7E2D5D163822B3A0F2BF9766B9 /* VaultPaymentMethodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA02A897C750507CA0849CE74B55431 /* VaultPaymentMethodViewModel.swift */; };
+		5D9198FA6D079DE47A98EF155E9731D9 /* PrimerCheckoutVoucherAdditionalInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E6ADF8985A5ED1D201E6F81423AE8 /* PrimerCheckoutVoucherAdditionalInfo.swift */; };
+		5E290CA468C68621963E82B3DA8431C8 /* PrimerRawCardDataRedirectTokenizationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF1C199E2CD2B5737740E1C24BC8AA47 /* PrimerRawCardDataRedirectTokenizationBuilder.swift */; };
+		5EC3191DDCFD3FE210F1321958B4C0DA /* el.json in Resources */ = {isa = PBXBuildFile; fileRef = 4C9A28C3BCAEFE9BD5AB757E551C3293 /* el.json */; };
+		5EF5BC8F9F91271692A25668864EB240 /* Weak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F357409294319906FBAF58233E2080 /* Weak.swift */; };
+		60766B2E178CF0A69EC093236389DFF6 /* PrimerSDKIntegrationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D213E92F2A057C6223AC3D32D4FAFACF /* PrimerSDKIntegrationType.swift */; };
+		60AA658765BF7371041F4D8A1A29B93C /* Primer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B425735AD0440C017E0D53AFB3789334 /* Primer.swift */; };
+		6161254769D1D2CA2AF37A89816B5CAA /* Mock3DSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295658BEB9FC559F1C7C786513AE78EE /* Mock3DSService.swift */; };
+		61624F1FDE241B8786142E5FCF878EF5 /* PrimerCardNumberFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72CFC4735220124F1C27518F5795CCFF /* PrimerCardNumberFieldView.swift */; };
+		616CCEBD27A3EDD03FB2EC15DD1DDB28 /* CardFormPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E13CEC6801594CE09EE0D4F92DAC184 /* CardFormPaymentMethodTokenizationViewModel.swift */; };
+		62558304A5F51F14F6DA4CF11B787247 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCCF5CAD3C150CA38CA653BB6AA19D1B /* Box.swift */; };
+		62B26BDC8B6C86C7C53A41EEAB3B7944 /* CardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69751B148853A2C903CA0E5D360F71CB /* CardButton.swift */; };
+		63C751378CCFE26D0CA7A5D53F476488 /* Consolable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50EE3344C0E727B6268B6A3C50ECE8C /* Consolable.swift */; };
+		6498ACFF45A6D29AA456C1CB90198BF9 /* pl.json in Resources */ = {isa = PBXBuildFile; fileRef = D13D585BB4F26D9D79CBE16CBD0B1362 /* pl.json */; };
+		665E0721793376E6AB3F3BB1190E576B /* bg.json in Resources */ = {isa = PBXBuildFile; fileRef = 1A98363F99139D5B9B01EA53F46BBD85 /* bg.json */; };
+		66DEDA93DB0A1E016FC92E568E10B159 /* Klarna.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384310CE541E1E342ADEA8C381CE4CE2 /* Klarna.swift */; };
+		6722B084ADD9DA4AC3DABA50F8C52BFF /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53BF9A4F2B75AA0E6AE8CD0E127A3C8B /* Thenable.swift */; };
+		67C42DC99CAB6FB5F70E1DEA35D50B0E /* PrimerTheme+Buttons.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30F920C49BE7B4AD210E011736F2818 /* PrimerTheme+Buttons.swift */; };
+		68B7DA7338FAF48893A3159432B4E12D /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E678F93CD7D86FF3DA682F680132F1 /* AnyDecodable.swift */; };
 		68EF3B10BA80E7B096C5BB6D13D2FCC0 /* Primer3DSError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15924FCA59DFA2A8C5A284117050AAC /* Primer3DSError.swift */; };
-		6B98CC78B0B433580D5FB99C5AD4DC8A /* CreateResumePaymentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F91464987A23B4425A1988E1CBC420A3 /* CreateResumePaymentService.swift */; };
-		6C2A557E1A095CBA8E8325D6DAA84CA8 /* PrimerCheckoutQRCodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B19A54D227949ACC847904D7F9C6BEB /* PrimerCheckoutQRCodeInfo.swift */; };
-		6C38C147792DC9215861821F89E21751 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02784547B176EA2ACAAD8AC90276D48 /* AnyDecodable.swift */; };
-		6C5314ED927C8464E485C309DB83E554 /* kk.json in Resources */ = {isa = PBXBuildFile; fileRef = 12F049D553385B220511DA5324E73CAC /* kk.json */; };
-		6C588008FB9A067778A7839C86D1C39C /* PrimerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19E148415476719682D2C8368A32882D /* PrimerDelegate.swift */; };
-		6CDBE386A918159F9DBD3AC06F436BDD /* PrimerTextFieldView+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6942EEB75589F8096F31A852E985DC5A /* PrimerTextFieldView+Analytics.swift */; };
-		6D1056B74A7C33A8AB9C67AC59A7590E /* PrimerTextFieldView+CardFormFieldsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CDD75F8BD3124D3057BDBC8548F8B7F /* PrimerTextFieldView+CardFormFieldsAnalytics.swift */; };
-		6D1C13F088C0C92E455455618DBFE41B /* FirstNameField.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3AEB607A42E7813FA5CC05C2E22893 /* FirstNameField.swift */; };
-		6DA37F26D380A1A52F6A7CDBB4B7E962 /* nn.json in Resources */ = {isa = PBXBuildFile; fileRef = D3D99E723F3EFB3D2C3BE3BD7D65A31E /* nn.json */; };
-		6DCB9C1B91858FC3FE5592E6756D1055 /* NSErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA4A4667E5FDDAC93F09F3D2C931362F /* NSErrorExtension.swift */; };
+		6A1E5BAAD92FC13481C0B3E205CA7452 /* CardNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D143DD4A791491A789B0431D6D723989 /* CardNetwork.swift */; };
+		6D0A41B3B3CEA4A5F879D6F54EA7849F /* HeaderFooterLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F7412D45858B66147EECAEDA4AD2F0 /* HeaderFooterLabelView.swift */; };
 		6E9BBFFFCC027489169E0C0D80A79478 /* Primer3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81AE82A628E72F5492DD077308038416 /* Primer3DS.swift */; };
-		6ECE60EE09F8B72456125F748CE1891A /* PrimerVaultedCardAdditionalData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54FA7720C78342B5439459172907A60 /* PrimerVaultedCardAdditionalData.swift */; };
-		6F4E73BBCE30AB6B5B7AB5E03C6FC1E7 /* PrimerMultibancoCheckoutAdditionalInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B781E11A79C388D813B06730D8D4DD /* PrimerMultibancoCheckoutAdditionalInfo.swift */; };
-		6FB3F69390BC961E5866FDC437FB3654 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E92EE860BD6063D1EE4ACE39842D2A82 /* Parser.swift */; };
-		711351EA81E43872032020A35C1545B7 /* PrimerRawData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD9839D3A21F0287751A379E0C7A708 /* PrimerRawData.swift */; };
-		71FF48FC4AFCA46B18DAD5403BEFB673 /* VaultPaymentMethodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C344CC918ADCA293407831E1C5025 /* VaultPaymentMethodView.swift */; };
-		7319016F79E9DA518388FBB3F8C69526 /* LastNameField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81C1DB85FAF3F49403DF67E2C7D8A5E /* LastNameField.swift */; };
-		735AB4AE5A2FA7666B2F59725816D9CB /* sr.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CFE031BD7589055BFCEEB1119F8C153 /* sr.json */; };
-		73BE082FA9CDD65597D25B5910AF9016 /* PaymentResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C4A9E16F4E2DAB60510F9F8C696597 /* PaymentResponse.swift */; };
-		746BA51131AD06750526B1AD752B8AAC /* es.json in Resources */ = {isa = PBXBuildFile; fileRef = B72E54D3874156D1405A9599AAAD83E9 /* es.json */; };
-		74B2115BAAF64D321F97FB799725242E /* it.json in Resources */ = {isa = PBXBuildFile; fileRef = 958DF5DC676C76B87FD38B6C4BE484F3 /* it.json */; };
+		6FB35AE2668B5590FE8DE098DE348934 /* PrimerWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CA173614296EA7DBB395D06223E69A /* PrimerWebViewController.swift */; };
+		7067DB8DE6C9923E8FC68F0268A5B1E6 /* PrimerResultComponentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7929645639832C86A4A793856AC218FC /* PrimerResultComponentView.swift */; };
+		70AF069FE09421FA59A463A9EA547450 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14DA91E266DC6F936AFBDDE4DE581DA /* Configuration.swift */; };
+		70F9EF93D422C7D3942B4B072F140872 /* PrimerPostalCodeFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376188E5CA6FE63BE415B61E6BEE50D5 /* PrimerPostalCodeFieldView.swift */; };
+		710C88B920EF2B8835FEABF45A0A6E2D /* lv.json in Resources */ = {isa = PBXBuildFile; fileRef = BD1470B97657B6C4BDBACC9E553269AD /* lv.json */; };
+		73B63C0A95EB7EEAE6FB4882D490E72F /* ps.json in Resources */ = {isa = PBXBuildFile; fileRef = 2D60F047DE49B9E1CB784CA58F775EAE /* ps.json */; };
+		746A5DE654FEA255F60F701F14BEA79F /* sw.json in Resources */ = {isa = PBXBuildFile; fileRef = D8A78C9A95D42B03B85DE293D09C6831 /* sw.json */; };
+		750A5410E582D090A07B81F505F11DF3 /* PrimerCVVFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798185C0AAF883967105163189763B53 /* PrimerCVVFieldView.swift */; };
+		75729AE2A7738C353D22D1DA439D604F /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E025A3E214DBB9676536F35385694E5E /* Dispatcher.swift */; };
 		75D0CDDF4FDBB53D75BADA009EF1CEE5 /* Pods-Debug App Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 13E57A9033664934BB815C9ABE12CB43 /* Pods-Debug App Tests-dummy.m */; };
-		769353053EA80213EF441E5DE41DF823 /* PrimerNibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24CD24F268D7252CA8F3E99D6CAC1D2 /* PrimerNibView.swift */; };
-		770BE13A9D82192E3A58A21A9F3021DF /* RateLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F42F8ED46021BBDDAE4541C3E02327C /* RateLimitedDispatcher.swift */; };
-		774D920A9C2D5695C9E9828EBAAF039B /* PrimerCityFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F1D9613A2366B3F5224FB667DD56DE /* PrimerCityFieldView.swift */; };
-		78E9DE6814AD0B6CAD24E6E07E3EA1F9 /* PrimerUIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4F8BF23E74B8A9811AF0145DDF82D00 /* PrimerUIManager.swift */; };
-		79E09E6B6F18F2E3D31D7A76B8696D32 /* VaultManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E576BDDB4E79A57CE3045FD25A4E450 /* VaultManager.swift */; };
-		7A80F5A95C8D78D8410BD45DCBE66A6E /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9320FDCA77DBA0E62C540F6DE339266 /* Dispatcher.swift */; };
-		7AA027CD74DC030D017A0A32F3D744D3 /* uk.json in Resources */ = {isa = PBXBuildFile; fileRef = B79C83472C36ACC8CA5F9E1B0014E4A4 /* uk.json */; };
-		7AF17C27FDD1ED990159DEB114B44725 /* PrimerCVVFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC639942D4366A5AA567E6912B6C66C3 /* PrimerCVVFieldView.swift */; };
-		7B9C8FFA2658F7CAED064291F9904606 /* CardFormPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424E17EAD5C6A4D0775B89D66167B1F3 /* CardFormPaymentMethodTokenizationViewModel.swift */; };
-		7C83B7715B581A2D8D97FD8E31EF3427 /* ms.json in Resources */ = {isa = PBXBuildFile; fileRef = 3F61EEC23B1A888114C4C1ADF4A86673 /* ms.json */; };
-		7DB2346F02620ECBC0D057BF2CC5C436 /* UIScreenExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F087DB1B37A42AFDE479741B0685DB /* UIScreenExtension.swift */; };
-		7E20082F41C80E00AA9CB734F9C63108 /* PrimerThemeData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F972271981C552CAC86D444BA3DE791 /* PrimerThemeData.swift */; };
-		7F655860A1071864B0A6A691068925C7 /* XenditRetailOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD562A76991139BF0C87B8B2B6A9280C /* XenditRetailOutlets.swift */; };
-		7F809FADFA983E4CD80BE6857060D766 /* ConcurrencyLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 812E080E981922506FDB77AB628466A0 /* ConcurrencyLimitedDispatcher.swift */; };
-		80FCA5A86BA0E93A4EA53B3FDD6F8EF5 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B52689B762A3CB52BD072A91E2EC1C1 /* DateExtension.swift */; };
-		810EC0426A9F3F9A6AA97538B491FE99 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1437FAD4E45E8929285D343D53E42338 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift */; };
-		81696D29BCA1E116786093E4DBED1974 /* PrimerInputElements.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD0935E4B2588CB2DA6A40F62D00F08D /* PrimerInputElements.swift */; };
+		75E17503A7FABAA4A72356895F537839 /* PrimerFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911B56AB0AD9B3D86A426EEAA4366161 /* PrimerFormViewController.swift */; };
+		76741435B0939E7F5B64C17ED8FAA92D /* PayPal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75A1840CD1E5769FED0C402B1E716879 /* PayPal.swift */; };
+		798759292CC8F37C6DC6191315946811 /* PrimerExpiryDateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8743B83727ED04C6EEFB6676A7294731 /* PrimerExpiryDateFieldView.swift */; };
+		79A5D1DD6812CC64723437B0519ACBC3 /* PrimerTheme+Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE63293F2752157771515FEF5A232D /* PrimerTheme+Colors.swift */; };
+		7A803B561ED06FCCA76114EE49FCB9BE /* URLSessionStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22F17017930269FC0D4E88BB05BEC8E /* URLSessionStack.swift */; };
+		7B6C050C0706422EFEC6F957958C864A /* PaymentMethodTokenizationViewModel+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C842A7DBF96DDC64E5EF713CFA9999 /* PaymentMethodTokenizationViewModel+Logic.swift */; };
+		7C492879F072CD000DE5EC816AACA14A /* PrimerVoucherInfoPaymentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AAB1BDBB913DA8B0155AEC46064F30 /* PrimerVoucherInfoPaymentViewController.swift */; };
+		7DB78C6B612412BC66841DD9D9CDEABF /* UserDefaultsExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903452C2F03311E9F54893E00CF2991F /* UserDefaultsExtension.swift */; };
+		7EC57E10386C8DD31099002EB8A81782 /* PrimerNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4B086002167B86FB152200CB5F4C3F /* PrimerNavigationBar.swift */; };
+		80F800D5CB99614EF506AFF3F63B306F /* PrimerTheme+Views.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB08C138B9B1F3AE0259F9F24B581AA /* PrimerTheme+Views.swift */; };
 		82460C7CCC4199767BED8B59B8DD25B1 /* Ipay.h in Headers */ = {isa = PBXBuildFile; fileRef = C74D9FD357F458A288C717E68E895194 /* Ipay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		826AB5A88C1611E104B4B1600D767299 /* StrictRateLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97797B3A826695B50126CEBA1DF3D1C4 /* StrictRateLimitedDispatcher.swift */; };
-		82915469183481164C4AF527615835DB /* zh.json in Resources */ = {isa = PBXBuildFile; fileRef = 70248D6685AE5AFEA64D59F62D4A16C8 /* zh.json */; };
-		832CD4420A092EB1F7F054925ECCDE44 /* PrimerNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E63F745E427E987E09670C63FFB0AAD /* PrimerNavigationController.swift */; };
-		833D04BCF4A56EFAEBDEB7AE603CB22D /* ThenableWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDE2DE281F0EABFABF487C99974EC99 /* ThenableWrappers.swift */; };
-		840215AFA76EF6FE97DAD17EFBD84824 /* phone_number_country_codes.json in Resources */ = {isa = PBXBuildFile; fileRef = 54AB737F3043554978BCE0BD76000729 /* phone_number_country_codes.json */; };
-		84BCDEBC9E53917DCDC895D62CDE7241 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C261F7EADFA6BAC30B19D15FC9DD783E /* CustomStringConvertible.swift */; };
-		84D8DC7534E302AECB98BA589C40C854 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD89B0D3B0B712AE738025E0B73D538 /* Optional+Extensions.swift */; };
-		8626B60C98BF2CA62298DD565BF126FB /* TokenizationRequestPaymentInstrument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 105344FCAA5C83C80B929CC49544A9CE /* TokenizationRequestPaymentInstrument.swift */; };
-		8661F5DC74EBE1B8F59CD1FF20C67A42 /* PrimerFlowEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10526B5EF46C2F86753394A25C7D0445 /* PrimerFlowEnums.swift */; };
-		8667E405A7FBA6C9816F833EA7697AE6 /* Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39747BEC69572C1757907F113F6B19C5 /* Connectivity.swift */; };
-		866F2CE977080DDF05E6A02C95B00E5A /* TokenizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A572AB697E2F05A71DD3D8B2776AD7DC /* TokenizationService.swift */; };
+		826BA116192C52E349A7282DB602B967 /* PrimerFirstNameFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252D6E7F7CB70F687EC5A87FEB990D30 /* PrimerFirstNameFieldView.swift */; };
+		83D436ADAFFC0C4AEE5C464104E185EA /* PrimerTheme+TextStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB24D04FD39B8B5319F6AD122E20A801 /* PrimerTheme+TextStyles.swift */; };
+		860DB50528DF2CE07812E52D0E11F2C8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
+		8610F300668A73B555A1692DBEECFA65 /* ApplePay.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE68C0FA4CD2468699A63315D599EA4 /* ApplePay.swift */; };
+		861DCE334FC92AB4CEFB8138C2D1A90C /* CardNumberField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7C89BF054E74D49332F76E03F4B2ECD /* CardNumberField.swift */; };
+		86A8876BAE5C57C36A2996C56BC36940 /* UserInterfaceModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2832A895415923855F604D702DFEB066 /* UserInterfaceModule.swift */; };
 		86CEB140C505DC86F7C3EBDED880A3E9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		86E9A3F4A7B8E05FAA61E978393ED1A3 /* VaultedPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2FF4FF9CA6622553575894E48FF1AB /* VaultedPaymentMethods.swift */; };
-		875EABC36D7C52A79ECF7C5EC4E517EA /* ko.json in Resources */ = {isa = PBXBuildFile; fileRef = 09A090A65E85F0E260BBBC518FAFDD22 /* ko.json */; };
-		87C890C697BD6516C1127687C5376281 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74175679E2F8D1320AF2DCCF0D19A0C1 /* Strings.swift */; };
-		87F29E7DA43653C3719FE3070D1EDE32 /* PrimerWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BFD6F8F465F8A708FE03A17414427 /* PrimerWebViewController.swift */; };
-		89F9A4C99F7456F9F26D259B908BAB2A /* et.json in Resources */ = {isa = PBXBuildFile; fileRef = 3EE5B0DBF4ADCE0BC50EFA7DCA887F8D /* et.json */; };
-		8A0237F193CF59410CDB8D0D1B9C1691 /* PrimerScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 651FF45F7CE8B91761113CF106217967 /* PrimerScrollView.swift */; };
-		8A61D0B062C84295CE16A367BD1975C0 /* PrimerFirstNameFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16B961BCEA56E1E787141DF5A81C0B3 /* PrimerFirstNameFieldView.swift */; };
-		8A9DE5459039C8A9D640DE47AD46D2E1 /* ClientSessionActionsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80AB2877BC6D8647D57A95FBA70289E /* ClientSessionActionsModule.swift */; };
-		8AFAAB65F988D72181C68200863D2E3A /* ArrayExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8065232778925761294C43BC52D3166A /* ArrayExtension.swift */; };
-		8B02449E7354A1EB1D770568A20021D1 /* is.json in Resources */ = {isa = PBXBuildFile; fileRef = E748D2D45994BFBE4E57575B230B0427 /* is.json */; };
-		8DD3F8A314C8A9CCCC3ABBDF9CB867D6 /* UserInterfaceModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703B7306E142EC188CB5862A3386412B /* UserInterfaceModule.swift */; };
-		8E364F09CFE7E5C36E42748A0A3844A3 /* CountrySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D803FB62A01F2DB010435FC0D6B72FE /* CountrySelectorViewController.swift */; };
-		8E8091EF91DB17E367068EB0584D9997 /* SuccessResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41597C1A733DB1BD5944A6326180453D /* SuccessResponse.swift */; };
-		8EB59290371F04C139482A787F9925D9 /* Field.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571542B6D7831B459B37FF0196AC9727 /* Field.swift */; };
-		8EBC4F9180AEF3A2ABB8B1405A538E5E /* PrimerStateFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E83B8F8F0ECE8ECEDC17E44428515C7 /* PrimerStateFieldView.swift */; };
-		8EF9F4599EDC147FAEFEB5D3D6580DA1 /* PrimerResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E559541AB9C303C0205C05EBBD2103B9 /* PrimerResultViewController.swift */; };
-		8F4F784BAE3A358BC922A219346644CC /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96AA8C1AB48CC807A9F245E71E0536B /* AnalyticsEvent.swift */; };
-		8FD9E9736E18EB88B8E425506A3CA7FF /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CA37C2FE6FB9EFDFFDD60DE151158B /* Queue.swift */; };
-		90BF90D2594E0B8EB02B0F5879BA8E31 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F0A1B7C84315DFF960C70DB61CA8B4 /* NetworkService.swift */; };
-		91FA7BE4C9D94425610BD0DB3E3151A4 /* PrimerAPIClient+3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAC1DC0B5F5979EF3D8E6494A9E5713 /* PrimerAPIClient+3DS.swift */; };
-		929519986E7EC1B2B79186340026F423 /* CountryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26238DDBA62CD3748B820A6A1EDE9B01 /* CountryTableViewCell.swift */; };
-		9318CA1646A7401F4B6DF7F24B355CAF /* PrimerDemo3DSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7DE3C637C159DD04B51F8624B44624 /* PrimerDemo3DSViewController.swift */; };
-		932ED4B25DD6AFAE979205B6E6A48BDC /* UILocalizableUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F464B2AC0B131BFCE9FFBB964BBB9E21 /* UILocalizableUtil.swift */; };
-		9452A1B60059ED90AC149CBEA50166EB /* fa.json in Resources */ = {isa = PBXBuildFile; fileRef = 9DA99FE5EE965E84DBF481F457B7FBB8 /* fa.json */; };
-		9525C251ACCEA5EDAC1896B6AE7ACCD8 /* ro.json in Resources */ = {isa = PBXBuildFile; fileRef = A6EB9488B303B043EBC9D2CFC453B832 /* ro.json */; };
+		86D1903A1A4257CD70E188406BC4F489 /* PrimerAddressLineFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 975ABDB41E168304DC5E0F16A46D5F86 /* PrimerAddressLineFieldView.swift */; };
+		8734C3843CFBFCE5E0783B610348E174 /* PrimerAccountInfoPaymentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E4CE9C3AEBD32B0C6532B6E1D70771 /* PrimerAccountInfoPaymentViewController.swift */; };
+		874FC34E431B9401CEA26CEFFCB23EBB /* CheckoutModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEC3EB132704A13BD7DB3EAC4E6C727 /* CheckoutModule.swift */; };
+		87C41F5F698D3ADF39E2114C595FD3A8 /* DependencyInjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CFE7582EBED3AD762E268632D3C4DE /* DependencyInjection.swift */; };
+		87C55EF8F9144348B0FAFD80D592E942 /* zh-TW.json in Resources */ = {isa = PBXBuildFile; fileRef = 8391C5AC38DC9940E6C112E51A37E47C /* zh-TW.json */; };
+		8842F56D7D93F82438A4767AD842743F /* PrimerTestPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772B0F5796A2BAB9581DDF873202F9B9 /* PrimerTestPaymentMethodTokenizationViewModel.swift */; };
+		8889364F8E43DA05CCD356A26D7F3273 /* CardholderNameField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 825260542897EEC7C355908ED05D63EF /* CardholderNameField.swift */; };
+		89684057B1971C6FA6C89A5C4F2D8715 /* WrapperProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06C2E58C08ACB95D74FE622FE32A6C3 /* WrapperProtocols.swift */; };
+		8B0F1327013B30F3861831F48C44CF17 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52413C8A5C07398BBC5127429551597 /* DateFormatter+Extensions.swift */; };
+		8B314CBD511D76DE1718E369A718B74B /* CheckoutEventsNotifierModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A990031D4592237BFB5289337A600 /* CheckoutEventsNotifierModule.swift */; };
+		8B47FA494AE86067A0A69052D20BC47A /* hr.json in Resources */ = {isa = PBXBuildFile; fileRef = 1B8F0E0D1F895D7FBC080355D9E0D08B /* hr.json */; };
+		8D85B2F3BC9C2410AFE245FDCC8AF354 /* PrimerLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E33DED88C753F774E07438BEFEA587 /* PrimerLoadingViewController.swift */; };
+		8E2C7AE71DAE348904D2F065D8D2601C /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12CB36C753AA3EFECA8803A4909B722D /* DataExtension.swift */; };
+		8E7C2E6C79F2C18A8B3F1B9E247E5266 /* de.json in Resources */ = {isa = PBXBuildFile; fileRef = D6BC88E1C31DC1249EF7119D251BA204 /* de.json */; };
+		8FF05675EA291968E2ECF69D02855186 /* PrimerSDK-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AAB7DA46BCC03ACEFF4CDD2153279AE /* PrimerSDK-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9056D0BF2FF4FAE51B4BA8B5AD796D67 /* PrimerTheme+Borders.swift in Sources */ = {isa = PBXBuildFile; fileRef = E232F12546E5C86663B55B942844EFBA /* PrimerTheme+Borders.swift */; };
+		91AE90FCAAA605A5C8A3F8F45518FDF8 /* TokenizationRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109977FD597C2B8FD31B3BD33B2B356C /* TokenizationRequestBody.swift */; };
+		924C31A2B8D8892E9AD9CA29B16BFDD7 /* CoreDataDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AEAA7CE084F88A8F7A2CD0CEA5A653 /* CoreDataDispatcher.swift */; };
+		929D946937DE8CA191B212FD5599A84F /* UINavigationController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5929A82D3FF45FCDE5E499D31F7CC018 /* UINavigationController+Extensions.swift */; };
+		92E286EA4FB846EFEBC230CC0A1CF5E2 /* PrimerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C74DCA6DE0FC3BECB04A1CD06D6A314 /* PrimerTableViewCell.swift */; };
+		93187FE69443EBA952AEFA9B6FCC6938 /* PrimerFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EEC75B7B1B82C1B674974260346A05 /* PrimerFormView.swift */; };
+		938EB36DE7BF084D418AF662EB6A3BBB /* UIDeviceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B050FDD714CC6E742FD9B1C5431DE0A2 /* UIDeviceExtension.swift */; };
+		93DDD3E6F43B0B582AEA0F51A5FAC345 /* GuaranteeWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4910CA5607B33113176110B0E7FFDA6 /* GuaranteeWrappers.swift */; };
+		94635F0350F5B14F1628CF4E21A57B31 /* UIScreenExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEE19A51E07C151053E75A5335CA468 /* UIScreenExtension.swift */; };
 		955B62FB6DF16FB118E198F3FFF1ACD3 /* PrimerKlarnaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F9DF091B832A01099152CA0D21E5E2 /* PrimerKlarnaError.swift */; };
-		957CDE4F5C3C84976525CD591211501D /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED1DCCC3BE7EDEB962787A8E30A6F96 /* AnyCodable.swift */; };
-		9615F418C13E6B019CA1FBCEE4634368 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5241D5AB36F0290E407D6A25D1058C04 /* Notification.swift */; };
-		963070261D5988FE5852A590443384FA /* FlowDecisionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27ADB4294EBF96BDDC56D895E9C695F0 /* FlowDecisionTableViewCell.swift */; };
-		9653BCC12AD7465C6CA0FF63AE163DEB /* CheckoutWithVaultedPaymentMethodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25C166BF577DFC28F1BF4A07FA174775 /* CheckoutWithVaultedPaymentMethodViewModel.swift */; };
-		966AA40CF4E8B6078593931CDADEF06E /* hr.json in Resources */ = {isa = PBXBuildFile; fileRef = 8E982532F5FBC7DEB03C0F6F70AC0AB7 /* hr.json */; };
-		973580F2C85ADB174A8B7787BBB16D2C /* ku.json in Resources */ = {isa = PBXBuildFile; fileRef = 7731D330DFFDE5BDB7262CBFE75CFA39 /* ku.json */; };
-		9741DF8F1E7FDECD2E973317BD802D6F /* PrimerInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2685D22CAE31BD438AFCFDB151DB700A /* PrimerInternal.swift */; };
-		983A0A82BDAD071D43676D836270DB95 /* af.json in Resources */ = {isa = PBXBuildFile; fileRef = 23008DCE30635C2A48179C8955173D36 /* af.json */; };
-		9862FDA20AA52FA011F52DA8392722C8 /* AlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC65978AB3603D3CC369B2F3256AE3D /* AlertController.swift */; };
-		99373AEFC79F35130A5278872B48AFFB /* CancellablePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = A737E9A220CDE88BDFAFFDFCBB3E6FC8 /* CancellablePromise.swift */; };
-		9A6B059C3E1E53108B246E340BC56C58 /* SuccessMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D268AD02ED69536B16928179380A7B5 /* SuccessMessage.swift */; };
-		9ACD87859E74D886FAC25AA89AA14294 /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A4CE6F1CC363A481904B25055BD090 /* LogEvent.swift */; };
-		9C4B35E019D1720DEBCDAF69E3E2C689 /* Primer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416909675AF7DE52F724EDD75BDE04E8 /* Primer.swift */; };
-		9CE397E3EA1E6F920AACD4DC02B81C4E /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A02E51F9DDD9CBB429D9AC7629F987E /* race.swift */; };
-		9CF848F1F9AD50523AF5EBB908CEEDEC /* PrimerIntegrationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3E2B044C716428041F1D0811B3020A /* PrimerIntegrationOptions.swift */; };
-		9E57D88D90F1E015D49D1EFEAB35BCE1 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A959FADE6100F477E9A88FBF7BE17B5 /* Logger.swift */; };
-		9E75CD03EB24E31AA4A726DD28DF2198 /* FinallyWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC112EEE2F4BA17EEC9EFEFADF148540 /* FinallyWrappers.swift */; };
-		9EBF8AA4485C29D34CC5666C589A9621 /* dv.json in Resources */ = {isa = PBXBuildFile; fileRef = D5AA7F2B319372A3BCC38F1C1FA73FD2 /* dv.json */; };
-		9F10A15F75EBA6E273788FA3FC62DF5D /* bg.json in Resources */ = {isa = PBXBuildFile; fileRef = 091C52DB4E0BF544AAB20BF31610BE30 /* bg.json */; };
-		A11411FF83DE56C6B4C61144E1F865CB /* CardButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5AB512118494BC502B5323CFA02BF0 /* CardButton.swift */; };
-		A14008C0A96ED637E95C920620618793 /* PrimerContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5A8E285FB2A6884A07A5FF0B847E32 /* PrimerContainerViewController.swift */; };
-		A146CCA5BFB8855BAE251E271FCC7033 /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5342C453BE0BC7A67288BB880930860 /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift */; };
-		A16320AE4C50CA2B96C8017B5E115ACF /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8773AEACAE4EA5CB563B2BE3205E04D9 /* AnalyticsService.swift */; };
-		A1869358FCBF25E7BB241894C5768C94 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = A868F8F8AE186AD14381696AF523D3E1 /* Keychain.swift */; };
-		A199F24A0A847471A5DA67CBA1473735 /* PrimerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666D95E8D4302FED5DF81F797FFBB301 /* PrimerTableViewCell.swift */; };
-		A1C2C6A7FE57E4D77CA87971217A9BDD /* FormPaymentMethodTokenizationViewModel+FormViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B15B62F11C383393F1DECF26A5DFF6 /* FormPaymentMethodTokenizationViewModel+FormViews.swift */; };
-		A209FCF1CBB9DEC05DC6A060108E02B3 /* Weak.swift in Sources */ = {isa = PBXBuildFile; fileRef = B070035BEF45F872802D2C617B7BEE8F /* Weak.swift */; };
+		95AD474739E2C9485658113EF70F7738 /* PrimerAPIClient+PCI.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF4666584FA7A50B9E8A199F8D4CC3D /* PrimerAPIClient+PCI.swift */; };
+		95B522E9A0763F91B36E62600E85FE89 /* VaultedPaymentMethods.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30AA83D4E70802B46864623386CDE15F /* VaultedPaymentMethods.swift */; };
+		97BE6E19021709989310C4FBABDA697E /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E149402472998D402CC08A36B9ED04E /* when.swift */; };
+		98D7CF09AF8506C5BB95D34410E31033 /* tt.json in Resources */ = {isa = PBXBuildFile; fileRef = 985AF13E3948D7D025AC1B019B99D045 /* tt.json */; };
+		9910658DECB1E40CF4E2CD4FCA64A931 /* 3DSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CDBA87C49E2F7988858775788B6589 /* 3DSService.swift */; };
+		9C069FBA6B0862F59BB0E224BCF8353C /* TimerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A501D3D16752F32AC3F057D2F8D47E79 /* TimerExtension.swift */; };
+		9C3C7FB8351E6D4CF035B08639DA405F /* Downloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DDEB4BFDD82D2B3C1999FC0D6C2F87 /* Downloader.swift */; };
+		9C8FBB8C6B16F1C440E9B7EC65EC9071 /* mn.json in Resources */ = {isa = PBXBuildFile; fileRef = BEF5C2A116F901093DC28689676D0D7B /* mn.json */; };
+		9CD4DBEE36C2A732329EE14F555A4D0C /* PrimerTheme+Inputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = A88C932B6FC5FAE95C0C752509E0F898 /* PrimerTheme+Inputs.swift */; };
+		9CD9BCE5FDD4DF5C41473C0A63FFB2A4 /* PrimerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576786592FCD001C69C87A203233A0A3 /* PrimerAPI.swift */; };
+		A0D0B12282F17401E20BF7E6A817A5EB /* ApplePayTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B5660D65829BEF7971C5A60654F1A6 /* ApplePayTokenizationViewModel.swift */; };
 		A3030DC26DB282687CBFFD42E4DD26A8 /* ThreeDS_SDK.Transaction+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34FCEC2CF890D19452F3FFE895FD2D39 /* ThreeDS_SDK.Transaction+Helpers.swift */; };
-		A33FCE865A8BC4960CC5874F4023FA70 /* PrimerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77D77D924D9D8A4F3B31A8DC78BC7214 /* PrimerSettings.swift */; };
-		A4FAC82BCDD056CC9D573F688F6FBC5F /* bs.json in Resources */ = {isa = PBXBuildFile; fileRef = 980024E63BCCDC799A4FB8E643F4B7EE /* bs.json */; };
-		A57869D5C44040198C89892DAC2F943D /* bn.json in Resources */ = {isa = PBXBuildFile; fileRef = CAFD03D52BC86E04D48749A8276E6435 /* bn.json */; };
-		A5F4BB9612668326188E6FB6E60EE912 /* PrimerSearchTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BD7F4864DA4F3847A569AE1AC6892C /* PrimerSearchTextField.swift */; };
-		A6809D53B64CC470AC9347B59F769B46 /* PrimerPaymentPendingInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE90A0AF7BD80B38DC3402043B60F5CD /* PrimerPaymentPendingInfoViewController.swift */; };
-		A779FDFDCA9D954447C2423A02435D3B /* BankSelectorTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7A695188A525A8B0AB1A92A82EAE48 /* BankSelectorTokenizationViewModel.swift */; };
+		A440311C648C82F03FDC4D3344632864 /* ja.json in Resources */ = {isa = PBXBuildFile; fileRef = CBA439F33C6B71CA66767C4D3C657DBF /* ja.json */; };
+		A4DAA605C1A0CBB01CD307103D16DC3F /* OrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B44B13262EA78104B2A50C4D26690A1C /* OrderItem.swift */; };
+		A7357D9AFC7AAD55BDAAC8D0B9E5ED51 /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2582D5434BE2D2D928A025C6BB6A0CBD /* Notification.swift */; };
+		A75079A75A17F259A6AD440B844D3D3A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F970CB7C0D80D515A6B60786C926E196 /* Localizable.strings */; };
 		A7A281E9620AE42E1B37FFF1273F7B1B /* Primer3DS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = ED14DA1A3C6EA9245818ABFE97E8ED47 /* Primer3DS-dummy.m */; };
-		A857A5EF7C79D22301BB8A99A7A06596 /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211E41E3017C0C184A700A94A3E5AD87 /* hang.swift */; };
-		A88B597299BDC3EB121E5A922450650E /* ReloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88BBFB31782058675116A1EF8DF9BD73 /* ReloadDelegate.swift */; };
-		A92E54AB8466F171B6FF82E25B037C3A /* PrimerVaultManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF62A4EBA4EDBA912B5ACEB9B84BA64A /* PrimerVaultManagerViewController.swift */; };
-		A96E378A39B0BAC0598F3918136BAB50 /* UIDeviceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7E40195DF13E27C66AAAFB4107A989 /* UIDeviceExtension.swift */; };
-		AA218DE90374491E229FC6F8DA291A4A /* PrimerUIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD7B9DE66B36FC501E03FE83C88329D /* PrimerUIImage.swift */; };
+		A9AB53119611E2B0A61D29277B76BC79 /* version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511523BE2DE03BF88740C3B799E7E8E8 /* version.swift */; };
 		AAE6773E55A3F6005B1ADA0BC7EC5834 /* Pods-Debug App-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A093E92ECC60A54E3D72F38ABD8A3DEF /* Pods-Debug App-dummy.m */; };
-		ABA4EF4502A2BC2A0BC3B08A7B02C445 /* URLExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B6B05ABD3E84D51BBFF140D357117F /* URLExtension.swift */; };
-		ACB2CE42E1568ABAC6C47CB883D055F5 /* PaymentMethodTokenizationViewModel+Logic.swift in Sources */ = {isa = PBXBuildFile; fileRef = B317B5E77B5E6510922D19F65AA6E8CD /* PaymentMethodTokenizationViewModel+Logic.swift */; };
-		ACBAF8A7582940A39EA37145B6821728 /* URLSessionStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13D715A28E38B1A41D9B3671C0F90CF /* URLSessionStack.swift */; };
-		AD164C6467AD8FDAED9FEC22B0E52BFD /* PrimerSimpleCardFormTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B847413264FC8E4DE2484CEC473289CB /* PrimerSimpleCardFormTextFieldView.swift */; };
-		B07E70D5283CE2E696AE03409C6BFD9E /* ur.json in Resources */ = {isa = PBXBuildFile; fileRef = AA9C05DD563B3DC1156264E53846CC54 /* ur.json */; };
-		B12634601C435E330B118EF3181EADD3 /* ka.json in Resources */ = {isa = PBXBuildFile; fileRef = C5892FD01BAD8F04E4AA744ED4E8DCD7 /* ka.json */; };
+		ABD82D493D7034BE7ED4C7E5295C7452 /* PrimerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA51F072EAFD4C445FA9B718399C82B1 /* PrimerSettings.swift */; };
+		AC33EE124E866FD09D727DF5E23EBA79 /* PrimerFlowEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E9F71E24188E053147F98DDAA1D240 /* PrimerFlowEnums.swift */; };
+		AE2B8AA6C0CF1889F58DE49BE7D19E00 /* ca.json in Resources */ = {isa = PBXBuildFile; fileRef = A4DDC3E610AE18626518A71E64F31FD8 /* ca.json */; };
+		AE3A3780267492B92D9D78FC726F1DB7 /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE48F48CCAA57BABEC5152F8FF0107F /* JSONParser.swift */; };
+		AE7E0E63239B62E7C1046E3F484A755A /* PrimerCheckoutQRCodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A227ACCD0C963316AB914A601C266CD1 /* PrimerCheckoutQRCodeInfo.swift */; };
+		AEE0B4493E680A5631B68F708EDCE130 /* ConcurrencyLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B1C6967F9433EA11FDB7D0E230C1142 /* ConcurrencyLimitedDispatcher.swift */; };
+		AEFF9808E2B0B3B85D3638E9BC50BF77 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861B719BB7AC6DCB3267D345ECEC120F /* Optional+Extensions.swift */; };
+		AF5947F738E745254FCDB3F5AF67BD0B /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE7D6C0C6AC8F4A135668BDB6C1517CA /* Catchable.swift */; };
 		B13C3AB10962618311765FC67A240ECC /* Primer3DS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CEAFB01FBCF6405EEA41A57F47836BB /* Primer3DS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B2069F3F63574996CD79F7A8E99F7B2E /* ca.json in Resources */ = {isa = PBXBuildFile; fileRef = E6E126C004CE794EDFA7032CF6351974 /* ca.json */; };
-		B24CC404D253425FB636C44C9BC52038 /* Throwable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA4574401EEB535ABC2ECC64430D181 /* Throwable.swift */; };
-		B26247834F1D88963334E8BD9C537200 /* CardComponentsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D818DA62200FE99F17329E4AD45DDC /* CardComponentsManager.swift */; };
-		B2D952BB3A9B7880FC85E1D08F8EFFB9 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E00F164B68EF354AADE291BF744C3F3 /* after.swift */; };
-		B34234FCC1A0D6D4A7C8DDD287A3D8E1 /* FormType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A42D0CFF172D36E04B660BDEA23C9C /* FormType.swift */; };
-		B4E97335991CF743002AD88C1507E872 /* PrimerAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B00EB0B836D5100D8906245B8B9661 /* PrimerAPIClient.swift */; };
-		B66BD240C9F0F783615C391AB9C0AA04 /* AssetsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA52BDA0E27F4AC98488EEB595A22985 /* AssetsManager.swift */; };
-		B680028AE15290BD492DC6967F3DC29D /* PrimerVoucherInfoPaymentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3613D9723544DFCA6CB7871DA72A105D /* PrimerVoucherInfoPaymentViewController.swift */; };
-		B680DBCB4FA0E8BE1891A2563A7CD370 /* PrimerUniversalCheckoutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D06A2CDE452ACD10D1C7D44B64CB297 /* PrimerUniversalCheckoutViewController.swift */; };
-		B736CEDA4F4E630C1C5522255AA6D907 /* UINavigationController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8553901DF5E05FEE1FD261595F9EA449 /* UINavigationController+Extensions.swift */; };
+		B16703121928EECE16278487A7F0CDFD /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA2244D72F2463C99B2B8BEF584E38FE /* Logger.swift */; };
+		B2287C7924A7CC5DB594D4EC95994892 /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F17EDDF46611F1B4C439953451A6E50 /* Guarantee.swift */; };
+		B29BB998854AA8268C9A7A14F138CB60 /* af.json in Resources */ = {isa = PBXBuildFile; fileRef = E3F086A1612812EEB7F60FE75B9F764C /* af.json */; };
+		B33AF23503661100A632AF4834CFE0B0 /* kk.json in Resources */ = {isa = PBXBuildFile; fileRef = 409C1D1713CED34744C259E39762DA48 /* kk.json */; };
+		B399F7D2FFF9989C27F80B5FB648E7DF /* PrimerRawCardDataTokenizationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05000A05B1C43ADBCB50A311617CC33 /* PrimerRawCardDataTokenizationBuilder.swift */; };
+		B3BB15F4274DF8A878EA1FFA043DC52F /* PrimerUIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F076F54BD9CE05779AABC4D587EF7D1C /* PrimerUIImage.swift */; };
+		B3E70FE8D44A299BDC7240BB4E8831BC /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 19783814363AE8875B4B3FA0F62B90B4 /* Icons.xcassets */; };
+		B4890981C3F2CBE2F592639C7657D25A /* PrimerStackVIew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64E5CBA74B8AE23B563020A92BE93851 /* PrimerStackVIew.swift */; };
+		B593A88D9A95BC538E0A54C00A784D77 /* vi.json in Resources */ = {isa = PBXBuildFile; fileRef = F0C5A3999803846187EAF8E85921D100 /* vi.json */; };
+		B6034449ACF8118BDA19C6BCB50845E0 /* PrimerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CAB132F350CE2AA9EA91A1CCF60526 /* PrimerDelegate.swift */; };
+		B604B3529CBD09291BBE42512ED1E2A5 /* sv.json in Resources */ = {isa = PBXBuildFile; fileRef = 7CFCB01CA35903EB7665DB1CEE88F1CC /* sv.json */; };
+		B62AD6900B78761449192DA9B50CDF22 /* AddressField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FB734F02E472954A35A5B040DA73DB /* AddressField.swift */; };
+		B684037856F57C85F5FB41523432E471 /* PrimerIntegrationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60814F9665A72583B5620F2418C11EF6 /* PrimerIntegrationOptions.swift */; };
+		B6CDD21A504E4EC3170DFFEF2C110829 /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F8C0AB63EE61A11B45676E80D0BD10 /* ImageManager.swift */; };
+		B75ECA140FB730142FABDBFFCCD8F4C5 /* EnsureWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94616AD54D2F7E38F70D0869C6B5010D /* EnsureWrappers.swift */; };
 		B7D31013BF9EFD2F9C727F7B3E8F31B1 /* IpayPayment.h in Headers */ = {isa = PBXBuildFile; fileRef = 2151B899A62EE15E2483007A778E8E7C /* IpayPayment.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BA00ECFFD78D8B7DED5E8BD60DF99C64 /* WrapperProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE871E7A7628A6EDCB416299F7D5C312 /* WrapperProtocols.swift */; };
-		BA4D2D268341237FE84ED147F10C8640 /* PrimerCardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025655E2356AE6CED57CD52291D755CE /* PrimerCardData.swift */; };
-		BA87B76CD1988636692B3751022944F7 /* PaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12C71BBF27B01BBE5B854B2CC1B4A651 /* PaymentMethod.swift */; };
-		BAC1D1E35E1A8DD1707AE9ED384B20E7 /* 3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC15F60DD4F3F7665ED569E4AE16ED4C /* 3DS.swift */; };
-		BBF17D69C53D70680F3F31528FA73D3D /* pt.json in Resources */ = {isa = PBXBuildFile; fileRef = 01DCCECEF6DE0816459294F7D4E380B3 /* pt.json */; };
-		BD0734B4C169F4FA88E8D6311BF78809 /* Apaya.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99342384F60ADE69EAEC663468C5BA21 /* Apaya.swift */; };
-		BE7569ED27CE84C3AD5BD3FD003A95F4 /* Mock3DSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF39310D7B33FA69131E4875E4A13290 /* Mock3DSService.swift */; };
-		BF69EE4430B749A3B4E91CA1C6A636C4 /* PrimerAPIClient+PCI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C29E21010341A1863EABED0426192B0C /* PrimerAPIClient+PCI.swift */; };
-		BFBB6FFA1690D623141CC894E2EBFB51 /* AdyenDotPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43315BD87EB298EC9B0C97E3C22B749D /* AdyenDotPay.swift */; };
-		C03208409B7A7C42DBC04FA3A979F815 /* CatchWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4705153D93FBBBAE0BA4277074112E /* CatchWrappers.swift */; };
-		C12E440189EC8403BEC7E4A735BABEBA /* PostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931FEB5AEACA42D4B737383BBD69447D /* PostalCode.swift */; };
-		C2118EDDCD32F6B7524DCFEA24C77389 /* km.json in Resources */ = {isa = PBXBuildFile; fileRef = 79B5FDC0D811DD22D438C8299147D10B /* km.json */; };
-		C2987619222467917FE9515C5E20CA0A /* VaultService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DDCF00E3E0AD992D1C7DBDE77038D7C /* VaultService.swift */; };
-		C2A8A9155A6C5DA43F2774409659E721 /* 3DSService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BDB1A39669149DDD85D9C2D48ACE042 /* 3DSService.swift */; };
+		B8506193F09E036A307173810C3BDC02 /* PaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2316669CC24E0E451AB6A1587D019581 /* PaymentMethodTokenizationViewModel.swift */; };
+		B9071E6561C46C7C3E0BBC9E5ABF93C6 /* ApayaTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1465A6F2592BDF95718A678C4FA81A02 /* ApayaTokenizationViewModel.swift */; };
+		B98C8DBCA1CF7174135DFF8E56733ADA /* PrimerPaymentMethodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6004A806CCD76E18FB5EE6B48C22BA33 /* PrimerPaymentMethodType.swift */; };
+		B9D090AAD04841F5DF878F554BE67DEF /* PrimerTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E651F2EF0359212D2E8D44E6C814C2 /* PrimerTextFieldView.swift */; };
+		B9E993E5D2CBF589A0ADFECF27F9DFC5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */; };
+		BA19D8A0232B442731FA116A27089854 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD49CD925E98AB5EEE20311B70F118A4 /* UserAgent.swift */; };
+		BA2867D40CDC47C32A6E7A6B7ADD8B0E /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221F8AC4FACB79EA04ABBC64AA49492B /* Parser.swift */; };
+		BAD1E84AF2077DC809EF10E354400AFF /* PrimerSimpleCardFormTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4C5FEF5E78F5DB0590B5B665402F9E /* PrimerSimpleCardFormTextFieldView.swift */; };
+		BB08AC80C2747AD10882553C802AA3D8 /* PrimerAPIConfigurationModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7751272A63728477FCB85DBF6D24C41F /* PrimerAPIConfigurationModule.swift */; };
+		BB0E65F06E775A6B564B66CC08531964 /* PrimerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B06EED324418903E3C84E07B69470750 /* PrimerConfiguration.swift */; };
+		BBE0ABD67AB18C95447A44E66C2634D0 /* VaultPaymentMethodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E2A15227CF22FFC4B4C56AAE533118 /* VaultPaymentMethodView.swift */; };
+		BC2DAA3B604E03F31A9D4CC717071573 /* PrimerRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C0C538E168130A05D5F9FA9C3E1674E /* PrimerRootViewController.swift */; };
+		BC67235BB1F43318E6A4066170253C65 /* CheckoutWithVaultedPaymentMethodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD940992476F2DC358CD251D257F5AA /* CheckoutWithVaultedPaymentMethodViewModel.swift */; };
+		BD646FA6B742558E00FDE8F2048D31C2 /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA87F9F7F6D7EEE2EE3D9936E8917E91 /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift */; };
+		BD740D09D30C50EB641FC9986A501A55 /* PrimerTestPaymentMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91875E09840CF3F6F8CE92360AB26659 /* PrimerTestPaymentMethodViewController.swift */; };
+		BDFDE885E132BCEE4A9A5ACA22AC0091 /* FirstNameField.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA1832ABD955A4B39AFD5E85F8D49F /* FirstNameField.swift */; };
+		BEC4D0C8667FE08CB71D556157BB78BB /* VersionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3E1CBC5614C1FA19A1770150551171 /* VersionUtils.swift */; };
+		BF6ABA7832162F51C875C329B4025559 /* PostalCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A3D3EB3C0B6EE702D3FFCF03F936666 /* PostalCode.swift */; };
+		BF9D9399062FFF0EA8D3B741E0BFBA72 /* WebViewUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8DAE5650418097986F7404E18C71541 /* WebViewUtil.swift */; };
+		BFB43D872B19D6B06C0CB971E65619D6 /* AES256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D94D6F1EA8ABFBD1EC98BB93CF85248 /* AES256.swift */; };
+		C232CB3C9459C1311BE9D32C07191AE4 /* PrimerDemo3DSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7935484F6C5ED13DE9B756AD5CCA7A39 /* PrimerDemo3DSViewController.swift */; };
+		C2FCF781492656879AD51363B12C0F1E /* nn.json in Resources */ = {isa = PBXBuildFile; fileRef = 2E1E4D5287D1BC23822FF2515E9248AE /* nn.json */; };
 		C30F707D3E55806E01E7D3BB478497E1 /* PrimerIPay88MYSDK-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = A889FF4523F520564912A3FDA3C91182 /* PrimerIPay88MYSDK-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C3A51CC724A231C3851A3F891A98E472 /* uz.json in Resources */ = {isa = PBXBuildFile; fileRef = C15FF3302B2650F6B206E8C98C61B6A4 /* uz.json */; };
+		C3131807367CE0D9F90C31B59AAB2F28 /* PrimerThemeData+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F7FF514DC158521EF4450F0BF89139 /* PrimerThemeData+Deprecated.swift */; };
+		C44568C311EC81A90383E5D58AAC61A0 /* ml.json in Resources */ = {isa = PBXBuildFile; fileRef = FD66BDF8CA86C83594B4B5985A5C5EFD /* ml.json */; };
 		C475DB550CC6CAEDCFDD8DCB7BD5ED01 /* PrimerKlarnaSDK-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 626ED1D07DD4BE16F1861F5747FECFEA /* PrimerKlarnaSDK-dummy.m */; };
-		C4907BB571A6B78C8FAB12417A752B3D /* PrimerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999B0869695391000743FA8993417DE1 /* PrimerImageView.swift */; };
 		C4C5B02172869E92705AF1E9331E4A35 /* Sequence+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44E15C725A433194F568EA0DF915951 /* Sequence+Helpers.swift */; };
-		C4FB4A76740C1CA1FABF85653CC0BEE7 /* ApayaTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5F22D270953E5CEAD29BE54F6F305 /* ApayaTokenizationViewModel.swift */; };
-		C6A2A57D5DB25341B764521F3E4C6434 /* CityField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E7D5002DB55BB9F9632D427714BB4D /* CityField.swift */; };
+		C6048C6C4F82A56A71843B129A2EBF74 /* PrimerViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76212726E96FAB1AEA9D22D13D8B2A26 /* PrimerViewExtensions.swift */; };
+		C64001BFB7A576583E9806AE70428D26 /* CreateResumePaymentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D2D8DE65B5AC4A0358B761D4004935 /* CreateResumePaymentService.swift */; };
 		C741082CD6202302F75CCABB42137380 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		C768ABABB25E6212C6B6E8E29C11D68F /* Dimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C62C92B25C4DD650DB6D989A3638B7 /* Dimensions.swift */; };
-		C7A74B0755EAEAA5C70A27E729210F05 /* hy.json in Resources */ = {isa = PBXBuildFile; fileRef = 04DE2790F4BA934C8B330CE4A023A484 /* hy.json */; };
-		C7F72861F4E85C3A49801F8BAA76922A /* ImageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC9E7DF45F1F430B386960FC32F8DE4 /* ImageManager.swift */; };
-		C984956292334CECAA52D4B6EC6D3393 /* PaymentMethodsGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5AAD964478E927406E375C8674D47C4 /* PaymentMethodsGroupView.swift */; };
-		C9D69E0410251A2DF83198BDDE6A05BB /* PrimerTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949CE6E65977A51E812ED6A48E8401C9 /* PrimerTextFieldView.swift */; };
-		CA152B107057FAFA2FA686EF5C4F4F76 /* PrimerCustomStyleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7851B1E6D972B53FDD5C84DEA2B2BA94 /* PrimerCustomStyleTextField.swift */; };
-		CABB070BDB8EAFE98DE010FBD0DD82AA /* PrimerTheme+Inputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC822C374C92D20C25D1DB80CE6930F /* PrimerTheme+Inputs.swift */; };
-		CB0B4C49754C3382583C3C530A41C67B /* currencies.json in Resources */ = {isa = PBXBuildFile; fileRef = 9B1F3303C4C025BE383B9236FF4CCA51 /* currencies.json */; };
-		CB33E63CD85746176E34828238C59AE6 /* tt.json in Resources */ = {isa = PBXBuildFile; fileRef = 5329A0B8367E43F6DE39ABE055E9D040 /* tt.json */; };
-		CB8B304640BEC8B9F5A36F2A557D683D /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = E701688A7539F7F476C08E5EFDB6E654 /* Box.swift */; };
-		CBFB9998825BDE248B0273B5CB836D00 /* PrimerRawRetailerDataTokenizationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBC487EDD403A3B04E9CE4657D379494 /* PrimerRawRetailerDataTokenizationBuilder.swift */; };
-		CBFD4B33ECA7EFDB0B993B2C2335D230 /* SequenceWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CAF284EDC26FEF7841A7544FE7A32BF /* SequenceWrappers.swift */; };
-		CC19CDC4D302359C586811C3F065E1C6 /* id.json in Resources */ = {isa = PBXBuildFile; fileRef = 8CE87FB7342A874BC723C9F2B2ED8AB3 /* id.json */; };
-		CC1E43E71993515CECCECC8B24287745 /* PrimerStackVIew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18234F9225DD0A2D3272048CD6BE9FFA /* PrimerStackVIew.swift */; };
-		CD85771AE9473EF0813C04F1EB4A58F9 /* he.json in Resources */ = {isa = PBXBuildFile; fileRef = CDACA4B200F86A610702409F061A2342 /* he.json */; };
-		CE1BB440ED4BB6FC9DFF9E32D8CD9684 /* StateField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B18397CD1BFAF65AECB88E78BAC0ADD /* StateField.swift */; };
-		CEB03B9A470236DE0FCD1BCF2A1E173C /* eu.json in Resources */ = {isa = PBXBuildFile; fileRef = 442C27AA6E002EB3C377B9C4198AFAF3 /* eu.json */; };
-		CED8C4D1670D280D3F5038A2EDC776AC /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C927AFD8E72E0A7EE2814F1716E37BA /* when.swift */; };
-		CF79C101A544A31D35961ABCB3469FBD /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB97AC5EF0A6842B110FC4438EA50F2B /* Catchable.swift */; };
-		CFFCD08DAF54388A55523EE19CE046C5 /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE3D6ADC481C2817934FEBE549C1675 /* Endpoint.swift */; };
-		D1554E1834FD3DB8C1F4D3869C2087D9 /* PrimerRawCardDataRedirectTokenizationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4D87C0A157CA00A9525CF0D0EE4B38 /* PrimerRawCardDataRedirectTokenizationBuilder.swift */; };
-		D296953F1AB9EA6F48D8F0BA4823802C /* am.json in Resources */ = {isa = PBXBuildFile; fileRef = F1E339730CCE3ED7B776D477C2269C47 /* am.json */; };
-		D2ECBF7F9F227AE9386B8648C917988A /* ml.json in Resources */ = {isa = PBXBuildFile; fileRef = 5857FE9CD25823EAB3D2A307A82BE32A /* ml.json */; };
-		D389E728F4E971CCC87E84B123C3FDA5 /* CheckoutModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90F653BB74E42ECC1D505557700C4F1 /* CheckoutModule.swift */; };
-		D5126C666BEEC75D033292C551D999D9 /* PaymentMethodConfigurationOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B91C4014A12B7961AD63B9CB1618597 /* PaymentMethodConfigurationOptions.swift */; };
-		D665B0D13E8B2F0DE0B01ED16F3D1189 /* el.json in Resources */ = {isa = PBXBuildFile; fileRef = 5183A3A34BBBB945AE29667C7553B603 /* el.json */; };
-		D68009A69E66784C03B1BB64DA536F56 /* PrimerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DE611C78184781092429D859F017EB /* PrimerAPI.swift */; };
-		D7265E0C55649147DE043E3B123A2E75 /* Consolable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5655E627608AFA927330EA4F085DC1E /* Consolable.swift */; };
-		D7DDDC7B7EE5BCFDA9C8ECD6D8B4B283 /* gl.json in Resources */ = {isa = PBXBuildFile; fileRef = 7E9EF19EBB79EF723BE66B549F0964B7 /* gl.json */; };
-		D7EACE861C11D105F007A281BA538B0C /* CancellableCatchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96C1C2310EE6FE1A26F847E3F502237 /* CancellableCatchable.swift */; };
-		D8544E39442F1C28C5B47D2F2EA8B2F3 /* DateFormatter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0828534D079454FFFF543D9866AA1AE1 /* DateFormatter+Extensions.swift */; };
-		D92FB4D55C68D4001615D6D3C7F2F098 /* RateLimitedDispatcherBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5707CA8EF477DEEB8CB41B18726CB8E5 /* RateLimitedDispatcherBase.swift */; };
-		D9B8AB72D903C3684910C1AD133373AE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */; };
-		D9D2FC875684F5902BB64C20CF4AC1A4 /* PrimerViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCCFF6ACD3423689A805F7A41F456C6 /* PrimerViewExtensions.swift */; };
+		C79664FA579D7B3059F98F40848AD1BE /* uz.json in Resources */ = {isa = PBXBuildFile; fileRef = B597C18CE138C83C3EB07E587B1FEE92 /* uz.json */; };
+		C7B08653B65DC8D19DC48CCE9EA3F71E /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC66D3EE583E0B15FC81F85A817ED1 /* Strings.swift */; };
+		C93869D5151D2D6F322AC763D4C74F66 /* PrimerCardData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A425DF08E1F6DC50BF7F38E3A29991 /* PrimerCardData.swift */; };
+		C94662E652FA3DC59B4A2976940A576F /* PrimerLocaleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C95796455CC521C8FF7C205F92B0EED /* PrimerLocaleData.swift */; };
+		C98B4AE5B8218FC2E3DE6E84DD6FC4C4 /* ta.json in Resources */ = {isa = PBXBuildFile; fileRef = 1FC60FD7327B5F605ACC509FDA36E3E3 /* ta.json */; };
+		CA9494C0BDA37194743348D4125BE2F1 /* ResumeHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA4A8CE5D93F1C448697BFBDB16C1AE /* ResumeHandlerProtocol.swift */; };
+		CB4E92C96C1DD0FB49250640EFC41EAF /* CVVField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0052C9E5ED38BFDEB3318B8B276FDC32 /* CVVField.swift */; };
+		CB997FFA9BC4DAF73E39D11B958577F0 /* PrimerGenericTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6972E4A97A6A938F9C2CC34E640F90 /* PrimerGenericTextFieldView.swift */; };
+		CC3850A078BB4CC97717463116A85BE0 /* ku.json in Resources */ = {isa = PBXBuildFile; fileRef = 97CA75D3D6AA933DE54DC8F409A234CA /* ku.json */; };
+		CC68922C84F6EC6A8CEB0B917B6B8CA4 /* PrimerMultibancoCheckoutAdditionalInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 507817C410C9D8FAE22BCC637B8AE857 /* PrimerMultibancoCheckoutAdditionalInfo.swift */; };
+		CCB04398206BC8362CC053F7E937FA63 /* ReloadDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8614A4F5C8920A48642780D10DA410C9 /* ReloadDelegate.swift */; };
+		CD034D6F9EE4E597493FE17CB34D0F0B /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F517C79AD2636FE2ED0CF5D63F1D294F /* BundleExtension.swift */; };
+		CD35E5E0D792555AB997529C770F411D /* ru.json in Resources */ = {isa = PBXBuildFile; fileRef = AFAB69FA82453448447AE6944EE6B068 /* ru.json */; };
+		CD3F73CD61A3A9E9A34A0988B357F51E /* cs.json in Resources */ = {isa = PBXBuildFile; fileRef = E55D99380D990C8DCFB88B73AB599FBC /* cs.json */; };
+		CD4F65001E86978876BC2FCF4142A769 /* PrimerLastNameFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7871C4AE895FF13DD22FCB53C2D9DF23 /* PrimerLastNameFieldView.swift */; };
+		CD74C0CB1F62AC5204D6AC41A8AAEE3D /* es.json in Resources */ = {isa = PBXBuildFile; fileRef = 68A1B21616905897DE02509A7829E281 /* es.json */; };
+		CD81A47B945C7055F79D96ADFBFB2231 /* Decisions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A075171B6B3301D77D84E221F8DC5E2 /* Decisions.swift */; };
+		CF9D5B788A51C19C6DACCAFE0D2133A8 /* URLExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31FFABD73529549DD0648E22237ED73 /* URLExtension.swift */; };
+		D0EE9958A36C558BCEAFF469BABE7906 /* cy.json in Resources */ = {isa = PBXBuildFile; fileRef = C28DA10BB82E4219207E02A998F75394 /* cy.json */; };
+		D0FC42A70DC0111B814CFCFF67A2854F /* Primer3DSErrorContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1ECA51C0DDC3F397B0C117FC191A099 /* Primer3DSErrorContainer.swift */; };
+		D13CECF148E95EB4491E5B3FA3950EEB /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB77F315E45888534C0F141F1D8BA34 /* Promise.swift */; };
+		D2745D36D41AF170B354169CC388CE49 /* RateLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AEF45F7CBBDB26A5BF0FD2C893529F3 /* RateLimitedDispatcher.swift */; };
+		D28100BC16A8FDA4F1C14A51099CCA22 /* PrimerTextFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 61A15B1951AF9CFA64C9A09F47AA0250 /* PrimerTextFieldView.xib */; };
+		D28CFF143F6E34FAE5F4DE67EB4E5F7E /* PrimerHeadlessUniversalCheckoutProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8A1682280920C97F800912B01DA37C5 /* PrimerHeadlessUniversalCheckoutProtocols.swift */; };
+		D432A31ED03CB4A0614B603DE313BE4F /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 600403423B116C4F1A1383A4FAB1FED6 /* ErrorHandler.swift */; };
+		D46507B03706B97C6C35CDFA7F71FD25 /* PrimerCardRedirectData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AE547C4FAFF96DA5F59CEE5E4507F3 /* PrimerCardRedirectData.swift */; };
+		D4AEEBB700BD713533BFC14E562FB493 /* PrimerCardFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD516439159EAF2C4962E9E3EA8A9B41 /* PrimerCardFormViewController.swift */; };
+		D4C3596C0C2DAE6A0C210CDB1DB9D78C /* zh-KH.json in Resources */ = {isa = PBXBuildFile; fileRef = B22B51EE13746464F156E7AC3365C078 /* zh-KH.json */; };
+		D4C697D94B7E4281D150049E4A7FF372 /* dv.json in Resources */ = {isa = PBXBuildFile; fileRef = 9F4DCEC4A50A61283DE3D94B7D7D83CE /* dv.json */; };
+		D539E01F14B01F4650A1674AEC7B4589 /* so.json in Resources */ = {isa = PBXBuildFile; fileRef = 6EC48B5C87BC19DD44808313ED2011ED /* so.json */; };
+		D5ADD4CFEA25171C6A7E7AB611C79742 /* Connectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2427D763745299B1B1C8A7A8F7166C90 /* Connectivity.swift */; };
+		D671E78C1B3EE3856F0F3721B5E69571 /* PrimerImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3CBD0EBF5F5385E9855BC3BAB991474 /* PrimerImage.swift */; };
+		D6A501D515E864C816776F6095DC27AC /* PrimerUIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B1AACEEFA843EB2D72C63081EF0EAB /* PrimerUIManager.swift */; };
+		D7118A0AB3D2B98C74F837A67FCAF142 /* az.json in Resources */ = {isa = PBXBuildFile; fileRef = 4FE10E4416F253ED2F8A7562226504A3 /* az.json */; };
+		D72987636C92BD1A4245BD19ABA30C05 /* 3DS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6068EAFC6DB3D82B549D2C5DF2BC560 /* 3DS.swift */; };
+		D760AF181B9733AEA2A1868A59CFA16C /* PrimerInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E4142BE00050FEA8E2151E032C95729 /* PrimerInputViewController.swift */; };
+		D870640BE0F7F4D05A77324D8F778CAA /* BankSelectorTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED03E3F4FA541F8FDB2AC3BB891673F /* BankSelectorTokenizationViewModel.swift */; };
+		D8DC8B901B0B768F60240969C67A627F /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3967A27848CBD48A31BBE753FDD7AA39 /* AnalyticsEvent.swift */; };
+		D907BFEF7E8C0DDA1543FC51E07083E9 /* FormPaymentMethodTokenizationViewModel+FormViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEA3E008E64C1F5EE29412E44B180F9 /* FormPaymentMethodTokenizationViewModel+FormViews.swift */; };
+		D96340F2CD37420E0956C022CEEDA35B /* NSObject+ClassName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8EFDD6D1662B6CC455CEC9599268B8 /* NSObject+ClassName.swift */; };
+		D98A0DB4BF083ECEB3CA97B9AF563970 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAF0408BD674A9D72D801E98E502399 /* UIColorExtension.swift */; };
+		D9913134A9B7ABDFA77DE4AEDA649C7D /* TokenizationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCEF0628DA33B24DD598C100D141528B /* TokenizationResponse.swift */; };
+		D9A13D90FE6F39BEB45FEA1041333D6C /* sk.json in Resources */ = {isa = PBXBuildFile; fileRef = 794A84E32A1C21271E3B869D970535BB /* sk.json */; };
 		DA05995CE04B366A0BD89940F9BCEDFB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		DAB4D685A784582B65B362FF483E9894 /* CardNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 783C2198F3C3B9492F9BE43E191B8507 /* CardNetwork.swift */; };
-		DC7D70C34A16AF2442628468A50DB8E3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
-		DCACB5CDA5373A3EF2E2E7F18DD8078E /* fi.json in Resources */ = {isa = PBXBuildFile; fileRef = D9D7EA565E96F5A5809133ED8B30E4D3 /* fi.json */; };
-		DD2BD6C3AFF47F17BBCB52A4D978D116 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75802316C029BB1D2F3FA33D0890975A /* UserAgent.swift */; };
-		DDFFE0A634DF5706B39F4BB7A0A747F1 /* ApplePayTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DB0A2C906E424C429F09EE8F4236C1 /* ApplePayTokenizationViewModel.swift */; };
-		DE1B527B70CFB8FF2D921C7D5517FCCF /* PrimerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2D76BD1B8AC84CA2D9720E5345DF1D /* PrimerButton.swift */; };
-		DE3C4C35AE75A535C5EA43B6D1203542 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE756423ACD98DA2114EA9F928D956A /* Colors.swift */; };
-		DED092689D57D4E60133CF48E8608F40 /* Primer3DSErrorContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3638BF5C0765A54B045E0BF6BE9394D1 /* Primer3DSErrorContainer.swift */; };
-		DF3A5CF67AF7D0DF6B3D4D22D6B74FB1 /* PrimerSDK-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9AAB7DA46BCC03ACEFF4CDD2153279AE /* PrimerSDK-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DF54F848D3EB18C1EB96AA3158BB9C43 /* PrimerTheme+Buttons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 318BA5A624F10FCFF9BD9A70E71E6C4C /* PrimerTheme+Buttons.swift */; };
-		DF6DAA3D8B437577B1AD90929A698E35 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323D8195FE7CB72DDEA0EBBF57E27D47 /* Device.swift */; };
-		DFA23092A3569518357C9987EF736821 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E71C583C1969BCCAAADC61A5C25C16A /* Request.swift */; };
-		E01497CAF069AC89228080029603516B /* PrimerAccountInfoPaymentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 167D824DCDED21787986848B8C99950E /* PrimerAccountInfoPaymentViewController.swift */; };
+		DA646B14FF3664645E2A99F299BB6A4B /* PayPalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20368BA39013F1101C007FC86ACEF0A /* PayPalService.swift */; };
+		DA8E6CD15E71A439671D29CFB7556AB4 /* XenditRetailOutlets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43A2E4402C1CA752A42AF300D20EAA2 /* XenditRetailOutlets.swift */; };
+		DA92A8F98B228DA006464D3AE9281ED2 /* FinallyWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91EF43C3BCF144189A667E7DDC7F6FB9 /* FinallyWrappers.swift */; };
+		DAAD066AFDAAC2DD71A2D48BA1FC8F01 /* TokenizationRequestPaymentInstrument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BBA9B8A7380F437830D563CAFC0CE2A /* TokenizationRequestPaymentInstrument.swift */; };
+		DB5A70CAC42F4DE6F78523F08EDCF587 /* PostalCodeField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496A63B242FDB61ECDFCAFFACE55FFD7 /* PostalCodeField.swift */; };
+		DBB7304E4E54DC7109ED595F9FA39A91 /* BankTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F50FE0EBE8CC7823E2C7664244636CC /* BankTableViewCell.swift */; };
+		DC83DDF5FB1096173B04A7DB16BB0FE2 /* CatchWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7654A8A8C6894FB779D817F3C41AB9 /* CatchWrappers.swift */; };
+		DD534498256AD30A803B5CCB933D44E3 /* gl.json in Resources */ = {isa = PBXBuildFile; fileRef = 8A401D6CD84605D71981212A4D86A86B /* gl.json */; };
+		DDB33AE363BB858324152DA3734D305E /* PrimerVaultedPaymentMethodAdditionalData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141C6965E5C32694A03343BEF0E92AC8 /* PrimerVaultedPaymentMethodAdditionalData.swift */; };
+		DF153155CD623940BE0E0450E9B8D9CC /* PrimerNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27FF8B3650A748481B91343F88669976 /* PrimerNavigationController.swift */; };
+		DF3D2365A243EBC0D230B252F36F67C4 /* PrimerInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5695576113B7185E09733A9CD2E2F320 /* PrimerInternal.swift */; };
+		DF415F70C769E65CEC31FF7A60757890 /* ro.json in Resources */ = {isa = PBXBuildFile; fileRef = 26BF1DF0CF7272AD3242B7D5FCD7BF60 /* ro.json */; };
+		DF5AF56CFB80DC88A3BF163C1CC461D1 /* PresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82D3986D0793B70A06C3786EE4EA38F /* PresentationController.swift */; };
+		DF71206C9759D436CD8CB377D170D96E /* bn.json in Resources */ = {isa = PBXBuildFile; fileRef = 40FA715D84A8FF6F50AAF6E5C550461B /* bn.json */; };
+		DFA482384717834EE7A3542D57101B56 /* AlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E793ED0ECBAA79C40A4F80E1E28E3B6 /* AlertController.swift */; };
+		E03406441CB9FE4E8B989BA20DC7495C /* eu.json in Resources */ = {isa = PBXBuildFile; fileRef = 4832C2449FCB88FB90840BFAFD2F8920 /* eu.json */; };
 		E08BBA3D1AD3E67C3B4F3D4E1DD3C865 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */; };
+		E1022A103B2D937E2E508B1A9EB01525 /* CancellableThenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DDA0306F9F9577B3D634F0D7564BDC5 /* CancellableThenable.swift */; };
+		E142908815AD1D9B0056CD10C34778FE /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE39D473D3D958AC7473DD88BDEA854 /* CountryCode.swift */; };
+		E179800124DE384C8ED5A9EAE4875B14 /* nb.json in Resources */ = {isa = PBXBuildFile; fileRef = F0BAAE6701EBBA54A56BC58E97505F84 /* nb.json */; };
+		E19EDD7D94F8370F7B30183E7EC0C84B /* FormPaymentMethodTokenizationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7761C41E744E52D98D8B4B7759A821 /* FormPaymentMethodTokenizationViewModel.swift */; };
 		E1DBF0C2B22438B89D671CF09FE515D9 /* PrimerIPay88Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8B1D6DD39AFB383F44343B08D4575F /* PrimerIPay88Error.swift */; };
-		E29A6FB22D2E2628BBB772888A125CC1 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CADC130631DE2358518093D1868771 /* firstly.swift */; };
+		E1F278BDE7B246AFCB80FEB50A63F49E /* Content.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6944A22CF2313B52996ADC782A2C883 /* Content.swift */; };
+		E20FD5C54202CE449897D4515460CFF0 /* UniversalCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6383DB335D5FFC48AB5AA7144C06A0FC /* UniversalCheckoutViewModel.swift */; };
+		E222A85074E9212F89CA7507CE83B1C2 /* km.json in Resources */ = {isa = PBXBuildFile; fileRef = 0703C47FE2E57ECE50F82429DA4A5691 /* km.json */; };
+		E36AB03FC42CB5436CB7FDDBE4110688 /* RecoverWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D17BC7C360E6C19D00E5F3146AA284 /* RecoverWrappers.swift */; };
+		E37B0E6775C5B84E1D5104F57E754A3E /* QRCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 282ED8E294D564E4AD424395536B4383 /* QRCodeViewController.swift */; };
 		E3A63C8A25987DAB9BC3208333CAB074 /* PrimerKlarnaSDK-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = F18BCB868F3724D32521D544D38E81FF /* PrimerKlarnaSDK-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E623437DD5C7DA4259778303BC444391 /* pl.json in Resources */ = {isa = PBXBuildFile; fileRef = AFED0419F58810B094B045A94F42778F /* pl.json */; };
-		E632D526F53A35050E9CA5A547E1E3C1 /* PrimerTextFieldView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 29A96B2E7EF83B15654E41E07CA9011B /* PrimerTextFieldView.xib */; };
-		E654B4193C079AF9E0394EEA1813CDF9 /* PayPal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A18C33E8EA3177FFB8E9F460AA11C3 /* PayPal.swift */; };
-		E6B2DCE00DBA478EF2F0A1BA3302D6CF /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C47EC51E5F91302F731C24E676785A2E /* Resolver.swift */; };
-		E73A65A74626A664BE1393D03BF6B9C0 /* PrimerCardRedirectData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C19D32F3F0BAF184A5959FDA7AD8BA /* PrimerCardRedirectData.swift */; };
-		E789A66622141D4D7E1502CB0B9067E7 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A9C0DF1386999EC3DF0E2399A99778 /* AnyEncodable.swift */; };
-		E7CB5AEF296C838AB2F6846C7A394DBF /* PrimerCardholderNameFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4763244FE4EDBBEBBE0F08E1A504653A /* PrimerCardholderNameFieldView.swift */; };
-		E7DB067FCD1914E4340AD0CCC6427B65 /* PrimerRootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6618008B201E5110B04678DF9385E9 /* PrimerRootViewController.swift */; };
-		E86F08D8DE17AB43C03C1BFCC90FC311 /* ResumeHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C178A25FF859EF537327E90C69CE3F /* ResumeHandlerProtocol.swift */; };
-		E97345ED46A5F4CB3CDD5F58E5B002BA /* PrimerImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5F402AF26A5D15C068808791BA701A /* PrimerImage.swift */; };
+		E549345AF63325A1EF5A957C7229D5DB /* StateField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 717DD5F963C60F4088A44B483EE5A52F /* StateField.swift */; };
+		E605A012AAABF91FEBDA186A5577947A /* PrimerRetailerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970DCB1EDAD600A566534DD364F00A6E /* PrimerRetailerData.swift */; };
+		E660A089587BA639932F6BB8A81974C4 /* hi.json in Resources */ = {isa = PBXBuildFile; fileRef = 7E3829BFC4A103319826826E33060597 /* hi.json */; };
+		E6DAE79409A54DAFD54D2CEF632E5595 /* DateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5ECAD1D6B458C0AA5A316A31D577C1 /* DateExtension.swift */; };
+		E744A5469C73D0C10B7325FE243F05BE /* PrimerInitializationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90742523FBAD3437CB449483BC9AB6C3 /* PrimerInitializationData.swift */; };
+		E749D59BC7283341382689C9EEE76A2C /* CountryField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5CC8C8A16059A657F0CADD5E61944F /* CountryField.swift */; };
+		E78811539F47C57B52FAE803893EF61E /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9DE2E33E4E2B002220B36F21D5D087 /* race.swift */; };
+		E7C099E2899AD97D9CA1258A2AE5CA5A /* hu.json in Resources */ = {isa = PBXBuildFile; fileRef = 22793AE5741A5F986FC0B459363EDB0D /* hu.json */; };
+		E8BF65312DF50B2218C51C7656972A3F /* pt.json in Resources */ = {isa = PBXBuildFile; fileRef = 8943A0F753665E1CDE97043C6D0B5144 /* pt.json */; };
+		E8E77747D51EC70140B8A7C08E916D38 /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CDDAD82B1C38F0BE836D756E5A56CC7 /* AnyEncodable.swift */; };
+		E9154B0B9CF20E145509140A3C3B7214 /* no.json in Resources */ = {isa = PBXBuildFile; fileRef = 4B18BAA9E78106A09D434DF7792F0632 /* no.json */; };
 		E9EEB1ACFE46ACF8D1B85B82BE121622 /* Pods-Debug App-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B624EBF5412516975BDAF22E1D53D9 /* Pods-Debug App-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EA882876CC706E98990DBBB573218172 /* PrimerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56CB9647CC8CDA9763FAE921DACC3E1F /* PrimerSource.swift */; };
-		EA8C2851AFD95208E20D0E180CDA4849 /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0CB5F76D1C29AF189A924DB990AA56 /* Response.swift */; };
 		EABB0F1491052F68A599CBDABF40F6AF /* Primer3DSSDKProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3D88D9E2B7D011FB604E94CDF53ACAC /* Primer3DSSDKProvider.swift */; };
-		EB0F240939F2DC39D537FB05E7A72980 /* BankSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0427E8C854C706F85DF8529F099FD /* BankSelectorViewController.swift */; };
-		EB10D2BF28265550E0168BF7B5671807 /* Currency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158FA9B9DBF1A80235CBB6C292AD3822 /* Currency.swift */; };
-		EB4196324EAF78474C515FD0221C7B18 /* ar.json in Resources */ = {isa = PBXBuildFile; fileRef = 0FBDA3A3F35DC75334856E3135A512A3 /* ar.json */; };
-		EC7E81943F96769CBFD9902C8E8409AC /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = A110D9DDF6D23AC5B92C9F94D65B5F84 /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift */; };
-		EC7EA89FCA052FB2E030ECAF4F243408 /* CVVField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81B733AB83E11404DA41A994E6DF0E9 /* CVVField.swift */; };
-		EC80644DB7761088F63AFC7FB021CAC8 /* IntExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF92DE9C2024A0DCE5088E1DC761A8A5 /* IntExtension.swift */; };
-		ECAF8BA773D686781DEDF814875D3851 /* Icons.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2B8E34C5AB81858E000094E1562BFE13 /* Icons.xcassets */; };
-		EDB2A4C62E16581A08CF3385841E4BF8 /* CoreDataDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8BFB4BF6C1343B4ACB13ACA968F483 /* CoreDataDispatcher.swift */; };
-		EE0CCE61EE1909ECEF6F204B278CCD6C /* PrimerAddressLineFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4F824F61AB7ED19B472516A3E9C8D /* PrimerAddressLineFieldView.swift */; };
-		EEB8C49A72E04185A67A9D7E9F8B6014 /* sk.json in Resources */ = {isa = PBXBuildFile; fileRef = 56B368F810A2AB543CC374D7AC273A20 /* sk.json */; };
-		F03699532AC2DB5700E4179D /* VersionUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03699522AC2DB5700E4179D /* VersionUtils.swift */; };
-		F0436570ADD72DF65293A1A25FA25F30 /* PrimerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE3CDE2B9BE96DC251CEB6FC68EC6E4 /* PrimerConfiguration.swift */; };
-		F097A00591647AE1226DA32369F0D4E6 /* PrimerInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D90FB6A5D795F4049AE61499E72F81 /* PrimerInputViewController.swift */; };
-		F219167FF3FE3C20BD85C39A075903FF /* PrimerRetailerData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0C1D9987D0E6274C876388CD7B764E /* PrimerRetailerData.swift */; };
-		F22B0A82D3A11725346534EB86D0B76F /* PrimerHeadlessUniversalCheckoutProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED316D11AA35ACCF831DB7531099B3A4 /* PrimerHeadlessUniversalCheckoutProtocols.swift */; };
-		F4C7A6049770CFAB2A664B28364F03EB /* PrimerNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41878BCFFB2F0774673FAF76C845093 /* PrimerNavigationBar.swift */; };
-		F56CF1FA9C17BF9927E675F8825B083A /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1547B16E14281179C5FE685621B67B38 /* Analytics.swift */; };
-		F57E3DC185601E906C10CAFE7D32C332 /* PrimerTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = E644D1C56D1D4998DED55F15CB97E65E /* PrimerTextField.swift */; };
-		F61BCA17069429B3154BCE97A1826259 /* HeaderFooterLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD82A811F119463D9AFE8CF7713F31E /* HeaderFooterLabelView.swift */; };
-		F7A51F5C092E54B9555330B7503DEA13 /* PrimerPhoneNumberData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB4E9AA4460DB6E3B6C1B7BF6D21C53 /* PrimerPhoneNumberData.swift */; };
-		F7B1EC4A8897700E48B98DC1FF07E011 /* PrimerThemeData+Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0924D8D07A2B8717AEE1B845A2907C21 /* PrimerThemeData+Deprecated.swift */; };
-		F873B1A2983553F28F9926B66ECBDE3F /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E94D787E8A251544ECBAA995DA1E9DD /* Error.swift */; };
-		F9A1A369A8B0CE25DCD66CA2E45D220D /* nl.json in Resources */ = {isa = PBXBuildFile; fileRef = FA140C6F6C4E7C0563354CB048666AAD /* nl.json */; };
-		FA64A67C1F4DDB1CBCCE5E76456228BA /* TokenizationRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100E01528D455CA7428CDF87A1F9DCE1 /* TokenizationRequestBody.swift */; };
-		FC4EEF009ADEFE96E61178DCB0461758 /* de.json in Resources */ = {isa = PBXBuildFile; fileRef = 3D5DD3A443EAFA64A6728D9623C32711 /* de.json */; };
-		FDF8BEA59D992C0E870098D3E0354FF4 /* version.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDA794A6B5D0DDDEC3CDCA3E9C09451 /* version.swift */; };
-		FE48C561A91EF1E78AA83681652EB36B /* tr.json in Resources */ = {isa = PBXBuildFile; fileRef = 661B567C4810A935CFBA7E116438230C /* tr.json */; };
-		FF0C26D15151E47E46AE60957C1D5DA8 /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EEC09164AC46A490D889A4B3A4E875 /* BundleExtension.swift */; };
-		FF130CAEFD0454DFAA5F304B8AC5C0E6 /* PrimerLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EA913A90FFF849E790BF1C22831A3E2 /* PrimerLoadingViewController.swift */; };
-		FF368EEEA31FECCFD5F15896E5F9595E /* PrimerCardFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B07423AA82A0FE4FA4CCA0106C9DE4 /* PrimerCardFormViewController.swift */; };
-		FFB2F495F4C53251F12D1CB996FE4C70 /* EnsureWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909AE2208208DEE0EA99951B5465CB24 /* EnsureWrappers.swift */; };
+		EB1327F3414A6780E304FD5DCEAF6FEF /* CountrySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A70671F7AA0DE263FAE41BF52094283 /* CountrySelectorViewController.swift */; };
+		ECFE457A75271F33C2F57145694D6A27 /* sd.json in Resources */ = {isa = PBXBuildFile; fileRef = 6124368491C700E91F5E7FFF9F75ACC6 /* sd.json */; };
+		EE25841E65825D0CE2186AF42EB38061 /* StrictRateLimitedDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AB959C423AD7C3414D505E8DEC2C0F6 /* StrictRateLimitedDispatcher.swift */; };
+		EE2AB4511296F36A85B2CA179B7A2BE3 /* ClientSessionAPIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12CA876226AACE3698AF07A0A1D48D31 /* ClientSessionAPIModel.swift */; };
+		EE7D8D77CBDA99D8A6C3EE5296FE13AC /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2601D30CBAD816B246C384DE0E6A35B /* StringExtension.swift */; };
+		EFA1882A1393417477BDD8A64A252797 /* FlowDecisionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F037BA6BC4DD15F6950FBE5EC386E10C /* FlowDecisionTableViewCell.swift */; };
+		EFDD9C8D7D2336B584F4AEAC4CBC78B9 /* AssetsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC47390466729A45FC745790F6C0900D /* AssetsManager.swift */; };
+		F1213C5E25D3BB57E7EB1DDF39BD9E56 /* CancelContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25402AB502E293F91B86FCC719BE0EC /* CancelContext.swift */; };
+		F12627F8E793A5D4377B46506A1C09E6 /* PrimerPaymentMethodManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA827D84EFC754C68CE6709D40AB093 /* PrimerPaymentMethodManager.swift */; };
+		F2531A0E5117149F13DEA91B634717E0 /* ar.json in Resources */ = {isa = PBXBuildFile; fileRef = D6F90BB1D517FA485D4412B287CB3B0E /* ar.json */; };
+		F2C5CF00B2908E7A6D53AEC8B9806C6D /* en.json in Resources */ = {isa = PBXBuildFile; fileRef = BA9AB5993CC6ABCE0808A95D838BA535 /* en.json */; };
+		F34E27989E563A6D98AA351E7FFF010A /* Mask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4347B3D833934D076AC54429CC9C73 /* Mask.swift */; };
+		F40785CD2DBD47A08922298197A3393C /* CancellableCatchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0080C787E33A5BFA9E346142D3959DE3 /* CancellableCatchable.swift */; };
+		F460BA338614C0B143374D1D0C29C5A8 /* bs.json in Resources */ = {isa = PBXBuildFile; fileRef = C4A936EA6139B2FA3457A56E75871EFB /* bs.json */; };
+		F46E0DA88E8EC478E075359C442057EE /* CityField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE1CD4CA67633AB5538A06FE3789905 /* CityField.swift */; };
+		F57E0A392BC5C52EC886128ED83F6754 /* PrimerTextFieldView+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5ADE0FE7A381434782E85FE2976D0815 /* PrimerTextFieldView+Analytics.swift */; };
+		F5C7F80F06FC54E68372DED8D3E21B41 /* CountryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA811C7A05459AC87527FED5F1BD368E /* CountryTableViewCell.swift */; };
+		F6A382F5D66E86C1CB2B6D4DC9BFF7F2 /* PrimerPaymentPendingInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463AC2D355BEA8F77BF070B1071D107D /* PrimerPaymentPendingInfoViewController.swift */; };
+		F6CE947F106A72E09F4BC8E154EF981C /* et.json in Resources */ = {isa = PBXBuildFile; fileRef = 7510600267C94A917C4B694DD9FC8A8B /* et.json */; };
+		F71CA7D762DE25EA50A2A40A258BAF99 /* ug.json in Resources */ = {isa = PBXBuildFile; fileRef = D6674E079526CF6D8F40E80278CC86A2 /* ug.json */; };
+		F722A59AA15B5BDB0F5C5362B0734A13 /* PrimerTextFieldView+CardFormFieldsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FE82A5D487EBEF4265FA2504EDEE18A /* PrimerTextFieldView+CardFormFieldsAnalytics.swift */; };
+		F75595ADEF7DFD9660358955529C5BF7 /* PrimerVaultedCardAdditionalData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82996D3CB228FAD7600248D51F582A7 /* PrimerVaultedCardAdditionalData.swift */; };
+		F989AB35A74BE27E16C022F0B3D11910 /* ko.json in Resources */ = {isa = PBXBuildFile; fileRef = 595EBEC18007F19642E3E4E4ACE00323 /* ko.json */; };
+		F9D4E56DE46B4C5BC8550D13396E2CD9 /* RawDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63743788C48EF14DE94A4FD85C978A68 /* RawDataManager.swift */; };
+		FBC66B851190E52896041216B08CE5FB /* id.json in Resources */ = {isa = PBXBuildFile; fileRef = A888A56ABB4E2264835636822B21D957 /* id.json */; };
+		FC68038AC11099228BC09136C5CE04C6 /* zh.json in Resources */ = {isa = PBXBuildFile; fileRef = 5BA577DA087EFF27F914174F351FCCE6 /* zh.json */; };
+		FD05512CE2215CC619D395325D4AEEFA /* PrimerSDK-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D67E38AE53D2DD65A16AF5CDC8AB67F /* PrimerSDK-dummy.m */; };
+		FE1AE3798E12D0992BB9F8E4FA176430 /* ImageName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650C7E386F269F18AC1CE5E91E8C3FE7 /* ImageName.swift */; };
+		FE521007E0962259151A9C837BEBF576 /* TokenizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BAAB2CA6A44B0B15C464EE9CA8C7C5 /* TokenizationService.swift */; };
+		FED55746A9DBB0AD2F03FCF5804D63EA /* he.json in Resources */ = {isa = PBXBuildFile; fileRef = A8C220F0252DF3030F67739D5D7CFC0C /* he.json */; };
+		FF04CA26888FF4CC567AB5A5799A109B /* currencies.json in Resources */ = {isa = PBXBuildFile; fileRef = 9C496E296853A66EE15500AEA2766747 /* currencies.json */; };
+		FFAD20E1275EB45E91BF20A1945638B1 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB7686329605392FBCB2FE172FC6126 /* Queue.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		1ACC4A73A1487D1AC301C59D3DDEAE39 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 6F5F0A81CAE773CFE5371059A81B5B6A;
-			remoteInfo = Primer3DS;
-		};
-		211BEB055EE4D700E332D9ECAA3E6173 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = AE0D1F6B2232EC9235B0E597AE598062;
-			remoteInfo = "Pods-Debug App";
-		};
-		277D368223672865BA1AAF6BBB943E74 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 46078E413137E8360E17944FC2E93839;
-			remoteInfo = PrimerKlarnaSDK;
-		};
-		45AAF336FA4B87FA058691C0FBA0A82C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F3BE9108C53B53949406218CEA55E0B2;
-			remoteInfo = PrimerSDK;
-		};
-		581CA5B990D3DDFB0532F8131F541EE6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CED402C355914FFED9773C1549264B8C;
-			remoteInfo = KlarnaMobileSDK;
-		};
-		5BB6C350E9383B50DFF1A6E8DD6760CB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = CED402C355914FFED9773C1549264B8C;
-			remoteInfo = KlarnaMobileSDK;
-		};
-		E49D3DDF11F735CE913D6E8E1249E2BF /* PBXContainerItemProxy */ = {
+		25543BDC4D05319E9EFEFD60058137C3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 6E6525C7043FBA7BB34A249010AF5593;
 			remoteInfo = "PrimerSDK-PrimerResources";
 		};
-		F6B821012F73712BAA9216B41954A5D8 /* PBXContainerItemProxy */ = {
+		551DEBFCD56AD448C0BC804A24E6C93F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AE0D1F6B2232EC9235B0E597AE598062;
+			remoteInfo = "Pods-Debug App";
+		};
+		636F9C9ED4C5676ECFA9F0BE24CF15C9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = F8E5FB3C062691E4A558AC2F38E07E63;
 			remoteInfo = PrimerIPay88MYSDK;
 		};
+		7D303E8160F602C5CC1A3DEC2BDA81FC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6F5F0A81CAE773CFE5371059A81B5B6A;
+			remoteInfo = Primer3DS;
+		};
+		B15A4DC2F5082785774B48D5252ABDA5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 46078E413137E8360E17944FC2E93839;
+			remoteInfo = PrimerKlarnaSDK;
+		};
+		EBB0E0EDEEBE106737507CFDAA2FAB29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CED402C355914FFED9773C1549264B8C;
+			remoteInfo = KlarnaMobileSDK;
+		};
+		FB2A023D65B0BE2FD4C38BBD1F866821 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F3BE9108C53B53949406218CEA55E0B2;
+			remoteInfo = PrimerSDK;
+		};
+		FC6E52886F3218093A3CB69EF1334B6C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BFDFE7DC352907FC980B868725387E98 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CED402C355914FFED9773C1549264B8C;
+			remoteInfo = KlarnaMobileSDK;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		001E05D511E77A6FA8C2963AC7FB50A5 /* PrimerCustomStyleTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCustomStyleTextField.swift; sourceTree = "<group>"; };
+		0052C9E5ED38BFDEB3318B8B276FDC32 /* CVVField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CVVField.swift; sourceTree = "<group>"; };
+		0080C787E33A5BFA9E346142D3959DE3 /* CancellableCatchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellableCatchable.swift; sourceTree = "<group>"; };
 		016508A0C946E61AFD1324092F7F4475 /* KlarnaMobileSDK-xcframeworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "KlarnaMobileSDK-xcframeworks.sh"; sourceTree = "<group>"; };
-		01DCCECEF6DE0816459294F7D4E380B3 /* pt.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = pt.json; sourceTree = "<group>"; };
-		025655E2356AE6CED57CD52291D755CE /* PrimerCardData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardData.swift; sourceTree = "<group>"; };
-		0292748EAA0F59FF63A048594369AFB0 /* PrimerVaultedPaymentMethodAdditionalData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultedPaymentMethodAdditionalData.swift; sourceTree = "<group>"; };
-		02E4F824F61AB7ED19B472516A3E9C8D /* PrimerAddressLineFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAddressLineFieldView.swift; sourceTree = "<group>"; };
+		016B82E8953680E3FDFB6CF99F8E820B /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		0247110EB538C01C77850CA1CFF0D9F5 /* TokenizationRequestPaymentSessionInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationRequestPaymentSessionInfo.swift; sourceTree = "<group>"; };
+		027EF89D51BC1409FF36F92A4B40695D /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutInputElementDelegate.swift; sourceTree = "<group>"; };
+		02DDEB4BFDD82D2B3C1999FC0D6C2F87 /* Downloader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
 		0432C455D98AF72FD6864C01E3E06BE5 /* PrimerSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerSDK.release.xcconfig; sourceTree = "<group>"; };
-		04CA368E1040DCDB874CFD05EB959664 /* BankTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BankTableViewCell.swift; sourceTree = "<group>"; };
-		04DE2790F4BA934C8B330CE4A023A484 /* hy.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = hy.json; sourceTree = "<group>"; };
-		059A44FD4398BD3ECD3A33D1571C4CA0 /* so.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = so.json; sourceTree = "<group>"; };
-		066A1F71DBE9D14ACDB2A63D48ADDF68 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
-		06EFDD6B847899803CDD6CEC7D495774 /* InternalCardComponentsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InternalCardComponentsManager.swift; sourceTree = "<group>"; };
-		0828534D079454FFFF543D9866AA1AE1 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
-		08B07423AA82A0FE4FA4CCA0106C9DE4 /* PrimerCardFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardFormViewController.swift; sourceTree = "<group>"; };
-		08D90FB6A5D795F4049AE61499E72F81 /* PrimerInputViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInputViewController.swift; sourceTree = "<group>"; };
-		091C52DB4E0BF544AAB20BF31610BE30 /* bg.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = bg.json; sourceTree = "<group>"; };
-		0924D8D07A2B8717AEE1B845A2907C21 /* PrimerThemeData+Deprecated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerThemeData+Deprecated.swift"; sourceTree = "<group>"; };
-		09A090A65E85F0E260BBBC518FAFDD22 /* ko.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ko.json; sourceTree = "<group>"; };
-		0A9B45FE4B61770CD32006E3F49CCBFB /* RawDataManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RawDataManager.swift; sourceTree = "<group>"; };
-		0A9BFD6F8F465F8A708FE03A17414427 /* PrimerWebViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerWebViewController.swift; sourceTree = "<group>"; };
-		0CEA1480749C8D81B0FFB635BDEB4705 /* PrimerResultComponentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerResultComponentView.swift; sourceTree = "<group>"; };
-		0CFE031BD7589055BFCEEB1119F8C153 /* sr.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sr.json; sourceTree = "<group>"; };
-		0D50B801A56ACD5BC022CAA60F462518 /* ThreeDS_SDK.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = ThreeDS_SDK.xcframework; path = Sources/Frameworks/ThreeDS_SDK.xcframework; sourceTree = "<group>"; };
+		043F404DDFA27D969C50608A28EEB47B /* VoucherValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoucherValue.swift; sourceTree = "<group>"; };
+		0703C47FE2E57ECE50F82429DA4A5691 /* km.json */ = {isa = PBXFileReference; includeInIndex = 1; path = km.json; sourceTree = "<group>"; };
+		0823CBC7355A73F7ED71C1AF4A115F82 /* Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		0B4F24B38DC7272A8BB20C6C3AB8911C /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		0BBA9B8A7380F437830D563CAFC0CE2A /* TokenizationRequestPaymentInstrument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationRequestPaymentInstrument.swift; sourceTree = "<group>"; };
+		0C0C538E168130A05D5F9FA9C3E1674E /* PrimerRootViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRootViewController.swift; sourceTree = "<group>"; };
+		0C74DCA6DE0FC3BECB04A1CD06D6A314 /* PrimerTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTableViewCell.swift; sourceTree = "<group>"; };
+		0D50B801A56ACD5BC022CAA60F462518 /* ThreeDS_SDK.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = ThreeDS_SDK.xcframework; path = Sources/Frameworks/ThreeDS_SDK.xcframework; sourceTree = "<group>"; };
 		0D67E38AE53D2DD65A16AF5CDC8AB67F /* PrimerSDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PrimerSDK-dummy.m"; sourceTree = "<group>"; };
-		0DB7F2D5BB97649A588DE3F579C41081 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		0E27177B7CCF2DA6BEAA61936C53BA02 /* TokenizationResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationResponse.swift; sourceTree = "<group>"; };
 		0EC45ABAE4CC9173E7137A76536C5003 /* PrimerKlarnaSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerKlarnaSDK.release.xcconfig; sourceTree = "<group>"; };
-		0FBDA3A3F35DC75334856E3135A512A3 /* ar.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ar.json; sourceTree = "<group>"; };
-		100E01528D455CA7428CDF87A1F9DCE1 /* TokenizationRequestBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationRequestBody.swift; sourceTree = "<group>"; };
-		10526B5EF46C2F86753394A25C7D0445 /* PrimerFlowEnums.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFlowEnums.swift; sourceTree = "<group>"; };
-		105344FCAA5C83C80B929CC49544A9CE /* TokenizationRequestPaymentInstrument.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationRequestPaymentInstrument.swift; sourceTree = "<group>"; };
-		12C71BBF27B01BBE5B854B2CC1B4A651 /* PaymentMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethod.swift; sourceTree = "<group>"; };
-		12F049D553385B220511DA5324E73CAC /* kk.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = kk.json; sourceTree = "<group>"; };
-		139D45FF1CFA7B8C5CE600B027FAB52E /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		10518419B19F405054471079A3497216 /* CardComponentsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardComponentsManager.swift; sourceTree = "<group>"; };
+		109977FD597C2B8FD31B3BD33B2B356C /* TokenizationRequestBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationRequestBody.swift; sourceTree = "<group>"; };
+		11E2A15227CF22FFC4B4C56AAE533118 /* VaultPaymentMethodView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodView.swift; sourceTree = "<group>"; };
+		11E678F93CD7D86FF3DA682F680132F1 /* AnyDecodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
+		123DE8A650ADC397D8B69D45F02E8575 /* phone_number_country_codes.json */ = {isa = PBXFileReference; includeInIndex = 1; path = phone_number_country_codes.json; sourceTree = "<group>"; };
+		12CA876226AACE3698AF07A0A1D48D31 /* ClientSessionAPIModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientSessionAPIModel.swift; sourceTree = "<group>"; };
+		12CB36C753AA3EFECA8803A4909B722D /* DataExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
 		13E57A9033664934BB815C9ABE12CB43 /* Pods-Debug App Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Debug App Tests-dummy.m"; sourceTree = "<group>"; };
-		1437FAD4E45E8929285D343D53E42338 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawPhoneNumberDataTokenizationBuilder.swift; sourceTree = "<group>"; };
+		141C6965E5C32694A03343BEF0E92AC8 /* PrimerVaultedPaymentMethodAdditionalData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultedPaymentMethodAdditionalData.swift; sourceTree = "<group>"; };
+		1465A6F2592BDF95718A678C4FA81A02 /* ApayaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApayaTokenizationViewModel.swift; sourceTree = "<group>"; };
 		14E4B175B8C879BEE4FB90D09483FFBD /* Pods-Debug App Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Debug App Tests-Info.plist"; sourceTree = "<group>"; };
-		1547B16E14281179C5FE685621B67B38 /* Analytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
-		158FA9B9DBF1A80235CBB6C292AD3822 /* Currency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
-		167D824DCDED21787986848B8C99950E /* PrimerAccountInfoPaymentViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAccountInfoPaymentViewController.swift; sourceTree = "<group>"; };
-		16A13FF37400C98AB78552A82F345D3C /* ru.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ru.json; sourceTree = "<group>"; };
-		16DB0A2C906E424C429F09EE8F4236C1 /* ApplePayTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePayTokenizationViewModel.swift; sourceTree = "<group>"; };
-		1701C2BA9780B96815CB6F6C83AA7974 /* PrimerAPIClient+Promises.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+Promises.swift"; sourceTree = "<group>"; };
-		18234F9225DD0A2D3272048CD6BE9FFA /* PrimerStackVIew.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerStackVIew.swift; sourceTree = "<group>"; };
-		185C900448A65C8F0C6739A8080914DB /* _PaymentAPIModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = _PaymentAPIModel.swift; sourceTree = "<group>"; };
-		18A9C0DF1386999EC3DF0E2399A99778 /* AnyEncodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
-		19DF40448DACEAE8218A622C7ACADE84 /* be.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = be.json; sourceTree = "<group>"; };
-		19E148415476719682D2C8368A32882D /* PrimerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerDelegate.swift; sourceTree = "<group>"; };
-		1A02E51F9DDD9CBB429D9AC7629F987E /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = race.swift; sourceTree = "<group>"; };
-		1AC0D5435EBA802F72AAD2E73D6F67D8 /* PrimerGenericTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerGenericTextFieldView.swift; sourceTree = "<group>"; };
-		1CDD75F8BD3124D3057BDBC8548F8B7F /* PrimerTextFieldView+CardFormFieldsAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTextFieldView+CardFormFieldsAnalytics.swift"; sourceTree = "<group>"; };
+		15CDBA87C49E2F7988858775788B6589 /* 3DSService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = 3DSService.swift; sourceTree = "<group>"; };
+		16E4CE9C3AEBD32B0C6532B6E1D70771 /* PrimerAccountInfoPaymentViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAccountInfoPaymentViewController.swift; sourceTree = "<group>"; };
+		16E651F2EF0359212D2E8D44E6C814C2 /* PrimerTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextFieldView.swift; sourceTree = "<group>"; };
+		19783814363AE8875B4B3FA0F62B90B4 /* Icons.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = Sources/PrimerSDK/Resources/Icons.xcassets; sourceTree = "<group>"; };
+		19AEAA7CE084F88A8F7A2CD0CEA5A653 /* CoreDataDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoreDataDispatcher.swift; sourceTree = "<group>"; };
+		1A815CA108556A535E26386C83B8C39D /* RetailOutletsRetail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RetailOutletsRetail.swift; sourceTree = "<group>"; };
+		1A98363F99139D5B9B01EA53F46BBD85 /* bg.json */ = {isa = PBXFileReference; includeInIndex = 1; path = bg.json; sourceTree = "<group>"; };
+		1AB77F315E45888534C0F141F1D8BA34 /* Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
+		1B4FE78145CB0E3CE9CA10F5B57E721B /* PrimerSearchTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSearchTextField.swift; sourceTree = "<group>"; };
+		1B8F0E0D1F895D7FBC080355D9E0D08B /* hr.json */ = {isa = PBXFileReference; includeInIndex = 1; path = hr.json; sourceTree = "<group>"; };
+		1D6971C4F3174907CE296FE18125901E /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		1D7F5643FEC6A897A8B48171D8D0AFD6 /* PrimerIPay88MYSDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PrimerIPay88MYSDK.modulemap; sourceTree = "<group>"; };
-		1DA399A7CEC10284AA5DFF7087AB1606 /* no.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = no.json; sourceTree = "<group>"; };
+		1DA02A897C750507CA0849CE74B55431 /* VaultPaymentMethodViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodViewModel.swift; sourceTree = "<group>"; };
+		1DAF0408BD674A9D72D801E98E502399 /* UIColorExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
+		1DE39D473D3D958AC7473DD88BDEA854 /* CountryCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryCode.swift; sourceTree = "<group>"; };
 		1E110BB01B6F3D4258B22B7B95A9777A /* PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PrimerSDK-Info.plist"; sourceTree = "<group>"; };
-		1EA4574401EEB535ABC2ECC64430D181 /* Throwable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Throwable.swift; sourceTree = "<group>"; };
-		1FEC86D93BAC13455F163218A9C1D20D /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
-		20B0427E8C854C706F85DF8529F099FD /* BankSelectorViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BankSelectorViewController.swift; sourceTree = "<group>"; };
-		211E41E3017C0C184A700A94A3E5AD87 /* hang.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = hang.swift; sourceTree = "<group>"; };
+		1ED03E3F4FA541F8FDB2AC3BB891673F /* BankSelectorTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BankSelectorTokenizationViewModel.swift; sourceTree = "<group>"; };
+		1FC60FD7327B5F605ACC509FDA36E3E3 /* ta.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ta.json; sourceTree = "<group>"; };
+		20F8C6339735F2D7EF116A79442C0A1C /* is.json */ = {isa = PBXFileReference; includeInIndex = 1; path = is.json; sourceTree = "<group>"; };
+		213B5FDF3D6350724D0E3CB989DD6807 /* hy.json */ = {isa = PBXFileReference; includeInIndex = 1; path = hy.json; sourceTree = "<group>"; };
 		2151B899A62EE15E2483007A778E8E7C /* IpayPayment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = IpayPayment.h; path = PrimerIPay88SDK/Frameworks/IpayPayment.h; sourceTree = "<group>"; };
-		22B89EDEC387A04C17D485DA9DBA096E /* OrderItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrderItem.swift; sourceTree = "<group>"; };
-		22E3B6E2350EC9C8A4FB2AB0DF81D119 /* CountryField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryField.swift; sourceTree = "<group>"; };
-		23008DCE30635C2A48179C8955173D36 /* af.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = af.json; sourceTree = "<group>"; };
+		21E33DED88C753F774E07438BEFEA587 /* PrimerLoadingViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerLoadingViewController.swift; sourceTree = "<group>"; };
+		221F8AC4FACB79EA04ABBC64AA49492B /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		2265FF9EA917CC753CDA43675489BBF9 /* NSErrorExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NSErrorExtension.swift; sourceTree = "<group>"; };
+		22793AE5741A5F986FC0B459363EDB0D /* hu.json */ = {isa = PBXFileReference; includeInIndex = 1; path = hu.json; sourceTree = "<group>"; };
+		22BC66D3EE583E0B15FC81F85A817ED1 /* Strings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
+		2316669CC24E0E451AB6A1587D019581 /* PaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
+		23D2D8DE65B5AC4A0358B761D4004935 /* CreateResumePaymentService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CreateResumePaymentService.swift; sourceTree = "<group>"; };
+		2427D763745299B1B1C8A7A8F7166C90 /* Connectivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Connectivity.swift; sourceTree = "<group>"; };
 		24D6FA47A795B7308C0D55A653CC3104 /* PrimerSDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PrimerSDK.modulemap; sourceTree = "<group>"; };
-		25C166BF577DFC28F1BF4A07FA174775 /* CheckoutWithVaultedPaymentMethodViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckoutWithVaultedPaymentMethodViewModel.swift; sourceTree = "<group>"; };
-		26238DDBA62CD3748B820A6A1EDE9B01 /* CountryTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryTableViewCell.swift; sourceTree = "<group>"; };
-		265216BCC916C3783AAD38C074BF98B7 /* ClientSession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientSession.swift; sourceTree = "<group>"; };
-		2685D22CAE31BD438AFCFDB151DB700A /* PrimerInternal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInternal.swift; sourceTree = "<group>"; };
-		269943DFE2671D1E4DB4BA0ADAC42F3F /* ClientToken.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientToken.swift; sourceTree = "<group>"; };
-		26B15B62F11C383393F1DECF26A5DFF6 /* FormPaymentMethodTokenizationViewModel+FormViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "FormPaymentMethodTokenizationViewModel+FormViews.swift"; sourceTree = "<group>"; };
-		26F9757ABA5220992213CD56B6C1A6E2 /* GuaranteeWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GuaranteeWrappers.swift; sourceTree = "<group>"; };
-		27ADB4294EBF96BDDC56D895E9C695F0 /* FlowDecisionTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FlowDecisionTableViewCell.swift; sourceTree = "<group>"; };
-		27E0ADF57D15D16B4B09330F015DAC41 /* PrimerPostalCodeFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPostalCodeFieldView.swift; sourceTree = "<group>"; };
+		252D6E7F7CB70F687EC5A87FEB990D30 /* PrimerFirstNameFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFirstNameFieldView.swift; sourceTree = "<group>"; };
+		2582D5434BE2D2D928A025C6BB6A0CBD /* Notification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
+		25CFE7582EBED3AD762E268632D3C4DE /* DependencyInjection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependencyInjection.swift; sourceTree = "<group>"; };
+		26BF1DF0CF7272AD3242B7D5FCD7BF60 /* ro.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ro.json; sourceTree = "<group>"; };
+		26F7FF514DC158521EF4450F0BF89139 /* PrimerThemeData+Deprecated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerThemeData+Deprecated.swift"; sourceTree = "<group>"; };
+		27FF8B3650A748481B91343F88669976 /* PrimerNavigationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationController.swift; sourceTree = "<group>"; };
+		282ED8E294D564E4AD424395536B4383 /* QRCodeViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeViewController.swift; sourceTree = "<group>"; };
+		2832A895415923855F604D702DFEB066 /* UserInterfaceModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserInterfaceModule.swift; sourceTree = "<group>"; };
 		28E47791C9F9D0A9BA05C719761A4F3F /* PrimerSDK */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PrimerSDK; path = PrimerSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		29A96B2E7EF83B15654E41E07CA9011B /* PrimerTextFieldView.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = PrimerTextFieldView.xib; sourceTree = "<group>"; };
-		2B2F07CE5498831C6E3A6EB73C38EE5E /* PrimerTestPaymentMethodViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTestPaymentMethodViewController.swift; sourceTree = "<group>"; };
+		292F09167F7D41E75E311819BF0A00A9 /* WebRedirectPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebRedirectPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
+		2935E4B0A5808F755F54846BEE6AF5E9 /* PrimerCountryFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCountryFieldView.swift; sourceTree = "<group>"; };
+		294457E6EC1065D042CE94502D6F82B3 /* CustomStringConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomStringConvertible.swift; sourceTree = "<group>"; };
+		295658BEB9FC559F1C7C786513AE78EE /* Mock3DSService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Mock3DSService.swift; sourceTree = "<group>"; };
+		2A3D3EB3C0B6EE702D3FFCF03F936666 /* PostalCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostalCode.swift; sourceTree = "<group>"; };
+		2A70671F7AA0DE263FAE41BF52094283 /* CountrySelectorViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewController.swift; sourceTree = "<group>"; };
+		2A98A4CC4194D2E133E1A93105BECAA7 /* InternalCardComponentsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InternalCardComponentsManager.swift; sourceTree = "<group>"; };
+		2AB885AFB60EE0C6B39062DFE30176AC /* lt.json */ = {isa = PBXFileReference; includeInIndex = 1; path = lt.json; sourceTree = "<group>"; };
+		2ABDA4A40D9E4BB020FAE8D4159CD91F /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2AEF45F7CBBDB26A5BF0FD2C893529F3 /* RateLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RateLimitedDispatcher.swift; sourceTree = "<group>"; };
+		2AF1D4F681057F4721C0662C745E8E8D /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
+		2B1C6967F9433EA11FDB7D0E230C1142 /* ConcurrencyLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConcurrencyLimitedDispatcher.swift; sourceTree = "<group>"; };
 		2B3503702FC179F079465856826B186A /* ResourceBundle-PrimerResources-PrimerSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-PrimerResources-PrimerSDK-Info.plist"; sourceTree = "<group>"; };
-		2B8E34C5AB81858E000094E1562BFE13 /* Icons.xcassets */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder.assetcatalog; name = Icons.xcassets; path = Sources/PrimerSDK/Resources/Icons.xcassets; sourceTree = "<group>"; };
-		2BDB1A39669149DDD85D9C2D48ACE042 /* 3DSService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = 3DSService.swift; sourceTree = "<group>"; };
+		2C3750940B2FA6D58AE93382E53D20C4 /* PrimerRawData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawData.swift; sourceTree = "<group>"; };
 		2CB46A21DBAC34A6131F27F401CAD3D4 /* Pods-Debug App Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Debug App Tests.release.xcconfig"; sourceTree = "<group>"; };
-		2D222B2A5D57E2055C9EF12BCAE26F26 /* hu.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = hu.json; sourceTree = "<group>"; };
-		2E7E40195DF13E27C66AAAFB4107A989 /* UIDeviceExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIDeviceExtension.swift; sourceTree = "<group>"; };
-		2E94D787E8A251544ECBAA995DA1E9DD /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
-		2EA913A90FFF849E790BF1C22831A3E2 /* PrimerLoadingViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerLoadingViewController.swift; sourceTree = "<group>"; };
-		2F76FB1A589EF365F1AEBAB99EBFA5F5 /* PresentationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PresentationController.swift; sourceTree = "<group>"; };
-		2F862A072948ABE92A6870DD4AD7B0FD /* NSObject+ClassName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSObject+ClassName.swift"; sourceTree = "<group>"; };
-		301374484CD143E215F45C43DD6875D7 /* PrimerCardNumberFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardNumberFieldView.swift; sourceTree = "<group>"; };
-		30424A15FF625421E63F306D4DCA634A /* PrimerTheme+Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Colors.swift"; sourceTree = "<group>"; };
+		2D60F047DE49B9E1CB784CA58F775EAE /* ps.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ps.json; sourceTree = "<group>"; };
+		2E125144112EB19BFE978F77064D400C /* ur.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ur.json; sourceTree = "<group>"; };
+		2E1E4D5287D1BC23822FF2515E9248AE /* nn.json */ = {isa = PBXFileReference; includeInIndex = 1; path = nn.json; sourceTree = "<group>"; };
+		300244607D16CA9353D9E8A3BC84638D /* RateLimitedDispatcherBase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RateLimitedDispatcherBase.swift; sourceTree = "<group>"; };
 		306C952ED493894150536F8CD8BECB6D /* Pods-Debug App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Debug App.debug.xcconfig"; sourceTree = "<group>"; };
-		30D818DA62200FE99F17329E4AD45DDC /* CardComponentsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardComponentsManager.swift; sourceTree = "<group>"; };
-		30E5D8C43EE6F0E901F1F460DB736C49 /* sq.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sq.json; sourceTree = "<group>"; };
-		318BA5A624F10FCFF9BD9A70E71E6C4C /* PrimerTheme+Buttons.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Buttons.swift"; sourceTree = "<group>"; };
-		323D8195FE7CB72DDEA0EBBF57E27D47 /* Device.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
-		3378FDE7CF6756B16256FFBF993DA91A /* AES256.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AES256.swift; sourceTree = "<group>"; };
-		33A68EB2935D68427FAB53A08D703711 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
-		3406163F77D2FB6CF057AA67D4E34DF9 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ms.lproj/Localizable.strings; sourceTree = "<group>"; };
+		307663AD5935C039472F05A5DD7574B0 /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
+		30AA83D4E70802B46864623386CDE15F /* VaultedPaymentMethods.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultedPaymentMethods.swift; sourceTree = "<group>"; };
+		31804F20060164582477B07E26D95BBA /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		318698473C98A0165F9B976398542408 /* PrimerTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
+		31878C04FDEA377DA4D75BACEDA06152 /* PollingModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PollingModule.swift; sourceTree = "<group>"; };
+		31FE9C6312D13374285B21F2E910631C /* PaymentMethodsGroupView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodsGroupView.swift; sourceTree = "<group>"; };
+		34D5898376477D28E2A203F36651F59C /* PrimerButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerButton.swift; sourceTree = "<group>"; };
 		34FCEC2CF890D19452F3FFE895FD2D39 /* ThreeDS_SDK.Transaction+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ThreeDS_SDK.Transaction+Helpers.swift"; path = "Sources/Primer3DS/Classes/ThreeDS_SDK.Transaction+Helpers.swift"; sourceTree = "<group>"; };
-		3613D9723544DFCA6CB7871DA72A105D /* PrimerVoucherInfoPaymentViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVoucherInfoPaymentViewController.swift; sourceTree = "<group>"; };
-		3638BF5C0765A54B045E0BF6BE9394D1 /* Primer3DSErrorContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Primer3DSErrorContainer.swift; sourceTree = "<group>"; };
-		36B00EB0B836D5100D8906245B8B9661 /* PrimerAPIClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPIClient.swift; sourceTree = "<group>"; };
-		37C4A9E16F4E2DAB60510F9F8C696597 /* PaymentResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentResponse.swift; sourceTree = "<group>"; };
-		38135FC951FDE8E3032F3CC26C45B06D /* PostalCodeField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostalCodeField.swift; sourceTree = "<group>"; };
-		3830E414F3EB4A0C9C40924BC94F52B5 /* ja.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ja.json; sourceTree = "<group>"; };
-		38F0A1B7C84315DFF960C70DB61CA8B4 /* NetworkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		36AAB1BDBB913DA8B0155AEC46064F30 /* PrimerVoucherInfoPaymentViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVoucherInfoPaymentViewController.swift; sourceTree = "<group>"; };
+		36AE63293F2752157771515FEF5A232D /* PrimerTheme+Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Colors.swift"; sourceTree = "<group>"; };
+		372BA201AC4938F7D167D5060203BB85 /* PrimerAPIClient+3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+3DS.swift"; sourceTree = "<group>"; };
+		374EFD57A0283E73FBB80FBF949DB664 /* PrimerAPIClient+Promises.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+Promises.swift"; sourceTree = "<group>"; };
+		376188E5CA6FE63BE415B61E6BEE50D5 /* PrimerPostalCodeFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPostalCodeFieldView.swift; sourceTree = "<group>"; };
+		384310CE541E1E342ADEA8C381CE4CE2 /* Klarna.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Klarna.swift; sourceTree = "<group>"; };
+		38A824B2812F36EF238ACDF467425101 /* PrimerCardholderNameFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardholderNameFieldView.swift; sourceTree = "<group>"; };
 		39397A68F8DB8974205E95E52C42B4B3 /* Pods-Debug App Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Debug App Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		39747BEC69572C1757907F113F6B19C5 /* Connectivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Connectivity.swift; sourceTree = "<group>"; };
+		3967A27848CBD48A31BBE753FDD7AA39 /* AnalyticsEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
+		3A075171B6B3301D77D84E221F8DC5E2 /* Decisions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Decisions.swift; sourceTree = "<group>"; };
+		3A0DE56B2DF2205BD309227E499DAC80 /* Analytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		3A3E74479A31CC9E74D03296171FE3E9 /* PrimerIPay88Payment.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimerIPay88Payment.swift; path = PrimerIPay88SDK/Classes/PrimerIPay88Payment.swift; sourceTree = "<group>"; };
-		3AE3D6ADC481C2817934FEBE549C1675 /* Endpoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
-		3B52689B762A3CB52BD072A91E2EC1C1 /* DateExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
-		3BB30024C6CE1D203C1A1ECB896CF5CC /* ImageName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageName.swift; sourceTree = "<group>"; };
-		3BC65978AB3603D3CC369B2F3256AE3D /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
-		3BCDD17220E89326943E0B5A24F8505F /* TokenizationRequestPaymentSessionInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationRequestPaymentSessionInfo.swift; sourceTree = "<group>"; };
+		3B3B5D594811C6D3791379596AE24942 /* Throwable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Throwable.swift; sourceTree = "<group>"; };
+		3BE2983E904B9562D062C90EDB0F7369 /* fi.json */ = {isa = PBXFileReference; includeInIndex = 1; path = fi.json; sourceTree = "<group>"; };
 		3C8B1D6DD39AFB383F44343B08D4575F /* PrimerIPay88Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimerIPay88Error.swift; path = PrimerIPay88SDK/Classes/PrimerIPay88Error.swift; sourceTree = "<group>"; };
-		3CCCFF6ACD3423689A805F7A41F456C6 /* PrimerViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerViewExtensions.swift; sourceTree = "<group>"; };
-		3D5DD3A443EAFA64A6728D9623C32711 /* de.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = de.json; sourceTree = "<group>"; };
-		3D6C93E9B8E12ADD7F2EAC90F253F50B /* WebRedirectPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebRedirectPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
-		3D803FB62A01F2DB010435FC0D6B72FE /* CountrySelectorViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewController.swift; sourceTree = "<group>"; };
+		3D347F7C4C935764556D644C5440D140 /* KlarnaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KlarnaTokenizationViewModel.swift; sourceTree = "<group>"; };
+		3D4869523FCF15EA32B37EC87DD6F19A /* VaultService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultService.swift; sourceTree = "<group>"; };
 		3DB1E4A809AB5A63367A70A754CF2CE0 /* PrimerKlarnaSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerKlarnaSDK.debug.xcconfig; sourceTree = "<group>"; };
-		3DCE173F1CCAF4B0D75CB8CC7AA5F677 /* hi.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = hi.json; sourceTree = "<group>"; };
-		3E83B8F8F0ECE8ECEDC17E44428515C7 /* PrimerStateFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerStateFieldView.swift; sourceTree = "<group>"; };
-		3E85F286365CE24446B8414E7519ABDA /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		3ECCC38DA7558D2053B8F5633AAAAF79 /* Mask.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Mask.swift; sourceTree = "<group>"; };
-		3ED1DCCC3BE7EDEB962787A8E30A6F96 /* AnyCodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
-		3EE5B0DBF4ADCE0BC50EFA7DCA887F8D /* et.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = et.json; sourceTree = "<group>"; };
-		3F61EEC23B1A888114C4C1ADF4A86673 /* ms.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ms.json; sourceTree = "<group>"; };
-		3F972271981C552CAC86D444BA3DE791 /* PrimerThemeData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerThemeData.swift; sourceTree = "<group>"; };
-		41597C1A733DB1BD5944A6326180453D /* SuccessResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuccessResponse.swift; sourceTree = "<group>"; };
-		416909675AF7DE52F724EDD75BDE04E8 /* Primer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Primer.swift; sourceTree = "<group>"; };
-		424E17EAD5C6A4D0775B89D66167B1F3 /* CardFormPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardFormPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
-		43315BD87EB298EC9B0C97E3C22B749D /* AdyenDotPay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdyenDotPay.swift; sourceTree = "<group>"; };
+		3E1B8D416406FEAA3A9068980F70516F /* PrimerStateFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerStateFieldView.swift; sourceTree = "<group>"; };
+		3E4B086002167B86FB152200CB5F4C3F /* PrimerNavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationBar.swift; sourceTree = "<group>"; };
+		3E85F286365CE24446B8414E7519ABDA /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; path = README.md; sourceTree = "<group>"; };
+		3F4D40A84A2FD64608BF069DDCFB78B8 /* ka.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ka.json; sourceTree = "<group>"; };
+		3F5CC8C8A16059A657F0CADD5E61944F /* CountryField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryField.swift; sourceTree = "<group>"; };
+		409C1D1713CED34744C259E39762DA48 /* kk.json */ = {isa = PBXFileReference; includeInIndex = 1; path = kk.json; sourceTree = "<group>"; };
+		40FA715D84A8FF6F50AAF6E5C550461B /* bn.json */ = {isa = PBXFileReference; includeInIndex = 1; path = bn.json; sourceTree = "<group>"; };
 		435935B2F316A11311905DAD68C8DDAC /* PrimerSDK-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerSDK-prefix.pch"; sourceTree = "<group>"; };
-		43AEB5A843B70ED85E8FF9395AD90F72 /* PrimerHeadlessUniversalCheckoutInputElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutInputElement.swift; sourceTree = "<group>"; };
 		43C681726407CC7178476F02DD75F944 /* Primer3DSProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSProtocols.swift; path = Sources/Primer3DS/Classes/Primer3DSProtocols.swift; sourceTree = "<group>"; };
-		442C27AA6E002EB3C377B9C4198AFAF3 /* eu.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = eu.json; sourceTree = "<group>"; };
-		44C586906ABD4A1190735F29E3788C85 /* VaultPaymentMethodViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodViewController.swift; sourceTree = "<group>"; };
-		45B781E11A79C388D813B06730D8D4DD /* PrimerMultibancoCheckoutAdditionalInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerMultibancoCheckoutAdditionalInfo.swift; sourceTree = "<group>"; };
-		466113CEF6EAC19D866900CCB282BEC2 /* PrimerTheme+Views.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Views.swift"; sourceTree = "<group>"; };
-		46BE40CF3D522E23F0A1AC4996C89EB1 /* PrimerFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFormViewController.swift; sourceTree = "<group>"; };
-		46C178A25FF859EF537327E90C69CE3F /* ResumeHandlerProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResumeHandlerProtocol.swift; sourceTree = "<group>"; };
-		46DF979C091AAEB2188A67A4E60973E0 /* az.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = az.json; sourceTree = "<group>"; };
-		4763244FE4EDBBEBBE0F08E1A504653A /* PrimerCardholderNameFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardholderNameFieldView.swift; sourceTree = "<group>"; };
-		4904C99F7D4BCDF5793E01B9EB59BA89 /* Content.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Content.swift; sourceTree = "<group>"; };
-		4AA5F22D270953E5CEAD29BE54F6F305 /* ApayaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApayaTokenizationViewModel.swift; sourceTree = "<group>"; };
-		4B19A54D227949ACC847904D7F9C6BEB /* PrimerCheckoutQRCodeInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCheckoutQRCodeInfo.swift; sourceTree = "<group>"; };
-		4C927AFD8E72E0A7EE2814F1716E37BA /* when.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = when.swift; sourceTree = "<group>"; };
-		4CD7B9DE66B36FC501E03FE83C88329D /* PrimerUIImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUIImage.swift; sourceTree = "<group>"; };
-		4D268AD02ED69536B16928179380A7B5 /* SuccessMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuccessMessage.swift; sourceTree = "<group>"; };
-		4D2ECACF0E03330C7C331270B918C78B /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = "zh-CN.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		4DDCF00E3E0AD992D1C7DBDE77038D7C /* VaultService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultService.swift; sourceTree = "<group>"; };
-		4E71C583C1969BCCAAADC61A5C25C16A /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
-		4F6618008B201E5110B04678DF9385E9 /* PrimerRootViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRootViewController.swift; sourceTree = "<group>"; };
-		4FD32028FD5BF0AEA431D16151440339 /* Identifiable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
+		44162EBABABA5203CEA22C4AD66FDEA9 /* Cancellable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
+		463AC2D355BEA8F77BF070B1071D107D /* PrimerPaymentPendingInfoViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPaymentPendingInfoViewController.swift; sourceTree = "<group>"; };
+		46B3EA56B0956E1AF30EDF2B734CE19C /* fa.json */ = {isa = PBXFileReference; includeInIndex = 1; path = fa.json; sourceTree = "<group>"; };
+		4771BAAA633C309EACC1EB3E2FCD159F /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ms.lproj/Localizable.strings; sourceTree = "<group>"; };
+		47F357409294319906FBAF58233E2080 /* Weak.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Weak.swift; sourceTree = "<group>"; };
+		4832C2449FCB88FB90840BFAFD2F8920 /* eu.json */ = {isa = PBXFileReference; includeInIndex = 1; path = eu.json; sourceTree = "<group>"; };
+		496A63B242FDB61ECDFCAFFACE55FFD7 /* PostalCodeField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostalCodeField.swift; sourceTree = "<group>"; };
+		49C842A7DBF96DDC64E5EF713CFA9999 /* PaymentMethodTokenizationViewModel+Logic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PaymentMethodTokenizationViewModel+Logic.swift"; sourceTree = "<group>"; };
+		4A976165D788F0CD483FCDE40AFD93D6 /* uk.json */ = {isa = PBXFileReference; includeInIndex = 1; path = uk.json; sourceTree = "<group>"; };
+		4B18BAA9E78106A09D434DF7792F0632 /* no.json */ = {isa = PBXFileReference; includeInIndex = 1; path = no.json; sourceTree = "<group>"; };
+		4C1A622C0E32F4C7F85CBF2F78B95636 /* CardButtonViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardButtonViewModel.swift; sourceTree = "<group>"; };
+		4C3E1CBC5614C1FA19A1770150551171 /* VersionUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VersionUtils.swift; sourceTree = "<group>"; };
+		4C87A27D9176D689333D6F72470419B6 /* PrimerSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSource.swift; sourceTree = "<group>"; };
+		4C9A28C3BCAEFE9BD5AB757E551C3293 /* el.json */ = {isa = PBXFileReference; includeInIndex = 1; path = el.json; sourceTree = "<group>"; };
+		4D94D6F1EA8ABFBD1EC98BB93CF85248 /* AES256.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AES256.swift; sourceTree = "<group>"; };
+		4E4142BE00050FEA8E2151E032C95729 /* PrimerInputViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInputViewController.swift; sourceTree = "<group>"; };
+		4E530B50E3299919F005E3567B4CA23E /* ms.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ms.json; sourceTree = "<group>"; };
+		4E8EFDD6D1662B6CC455CEC9599268B8 /* NSObject+ClassName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSObject+ClassName.swift"; sourceTree = "<group>"; };
 		4FDC593A82D77E5EF706A60594B1B94C /* Primer3DS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Primer3DS-prefix.pch"; sourceTree = "<group>"; };
-		5183A3A34BBBB945AE29667C7553B603 /* el.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = el.json; sourceTree = "<group>"; };
-		5241D5AB36F0290E407D6A25D1058C04 /* Notification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
-		529B61E5B348E049881C610F2A08C40F /* KlarnaTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KlarnaTokenizationViewModel.swift; sourceTree = "<group>"; };
-		5329A0B8367E43F6DE39ABE055E9D040 /* tt.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = tt.json; sourceTree = "<group>"; };
-		5335514016E0A6B50E5A03D318A7CC71 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
-		540DEED9BBAEB1E131517E332CA97BF0 /* PaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
-		54AB737F3043554978BCE0BD76000729 /* phone_number_country_codes.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = phone_number_country_codes.json; sourceTree = "<group>"; };
-		5536D76A02FB86E84689A5D3B051CBDA /* zh-KH.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = "zh-KH.json"; sourceTree = "<group>"; };
-		559CE23A5F2B394A14101BA2F258C75A /* ta.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ta.json; sourceTree = "<group>"; };
-		5602C99E5A9BBF31FEE8709F61A81EF8 /* vi.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = vi.json; sourceTree = "<group>"; };
-		56B368F810A2AB543CC374D7AC273A20 /* sk.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sk.json; sourceTree = "<group>"; };
-		56CB9647CC8CDA9763FAE921DACC3E1F /* PrimerSource.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSource.swift; sourceTree = "<group>"; };
-		5707CA8EF477DEEB8CB41B18726CB8E5 /* RateLimitedDispatcherBase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RateLimitedDispatcherBase.swift; sourceTree = "<group>"; };
-		571542B6D7831B459B37FF0196AC9727 /* Field.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Field.swift; sourceTree = "<group>"; };
+		4FE10E4416F253ED2F8A7562226504A3 /* az.json */ = {isa = PBXFileReference; includeInIndex = 1; path = az.json; sourceTree = "<group>"; };
+		507817C410C9D8FAE22BCC637B8AE857 /* PrimerMultibancoCheckoutAdditionalInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerMultibancoCheckoutAdditionalInfo.swift; sourceTree = "<group>"; };
+		511523BE2DE03BF88740C3B799E7E8E8 /* version.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = version.swift; path = Sources/PrimerSDK/Classes/version.swift; sourceTree = "<group>"; };
+		517718981FB204D4344CF16DA72C1765 /* NativeUIManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NativeUIManager.swift; sourceTree = "<group>"; };
+		524E15085489715E24AB2EEDFA319E33 /* BankSelectorViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BankSelectorViewController.swift; sourceTree = "<group>"; };
+		52F16846F426A104F596734101DA7B30 /* ClientSessionActionsModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientSessionActionsModule.swift; sourceTree = "<group>"; };
+		53BF9A4F2B75AA0E6AE8CD0E127A3C8B /* Thenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Thenable.swift; sourceTree = "<group>"; };
+		543B41C5C2EDE9AA3BB42EB5694F0714 /* AnalyticsService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
+		546760DB141F1C41C74B89B193EED62D /* NetworkService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
+		54D981578A2AB7D51245C718C5A2981B /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = "zh-TW.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		565C2F154D3AF2C4CF0567D742493C93 /* PrimerRawRetailerDataTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawRetailerDataTokenizationBuilder.swift; sourceTree = "<group>"; };
+		5695576113B7185E09733A9CD2E2F320 /* PrimerInternal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInternal.swift; sourceTree = "<group>"; };
 		5765DC8F588CF473C2FFA0F6182C0D8A /* PrimerIPay88MYSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PrimerIPay88MYSDK-Info.plist"; sourceTree = "<group>"; };
-		576918A6C15D07BD412AAF448EA54616 /* PrimerTheme+Borders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Borders.swift"; sourceTree = "<group>"; };
-		57F087DB1B37A42AFDE479741B0685DB /* UIScreenExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIScreenExtension.swift; sourceTree = "<group>"; };
-		5857FE9CD25823EAB3D2A307A82BE32A /* ml.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ml.json; sourceTree = "<group>"; };
-		58D0B252742894B8F436E2D6226EE52E /* th.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = th.json; sourceTree = "<group>"; };
-		5B0FE5BEF2FD855A8FF77C7511E26F6D /* tg.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = tg.json; sourceTree = "<group>"; };
-		5B711EB42C8FFABADACBF36D08837634 /* sw.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sw.json; sourceTree = "<group>"; };
-		5C7DE3C637C159DD04B51F8624B44624 /* PrimerDemo3DSViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerDemo3DSViewController.swift; sourceTree = "<group>"; };
-		5CDA794A6B5D0DDDEC3CDCA3E9C09451 /* version.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = version.swift; path = Sources/PrimerSDK/Classes/version.swift; sourceTree = "<group>"; };
-		5D7A695188A525A8B0AB1A92A82EAE48 /* BankSelectorTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BankSelectorTokenizationViewModel.swift; sourceTree = "<group>"; };
-		5E00F164B68EF354AADE291BF744C3F3 /* after.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = after.swift; sourceTree = "<group>"; };
-		5E54933A4E92ADB9FFE676EAE0DF5E91 /* UniversalCheckoutViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UniversalCheckoutViewModel.swift; sourceTree = "<group>"; };
-		5EB4E9AA4460DB6E3B6C1B7BF6D21C53 /* PrimerPhoneNumberData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPhoneNumberData.swift; sourceTree = "<group>"; };
-		6098CE9116BFC3845DD96AD652C04E36 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
-		61E7AFAA58AAFA31C00BACCCF8559AC5 /* QRCodeViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeViewController.swift; sourceTree = "<group>"; };
-		626D728BC82242ED9E4EC34D4ABC2559 /* KlarnaMobileSDK.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = KlarnaMobileSDK.xcframework; path = ios/XCFramework/full/universal/KlarnaMobileSDK.xcframework; sourceTree = "<group>"; };
+		576786592FCD001C69C87A203233A0A3 /* PrimerAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPI.swift; sourceTree = "<group>"; };
+		5929A82D3FF45FCDE5E499D31F7CC018 /* UINavigationController+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Extensions.swift"; sourceTree = "<group>"; };
+		595EBEC18007F19642E3E4E4ACE00323 /* ko.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ko.json; sourceTree = "<group>"; };
+		5ADE0FE7A381434782E85FE2976D0815 /* PrimerTextFieldView+Analytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTextFieldView+Analytics.swift"; sourceTree = "<group>"; };
+		5B76A46C31B6739890DE6910AD4BF0EC /* ClientSession.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientSession.swift; sourceTree = "<group>"; };
+		5BA577DA087EFF27F914174F351FCCE6 /* zh.json */ = {isa = PBXFileReference; includeInIndex = 1; path = zh.json; sourceTree = "<group>"; };
+		5E793ED0ECBAA79C40A4F80E1E28E3B6 /* AlertController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AlertController.swift; sourceTree = "<group>"; };
+		600403423B116C4F1A1383A4FAB1FED6 /* ErrorHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
+		6004A806CCD76E18FB5EE6B48C22BA33 /* PrimerPaymentMethodType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPaymentMethodType.swift; sourceTree = "<group>"; };
+		60814F9665A72583B5620F2418C11EF6 /* PrimerIntegrationOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerIntegrationOptions.swift; sourceTree = "<group>"; };
+		60FE8FC3ABBE39B2E52060DF3AC064DC /* Endpoint.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
+		6124368491C700E91F5E7FFF9F75ACC6 /* sd.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sd.json; sourceTree = "<group>"; };
+		61A15B1951AF9CFA64C9A09F47AA0250 /* PrimerTextFieldView.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = PrimerTextFieldView.xib; sourceTree = "<group>"; };
+		61F7412D45858B66147EECAEDA4AD2F0 /* HeaderFooterLabelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HeaderFooterLabelView.swift; sourceTree = "<group>"; };
+		626D728BC82242ED9E4EC34D4ABC2559 /* KlarnaMobileSDK.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = KlarnaMobileSDK.xcframework; path = ios/XCFramework/full/universal/KlarnaMobileSDK.xcframework; sourceTree = "<group>"; };
 		626ED1D07DD4BE16F1861F5747FECFEA /* PrimerKlarnaSDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PrimerKlarnaSDK-dummy.m"; sourceTree = "<group>"; };
-		62A18C33E8EA3177FFB8E9F460AA11C3 /* PayPal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPal.swift; sourceTree = "<group>"; };
-		62C19D32F3F0BAF184A5959FDA7AD8BA /* PrimerCardRedirectData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardRedirectData.swift; sourceTree = "<group>"; };
-		63C72E6699818410EB0A9F8081A9EC1E /* zh-TW.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = "zh-TW.json"; sourceTree = "<group>"; };
-		64B6B05ABD3E84D51BBFF140D357117F /* URLExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLExtension.swift; sourceTree = "<group>"; };
+		62C187F5DFF3075C9D1790B79AA29905 /* AnyCodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
+		631718A3A98AB5B6B06E017715D36CE9 /* ExpiryDateField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExpiryDateField.swift; sourceTree = "<group>"; };
+		63743788C48EF14DE94A4FD85C978A68 /* RawDataManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RawDataManager.swift; sourceTree = "<group>"; };
+		637B454A256CADC4D8EFD5280ED58548 /* ha.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ha.json; sourceTree = "<group>"; };
+		6383DB335D5FFC48AB5AA7144C06A0FC /* UniversalCheckoutViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UniversalCheckoutViewModel.swift; sourceTree = "<group>"; };
 		64C256376B658E0EEEAD460E6A30370D /* Pods-Debug App Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Debug App Tests.modulemap"; sourceTree = "<group>"; };
 		64CB452411D8A47E63F1EBD0B6DE437B /* Primer3DS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = Primer3DS.modulemap; sourceTree = "<group>"; };
 		64CBFA62F2D6AAF317BC06264BE89578 /* Primer3DS-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Primer3DS-Info.plist"; sourceTree = "<group>"; };
-		651FF45F7CE8B91761113CF106217967 /* PrimerScrollView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerScrollView.swift; sourceTree = "<group>"; };
+		64E5CBA74B8AE23B563020A92BE93851 /* PrimerStackVIew.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerStackVIew.swift; sourceTree = "<group>"; };
+		650C7E386F269F18AC1CE5E91E8C3FE7 /* ImageName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageName.swift; sourceTree = "<group>"; };
 		65B624EBF5412516975BDAF22E1D53D9 /* Pods-Debug App-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Debug App-umbrella.h"; sourceTree = "<group>"; };
-		65EEC09164AC46A490D889A4B3A4E875 /* BundleExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
-		661B567C4810A935CFBA7E116438230C /* tr.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = tr.json; sourceTree = "<group>"; };
-		666D95E8D4302FED5DF81F797FFBB301 /* PrimerTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTableViewCell.swift; sourceTree = "<group>"; };
-		67D4FB0F9B75B23896A5A80E46D02369 /* lv.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = lv.json; sourceTree = "<group>"; };
+		65D17BC7C360E6C19D00E5F3146AA284 /* RecoverWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecoverWrappers.swift; sourceTree = "<group>"; };
 		67F9DF091B832A01099152CA0D21E5E2 /* PrimerKlarnaError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimerKlarnaError.swift; path = PrimerKlarnaSDK/Classes/PrimerKlarnaError.swift; sourceTree = "<group>"; };
-		6813F8F686CB86F947CFCA3AA6A59FD5 /* ErrorHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
-		6942EEB75589F8096F31A852E985DC5A /* PrimerTextFieldView+Analytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTextFieldView+Analytics.swift"; sourceTree = "<group>"; };
-		6A7BBE63AFAE496E1D588F9F8EE93954 /* PrimerLastNameFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerLastNameFieldView.swift; sourceTree = "<group>"; };
-		6B4D87C0A157CA00A9525CF0D0EE4B38 /* PrimerRawCardDataRedirectTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawCardDataRedirectTokenizationBuilder.swift; sourceTree = "<group>"; };
-		6B5A8E285FB2A6884A07A5FF0B847E32 /* PrimerContainerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerContainerViewController.swift; sourceTree = "<group>"; };
-		6BC822C374C92D20C25D1DB80CE6930F /* PrimerTheme+Inputs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Inputs.swift"; sourceTree = "<group>"; };
-		6BDE2DE281F0EABFABF487C99974EC99 /* ThenableWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThenableWrappers.swift; sourceTree = "<group>"; };
-		6C6281B16544CCC7823F456512C67B53 /* Promise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
-		6C80A02EA38330B87DF2A01E76DA99CF /* AddressField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddressField.swift; sourceTree = "<group>"; };
-		6CAF284EDC26FEF7841A7544FE7A32BF /* SequenceWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SequenceWrappers.swift; sourceTree = "<group>"; };
+		68A1B21616905897DE02509A7829E281 /* es.json */ = {isa = PBXFileReference; includeInIndex = 1; path = es.json; sourceTree = "<group>"; };
+		68A425DF08E1F6DC50BF7F38E3A29991 /* PrimerCardData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardData.swift; sourceTree = "<group>"; };
+		69751B148853A2C903CA0E5D360F71CB /* CardButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardButton.swift; sourceTree = "<group>"; };
+		697F562017C7745AC1D8B516C087C7BE /* PaymentMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethod.swift; sourceTree = "<group>"; };
+		6A5084423FF5D474B7098BAF76BCC636 /* PaymentAPIModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentAPIModel.swift; sourceTree = "<group>"; };
+		6AB959C423AD7C3414D505E8DEC2C0F6 /* StrictRateLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StrictRateLimitedDispatcher.swift; sourceTree = "<group>"; };
+		6B0806BEFC9CC9998C48890016E52486 /* nl.json */ = {isa = PBXFileReference; includeInIndex = 1; path = nl.json; sourceTree = "<group>"; };
+		6BA2A455CF52819239E4F86D36167A86 /* IntExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntExtension.swift; sourceTree = "<group>"; };
+		6BEC3EB132704A13BD7DB3EAC4E6C727 /* CheckoutModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckoutModule.swift; sourceTree = "<group>"; };
+		6C95796455CC521C8FF7C205F92B0EED /* PrimerLocaleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerLocaleData.swift; sourceTree = "<group>"; };
+		6CDDAD82B1C38F0BE836D756E5A56CC7 /* AnyEncodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		6DA2540D3BC7689BF9C7C5B4C5D639DD /* Primer3DS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Primer3DS.release.xcconfig; sourceTree = "<group>"; };
-		6E2D380EA6458429CFE29C01BD613DA1 /* ClientSessionAPIModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientSessionAPIModel.swift; sourceTree = "<group>"; };
-		70248D6685AE5AFEA64D59F62D4A16C8 /* zh.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = zh.json; sourceTree = "<group>"; };
-		703B7306E142EC188CB5862A3386412B /* UserInterfaceModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserInterfaceModule.swift; sourceTree = "<group>"; };
+		6DD3ECFAF50DF47E3F4EBE777CEF518B /* Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		6E149402472998D402CC08A36B9ED04E /* when.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = when.swift; sourceTree = "<group>"; };
+		6EC48B5C87BC19DD44808313ED2011ED /* so.json */ = {isa = PBXFileReference; includeInIndex = 1; path = so.json; sourceTree = "<group>"; };
+		6ED7263654A9F15F9AA18ADCEDDFD5A6 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		70D18DEBD3D9202B61D938D18A963228 /* Pods-Debug App-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Debug App-Info.plist"; sourceTree = "<group>"; };
-		70DE611C78184781092429D859F017EB /* PrimerAPI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPI.swift; sourceTree = "<group>"; };
+		7152E639D865A2AB5D0E967175881AA7 /* firstly.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = firstly.swift; sourceTree = "<group>"; };
+		715B7A9737972FC4CFF322C9D09BA162 /* PrimerNibView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNibView.swift; sourceTree = "<group>"; };
+		717DD5F963C60F4088A44B483EE5A52F /* StateField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StateField.swift; sourceTree = "<group>"; };
+		71AD1E849E719DD50A376226ECBBEED3 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		71CB22A248E6C3F8A502B7539BBCF73C /* PrimerPhoneNumberData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPhoneNumberData.swift; sourceTree = "<group>"; };
 		71E9852D0BF43427B1E42FB955765872 /* PrimerIPay88MYSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerIPay88MYSDK.release.xcconfig; sourceTree = "<group>"; };
-		72E7D5002DB55BB9F9632D427714BB4D /* CityField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CityField.swift; sourceTree = "<group>"; };
-		74175679E2F8D1320AF2DCCF0D19A0C1 /* Strings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
-		74FD99B3B52E4F690CAB441EDBA07126 /* VoucherValue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoucherValue.swift; sourceTree = "<group>"; };
-		752B234AD397FFDF2C3E7ABB54273544 /* Klarna.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Klarna.swift; sourceTree = "<group>"; };
-		75802316C029BB1D2F3FA33D0890975A /* UserAgent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
-		768DFADB4567BC5D42C0BE71D3D87CCA /* PrimerTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTheme.swift; sourceTree = "<group>"; };
-		76E3578E4B628CC91F9BC1B6C5C4FC73 /* ExpiryDateField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExpiryDateField.swift; sourceTree = "<group>"; };
-		7731D330DFFDE5BDB7262CBFE75CFA39 /* ku.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ku.json; sourceTree = "<group>"; };
-		77D77D924D9D8A4F3B31A8DC78BC7214 /* PrimerSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSettings.swift; sourceTree = "<group>"; };
-		783C2198F3C3B9492F9BE43E191B8507 /* CardNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardNetwork.swift; sourceTree = "<group>"; };
-		7851B1E6D972B53FDD5C84DEA2B2BA94 /* PrimerCustomStyleTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCustomStyleTextField.swift; sourceTree = "<group>"; };
+		7204F6CB5015623899D7FD0266BAEC8A /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
+		72CFC4735220124F1C27518F5795CCFF /* PrimerCardNumberFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardNumberFieldView.swift; sourceTree = "<group>"; };
+		747C2640DE0A63351A972AE55921A08F /* PrimerError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerError.swift; sourceTree = "<group>"; };
+		7510600267C94A917C4B694DD9FC8A8B /* et.json */ = {isa = PBXFileReference; includeInIndex = 1; path = et.json; sourceTree = "<group>"; };
+		75A1840CD1E5769FED0C402B1E716879 /* PayPal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPal.swift; sourceTree = "<group>"; };
+		76212726E96FAB1AEA9D22D13D8B2A26 /* PrimerViewExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerViewExtensions.swift; sourceTree = "<group>"; };
+		7715BCA22D1D7480C14034B239384E02 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		772B0F5796A2BAB9581DDF873202F9B9 /* PrimerTestPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTestPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
+		7751272A63728477FCB85DBF6D24C41F /* PrimerAPIConfigurationModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPIConfigurationModule.swift; sourceTree = "<group>"; };
+		77C82FF4240C6EBBC2703286D663E3FC /* _PaymentAPIModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = _PaymentAPIModel.swift; sourceTree = "<group>"; };
+		7871C4AE895FF13DD22FCB53C2D9DF23 /* PrimerLastNameFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerLastNameFieldView.swift; sourceTree = "<group>"; };
 		788823208848A5A159A527490F431C70 /* PrimerKlarnaViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimerKlarnaViewController.swift; path = PrimerKlarnaSDK/Classes/PrimerKlarnaViewController.swift; sourceTree = "<group>"; };
-		79B5FDC0D811DD22D438C8299147D10B /* km.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = km.json; sourceTree = "<group>"; };
+		7929645639832C86A4A793856AC218FC /* PrimerResultComponentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerResultComponentView.swift; sourceTree = "<group>"; };
+		7935484F6C5ED13DE9B756AD5CCA7A39 /* PrimerDemo3DSViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerDemo3DSViewController.swift; sourceTree = "<group>"; };
+		794A84E32A1C21271E3B869D970535BB /* sk.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sk.json; sourceTree = "<group>"; };
+		79520503C17021C8D802355B38DBA688 /* Apaya.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Apaya.swift; sourceTree = "<group>"; };
+		798185C0AAF883967105163189763B53 /* PrimerCVVFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCVVFieldView.swift; sourceTree = "<group>"; };
+		79FEB8CEBD39C9AEB4C37603C20372C4 /* it.json */ = {isa = PBXFileReference; includeInIndex = 1; path = it.json; sourceTree = "<group>"; };
+		7AA827D84EFC754C68CE6709D40AB093 /* PrimerPaymentMethodManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPaymentMethodManager.swift; sourceTree = "<group>"; };
+		7B53B2736E88AB8E197388914CF53DC8 /* CancellablePromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellablePromise.swift; sourceTree = "<group>"; };
 		7CEAFB01FBCF6405EEA41A57F47836BB /* Primer3DS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Primer3DS-umbrella.h"; sourceTree = "<group>"; };
+		7CFCB01CA35903EB7665DB1CEE88F1CC /* sv.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sv.json; sourceTree = "<group>"; };
+		7D6972E4A97A6A938F9C2CC34E640F90 /* PrimerGenericTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerGenericTextFieldView.swift; sourceTree = "<group>"; };
+		7DDA0306F9F9577B3D634F0D7564BDC5 /* CancellableThenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellableThenable.swift; sourceTree = "<group>"; };
 		7DFB82FC49735A1C87A9ADAF73EBD766 /* PrimerIPay88MYSDK-xcframeworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "PrimerIPay88MYSDK-xcframeworks.sh"; sourceTree = "<group>"; };
-		7E576BDDB4E79A57CE3045FD25A4E450 /* VaultManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultManager.swift; sourceTree = "<group>"; };
-		7E63F745E427E987E09670C63FFB0AAD /* PrimerNavigationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationController.swift; sourceTree = "<group>"; };
-		7E9EF19EBB79EF723BE66B549F0964B7 /* gl.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = gl.json; sourceTree = "<group>"; };
-		7EC9E7DF45F1F430B386960FC32F8DE4 /* ImageManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
-		8065232778925761294C43BC52D3166A /* ArrayExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
-		80CA37C2FE6FB9EFDFFDD60DE151158B /* Queue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
-		810EAC7B6BF98765F2675614D2007FF5 /* sv.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sv.json; sourceTree = "<group>"; };
-		812E080E981922506FDB77AB628466A0 /* ConcurrencyLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConcurrencyLimitedDispatcher.swift; sourceTree = "<group>"; };
-		816A780D0C2C1EFA953A2F9344D73E85 /* PayPalService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalService.swift; sourceTree = "<group>"; };
+		7E3829BFC4A103319826826E33060597 /* hi.json */ = {isa = PBXFileReference; includeInIndex = 1; path = hi.json; sourceTree = "<group>"; };
+		7EA5F939D4E2AE50BF6269EDDAA890A4 /* ky.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ky.json; sourceTree = "<group>"; };
 		81AE82A628E72F5492DD077308038416 /* Primer3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DS.swift; path = Sources/Primer3DS/Classes/Primer3DS.swift; sourceTree = "<group>"; };
-		827092588059F50742C1CF6F40847E91 /* nb.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = nb.json; sourceTree = "<group>"; };
-		8332AEB6F0EF946984EC5330A3BD7049 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = "zh-TW.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		83C62C92B25C4DD650DB6D989A3638B7 /* Dimensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dimensions.swift; sourceTree = "<group>"; };
-		84515E13647664B38A39E91DD35FBCAD /* PrimerSDKIntegrationType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSDKIntegrationType.swift; sourceTree = "<group>"; };
-		8504B12C19D5BE4EC28864CDA892D4EB /* da.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = da.json; sourceTree = "<group>"; };
-		8553901DF5E05FEE1FD261595F9EA449 /* UINavigationController+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Extensions.swift"; sourceTree = "<group>"; };
-		8773AEACAE4EA5CB563B2BE3205E04D9 /* AnalyticsService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
+		82383F3DEAFBE1C349DFE724310C8181 /* ClientToken.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientToken.swift; sourceTree = "<group>"; };
+		825260542897EEC7C355908ED05D63EF /* CardholderNameField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardholderNameField.swift; sourceTree = "<group>"; };
+		8391C5AC38DC9940E6C112E51A37E47C /* zh-TW.json */ = {isa = PBXFileReference; includeInIndex = 1; path = "zh-TW.json"; sourceTree = "<group>"; };
+		8501ED6EC044D3BD2043B3952D8123F5 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = "zh-CN.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		8577639BB5E2ADF2D73E37E2D5645366 /* PrimerCityFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCityFieldView.swift; sourceTree = "<group>"; };
+		8614A4F5C8920A48642780D10DA410C9 /* ReloadDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReloadDelegate.swift; sourceTree = "<group>"; };
+		861B719BB7AC6DCB3267D345ECEC120F /* Optional+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
+		86B1AACEEFA843EB2D72C63081EF0EAB /* PrimerUIManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUIManager.swift; sourceTree = "<group>"; };
+		87394339D5F31F4ED7E321E376ACB274 /* PrimerHeadlessUniversalCheckout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckout.swift; sourceTree = "<group>"; };
+		8743B83727ED04C6EEFB6676A7294731 /* PrimerExpiryDateFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerExpiryDateFieldView.swift; sourceTree = "<group>"; };
 		883415DFDF218C8F2FB7036E78A986FE /* PrimerKlarnaSDK-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "PrimerKlarnaSDK-Info.plist"; sourceTree = "<group>"; };
+		887D600A945B48F43F00E7255BBE5D05 /* PaymentResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentResponse.swift; sourceTree = "<group>"; };
 		888FBD5E97C880FD2A9903DB991B7684 /* PrimerIPay88MYSDK-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerIPay88MYSDK-prefix.pch"; sourceTree = "<group>"; };
-		88BBFB31782058675116A1EF8DF9BD73 /* ReloadDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReloadDelegate.swift; sourceTree = "<group>"; };
-		8B18397CD1BFAF65AECB88E78BAC0ADD /* StateField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StateField.swift; sourceTree = "<group>"; };
-		8B91C4014A12B7961AD63B9CB1618597 /* PaymentMethodConfigurationOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodConfigurationOptions.swift; sourceTree = "<group>"; };
-		8CE87FB7342A874BC723C9F2B2ED8AB3 /* id.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = id.json; sourceTree = "<group>"; };
-		8E982532F5FBC7DEB03C0F6F70AC0AB7 /* hr.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = hr.json; sourceTree = "<group>"; };
-		8F42F8ED46021BBDDAE4541C3E02327C /* RateLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RateLimitedDispatcher.swift; sourceTree = "<group>"; };
-		8F8BFB4BF6C1343B4ACB13ACA968F483 /* CoreDataDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoreDataDispatcher.swift; sourceTree = "<group>"; };
-		8FB0823F6509EFDB7D3DD9F61B99EDF8 /* DependencyInjection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DependencyInjection.swift; sourceTree = "<group>"; };
-		8FE1F56967A901690D1F1C9ADE944D2F /* VaultPaymentMethodViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodViewModel.swift; sourceTree = "<group>"; };
-		909AE2208208DEE0EA99951B5465CB24 /* EnsureWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EnsureWrappers.swift; sourceTree = "<group>"; };
+		8943A0F753665E1CDE97043C6D0B5144 /* pt.json */ = {isa = PBXFileReference; includeInIndex = 1; path = pt.json; sourceTree = "<group>"; };
+		89CD109AF48504DEE37CFC24F53DACD2 /* VaultManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultManager.swift; sourceTree = "<group>"; };
+		8A401D6CD84605D71981212A4D86A86B /* gl.json */ = {isa = PBXFileReference; includeInIndex = 1; path = gl.json; sourceTree = "<group>"; };
+		8A4347B3D833934D076AC54429CC9C73 /* Mask.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Mask.swift; sourceTree = "<group>"; };
+		8B7E6ADF8985A5ED1D201E6F81423AE8 /* PrimerCheckoutVoucherAdditionalInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCheckoutVoucherAdditionalInfo.swift; sourceTree = "<group>"; };
+		8BDFEEE6924BE67058D42627DB539218 /* AdyenDotPay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AdyenDotPay.swift; sourceTree = "<group>"; };
+		8C1938219645ECD7444E7368C7AE41EC /* PrimerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerViewController.swift; sourceTree = "<group>"; };
+		8C5FF4C72E7E2C6ADD0AA37002B72A81 /* PrimerAPIClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPIClient.swift; sourceTree = "<group>"; };
+		8CE1CD4CA67633AB5538A06FE3789905 /* CityField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CityField.swift; sourceTree = "<group>"; };
+		8E9DE2E33E4E2B002220B36F21D5D087 /* race.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = race.swift; sourceTree = "<group>"; };
+		8EB08C138B9B1F3AE0259F9F24B581AA /* PrimerTheme+Views.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Views.swift"; sourceTree = "<group>"; };
+		8F038A4E81716AB1E8C552E2504CF13C /* VaultPaymentMethodViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodViewController.swift; sourceTree = "<group>"; };
+		8F17EDDF46611F1B4C439953451A6E50 /* Guarantee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Guarantee.swift; sourceTree = "<group>"; };
+		8FE82A5D487EBEF4265FA2504EDEE18A /* PrimerTextFieldView+CardFormFieldsAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTextFieldView+CardFormFieldsAnalytics.swift"; sourceTree = "<group>"; };
+		903452C2F03311E9F54893E00CF2991F /* UserDefaultsExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtension.swift; sourceTree = "<group>"; };
+		90742523FBAD3437CB449483BC9AB6C3 /* PrimerInitializationData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInitializationData.swift; sourceTree = "<group>"; };
+		911B56AB0AD9B3D86A426EEAA4366161 /* PrimerFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFormViewController.swift; sourceTree = "<group>"; };
+		914AEED83D36A581262868890D3DAA85 /* SuccessMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuccessMessage.swift; sourceTree = "<group>"; };
 		915D4D4E7D35CF8478DADF021C562F7F /* Pods-Debug App-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Debug App-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9277A876AC31CA1290A688A1EDB7AB9E /* PrimerCheckoutAdditionalInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCheckoutAdditionalInfo.swift; sourceTree = "<group>"; };
-		931FEB5AEACA42D4B737383BBD69447D /* PostalCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PostalCode.swift; sourceTree = "<group>"; };
-		932B912B4240B649996034B90C5C83CA /* TimerExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimerExtension.swift; sourceTree = "<group>"; };
-		9376E09A9CF791A7E524DAE45024EE8D /* PrimerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerViewController.swift; sourceTree = "<group>"; };
+		91875E09840CF3F6F8CE92360AB26659 /* PrimerTestPaymentMethodViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTestPaymentMethodViewController.swift; sourceTree = "<group>"; };
+		91EF43C3BCF144189A667E7DDC7F6FB9 /* FinallyWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FinallyWrappers.swift; sourceTree = "<group>"; };
+		929B7338F092F3735EFE03928AF9FD3D /* PrimerImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerImageView.swift; sourceTree = "<group>"; };
 		93A25D32A132A902D0DCB08F3A936C0D /* Pods-Debug App.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "Pods-Debug App.modulemap"; sourceTree = "<group>"; };
-		940D103C6AB77833ADB6DD2AED6ABE4D /* PayPalTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalTokenizationViewModel.swift; sourceTree = "<group>"; };
-		949CE6E65977A51E812ED6A48E8401C9 /* PrimerTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextFieldView.swift; sourceTree = "<group>"; };
-		958DF5DC676C76B87FD38B6C4BE484F3 /* it.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = it.json; sourceTree = "<group>"; };
-		96245C913D414469B1B055FE759BCE36 /* Downloader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Downloader.swift; sourceTree = "<group>"; };
+		94616AD54D2F7E38F70D0869C6B5010D /* EnsureWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EnsureWrappers.swift; sourceTree = "<group>"; };
 		967B58577CC95960D03E88A8367394BB /* KlarnaMobileSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = KlarnaMobileSDK.debug.xcconfig; sourceTree = "<group>"; };
-		96E5CD74C7CEF13F144389B9A7954C9C /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
-		971A091B046B3E3D91DE2A49AD38C415 /* ha.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ha.json; sourceTree = "<group>"; };
-		97797B3A826695B50126CEBA1DF3D1C4 /* StrictRateLimitedDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StrictRateLimitedDispatcher.swift; sourceTree = "<group>"; };
-		980024E63BCCDC799A4FB8E643F4B7EE /* bs.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = bs.json; sourceTree = "<group>"; };
-		99342384F60ADE69EAEC663468C5BA21 /* Apaya.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Apaya.swift; sourceTree = "<group>"; };
-		999B0869695391000743FA8993417DE1 /* PrimerImageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerImageView.swift; sourceTree = "<group>"; };
-		9A959FADE6100F477E9A88FBF7BE17B5 /* Logger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		96E5CD74C7CEF13F144389B9A7954C9C /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; path = LICENSE; sourceTree = "<group>"; };
+		970DCB1EDAD600A566534DD364F00A6E /* PrimerRetailerData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRetailerData.swift; sourceTree = "<group>"; };
+		973F4605FB509D06C59F6AB96ED9EDF0 /* da.json */ = {isa = PBXFileReference; includeInIndex = 1; path = da.json; sourceTree = "<group>"; };
+		975ABDB41E168304DC5E0F16A46D5F86 /* PrimerAddressLineFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAddressLineFieldView.swift; sourceTree = "<group>"; };
+		978B4EC5FF8648A451F56A4CB9A64D62 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = "zh-HK.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		97CA75D3D6AA933DE54DC8F409A234CA /* ku.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ku.json; sourceTree = "<group>"; };
+		97FCE2DA2B80A0F125D65996840608AA /* SuccessResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SuccessResponse.swift; sourceTree = "<group>"; };
+		985AF13E3948D7D025AC1B019B99D045 /* tt.json */ = {isa = PBXFileReference; includeInIndex = 1; path = tt.json; sourceTree = "<group>"; };
 		9AAB7DA46BCC03ACEFF4CDD2153279AE /* PrimerSDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerSDK-umbrella.h"; sourceTree = "<group>"; };
 		9ABC4030035F85290FD763D2D6531134 /* Pods-Debug App Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Debug App Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		9B1F3303C4C025BE383B9236FF4CCA51 /* currencies.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = currencies.json; sourceTree = "<group>"; };
 		9C062FCDF5BFF61AE88C845C637AB4D3 /* Pods-Debug App Tests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-Debug App Tests"; path = Pods_Debug_App_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9CEDC7C2CEA211E2F43BE2A99F644487 /* PrimerFormView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFormView.swift; sourceTree = "<group>"; };
-		9D06A2CDE452ACD10D1C7D44B64CB297 /* PrimerUniversalCheckoutViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUniversalCheckoutViewController.swift; sourceTree = "<group>"; };
-		9D78288C113DF70776B53F4AEE36AA99 /* RecoverWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecoverWrappers.swift; sourceTree = "<group>"; };
+		9C496E296853A66EE15500AEA2766747 /* currencies.json */ = {isa = PBXFileReference; includeInIndex = 1; path = currencies.json; sourceTree = "<group>"; };
+		9C68FFDC0DB7E31F13437D793D85EEA8 /* PrimerVaultManagerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultManagerViewController.swift; sourceTree = "<group>"; };
 		9D7C958BD41FAEE38C857055F4768929 /* Pods-Debug App-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Debug App-acknowledgements.plist"; sourceTree = "<group>"; };
-		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		9DA99FE5EE965E84DBF481F457B7FBB8 /* fa.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = fa.json; sourceTree = "<group>"; };
-		9DF67D061C1A24B3FCA790F0F1686FEC /* PrimerError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerError.swift; sourceTree = "<group>"; };
-		9E30A8643A102CCE33849AEF658FA34B /* ps.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ps.json; sourceTree = "<group>"; };
+		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		9E13CEC6801594CE09EE0D4F92DAC184 /* CardFormPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardFormPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
 		9EA4A71D94958A6D770D8022282CF78E /* Pods-Debug App Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Debug App Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		9FD9839D3A21F0287751A379E0C7A708 /* PrimerRawData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawData.swift; sourceTree = "<group>"; };
-		A02784547B176EA2ACAAD8AC90276D48 /* AnyDecodable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
+		9F4DCEC4A50A61283DE3D94B7D7D83CE /* dv.json */ = {isa = PBXFileReference; includeInIndex = 1; path = dv.json; sourceTree = "<group>"; };
+		9F50FE0EBE8CC7823E2C7664244636CC /* BankTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BankTableViewCell.swift; sourceTree = "<group>"; };
+		A01CB8FDA4F59661CDB4F887F79ED7B4 /* PrimerTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTheme.swift; sourceTree = "<group>"; };
 		A093E92ECC60A54E3D72F38ABD8A3DEF /* Pods-Debug App-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Debug App-dummy.m"; sourceTree = "<group>"; };
-		A110D9DDF6D23AC5B92C9F94D65B5F84 /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutPaymentMethod.swift; sourceTree = "<group>"; };
-		A1E5897C9ECB8AC1D141436435B05A6F /* PrimerPaymentMethodType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPaymentMethodType.swift; sourceTree = "<group>"; };
+		A16ADD8E6E4EC877AC44728F26B1DEBB /* hang.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = hang.swift; sourceTree = "<group>"; };
+		A227ACCD0C963316AB914A601C266CD1 /* PrimerCheckoutQRCodeInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCheckoutQRCodeInfo.swift; sourceTree = "<group>"; };
 		A252432FFEB07C24EB6DF2EBF951D32A /* PrimerIPay88MYSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerIPay88MYSDK.debug.xcconfig; sourceTree = "<group>"; };
 		A2B0F5B516F1F27FB337A11ED5BB3CAD /* String+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Helpers.swift"; path = "Sources/Primer3DS/Classes/String+Helpers.swift"; sourceTree = "<group>"; };
-		A2CADC130631DE2358518093D1868771 /* firstly.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = firstly.swift; sourceTree = "<group>"; };
 		A2F1DBC7EC3CE0C7682C1FF340D32CB7 /* KlarnaMobileSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = KlarnaMobileSDK.release.xcconfig; sourceTree = "<group>"; };
+		A3CA173614296EA7DBB395D06223E69A /* PrimerWebViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerWebViewController.swift; sourceTree = "<group>"; };
+		A43A2E4402C1CA752A42AF300D20EAA2 /* XenditRetailOutlets.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = XenditRetailOutlets.swift; sourceTree = "<group>"; };
+		A4545C55DFE17BDBA7005AED27FF9E22 /* mk.json */ = {isa = PBXFileReference; includeInIndex = 1; path = mk.json; sourceTree = "<group>"; };
+		A458D6481F4DE942B95A0A4A062F0A83 /* PrimerCheckoutAdditionalInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCheckoutAdditionalInfo.swift; sourceTree = "<group>"; };
 		A4AAED7379CB520FE9B31015D8D14E60 /* Primer3DS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Primer3DS.debug.xcconfig; sourceTree = "<group>"; };
-		A572AB697E2F05A71DD3D8B2776AD7DC /* TokenizationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationService.swift; sourceTree = "<group>"; };
-		A5AAD964478E927406E375C8674D47C4 /* PaymentMethodsGroupView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodsGroupView.swift; sourceTree = "<group>"; };
-		A61E7B7CCD27CE3F5AFAF67768319512 /* CardholderNameField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardholderNameField.swift; sourceTree = "<group>"; };
-		A6210190AB0CCA765D073F0650BDB241 /* fr.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = fr.json; sourceTree = "<group>"; };
-		A6411C49128C3CFB8AA377695C2104AE /* UIColorExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
-		A6EB9488B303B043EBC9D2CFC453B832 /* ro.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ro.json; sourceTree = "<group>"; };
-		A737E9A220CDE88BDFAFFDFCBB3E6FC8 /* CancellablePromise.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellablePromise.swift; sourceTree = "<group>"; };
+		A4DDC3E610AE18626518A71E64F31FD8 /* ca.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ca.json; sourceTree = "<group>"; };
+		A501D3D16752F32AC3F057D2F8D47E79 /* TimerExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimerExtension.swift; sourceTree = "<group>"; };
+		A6C00E0D3A4D85BDA30C8760990EE13C /* PrimerResultViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerResultViewController.swift; sourceTree = "<group>"; };
+		A6E9F71E24188E053147F98DDAA1D240 /* PrimerFlowEnums.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFlowEnums.swift; sourceTree = "<group>"; };
 		A7E7C922FA3D5E9F00F096D43C00BE9D /* Pods-Debug App-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Debug App-frameworks.sh"; sourceTree = "<group>"; };
-		A868F8F8AE186AD14381696AF523D3E1 /* Keychain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		A888A56ABB4E2264835636822B21D957 /* id.json */ = {isa = PBXFileReference; includeInIndex = 1; path = id.json; sourceTree = "<group>"; };
 		A889FF4523F520564912A3FDA3C91182 /* PrimerIPay88MYSDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerIPay88MYSDK-umbrella.h"; sourceTree = "<group>"; };
+		A88C932B6FC5FAE95C0C752509E0F898 /* PrimerTheme+Inputs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Inputs.swift"; sourceTree = "<group>"; };
 		A8B3BC107C2BDC3C03D961866F721265 /* PrimerSDK-PrimerResources */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "PrimerSDK-PrimerResources"; path = PrimerResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
-		A96C1C2310EE6FE1A26F847E3F502237 /* CancellableCatchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellableCatchable.swift; sourceTree = "<group>"; };
-		AA9C05DD563B3DC1156264E53846CC54 /* ur.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ur.json; sourceTree = "<group>"; };
-		AC15F60DD4F3F7665ED569E4AE16ED4C /* 3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = 3DS.swift; sourceTree = "<group>"; };
-		AC2FF4FF9CA6622553575894E48FF1AB /* VaultedPaymentMethods.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultedPaymentMethods.swift; sourceTree = "<group>"; };
-		ACE756423ACD98DA2114EA9F928D956A /* Colors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
-		ACEBE3BDAA2D803EC20D1C7BF48D6671 /* JSONParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
-		AD7653830962AC27B8ACE623177ABA58 /* CardButtonViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardButtonViewModel.swift; sourceTree = "<group>"; };
-		AE74B9F2D48722B979E0F7CCB0D926CC /* CountryCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryCode.swift; sourceTree = "<group>"; };
-		AE871E7A7628A6EDCB416299F7D5C312 /* WrapperProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WrapperProtocols.swift; sourceTree = "<group>"; };
-		AFED0419F58810B094B045A94F42778F /* pl.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = pl.json; sourceTree = "<group>"; };
-		B070035BEF45F872802D2C617B7BEE8F /* Weak.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Weak.swift; sourceTree = "<group>"; };
+		A8C220F0252DF3030F67739D5D7CFC0C /* he.json */ = {isa = PBXFileReference; includeInIndex = 1; path = he.json; sourceTree = "<group>"; };
+		A9EEC75B7B1B82C1B674974260346A05 /* PrimerFormView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFormView.swift; sourceTree = "<group>"; };
+		AAA4A8CE5D93F1C448697BFBDB16C1AE /* ResumeHandlerProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResumeHandlerProtocol.swift; sourceTree = "<group>"; };
+		AB0DE4CDFEDDADC6C799DCF98FA4027D /* Identifiable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
+		ACDC3243C2E4F76161D1FD8B607AB018 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawPhoneNumberDataTokenizationBuilder.swift; sourceTree = "<group>"; };
+		AD516439159EAF2C4962E9E3EA8A9B41 /* PrimerCardFormViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardFormViewController.swift; sourceTree = "<group>"; };
+		ADE68C0FA4CD2468699A63315D599EA4 /* ApplePay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePay.swift; sourceTree = "<group>"; };
+		AE1B3A54375C99482321E8D936194200 /* Keychain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		AEEA3E008E64C1F5EE29412E44B180F9 /* FormPaymentMethodTokenizationViewModel+FormViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "FormPaymentMethodTokenizationViewModel+FormViews.swift"; sourceTree = "<group>"; };
+		AFAB69FA82453448447AE6944EE6B068 /* ru.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ru.json; sourceTree = "<group>"; };
+		AFEE19A51E07C151053E75A5335CA468 /* UIScreenExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIScreenExtension.swift; sourceTree = "<group>"; };
+		B050FDD714CC6E742FD9B1C5431DE0A2 /* UIDeviceExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIDeviceExtension.swift; sourceTree = "<group>"; };
+		B06C2E58C08ACB95D74FE622FE32A6C3 /* WrapperProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WrapperProtocols.swift; sourceTree = "<group>"; };
+		B06EED324418903E3C84E07B69470750 /* PrimerConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerConfiguration.swift; sourceTree = "<group>"; };
 		B0BD9C15AD36B10902A3BE3A8FD99FE7 /* PrimerKlarnaSDK.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = PrimerKlarnaSDK.modulemap; sourceTree = "<group>"; };
-		B17DF89D13BDE22B8A4D2168769C4E48 /* PrimerRawCardDataTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawCardDataTokenizationBuilder.swift; sourceTree = "<group>"; };
-		B1F7C27DA3C1925E73955990BEF67E0A /* CardNumberField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardNumberField.swift; sourceTree = "<group>"; };
-		B2B221963E70220E6B3394DEF7763AB4 /* CheckoutEventsNotifierModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckoutEventsNotifierModule.swift; sourceTree = "<group>"; };
-		B317B5E77B5E6510922D19F65AA6E8CD /* PaymentMethodTokenizationViewModel+Logic.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PaymentMethodTokenizationViewModel+Logic.swift"; sourceTree = "<group>"; };
-		B41878BCFFB2F0774673FAF76C845093 /* PrimerNavigationBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNavigationBar.swift; sourceTree = "<group>"; };
-		B4A4CE6F1CC363A481904B25055BD090 /* LogEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogEvent.swift; sourceTree = "<group>"; };
-		B5C4ED515E094C4A43320B79DF8524FB /* Guarantee.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Guarantee.swift; sourceTree = "<group>"; };
-		B61DC9B4534E5B21A28E037B2A53A371 /* mn.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = mn.json; sourceTree = "<group>"; };
-		B6BD7F4864DA4F3847A569AE1AC6892C /* PrimerSearchTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSearchTextField.swift; sourceTree = "<group>"; };
-		B6F06C6C20AF0AFB2E34E54D37EB61B9 /* Thenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Thenable.swift; sourceTree = "<group>"; };
-		B72E54D3874156D1405A9599AAAD83E9 /* es.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = es.json; sourceTree = "<group>"; };
-		B79C83472C36ACC8CA5F9E1B0014E4A4 /* uk.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = uk.json; sourceTree = "<group>"; };
-		B7F1D9613A2366B3F5224FB667DD56DE /* PrimerCityFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCityFieldView.swift; sourceTree = "<group>"; };
-		B7F35FC28E43595B3B10E170BB27463E /* UIUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIUtils.swift; sourceTree = "<group>"; };
-		B847413264FC8E4DE2484CEC473289CB /* PrimerSimpleCardFormTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSimpleCardFormTextFieldView.swift; sourceTree = "<group>"; };
-		B866BC8CB195144C70D5613B2260BCFE /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		BA4A4667E5FDDAC93F09F3D2C931362F /* NSErrorExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NSErrorExtension.swift; sourceTree = "<group>"; };
-		BA5F402AF26A5D15C068808791BA701A /* PrimerImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerImage.swift; sourceTree = "<group>"; };
-		BACB9741092B773E390ABBF54027853F /* PrimerLocaleData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerLocaleData.swift; sourceTree = "<group>"; };
-		BB21E1376352DE378AADDC08EFEF7AC3 /* PrimerTheme+TextStyles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+TextStyles.swift"; sourceTree = "<group>"; };
-		BB51DD55C93705722B61C0C1C641F20C /* PrimerAPIConfigurationModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerAPIConfigurationModule.swift; sourceTree = "<group>"; };
-		BBD82A811F119463D9AFE8CF7713F31E /* HeaderFooterLabelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HeaderFooterLabelView.swift; sourceTree = "<group>"; };
-		BC112EEE2F4BA17EEC9EFEFADF148540 /* FinallyWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FinallyWrappers.swift; sourceTree = "<group>"; };
-		BC639942D4366A5AA567E6912B6C66C3 /* PrimerCVVFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCVVFieldView.swift; sourceTree = "<group>"; };
-		BC6E909C3027887A486C44600B79E2C4 /* en.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = en.json; sourceTree = "<group>"; };
-		BD1AC8628545D02AF110941128880271 /* CancellableThenable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancellableThenable.swift; sourceTree = "<group>"; };
-		BD241F41F82B185EBCCAE78E790C9528 /* WebViewUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewUtil.swift; sourceTree = "<group>"; };
-		BD91667428047551AF217B76A0AA3019 /* StringExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
-		BEC2D85A6C68596EFED767F643DE8B23 /* QRCodeTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeTokenizationViewModel.swift; sourceTree = "<group>"; };
-		BED4F9C90B56C0E6349C4371D676C991 /* IPay88TokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IPay88TokenizationViewModel.swift; sourceTree = "<group>"; };
-		BF39310D7B33FA69131E4875E4A13290 /* Mock3DSService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Mock3DSService.swift; sourceTree = "<group>"; };
-		BF50BA2C098F8594D41E91FF6C94A457 /* Decisions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Decisions.swift; sourceTree = "<group>"; };
-		BF5AB512118494BC502B5323CFA02BF0 /* CardButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardButton.swift; sourceTree = "<group>"; };
-		BF7DE13FF2DF199E58D9F85F4BB36999 /* PrimerPaymentMethodManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPaymentMethodManager.swift; sourceTree = "<group>"; };
-		BFE3CDE2B9BE96DC251CEB6FC68EC6E4 /* PrimerConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerConfiguration.swift; sourceTree = "<group>"; };
+		B22B51EE13746464F156E7AC3365C078 /* zh-KH.json */ = {isa = PBXFileReference; includeInIndex = 1; path = "zh-KH.json"; sourceTree = "<group>"; };
+		B30F920C49BE7B4AD210E011736F2818 /* PrimerTheme+Buttons.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Buttons.swift"; sourceTree = "<group>"; };
+		B425735AD0440C017E0D53AFB3789334 /* Primer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Primer.swift; sourceTree = "<group>"; };
+		B44864A6EC767509F172A34423DCDB50 /* PayPalTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalTokenizationViewModel.swift; sourceTree = "<group>"; };
+		B44B13262EA78104B2A50C4D26690A1C /* OrderItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrderItem.swift; sourceTree = "<group>"; };
+		B597C18CE138C83C3EB07E587B1FEE92 /* uz.json */ = {isa = PBXFileReference; includeInIndex = 1; path = uz.json; sourceTree = "<group>"; };
+		B5B8121BE683E18C1BD5CA7EE3581141 /* ArrayExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArrayExtension.swift; sourceTree = "<group>"; };
+		B6944A22CF2313B52996ADC782A2C883 /* Content.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Content.swift; sourceTree = "<group>"; };
+		B7B5660D65829BEF7971C5A60654F1A6 /* ApplePayTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePayTokenizationViewModel.swift; sourceTree = "<group>"; };
+		B86DA92035CFB330FDA160250182919A /* Currency.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Currency.swift; sourceTree = "<group>"; };
+		BA2244D72F2463C99B2B8BEF584E38FE /* Logger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		BA9AB5993CC6ABCE0808A95D838BA535 /* en.json */ = {isa = PBXFileReference; includeInIndex = 1; path = en.json; sourceTree = "<group>"; };
+		BAD688DF63876C2E1AE5B532F18C7D0D /* tg.json */ = {isa = PBXFileReference; includeInIndex = 1; path = tg.json; sourceTree = "<group>"; };
+		BBE9A4BD522623C67BCCB016D50A9029 /* tr.json */ = {isa = PBXFileReference; includeInIndex = 1; path = tr.json; sourceTree = "<group>"; };
+		BC400E34349A965A8870B2ABCA6BB701 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		BC7761C41E744E52D98D8B4B7759A821 /* FormPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
+		BD1470B97657B6C4BDBACC9E553269AD /* lv.json */ = {isa = PBXFileReference; includeInIndex = 1; path = lv.json; sourceTree = "<group>"; };
+		BE0317C27EC0D1EE81480B338605D14E /* ThenableWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThenableWrappers.swift; sourceTree = "<group>"; };
+		BEAE956392261FC2FEF850F716750641 /* QRCodeTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeTokenizationViewModel.swift; sourceTree = "<group>"; };
+		BEE8D111E172A4BCC76ACD0E62DB9972 /* SequenceWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SequenceWrappers.swift; sourceTree = "<group>"; };
+		BEF5C2A116F901093DC28689676D0D7B /* mn.json */ = {isa = PBXFileReference; includeInIndex = 1; path = mn.json; sourceTree = "<group>"; };
+		BFB7686329605392FBCB2FE172FC6126 /* Queue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		C05000A05B1C43ADBCB50A311617CC33 /* PrimerRawCardDataTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawCardDataTokenizationBuilder.swift; sourceTree = "<group>"; };
 		C15924FCA59DFA2A8C5A284117050AAC /* Primer3DSError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSError.swift; path = Sources/Primer3DS/Classes/Primer3DSError.swift; sourceTree = "<group>"; };
-		C15FF3302B2650F6B206E8C98C61B6A4 /* uz.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = uz.json; sourceTree = "<group>"; };
-		C261F7EADFA6BAC30B19D15FC9DD783E /* CustomStringConvertible.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomStringConvertible.swift; sourceTree = "<group>"; };
-		C29E21010341A1863EABED0426192B0C /* PrimerAPIClient+PCI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+PCI.swift"; sourceTree = "<group>"; };
-		C2B4A5EC72F45CCBD072612DD8D0FFD8 /* cy.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = cy.json; sourceTree = "<group>"; };
-		C2E84F0E6CADC0D66E56DE50C04D9C1B /* sl.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sl.json; sourceTree = "<group>"; };
-		C47EC51E5F91302F731C24E676785A2E /* Resolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
+		C15B03C6068D04B239AB92399510FEB5 /* am.json */ = {isa = PBXFileReference; includeInIndex = 1; path = am.json; sourceTree = "<group>"; };
+		C28DA10BB82E4219207E02A998F75394 /* cy.json */ = {isa = PBXFileReference; includeInIndex = 1; path = cy.json; sourceTree = "<group>"; };
+		C3E2546D6816E142BAD4DDA304274D32 /* sr.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sr.json; sourceTree = "<group>"; };
+		C4910CA5607B33113176110B0E7FFDA6 /* GuaranteeWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GuaranteeWrappers.swift; sourceTree = "<group>"; };
+		C4A936EA6139B2FA3457A56E75871EFB /* bs.json */ = {isa = PBXFileReference; includeInIndex = 1; path = bs.json; sourceTree = "<group>"; };
 		C55F57D8EB2561C31E768A27EAE77E37 /* Primer3DSStructures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSStructures.swift; path = Sources/Primer3DS/Classes/Primer3DSStructures.swift; sourceTree = "<group>"; };
-		C5892FD01BAD8F04E4AA744ED4E8DCD7 /* ka.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ka.json; sourceTree = "<group>"; };
-		C5D152F5C198FFCC1BADCADFEE4A9DBB /* DataExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
-		C69E70953DB1701A8251042C30D374FD /* PrimerCountryFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCountryFieldView.swift; sourceTree = "<group>"; };
-		C71C344CC918ADCA293407831E1C5025 /* VaultPaymentMethodView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultPaymentMethodView.swift; sourceTree = "<group>"; };
+		C5A025D9F91E2FF89B8464E303E74DB9 /* after.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = after.swift; sourceTree = "<group>"; };
+		C6068EAFC6DB3D82B549D2C5DF2BC560 /* 3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = 3DS.swift; sourceTree = "<group>"; };
 		C74D9FD357F458A288C717E68E895194 /* Ipay.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Ipay.h; path = PrimerIPay88SDK/Frameworks/Ipay.h; sourceTree = "<group>"; };
-		C96AA8C1AB48CC807A9F245E71E0536B /* AnalyticsEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
-		C9A892EA6945752EE41ED16A748E8593 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
-		C9F9D0BE575001BCCB6589A9BC14F891 /* PrimerTestPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTestPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
-		CAAC1DC0B5F5979EF3D8E6494A9E5713 /* PrimerAPIClient+3DS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+3DS.swift"; sourceTree = "<group>"; };
-		CAFD03D52BC86E04D48749A8276E6435 /* bn.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = bn.json; sourceTree = "<group>"; };
-		CB2D76BD1B8AC84CA2D9720E5345DF1D /* PrimerButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerButton.swift; sourceTree = "<group>"; };
-		CB83F002475DA8C34F8A8E93D336C3C4 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = "zh-HK.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		CDACA4B200F86A610702409F061A2342 /* he.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = he.json; sourceTree = "<group>"; };
-		CF62A4EBA4EDBA912B5ACEB9B84BA64A /* PrimerVaultManagerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultManagerViewController.swift; sourceTree = "<group>"; };
-		CF92DE9C2024A0DCE5088E1DC761A8A5 /* IntExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntExtension.swift; sourceTree = "<group>"; };
-		D03FF889913EE3797E582422BEFFC4E3 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
+		C7C836C26AC3E7BB20F867B3EAF13164 /* Dimensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dimensions.swift; sourceTree = "<group>"; };
+		C804BEAF37C2336475DC11C3E7F65379 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		C82996D3CB228FAD7600248D51F582A7 /* PrimerVaultedCardAdditionalData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultedCardAdditionalData.swift; sourceTree = "<group>"; };
+		C82D3986D0793B70A06C3786EE4EA38F /* PresentationController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PresentationController.swift; sourceTree = "<group>"; };
+		C92CF359D03821C1FE9C01C1CB3D70A5 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		CA0A9B1EE87D12DD49DFECABE956A051 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
+		CA87F9F7F6D7EEE2EE3D9936E8917E91 /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutPaymentMethod.swift; sourceTree = "<group>"; };
+		CBA439F33C6B71CA66767C4D3C657DBF /* ja.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ja.json; sourceTree = "<group>"; };
+		CE6A990031D4592237BFB5289337A600 /* CheckoutEventsNotifierModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckoutEventsNotifierModule.swift; sourceTree = "<group>"; };
+		CFD940992476F2DC358CD251D257F5AA /* CheckoutWithVaultedPaymentMethodViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckoutWithVaultedPaymentMethodViewModel.swift; sourceTree = "<group>"; };
+		D13D585BB4F26D9D79CBE16CBD0B1362 /* pl.json */ = {isa = PBXFileReference; includeInIndex = 1; path = pl.json; sourceTree = "<group>"; };
+		D143DD4A791491A789B0431D6D723989 /* CardNetwork.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardNetwork.swift; sourceTree = "<group>"; };
+		D1A6FCB18ED6D61CB1B602B5C540367D /* Field.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Field.swift; sourceTree = "<group>"; };
+		D213E92F2A057C6223AC3D32D4FAFACF /* PrimerSDKIntegrationType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSDKIntegrationType.swift; sourceTree = "<group>"; };
 		D245E0514AAC1A2B9A6D5EA2F383E90F /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		D24CD24F268D7252CA8F3E99D6CAC1D2 /* PrimerNibView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerNibView.swift; sourceTree = "<group>"; };
-		D258EE2578C0D3E4396FE13FE69516DD /* PrimerHeadlessUniversalCheckout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckout.swift; sourceTree = "<group>"; };
-		D3A7E9C2363E309FB79C2CD38C041213 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		D3D99E723F3EFB3D2C3BE3BD7D65A31E /* nn.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = nn.json; sourceTree = "<group>"; };
-		D54B45F9C5D3FD0C7451109D6DD7C14F /* AppState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
-		D54FA7720C78342B5439459172907A60 /* PrimerVaultedCardAdditionalData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerVaultedCardAdditionalData.swift; sourceTree = "<group>"; };
-		D5AA7F2B319372A3BCC38F1C1FA73FD2 /* dv.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = dv.json; sourceTree = "<group>"; };
-		D5E82976D4CF476DD8CD1853E13FE271 /* lt.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = lt.json; sourceTree = "<group>"; };
-		D64EE816E96456BBED6752EF8A36E8FE /* PrimerCheckoutVoucherAdditionalInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCheckoutVoucherAdditionalInfo.swift; sourceTree = "<group>"; };
-		D6B512BDDA31559E37688AEDA591FA63 /* ApplePay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ApplePay.swift; sourceTree = "<group>"; };
-		D7216679FBF84EF0B6A60C80BEE735FA /* cs.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = cs.json; sourceTree = "<group>"; };
-		D7D904908A5EC60003EC3C0C7137DBBF /* PaymentAPIModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentAPIModel.swift; sourceTree = "<group>"; };
-		D81C1DB85FAF3F49403DF67E2C7D8A5E /* LastNameField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LastNameField.swift; sourceTree = "<group>"; };
-		D86DD8C26E739EFE60DD76F302B92D95 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = el.lproj/Localizable.strings; sourceTree = "<group>"; };
-		D8A42D0CFF172D36E04B660BDEA23C9C /* FormType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormType.swift; sourceTree = "<group>"; };
-		D9D7EA565E96F5A5809133ED8B30E4D3 /* fi.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = fi.json; sourceTree = "<group>"; };
-		DA52BDA0E27F4AC98488EEB595A22985 /* AssetsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetsManager.swift; sourceTree = "<group>"; };
-		DBC487EDD403A3B04E9CE4657D379494 /* PrimerRawRetailerDataTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawRetailerDataTokenizationBuilder.swift; sourceTree = "<group>"; };
-		DC4D8F2C4DC84A5D2246A81EF8201817 /* mk.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = mk.json; sourceTree = "<group>"; };
-		DD562A76991139BF0C87B8B2B6A9280C /* XenditRetailOutlets.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = XenditRetailOutlets.swift; sourceTree = "<group>"; };
+		D31FFABD73529549DD0648E22237ED73 /* URLExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLExtension.swift; sourceTree = "<group>"; };
+		D35194EC2E6CDD5B61472DDC6541EA89 /* PaymentMethodConfigurationOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodConfigurationOptions.swift; sourceTree = "<group>"; };
+		D4C1587E41FF1F893688589214A1F24D /* sl.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sl.json; sourceTree = "<group>"; };
+		D5CA8CA6BB86462451ED4D675CC1E279 /* PrimerUniversalCheckoutViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUniversalCheckoutViewController.swift; sourceTree = "<group>"; };
+		D6674E079526CF6D8F40E80278CC86A2 /* ug.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ug.json; sourceTree = "<group>"; };
+		D6A8A6E0DF6DAFCAFAB8BC61C6252B63 /* FormType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormType.swift; sourceTree = "<group>"; };
+		D6BC88E1C31DC1249EF7119D251BA204 /* de.json */ = {isa = PBXFileReference; includeInIndex = 1; path = de.json; sourceTree = "<group>"; };
+		D6F90BB1D517FA485D4412B287CB3B0E /* ar.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ar.json; sourceTree = "<group>"; };
+		D8A78C9A95D42B03B85DE293D09C6831 /* sw.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sw.json; sourceTree = "<group>"; };
+		D8DAE5650418097986F7404E18C71541 /* WebViewUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewUtil.swift; sourceTree = "<group>"; };
+		D9E3ED96959579BEEE7BAF7E4A95AF12 /* sq.json */ = {isa = PBXFileReference; includeInIndex = 1; path = sq.json; sourceTree = "<group>"; };
+		DA51F072EAFD4C445FA9B718399C82B1 /* PrimerSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSettings.swift; sourceTree = "<group>"; };
+		DC47390466729A45FC745790F6C0900D /* AssetsManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AssetsManager.swift; sourceTree = "<group>"; };
+		DC965C17D86D28EEA7C1247831FB1B27 /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		DCCF5CAD3C150CA38CA653BB6AA19D1B /* Box.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
+		DD49CD925E98AB5EEE20311B70F118A4 /* UserAgent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserAgent.swift; sourceTree = "<group>"; };
 		DE2740CE0C1C407E24C98CDD0225339C /* PrimerKlarnaSDK-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerKlarnaSDK-prefix.pch"; sourceTree = "<group>"; };
-		DE4CA17ABBC956DFB5EBCB1FC341FEF2 /* Cancellable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Cancellable.swift; sourceTree = "<group>"; };
-		E13D715A28E38B1A41D9B3671C0F90CF /* URLSessionStack.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLSessionStack.swift; sourceTree = "<group>"; };
+		DE7654A8A8C6894FB779D817F3C41AB9 /* CatchWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatchWrappers.swift; sourceTree = "<group>"; };
+		DFE48F48CCAA57BABEC5152F8FF0107F /* JSONParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
+		E025A3E214DBB9676536F35385694E5E /* Dispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
+		E14DA91E266DC6F936AFBDDE4DE581DA /* Configuration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		E15ABAE5104151B28FB9FF95ABE5C19B /* Pods-Debug App */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-Debug App"; path = Pods_Debug_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E16B961BCEA56E1E787141DF5A81C0B3 /* PrimerFirstNameFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerFirstNameFieldView.swift; sourceTree = "<group>"; };
-		E1A8D570C8144D1E41B17235A8B0E377 /* EncodingDecodingContainerExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EncodingDecodingContainerExtensions.swift; sourceTree = "<group>"; };
-		E2D9E5496CC150463B46FBF6BD4C5B77 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
-		E43836F7676956C6AE724F137B96A47F /* UserDefaultsExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtension.swift; sourceTree = "<group>"; };
-		E5342C453BE0BC7A67288BB880930860 /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutInputElementDelegate.swift; sourceTree = "<group>"; };
-		E559541AB9C303C0205C05EBBD2103B9 /* PrimerResultViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerResultViewController.swift; sourceTree = "<group>"; };
-		E5655E627608AFA927330EA4F085DC1E /* Consolable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Consolable.swift; sourceTree = "<group>"; };
+		E1ADD94E9D154B6E0E2A53A5D06482DF /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = el.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E20368BA39013F1101C007FC86ACEF0A /* PayPalService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PayPalService.swift; sourceTree = "<group>"; };
+		E232F12546E5C86663B55B942844EFBA /* PrimerTheme+Borders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+Borders.swift"; sourceTree = "<group>"; };
+		E25402AB502E293F91B86FCC719BE0EC /* CancelContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancelContext.swift; sourceTree = "<group>"; };
+		E2FB734F02E472954A35A5B040DA73DB /* AddressField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddressField.swift; sourceTree = "<group>"; };
+		E3CBD0EBF5F5385E9855BC3BAB991474 /* PrimerImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerImage.swift; sourceTree = "<group>"; };
+		E3DA91531A79C93FB543A72149CB5D0F /* be.json */ = {isa = PBXFileReference; includeInIndex = 1; path = be.json; sourceTree = "<group>"; };
+		E3F086A1612812EEB7F60FE75B9F764C /* af.json */ = {isa = PBXFileReference; includeInIndex = 1; path = af.json; sourceTree = "<group>"; };
+		E4C51AE115C965E7B9FD010CCFF9695A /* Device.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
+		E55D99380D990C8DCFB88B73AB599FBC /* cs.json */ = {isa = PBXFileReference; includeInIndex = 1; path = cs.json; sourceTree = "<group>"; };
 		E57599F7963C47B5B97E6FD223D67623 /* PrimerIPay88MYSDK-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "PrimerIPay88MYSDK-dummy.m"; sourceTree = "<group>"; };
-		E644D1C56D1D4998DED55F15CB97E65E /* PrimerTextField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerTextField.swift; sourceTree = "<group>"; };
-		E6E126C004CE794EDFA7032CF6351974 /* ca.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ca.json; sourceTree = "<group>"; };
-		E701688A7539F7F476C08E5EFDB6E654 /* Box.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
-		E748D2D45994BFBE4E57575B230B0427 /* is.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = is.json; sourceTree = "<group>"; };
 		E7ED812FA013CBAC09A203CFBA13CBDC /* PrimerIPay88MYSDK */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PrimerIPay88MYSDK; path = PrimerIPay88MYSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E906FBDA07229BAB789B1402FE3C3585 /* libipay88sdk.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.xcframework; name = libipay88sdk.xcframework; path = PrimerIPay88SDK/Frameworks/libipay88sdk.xcframework; sourceTree = "<group>"; };
-		E90F653BB74E42ECC1D505557700C4F1 /* CheckoutModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CheckoutModule.swift; sourceTree = "<group>"; };
-		E92EE860BD6063D1EE4ACE39842D2A82 /* Parser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
-		EA3E2B044C716428041F1D0811B3020A /* PrimerIntegrationOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerIntegrationOptions.swift; sourceTree = "<group>"; };
-		EA4705153D93FBBBAE0BA4277074112E /* CatchWrappers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CatchWrappers.swift; sourceTree = "<group>"; };
+		E7F8C0AB63EE61A11B45676E80D0BD10 /* ImageManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
+		E8A1682280920C97F800912B01DA37C5 /* PrimerHeadlessUniversalCheckoutProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutProtocols.swift; sourceTree = "<group>"; };
+		E8BAAB2CA6A44B0B15C464EE9CA8C7C5 /* TokenizationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationService.swift; sourceTree = "<group>"; };
+		E906FBDA07229BAB789B1402FE3C3585 /* libipay88sdk.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = libipay88sdk.xcframework; path = PrimerIPay88SDK/Frameworks/libipay88sdk.xcframework; sourceTree = "<group>"; };
 		EAB6F611E86A4758835A715E4B4184F6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		EB97AC5EF0A6842B110FC4438EA50F2B /* Catchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Catchable.swift; sourceTree = "<group>"; };
+		EAF4666584FA7A50B9E8A199F8D4CC3D /* PrimerAPIClient+PCI.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerAPIClient+PCI.swift"; sourceTree = "<group>"; };
+		EC9BE98AD0A498B74ABC35971CBB1EA3 /* PrimerInputElements.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInputElements.swift; sourceTree = "<group>"; };
 		ED14DA1A3C6EA9245818ABFE97E8ED47 /* Primer3DS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Primer3DS-dummy.m"; sourceTree = "<group>"; };
-		ED316D11AA35ACCF831DB7531099B3A4 /* PrimerHeadlessUniversalCheckoutProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutProtocols.swift; sourceTree = "<group>"; };
-		EE90A0AF7BD80B38DC3402043B60F5CD /* PrimerPaymentPendingInfoViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerPaymentPendingInfoViewController.swift; sourceTree = "<group>"; };
-		F0237EB57F7AD1A4F815C165E0EFB038 /* FormPaymentMethodTokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FormPaymentMethodTokenizationViewModel.swift; sourceTree = "<group>"; };
-		F03699522AC2DB5700E4179D /* VersionUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionUtils.swift; sourceTree = "<group>"; };
+		ED3765E6101DD650B9FF36CD06892A83 /* UILocalizableUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UILocalizableUtil.swift; sourceTree = "<group>"; };
+		EF1C199E2CD2B5737740E1C24BC8AA47 /* PrimerRawCardDataRedirectTokenizationBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRawCardDataRedirectTokenizationBuilder.swift; sourceTree = "<group>"; };
+		F037BA6BC4DD15F6950FBE5EC386E10C /* FlowDecisionTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FlowDecisionTableViewCell.swift; sourceTree = "<group>"; };
 		F06F82B7CB435921C318E2F65F16D86F /* Pods-Debug App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Debug App.release.xcconfig"; sourceTree = "<group>"; };
-		F0D277A20A55FD3777A8DB8968C43D82 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
-		F106E4972B36125362E0E9C48D144360 /* ky.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ky.json; sourceTree = "<group>"; };
+		F076F54BD9CE05779AABC4D587EF7D1C /* PrimerUIImage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUIImage.swift; sourceTree = "<group>"; };
+		F09BC433DAF546E65AF30911F263AE73 /* PrimerHeadlessUniversalCheckoutInputElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessUniversalCheckoutInputElement.swift; sourceTree = "<group>"; };
+		F0BAAE6701EBBA54A56BC58E97505F84 /* nb.json */ = {isa = PBXFileReference; includeInIndex = 1; path = nb.json; sourceTree = "<group>"; };
+		F0BDB02350A2F210BF098C93DAD877DB /* PrimerContainerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerContainerViewController.swift; sourceTree = "<group>"; };
+		F0C5A3999803846187EAF8E85921D100 /* vi.json */ = {isa = PBXFileReference; includeInIndex = 1; path = vi.json; sourceTree = "<group>"; };
 		F1188C3FC901946A1FDBE86766A5B95C /* PrimerSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = PrimerSDK.debug.xcconfig; sourceTree = "<group>"; };
 		F18BCB868F3724D32521D544D38E81FF /* PrimerKlarnaSDK-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "PrimerKlarnaSDK-umbrella.h"; sourceTree = "<group>"; };
-		F1E339730CCE3ED7B776D477C2269C47 /* am.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = am.json; sourceTree = "<group>"; };
-		F28575A74077FCF39A3210CFB2F4AE85 /* PrimerSDK.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = PrimerSDK.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		F3813836067E9031CA7259B38E484389 /* NativeUIManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NativeUIManager.swift; sourceTree = "<group>"; };
+		F1ECA51C0DDC3F397B0C117FC191A099 /* Primer3DSErrorContainer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Primer3DSErrorContainer.swift; sourceTree = "<group>"; };
+		F22F17017930269FC0D4E88BB05BEC8E /* URLSessionStack.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = URLSessionStack.swift; sourceTree = "<group>"; };
+		F2601D30CBAD816B246C384DE0E6A35B /* StringExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
+		F28575A74077FCF39A3210CFB2F4AE85 /* PrimerSDK.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; lastKnownFileType = text; path = PrimerSDK.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		F3D88D9E2B7D011FB604E94CDF53ACAC /* Primer3DSSDKProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Primer3DSSDKProvider.swift; path = Sources/Primer3DS/Classes/Primer3DSSDKProvider.swift; sourceTree = "<group>"; };
+		F414173C1C3C202C11A4C20E0BB57ADD /* IPay88TokenizationViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IPay88TokenizationViewModel.swift; sourceTree = "<group>"; };
 		F44E15C725A433194F568EA0DF915951 /* Sequence+Helpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Sequence+Helpers.swift"; path = "Sources/Primer3DS/Classes/Sequence+Helpers.swift"; sourceTree = "<group>"; };
-		F464B2AC0B131BFCE9FFBB964BBB9E21 /* UILocalizableUtil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UILocalizableUtil.swift; sourceTree = "<group>"; };
-		F4BA008515B6E5DB751DCD7290E712B4 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = pt.lproj/Localizable.strings; sourceTree = "<group>"; };
-		F4F8BF23E74B8A9811AF0145DDF82D00 /* PrimerUIManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerUIManager.swift; sourceTree = "<group>"; };
-		F52B6F5E14121C09C0A1D067D35D33C2 /* PollingModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PollingModule.swift; sourceTree = "<group>"; };
-		F7443D3024DCD2FF2616FBE671774A2C /* ug.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = ug.json; sourceTree = "<group>"; };
+		F50EE3344C0E727B6268B6A3C50ECE8C /* Consolable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Consolable.swift; sourceTree = "<group>"; };
+		F517C79AD2636FE2ED0CF5D63F1D294F /* BundleExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
+		F52413C8A5C07398BBC5127429551597 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
+		F528C392D992975CBA53BB67D7133282 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		F5ABAA71946AE923EBDB4FB83DD4E012 /* PrimerScrollView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerScrollView.swift; sourceTree = "<group>"; };
+		F5AE547C4FAFF96DA5F59CEE5E4507F3 /* PrimerCardRedirectData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerCardRedirectData.swift; sourceTree = "<group>"; };
+		F7400A013AEDEF44A971F11CAD1BA407 /* UIUtils.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UIUtils.swift; sourceTree = "<group>"; };
 		F794734B826005672CB694B77118C250 /* Primer3DS-xcframeworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Primer3DS-xcframeworks.sh"; sourceTree = "<group>"; };
+		F7C89BF054E74D49332F76E03F4B2ECD /* CardNumberField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardNumberField.swift; sourceTree = "<group>"; };
 		F7C8B8D5DF70EDE81CC29CD5256B05DC /* Pods-Debug App Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Debug App Tests-umbrella.h"; sourceTree = "<group>"; };
-		F80AB2877BC6D8647D57A95FBA70289E /* ClientSessionActionsModule.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClientSessionActionsModule.swift; sourceTree = "<group>"; };
-		F81B733AB83E11404DA41A994E6DF0E9 /* CVVField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CVVField.swift; sourceTree = "<group>"; };
-		F85C15F141C35AC1BAD8B8D3C74122F7 /* PrimerExpiryDateFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerExpiryDateFieldView.swift; sourceTree = "<group>"; };
-		F8CE6370124F3692D2A038ACE8DA4376 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
-		F91464987A23B4425A1988E1CBC420A3 /* CreateResumePaymentService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CreateResumePaymentService.swift; sourceTree = "<group>"; };
-		F9320FDCA77DBA0E62C540F6DE339266 /* Dispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
-		F9BC26CC87B45CB05FEACEF3F0AA3520 /* PrimerInitializationData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInitializationData.swift; sourceTree = "<group>"; };
-		FA0C1D9987D0E6274C876388CD7B764E /* PrimerRetailerData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerRetailerData.swift; sourceTree = "<group>"; };
-		FA140C6F6C4E7C0563354CB048666AAD /* nl.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = nl.json; sourceTree = "<group>"; };
-		FA236D6CCC7FE519C6A4A34148702342 /* CancelContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CancelContext.swift; sourceTree = "<group>"; };
-		FAD89B0D3B0B712AE738025E0B73D538 /* Optional+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
-		FC3AEB607A42E7813FA5CC05C2E22893 /* FirstNameField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirstNameField.swift; sourceTree = "<group>"; };
-		FCDF6C3A22A8FF7C96EEF514CD7A64D0 /* sd.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; path = sd.json; sourceTree = "<group>"; };
-		FD0935E4B2588CB2DA6A40F62D00F08D /* PrimerInputElements.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerInputElements.swift; sourceTree = "<group>"; };
+		F887E16271844B36888D936B3045E36D /* fr.json */ = {isa = PBXFileReference; includeInIndex = 1; path = fr.json; sourceTree = "<group>"; };
+		F8EE2C72FA1F716181A3C2ED47540C02 /* PrimerThemeData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerThemeData.swift; sourceTree = "<group>"; };
+		F925EFEDD853C9FB5AF827E90ED6C9D5 /* Localizable.strings */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.strings; name = Localizable.strings; path = tr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		F95A46947102FD5D1FF05FA25E6C3E59 /* LogEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LogEvent.swift; sourceTree = "<group>"; };
+		F9CAB132F350CE2AA9EA91A1CCF60526 /* PrimerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerDelegate.swift; sourceTree = "<group>"; };
+		FA811C7A05459AC87527FED5F1BD368E /* CountryTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CountryTableViewCell.swift; sourceTree = "<group>"; };
+		FB24D04FD39B8B5319F6AD122E20A801 /* PrimerTheme+TextStyles.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "PrimerTheme+TextStyles.swift"; sourceTree = "<group>"; };
+		FCEF0628DA33B24DD598C100D141528B /* TokenizationResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenizationResponse.swift; sourceTree = "<group>"; };
 		FD1E076A29F1C07267338334E92B48A9 /* PrimerIPay88.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimerIPay88.swift; path = PrimerIPay88SDK/Classes/PrimerIPay88.swift; sourceTree = "<group>"; };
+		FD66BDF8CA86C83594B4B5985A5C5EFD /* ml.json */ = {isa = PBXFileReference; includeInIndex = 1; path = ml.json; sourceTree = "<group>"; };
 		FE0C1FD24F7ECFA7B9140F323CE3E83D /* PrimerKlarnaSDK */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = PrimerKlarnaSDK; path = PrimerKlarnaSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FF0CB5F76D1C29AF189A924DB990AA56 /* Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
-		FF8026BB771C9833F41AE8BDFDA671FE /* RetailOutletsRetail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RetailOutletsRetail.swift; sourceTree = "<group>"; };
+		FE4C5FEF5E78F5DB0590B5B665402F9E /* PrimerSimpleCardFormTextFieldView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrimerSimpleCardFormTextFieldView.swift; sourceTree = "<group>"; };
+		FE5ECAD1D6B458C0AA5A316A31D577C1 /* DateExtension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
+		FE7D6C0C6AC8F4A135668BDB6C1517CA /* Catchable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Catchable.swift; sourceTree = "<group>"; };
+		FEE6C260E8DFD5CEB5C5BACDB1620BAB /* th.json */ = {isa = PBXFileReference; includeInIndex = 1; path = th.json; sourceTree = "<group>"; };
+		FEFA1832ABD955A4B39AFD5E85F8D49F /* FirstNameField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FirstNameField.swift; sourceTree = "<group>"; };
+		FF5BC25EC635A1BF75DD2781EE799554 /* LastNameField.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LastNameField.swift; sourceTree = "<group>"; };
+		FFA1ACC3B92AF5E7BA2BD4CC83D6BBEE /* EncodingDecodingContainerExtensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EncodingDecodingContainerExtensions.swift; sourceTree = "<group>"; };
 		FFE8CD355A453EF1396E2D5E8E370F7A /* Primer3DS */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Primer3DS; path = Primer3DS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -970,10 +970,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		242555C7735855BCEB0673DF13F49FE1 /* Frameworks */ = {
+		7434B9BBD05C3F5210694B135C8A5A5D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9884039CEB87EFE5BDE56F95FDB60079 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				860DB50528DF2CE07812E52D0E11F2C8 /* Foundation.framework in Frameworks */,
+				B9E993E5D2CBF589A0ADFECF27F9DFC5 /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -993,15 +1002,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D27CC70B1B10E399B8DC40ABF4DA146E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DC7D70C34A16AF2442628468A50DB8E3 /* Foundation.framework in Frameworks */,
-				D9B8AB72D903C3684910C1AD133373AE /* UIKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		D57C7F53C312C715FFDF23FA19702474 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1013,104 +1013,45 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		000CA45554C4565D702DC5948364EFF5 /* API */ = {
+		10776146F8B2AD003E02715AAC44EE62 /* Payment Services */ = {
 			isa = PBXGroup;
 			children = (
-				C5F9EF159569E8D0D992ACC9346871A0 /* Primer */,
+				23D2D8DE65B5AC4A0358B761D4004935 /* CreateResumePaymentService.swift */,
+				E20368BA39013F1101C007FC86ACEF0A /* PayPalService.swift */,
+				7751272A63728477FCB85DBF6D24C41F /* PrimerAPIConfigurationModule.swift */,
+				3D4869523FCF15EA32B37EC87DD6F19A /* VaultService.swift */,
 			);
-			path = API;
+			name = "Payment Services";
+			path = "Payment Services";
 			sourceTree = "<group>";
 		};
-		0493EF5DA7534EE51A3AAF5393A46072 /* PromiseKit */ = {
+		1112231654CC821E058B32F7205A2EFE /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
-				5E00F164B68EF354AADE291BF744C3F3 /* after.swift */,
-				E701688A7539F7F476C08E5EFDB6E654 /* Box.swift */,
-				EB97AC5EF0A6842B110FC4438EA50F2B /* Catchable.swift */,
-				1FEC86D93BAC13455F163218A9C1D20D /* Configuration.swift */,
-				C261F7EADFA6BAC30B19D15FC9DD783E /* CustomStringConvertible.swift */,
-				F9320FDCA77DBA0E62C540F6DE339266 /* Dispatcher.swift */,
-				2E94D787E8A251544ECBAA995DA1E9DD /* Error.swift */,
-				A2CADC130631DE2358518093D1868771 /* firstly.swift */,
-				B5C4ED515E094C4A43320B79DF8524FB /* Guarantee.swift */,
-				211E41E3017C0C184A700A94A3E5AD87 /* hang.swift */,
-				B4A4CE6F1CC363A481904B25055BD090 /* LogEvent.swift */,
-				6C6281B16544CCC7823F456512C67B53 /* Promise.swift */,
-				1A02E51F9DDD9CBB429D9AC7629F987E /* race.swift */,
-				C47EC51E5F91302F731C24E676785A2E /* Resolver.swift */,
-				B6F06C6C20AF0AFB2E34E54D37EB61B9 /* Thenable.swift */,
-				4C927AFD8E72E0A7EE2814F1716E37BA /* when.swift */,
-				871B765E2AF32AED4056327D2AC28A8B /* Cancellation */,
-				B1BB7587E588AB3D40D39783F44D8DCF /* Dispatchers */,
-				160266FC42F0DDC4BDB933101AF1BD60 /* Wrappers */,
+				A3CA173614296EA7DBB395D06223E69A /* PrimerWebViewController.swift */,
 			);
-			path = PromiseKit;
+			name = OAuth;
+			path = OAuth;
 			sourceTree = "<group>";
 		};
-		0680F97659B4FEEABFECADE8CF824132 /* Generic */ = {
+		125BF7342515679E037239059190B1E5 /* Localizable */ = {
 			isa = PBXGroup;
 			children = (
-				1AC0D5435EBA802F72AAD2E73D6F67D8 /* PrimerGenericTextFieldView.swift */,
-				B847413264FC8E4DE2484CEC473289CB /* PrimerSimpleCardFormTextFieldView.swift */,
+				F970CB7C0D80D515A6B60786C926E196 /* Localizable.strings */,
 			);
-			path = Generic;
-			sourceTree = "<group>";
-		};
-		076F0ABEF4D9CB6727F733B27D75F94B /* Constants */ = {
-			isa = PBXGroup;
-			children = (
-				ACE756423ACD98DA2114EA9F928D956A /* Colors.swift */,
-				4904C99F7D4BCDF5793E01B9EB59BA89 /* Content.swift */,
-				83C62C92B25C4DD650DB6D989A3638B7 /* Dimensions.swift */,
-				74175679E2F8D1320AF2DCCF0D19A0C1 /* Strings.swift */,
-			);
-			path = Constants;
-			sourceTree = "<group>";
-		};
-		0C30A86041FA6C60519939331CCE5008 /* Public */ = {
-			isa = PBXGroup;
-			children = (
-				3F972271981C552CAC86D444BA3DE791 /* PrimerThemeData.swift */,
-				0924D8D07A2B8717AEE1B845A2907C21 /* PrimerThemeData+Deprecated.swift */,
-			);
-			path = Public;
-			sourceTree = "<group>";
-		};
-		149F4B88AA09CF9F9BF9A7A6495A15B4 /* Analytics */ = {
-			isa = PBXGroup;
-			children = (
-				1547B16E14281179C5FE685621B67B38 /* Analytics.swift */,
-				C96AA8C1AB48CC807A9F245E71E0536B /* AnalyticsEvent.swift */,
-				8773AEACAE4EA5CB563B2BE3205E04D9 /* AnalyticsService.swift */,
-				323D8195FE7CB72DDEA0EBBF57E27D47 /* Device.swift */,
-			);
-			path = Analytics;
+			name = Localizable;
+			path = Sources/PrimerSDK/Resources/Localizable;
 			sourceTree = "<group>";
 		};
 		153898A58692C494EA369FCAF1CDE801 /* PrimerSDK */ = {
 			isa = PBXGroup;
 			children = (
-				188FC436CA07C1B56ED4C57226612B96 /* Core */,
+				8B69713FE4714583F191334CF3C7E770 /* Core */,
 				CF09FDEDD112D10516F31E67FE070F1D /* Pod */,
 				33793B4DD5B0689D377B219A3AE80DE8 /* Support Files */,
 			);
 			name = PrimerSDK;
 			path = ../..;
-			sourceTree = "<group>";
-		};
-		160266FC42F0DDC4BDB933101AF1BD60 /* Wrappers */ = {
-			isa = PBXGroup;
-			children = (
-				EA4705153D93FBBBAE0BA4277074112E /* CatchWrappers.swift */,
-				909AE2208208DEE0EA99951B5465CB24 /* EnsureWrappers.swift */,
-				BC112EEE2F4BA17EEC9EFEFADF148540 /* FinallyWrappers.swift */,
-				26F9757ABA5220992213CD56B6C1A6E2 /* GuaranteeWrappers.swift */,
-				9D78288C113DF70776B53F4AEE36AA99 /* RecoverWrappers.swift */,
-				6CAF284EDC26FEF7841A7544FE7A32BF /* SequenceWrappers.swift */,
-				6BDE2DE281F0EABFABF487C99974EC99 /* ThenableWrappers.swift */,
-				AE871E7A7628A6EDCB416299F7D5C312 /* WrapperProtocols.swift */,
-			);
-			path = Wrappers;
 			sourceTree = "<group>";
 		};
 		1628BF05B4CAFDCC3549A101F5A10A17 /* Frameworks */ = {
@@ -1127,28 +1068,24 @@
 				E59AE524338A66D328434373B5ECC4BD /* full */,
 				B3770BD74A9165DBC013AC1357AEE513 /* Support Files */,
 			);
+			name = KlarnaMobileSDK;
 			path = KlarnaMobileSDK;
 			sourceTree = "<group>";
 		};
-		188FC436CA07C1B56ED4C57226612B96 /* Core */ = {
+		1A20051D4248404A18F68417DC5A2D14 /* Wrappers */ = {
 			isa = PBXGroup;
 			children = (
-				2B8E34C5AB81858E000094E1562BFE13 /* Icons.xcassets */,
-				5CDA794A6B5D0DDDEC3CDCA3E9C09451 /* version.swift */,
-				47D650B4C2F23A115BBC2F1C9C15A3C7 /* Core */,
-				25C23DCD0FE96933158647895B3EA381 /* Data Models */,
-				5E46380ADEFEA7C1C380AD2016556E8A /* Error Handler */,
-				B9026D51FBB9F2C480F9DFCAAD8EB5FE /* Extensions & Utilities */,
-				B2D815919F5AFA8A49486111E552EEAA /* JSONs */,
-				B854EF59AB1326AB7774184535098F45 /* Localizable */,
-				DB4BDD64573B9E5913B9F61B1DFBC076 /* Modules */,
-				BCA1F4FC261B5795F9EB66A41963E734 /* Nibs */,
-				CD3FEE2C3E183D9F5AC9EA786D044581 /* PCI */,
-				584F7D84C130CC2879755420508B7DAF /* Services */,
-				23593C2D34087C84C5B69EDEC496156D /* Third Party */,
-				D6566FD1F6220FDC81630314E152AB40 /* User Interface */,
+				DE7654A8A8C6894FB779D817F3C41AB9 /* CatchWrappers.swift */,
+				94616AD54D2F7E38F70D0869C6B5010D /* EnsureWrappers.swift */,
+				91EF43C3BCF144189A667E7DDC7F6FB9 /* FinallyWrappers.swift */,
+				C4910CA5607B33113176110B0E7FFDA6 /* GuaranteeWrappers.swift */,
+				65D17BC7C360E6C19D00E5F3146AA284 /* RecoverWrappers.swift */,
+				BEE8D111E172A4BCC76ACD0E62DB9972 /* SequenceWrappers.swift */,
+				BE0317C27EC0D1EE81480B338605D14E /* ThenableWrappers.swift */,
+				B06C2E58C08ACB95D74FE622FE32A6C3 /* WrapperProtocols.swift */,
 			);
-			name = Core;
+			name = Wrappers;
+			path = Wrappers;
 			sourceTree = "<group>";
 		};
 		1CF7E1697D2F513237355D0E5581D8DE /* PrimerIPay88MYSDK */ = {
@@ -1162,79 +1099,93 @@
 				E8986BCA747D691F5B00D6934671BC95 /* Frameworks */,
 				B3B6248A3659FFE79D1FF5FF0278D0EF /* Support Files */,
 			);
+			name = PrimerIPay88MYSDK;
 			path = PrimerIPay88MYSDK;
 			sourceTree = "<group>";
 		};
-		23593C2D34087C84C5B69EDEC496156D /* Third Party */ = {
+		1E56FD068CFE2D6260F9E4FA7A52F979 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
-				0493EF5DA7534EE51A3AAF5393A46072 /* PromiseKit */,
+				0823CBC7355A73F7ED71C1AF4A115F82 /* Colors.swift */,
+				B6944A22CF2313B52996ADC782A2C883 /* Content.swift */,
+				C7C836C26AC3E7BB20F867B3EAF13164 /* Dimensions.swift */,
+				22BC66D3EE583E0B15FC81F85A817ED1 /* Strings.swift */,
 			);
-			name = "Third Party";
-			path = "Sources/PrimerSDK/Classes/Third Party";
+			name = Constants;
+			path = Constants;
 			sourceTree = "<group>";
 		};
-		25C23DCD0FE96933158647895B3EA381 /* Data Models */ = {
+		1FF38A4AE39D2695460167BC06BA8B05 /* Data Models */ = {
 			isa = PBXGroup;
 			children = (
-				185C900448A65C8F0C6739A8080914DB /* _PaymentAPIModel.swift */,
-				43315BD87EB298EC9B0C97E3C22B749D /* AdyenDotPay.swift */,
-				99342384F60ADE69EAEC663468C5BA21 /* Apaya.swift */,
-				D6B512BDDA31559E37688AEDA591FA63 /* ApplePay.swift */,
-				AD7653830962AC27B8ACE623177ABA58 /* CardButtonViewModel.swift */,
-				783C2198F3C3B9492F9BE43E191B8507 /* CardNetwork.swift */,
-				E90F653BB74E42ECC1D505557700C4F1 /* CheckoutModule.swift */,
-				265216BCC916C3783AAD38C074BF98B7 /* ClientSession.swift */,
-				269943DFE2671D1E4DB4BA0ADAC42F3F /* ClientToken.swift */,
-				E5655E627608AFA927330EA4F085DC1E /* Consolable.swift */,
-				AE74B9F2D48722B979E0F7CCB0D926CC /* CountryCode.swift */,
-				158FA9B9DBF1A80235CBB6C292AD3822 /* Currency.swift */,
-				3BB30024C6CE1D203C1A1ECB896CF5CC /* ImageName.swift */,
-				752B234AD397FFDF2C3E7ABB54273544 /* Klarna.swift */,
-				5241D5AB36F0290E407D6A25D1058C04 /* Notification.swift */,
-				22B89EDEC387A04C17D485DA9DBA096E /* OrderItem.swift */,
-				12C71BBF27B01BBE5B854B2CC1B4A651 /* PaymentMethod.swift */,
-				8B91C4014A12B7961AD63B9CB1618597 /* PaymentMethodConfigurationOptions.swift */,
-				37C4A9E16F4E2DAB60510F9F8C696597 /* PaymentResponse.swift */,
-				62A18C33E8EA3177FFB8E9F460AA11C3 /* PayPal.swift */,
-				9277A876AC31CA1290A688A1EDB7AB9E /* PrimerCheckoutAdditionalInfo.swift */,
-				4B19A54D227949ACC847904D7F9C6BEB /* PrimerCheckoutQRCodeInfo.swift */,
-				D64EE816E96456BBED6752EF8A36E8FE /* PrimerCheckoutVoucherAdditionalInfo.swift */,
-				BFE3CDE2B9BE96DC251CEB6FC68EC6E4 /* PrimerConfiguration.swift */,
-				10526B5EF46C2F86753394A25C7D0445 /* PrimerFlowEnums.swift */,
-				F9BC26CC87B45CB05FEACEF3F0AA3520 /* PrimerInitializationData.swift */,
-				EA3E2B044C716428041F1D0811B3020A /* PrimerIntegrationOptions.swift */,
-				BACB9741092B773E390ABBF54027853F /* PrimerLocaleData.swift */,
-				45B781E11A79C388D813B06730D8D4DD /* PrimerMultibancoCheckoutAdditionalInfo.swift */,
-				A1E5897C9ECB8AC1D141436435B05A6F /* PrimerPaymentMethodType.swift */,
-				84515E13647664B38A39E91DD35FBCAD /* PrimerSDKIntegrationType.swift */,
-				77D77D924D9D8A4F3B31A8DC78BC7214 /* PrimerSettings.swift */,
-				D54FA7720C78342B5439459172907A60 /* PrimerVaultedCardAdditionalData.swift */,
-				0292748EAA0F59FF63A048594369AFB0 /* PrimerVaultedPaymentMethodAdditionalData.swift */,
-				FF8026BB771C9833F41AE8BDFDA671FE /* RetailOutletsRetail.swift */,
-				4D268AD02ED69536B16928179380A7B5 /* SuccessMessage.swift */,
-				1EA4574401EEB535ABC2ECC64430D181 /* Throwable.swift */,
-				100E01528D455CA7428CDF87A1F9DCE1 /* TokenizationRequestBody.swift */,
-				105344FCAA5C83C80B929CC49544A9CE /* TokenizationRequestPaymentInstrument.swift */,
-				3BCDD17220E89326943E0B5A24F8505F /* TokenizationRequestPaymentSessionInfo.swift */,
-				0E27177B7CCF2DA6BEAA61936C53BA02 /* TokenizationResponse.swift */,
-				5E54933A4E92ADB9FFE676EAE0DF5E91 /* UniversalCheckoutViewModel.swift */,
-				74FD99B3B52E4F690CAB441EDBA07126 /* VoucherValue.swift */,
-				DD562A76991139BF0C87B8B2B6A9280C /* XenditRetailOutlets.swift */,
-				52969CE43553A9E54E8B97F2799483A3 /* API */,
-				AFF98B27C22001A60C8C0EDD56933048 /* PCI */,
-				CF8D95340ADE9B69D22DF751EC3A7730 /* Theme */,
+				C6068EAFC6DB3D82B549D2C5DF2BC560 /* 3DS.swift */,
+			);
+			name = "Data Models";
+			path = "Data Models";
+			sourceTree = "<group>";
+		};
+		2022DD36CA4DBFFF8F9BF513891BBA9F /* Primer */ = {
+			isa = PBXGroup;
+			children = (
+				69751B148853A2C903CA0E5D360F71CB /* CardButton.swift */,
+			);
+			name = Primer;
+			path = Primer;
+			sourceTree = "<group>";
+		};
+		2573DC7EE0659F315A93B19E8E28E0FD /* Data Models */ = {
+			isa = PBXGroup;
+			children = (
+				77C82FF4240C6EBBC2703286D663E3FC /* _PaymentAPIModel.swift */,
+				8BDFEEE6924BE67058D42627DB539218 /* AdyenDotPay.swift */,
+				79520503C17021C8D802355B38DBA688 /* Apaya.swift */,
+				ADE68C0FA4CD2468699A63315D599EA4 /* ApplePay.swift */,
+				4C1A622C0E32F4C7F85CBF2F78B95636 /* CardButtonViewModel.swift */,
+				D143DD4A791491A789B0431D6D723989 /* CardNetwork.swift */,
+				6BEC3EB132704A13BD7DB3EAC4E6C727 /* CheckoutModule.swift */,
+				5B76A46C31B6739890DE6910AD4BF0EC /* ClientSession.swift */,
+				82383F3DEAFBE1C349DFE724310C8181 /* ClientToken.swift */,
+				F50EE3344C0E727B6268B6A3C50ECE8C /* Consolable.swift */,
+				1DE39D473D3D958AC7473DD88BDEA854 /* CountryCode.swift */,
+				B86DA92035CFB330FDA160250182919A /* Currency.swift */,
+				650C7E386F269F18AC1CE5E91E8C3FE7 /* ImageName.swift */,
+				384310CE541E1E342ADEA8C381CE4CE2 /* Klarna.swift */,
+				2582D5434BE2D2D928A025C6BB6A0CBD /* Notification.swift */,
+				B44B13262EA78104B2A50C4D26690A1C /* OrderItem.swift */,
+				697F562017C7745AC1D8B516C087C7BE /* PaymentMethod.swift */,
+				D35194EC2E6CDD5B61472DDC6541EA89 /* PaymentMethodConfigurationOptions.swift */,
+				887D600A945B48F43F00E7255BBE5D05 /* PaymentResponse.swift */,
+				75A1840CD1E5769FED0C402B1E716879 /* PayPal.swift */,
+				A458D6481F4DE942B95A0A4A062F0A83 /* PrimerCheckoutAdditionalInfo.swift */,
+				A227ACCD0C963316AB914A601C266CD1 /* PrimerCheckoutQRCodeInfo.swift */,
+				8B7E6ADF8985A5ED1D201E6F81423AE8 /* PrimerCheckoutVoucherAdditionalInfo.swift */,
+				B06EED324418903E3C84E07B69470750 /* PrimerConfiguration.swift */,
+				A6E9F71E24188E053147F98DDAA1D240 /* PrimerFlowEnums.swift */,
+				90742523FBAD3437CB449483BC9AB6C3 /* PrimerInitializationData.swift */,
+				60814F9665A72583B5620F2418C11EF6 /* PrimerIntegrationOptions.swift */,
+				6C95796455CC521C8FF7C205F92B0EED /* PrimerLocaleData.swift */,
+				507817C410C9D8FAE22BCC637B8AE857 /* PrimerMultibancoCheckoutAdditionalInfo.swift */,
+				6004A806CCD76E18FB5EE6B48C22BA33 /* PrimerPaymentMethodType.swift */,
+				D213E92F2A057C6223AC3D32D4FAFACF /* PrimerSDKIntegrationType.swift */,
+				DA51F072EAFD4C445FA9B718399C82B1 /* PrimerSettings.swift */,
+				C82996D3CB228FAD7600248D51F582A7 /* PrimerVaultedCardAdditionalData.swift */,
+				141C6965E5C32694A03343BEF0E92AC8 /* PrimerVaultedPaymentMethodAdditionalData.swift */,
+				1A815CA108556A535E26386C83B8C39D /* RetailOutletsRetail.swift */,
+				914AEED83D36A581262868890D3DAA85 /* SuccessMessage.swift */,
+				3B3B5D594811C6D3791379596AE24942 /* Throwable.swift */,
+				109977FD597C2B8FD31B3BD33B2B356C /* TokenizationRequestBody.swift */,
+				0BBA9B8A7380F437830D563CAFC0CE2A /* TokenizationRequestPaymentInstrument.swift */,
+				0247110EB538C01C77850CA1CFF0D9F5 /* TokenizationRequestPaymentSessionInfo.swift */,
+				FCEF0628DA33B24DD598C100D141528B /* TokenizationResponse.swift */,
+				6383DB335D5FFC48AB5AA7144C06A0FC /* UniversalCheckoutViewModel.swift */,
+				043F404DDFA27D969C50608A28EEB47B /* VoucherValue.swift */,
+				A43A2E4402C1CA752A42AF300D20EAA2 /* XenditRetailOutlets.swift */,
+				6CED766219C30F55F140AFF4A9F9C7D5 /* API */,
+				ADEFAC5629B619378A55BE39999B6E3E /* PCI */,
+				A7EB55112B943CCB0BB2C9EB1E22F6C8 /* Theme */,
 			);
 			name = "Data Models";
 			path = "Sources/PrimerSDK/Classes/Data Models";
-			sourceTree = "<group>";
-		};
-		2688D2B93191932BBEBF5E6BC5AA9BFA /* Connectivity */ = {
-			isa = PBXGroup;
-			children = (
-				39747BEC69572C1757907F113F6B19C5 /* Connectivity.swift */,
-			);
-			path = Connectivity;
 			sourceTree = "<group>";
 		};
 		28CBDFB3C4CF4B13FFC4A89754308FEB /* Support Files */ = {
@@ -1252,30 +1203,36 @@
 			path = "../Target Support Files/PrimerKlarnaSDK";
 			sourceTree = "<group>";
 		};
-		2C9E5CBE0AFD68568F730CEA1421411F /* Parser */ = {
+		2B467074626866293D5AB76562AC8C35 /* Banks */ = {
 			isa = PBXGroup;
 			children = (
-				E92EE860BD6063D1EE4ACE39842D2A82 /* Parser.swift */,
+				524E15085489715E24AB2EEDFA319E33 /* BankSelectorViewController.swift */,
+				9F50FE0EBE8CC7823E2C7664244636CC /* BankTableViewCell.swift */,
 			);
-			path = Parser;
+			name = Banks;
+			path = Banks;
 			sourceTree = "<group>";
 		};
-		2ECB21BE2B2BF43072338AF867898037 /* Services */ = {
+		2C610A58679C9117632C65D24E1FE255 /* UI Delegates */ = {
 			isa = PBXGroup;
 			children = (
-				000CA45554C4565D702DC5948364EFF5 /* API */,
-				F183F4030364A6D6AA087BA35BB1A61F /* Network */,
-				4A6950B7CC56CC38FEC802F75E2A77BC /* Parser */,
+				8614A4F5C8920A48642780D10DA410C9 /* ReloadDelegate.swift */,
 			);
-			path = Services;
+			name = "UI Delegates";
+			path = "UI Delegates";
 			sourceTree = "<group>";
 		};
-		31D53FA7E09A790E7EEB0B4240A2B6E2 /* JSON */ = {
+		31586FB4C752D46F45D0BA7260626C7F /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				ACEBE3BDAA2D803EC20D1C7BF48D6671 /* JSONParser.swift */,
+				60FE8FC3ABBE39B2E52060DF3AC064DC /* Endpoint.swift */,
+				546760DB141F1C41C74B89B193EED62D /* NetworkService.swift */,
+				8C5FF4C72E7E2C6ADD0AA37002B72A81 /* PrimerAPIClient.swift */,
+				374EFD57A0283E73FBB80FBF949DB664 /* PrimerAPIClient+Promises.swift */,
+				97FCE2DA2B80A0F125D65996840608AA /* SuccessResponse.swift */,
 			);
-			path = JSON;
+			name = Network;
+			path = Network;
 			sourceTree = "<group>";
 		};
 		33793B4DD5B0689D377B219A3AE80DE8 /* Support Files */ = {
@@ -1294,52 +1251,58 @@
 			path = "Debug App/Pods/Target Support Files/PrimerSDK";
 			sourceTree = "<group>";
 		};
-		349D84704BE9B12C53D2D2A99D7E34E3 /* Primer */ = {
+		35D217E337CBE5A779A90AC08B7362CE /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				D54B45F9C5D3FD0C7451109D6DD7C14F /* AppState.swift */,
-				8FB0823F6509EFDB7D3DD9F61B99EDF8 /* DependencyInjection.swift */,
-				416909675AF7DE52F724EDD75BDE04E8 /* Primer.swift */,
-				19E148415476719682D2C8368A32882D /* PrimerDelegate.swift */,
-				2685D22CAE31BD438AFCFDB151DB700A /* PrimerInternal.swift */,
-				56CB9647CC8CDA9763FAE921DACC3E1F /* PrimerSource.swift */,
-				46C178A25FF859EF537327E90C69CE3F /* ResumeHandlerProtocol.swift */,
-				4D29753161FB67C76BB309AC671DD565 /* Decision Handlers */,
+				F3995BD08F3DDE452A4FC53F2B16FA1D /* 3DS */,
+				D70FEA4D9CCAA7B6265D085FA9053C90 /* Analytics */,
+				D2C61E87F0C3E83CDCD7A89B7129341F /* Connectivity */,
+				1E56FD068CFE2D6260F9E4FA7A52F979 /* Constants */,
+				EEF26DE2DFC899951CC1B5BF293CA02D /* Crypto */,
+				611ACC6687A99B9A76F5EB139BCE385D /* Keychain */,
+				10776146F8B2AD003E02715AAC44EE62 /* Payment Services */,
+				E7205671470293C04694647D441B346B /* Primer */,
+				6072027A785309B67586D4871E4D9CAC /* PrimerHeadlessUniversalCheckout */,
 			);
-			path = Primer;
+			name = Core;
+			path = Sources/PrimerSDK/Classes/Core;
 			sourceTree = "<group>";
 		};
-		3657ECFC9B1AA39BA364A60C4F9D2BFB /* Models */ = {
+		37B1484349450C88EE64B3F13F7AFC9B /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				43AEB5A843B70ED85E8FF9395AD90F72 /* PrimerHeadlessUniversalCheckoutInputElement.swift */,
-				E5342C453BE0BC7A67288BB880930860 /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift */,
-				A110D9DDF6D23AC5B92C9F94D65B5F84 /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift */,
-				FA0C1D9987D0E6274C876388CD7B764E /* PrimerRetailerData.swift */,
+				31586FB4C752D46F45D0BA7260626C7F /* Network */,
+				384829C0C8D6B244035909671949C38A /* Parser */,
 			);
-			path = Models;
+			name = Services;
+			path = Sources/PrimerSDK/Classes/Services;
 			sourceTree = "<group>";
 		};
-		3A70404AA616BFD28BAC5A79415EAA24 /* Payment Method Managers */ = {
+		384829C0C8D6B244035909671949C38A /* Parser */ = {
 			isa = PBXGroup;
 			children = (
-				30D818DA62200FE99F17329E4AD45DDC /* CardComponentsManager.swift */,
-				F3813836067E9031CA7259B38E484389 /* NativeUIManager.swift */,
-				BF7DE13FF2DF199E58D9F85F4BB36999 /* PrimerPaymentMethodManager.swift */,
-				0A9B45FE4B61770CD32006E3F49CCBFB /* RawDataManager.swift */,
+				221F8AC4FACB79EA04ABBC64AA49492B /* Parser.swift */,
 			);
-			path = "Payment Method Managers";
+			name = Parser;
+			path = Parser;
 			sourceTree = "<group>";
 		};
-		3D01F1F169A939D89A537BB50D392CB0 /* 3DS */ = {
+		3B4C8BC289127C1F940B60B4C68AFA93 /* Decision Handlers */ = {
 			isa = PBXGroup;
 			children = (
-				2BDB1A39669149DDD85D9C2D48ACE042 /* 3DSService.swift */,
-				D6B6640B24BE844CED3F2D51BAD33B35 /* Data Models */,
-				A0BB1A8B295DFB412F3F87C014FDB0D1 /* Mock */,
-				BBB9D1FE04554DB9AC20289D7535AED5 /* Networking */,
+				3A075171B6B3301D77D84E221F8DC5E2 /* Decisions.swift */,
 			);
-			path = 3DS;
+			name = "Decision Handlers";
+			path = "Decision Handlers";
+			sourceTree = "<group>";
+		};
+		40366A8866BC14D21EA7D254C235B47C /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+				295658BEB9FC559F1C7C786513AE78EE /* Mock3DSService.swift */,
+			);
+			name = Mock;
+			path = Mock;
 			sourceTree = "<group>";
 		};
 		4111D2CFFAC423CDCD2A600EDA00B829 /* Pods-Debug App Tests */ = {
@@ -1358,89 +1321,64 @@
 			path = "Target Support Files/Pods-Debug App Tests";
 			sourceTree = "<group>";
 		};
-		442144B2C1B83E433FC3F328010C8A8A /* TokenizationViewModels */ = {
+		43F65EF49A7D5D75C503AB0FC0C8C6BB /* TokenizationViewControllers */ = {
 			isa = PBXGroup;
 			children = (
-				4AA5F22D270953E5CEAD29BE54F6F305 /* ApayaTokenizationViewModel.swift */,
-				16DB0A2C906E424C429F09EE8F4236C1 /* ApplePayTokenizationViewModel.swift */,
-				5D7A695188A525A8B0AB1A92A82EAE48 /* BankSelectorTokenizationViewModel.swift */,
-				25C166BF577DFC28F1BF4A07FA174775 /* CheckoutWithVaultedPaymentMethodViewModel.swift */,
-				BED4F9C90B56C0E6349C4371D676C991 /* IPay88TokenizationViewModel.swift */,
-				529B61E5B348E049881C610F2A08C40F /* KlarnaTokenizationViewModel.swift */,
-				540DEED9BBAEB1E131517E332CA97BF0 /* PaymentMethodTokenizationViewModel.swift */,
-				B317B5E77B5E6510922D19F65AA6E8CD /* PaymentMethodTokenizationViewModel+Logic.swift */,
-				940D103C6AB77833ADB6DD2AED6ABE4D /* PayPalTokenizationViewModel.swift */,
-				C9F9D0BE575001BCCB6589A9BC14F891 /* PrimerTestPaymentMethodTokenizationViewModel.swift */,
-				BEC2D85A6C68596EFED767F643DE8B23 /* QRCodeTokenizationViewModel.swift */,
-				3D6C93E9B8E12ADD7F2EAC90F253F50B /* WebRedirectPaymentMethodTokenizationViewModel.swift */,
+				282ED8E294D564E4AD424395536B4383 /* QRCodeViewController.swift */,
 			);
-			path = TokenizationViewModels;
+			name = TokenizationViewControllers;
+			path = TokenizationViewControllers;
 			sourceTree = "<group>";
 		};
-		47D650B4C2F23A115BBC2F1C9C15A3C7 /* Core */ = {
+		45D66F71B0186E3B289B1D2B9DC6A62E /* Text Fields */ = {
 			isa = PBXGroup;
 			children = (
-				3D01F1F169A939D89A537BB50D392CB0 /* 3DS */,
-				149F4B88AA09CF9F9BF9A7A6495A15B4 /* Analytics */,
-				2688D2B93191932BBEBF5E6BC5AA9BFA /* Connectivity */,
-				076F0ABEF4D9CB6727F733B27D75F94B /* Constants */,
-				85B6038EEA97F72CDA27A27CF70C1CEA /* Crypto */,
-				52DC1CB54BF19B61FE5CF0D284C6439E /* Keychain */,
-				AD0B889B9E8784572C27760EAD24028E /* Payment Services */,
-				349D84704BE9B12C53D2D2A99D7E34E3 /* Primer */,
-				74841C71F346CBD84A52C5C58D5D3725 /* PrimerHeadlessUniversalCheckout */,
+				975ABDB41E168304DC5E0F16A46D5F86 /* PrimerAddressLineFieldView.swift */,
+				8577639BB5E2ADF2D73E37E2D5645366 /* PrimerCityFieldView.swift */,
+				2935E4B0A5808F755F54846BEE6AF5E9 /* PrimerCountryFieldView.swift */,
+				252D6E7F7CB70F687EC5A87FEB990D30 /* PrimerFirstNameFieldView.swift */,
+				7871C4AE895FF13DD22FCB53C2D9DF23 /* PrimerLastNameFieldView.swift */,
+				376188E5CA6FE63BE415B61E6BEE50D5 /* PrimerPostalCodeFieldView.swift */,
+				3E1B8D416406FEAA3A9068980F70516F /* PrimerStateFieldView.swift */,
+				5ADE0FE7A381434782E85FE2976D0815 /* PrimerTextFieldView+Analytics.swift */,
+				8FE82A5D487EBEF4265FA2504EDEE18A /* PrimerTextFieldView+CardFormFieldsAnalytics.swift */,
+				8F43594A92617FA476940A0E5AA05840 /* Generic */,
 			);
-			name = Core;
-			path = Sources/PrimerSDK/Classes/Core;
-			sourceTree = "<group>";
-		};
-		4A6950B7CC56CC38FEC802F75E2A77BC /* Parser */ = {
-			isa = PBXGroup;
-			children = (
-				31D53FA7E09A790E7EEB0B4240A2B6E2 /* JSON */,
-			);
-			path = Parser;
-			sourceTree = "<group>";
-		};
-		4D29753161FB67C76BB309AC671DD565 /* Decision Handlers */ = {
-			isa = PBXGroup;
-			children = (
-				BF50BA2C098F8594D41E91FF6C94A457 /* Decisions.swift */,
-			);
-			path = "Decision Handlers";
-			sourceTree = "<group>";
-		};
-		4EC1BD9CC6162D39D51B8D2310C702FA /* Text Fields */ = {
-			isa = PBXGroup;
-			children = (
-				4763244FE4EDBBEBBE0F08E1A504653A /* PrimerCardholderNameFieldView.swift */,
-				301374484CD143E215F45C43DD6875D7 /* PrimerCardNumberFieldView.swift */,
-				BC639942D4366A5AA567E6912B6C66C3 /* PrimerCVVFieldView.swift */,
-				F85C15F141C35AC1BAD8B8D3C74122F7 /* PrimerExpiryDateFieldView.swift */,
-				E644D1C56D1D4998DED55F15CB97E65E /* PrimerTextField.swift */,
-				949CE6E65977A51E812ED6A48E8401C9 /* PrimerTextFieldView.swift */,
-			);
+			name = "Text Fields";
 			path = "Text Fields";
 			sourceTree = "<group>";
 		};
-		52969CE43553A9E54E8B97F2799483A3 /* API */ = {
+		47168EB07A3F1F058FAEADD89AC0E4D0 /* Payment Method Managers */ = {
 			isa = PBXGroup;
 			children = (
-				6E2D380EA6458429CFE29C01BD613DA1 /* ClientSessionAPIModel.swift */,
-				D7D904908A5EC60003EC3C0C7137DBBF /* PaymentAPIModel.swift */,
-				4E71C583C1969BCCAAADC61A5C25C16A /* Request.swift */,
-				FF0CB5F76D1C29AF189A924DB990AA56 /* Response.swift */,
-				AC2FF4FF9CA6622553575894E48FF1AB /* VaultedPaymentMethods.swift */,
+				10518419B19F405054471079A3497216 /* CardComponentsManager.swift */,
+				517718981FB204D4344CF16DA72C1765 /* NativeUIManager.swift */,
+				7AA827D84EFC754C68CE6709D40AB093 /* PrimerPaymentMethodManager.swift */,
+				63743788C48EF14DE94A4FD85C978A68 /* RawDataManager.swift */,
 			);
-			path = API;
+			name = "Payment Method Managers";
+			path = "Payment Method Managers";
 			sourceTree = "<group>";
 		};
-		52DC1CB54BF19B61FE5CF0D284C6439E /* Keychain */ = {
+		494625B223770C4AA5DEF9615D259A8B /* JSONs */ = {
 			isa = PBXGroup;
 			children = (
-				A868F8F8AE186AD14381696AF523D3E1 /* Keychain.swift */,
+				9C496E296853A66EE15500AEA2766747 /* currencies.json */,
+				123DE8A650ADC397D8B69D45F02E8575 /* phone_number_country_codes.json */,
+				C4849A8F6CC796B5F8E5A15636DB51F6 /* localized_countries */,
 			);
-			path = Keychain;
+			name = JSONs;
+			path = Sources/PrimerSDK/Resources/JSONs;
+			sourceTree = "<group>";
+		};
+		4AFE1E796B5610DEBCA14E5AF907ABF7 /* TestPaymentMethods */ = {
+			isa = PBXGroup;
+			children = (
+				F037BA6BC4DD15F6950FBE5EC386E10C /* FlowDecisionTableViewCell.swift */,
+				91875E09840CF3F6F8CE92360AB26659 /* PrimerTestPaymentMethodViewController.swift */,
+			);
+			name = TestPaymentMethods;
+			path = TestPaymentMethods;
 			sourceTree = "<group>";
 		};
 		5394A1B9C8A591970DAF7B3D84698488 /* Targets Support Files */ = {
@@ -1452,28 +1390,24 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		578B46DC031EA0605CDCB031D67FBD70 /* Checkout Components */ = {
+		597E64FB8AB4ED32F5AC7A323FA58417 /* TokenizationViewModels */ = {
 			isa = PBXGroup;
 			children = (
-				025655E2356AE6CED57CD52291D755CE /* PrimerCardData.swift */,
-				62C19D32F3F0BAF184A5959FDA7AD8BA /* PrimerCardRedirectData.swift */,
-				FD0935E4B2588CB2DA6A40F62D00F08D /* PrimerInputElements.swift */,
-				5EB4E9AA4460DB6E3B6C1B7BF6D21C53 /* PrimerPhoneNumberData.swift */,
-				6B4D87C0A157CA00A9525CF0D0EE4B38 /* PrimerRawCardDataRedirectTokenizationBuilder.swift */,
-				B17DF89D13BDE22B8A4D2168769C4E48 /* PrimerRawCardDataTokenizationBuilder.swift */,
-				9FD9839D3A21F0287751A379E0C7A708 /* PrimerRawData.swift */,
+				1465A6F2592BDF95718A678C4FA81A02 /* ApayaTokenizationViewModel.swift */,
+				B7B5660D65829BEF7971C5A60654F1A6 /* ApplePayTokenizationViewModel.swift */,
+				1ED03E3F4FA541F8FDB2AC3BB891673F /* BankSelectorTokenizationViewModel.swift */,
+				CFD940992476F2DC358CD251D257F5AA /* CheckoutWithVaultedPaymentMethodViewModel.swift */,
+				F414173C1C3C202C11A4C20E0BB57ADD /* IPay88TokenizationViewModel.swift */,
+				3D347F7C4C935764556D644C5440D140 /* KlarnaTokenizationViewModel.swift */,
+				2316669CC24E0E451AB6A1587D019581 /* PaymentMethodTokenizationViewModel.swift */,
+				49C842A7DBF96DDC64E5EF713CFA9999 /* PaymentMethodTokenizationViewModel+Logic.swift */,
+				B44864A6EC767509F172A34423DCDB50 /* PayPalTokenizationViewModel.swift */,
+				772B0F5796A2BAB9581DDF873202F9B9 /* PrimerTestPaymentMethodTokenizationViewModel.swift */,
+				BEAE956392261FC2FEF850F716750641 /* QRCodeTokenizationViewModel.swift */,
+				292F09167F7D41E75E311819BF0A00A9 /* WebRedirectPaymentMethodTokenizationViewModel.swift */,
 			);
-			path = "Checkout Components";
-			sourceTree = "<group>";
-		};
-		584F7D84C130CC2879755420508B7DAF /* Services */ = {
-			isa = PBXGroup;
-			children = (
-				658BE9D4AAE9343A2BB00890991038C8 /* Network */,
-				2C9E5CBE0AFD68568F730CEA1421411F /* Parser */,
-			);
-			name = Services;
-			path = Sources/PrimerSDK/Classes/Services;
+			name = TokenizationViewModels;
+			path = TokenizationViewModels;
 			sourceTree = "<group>";
 		};
 		59DA5C1F72E1D5BABC43EACBA672C3BA /* iOS */ = {
@@ -1485,25 +1419,16 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
-		5BEEE2EE0882B7BC12D42B57A5DD8E55 /* Vault */ = {
+		5F94E247879400C8D4E1147B44E979D8 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				C71C344CC918ADCA293407831E1C5025 /* VaultPaymentMethodView.swift */,
-				44C586906ABD4A1190735F29E3788C85 /* VaultPaymentMethodViewController.swift */,
-				8FE1F56967A901690D1F1C9ADE944D2F /* VaultPaymentMethodViewModel.swift */,
+				F09BC433DAF546E65AF30911F263AE73 /* PrimerHeadlessUniversalCheckoutInputElement.swift */,
+				027EF89D51BC1409FF36F92A4B40695D /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift */,
+				CA87F9F7F6D7EEE2EE3D9936E8917E91 /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift */,
+				970DCB1EDAD600A566534DD364F00A6E /* PrimerRetailerData.swift */,
 			);
-			path = Vault;
-			sourceTree = "<group>";
-		};
-		5E46380ADEFEA7C1C380AD2016556E8A /* Error Handler */ = {
-			isa = PBXGroup;
-			children = (
-				6813F8F686CB86F947CFCA3AA6A59FD5 /* ErrorHandler.swift */,
-				3638BF5C0765A54B045E0BF6BE9394D1 /* Primer3DSErrorContainer.swift */,
-				9DF67D061C1A24B3FCA790F0F1686FEC /* PrimerError.swift */,
-			);
-			name = "Error Handler";
-			path = "Sources/PrimerSDK/Classes/Error Handler";
+			name = Models;
+			path = Models;
 			sourceTree = "<group>";
 		};
 		60004DA877466865A07DA7F97341D3E6 /* Pods */ = {
@@ -1517,37 +1442,84 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		609EE354DA04651413B7D08AFB1C869B /* Tokenization View Models */ = {
+		6072027A785309B67586D4871E4D9CAC /* PrimerHeadlessUniversalCheckout */ = {
 			isa = PBXGroup;
 			children = (
-				84B550C489920745A7B99D0AB780D467 /* FormsTokenizationViewModel */,
+				87394339D5F31F4ED7E321E376ACB274 /* PrimerHeadlessUniversalCheckout.swift */,
+				E8A1682280920C97F800912B01DA37C5 /* PrimerHeadlessUniversalCheckoutProtocols.swift */,
+				BA432F27C0065F4F4D4B9EB85D8C3812 /* Managers */,
+				5F94E247879400C8D4E1147B44E979D8 /* Models */,
 			);
-			path = "Tokenization View Models";
+			name = PrimerHeadlessUniversalCheckout;
+			path = PrimerHeadlessUniversalCheckout;
 			sourceTree = "<group>";
 		};
-		658BE9D4AAE9343A2BB00890991038C8 /* Network */ = {
+		611ACC6687A99B9A76F5EB139BCE385D /* Keychain */ = {
 			isa = PBXGroup;
 			children = (
-				3AE3D6ADC481C2817934FEBE549C1675 /* Endpoint.swift */,
-				38F0A1B7C84315DFF960C70DB61CA8B4 /* NetworkService.swift */,
-				36B00EB0B836D5100D8906245B8B9661 /* PrimerAPIClient.swift */,
-				1701C2BA9780B96815CB6F6C83AA7974 /* PrimerAPIClient+Promises.swift */,
-				41597C1A733DB1BD5944A6326180453D /* SuccessResponse.swift */,
+				AE1B3A54375C99482321E8D936194200 /* Keychain.swift */,
 			);
-			path = Network;
+			name = Keychain;
+			path = Keychain;
 			sourceTree = "<group>";
 		};
-		680359D66F46C2951A78C19ED2AC9FD9 /* Internal */ = {
+		619717D4B476631E943328D4C8CB3A72 /* Checkout Components */ = {
 			isa = PBXGroup;
 			children = (
-				576918A6C15D07BD412AAF448EA54616 /* PrimerTheme+Borders.swift */,
-				318BA5A624F10FCFF9BD9A70E71E6C4C /* PrimerTheme+Buttons.swift */,
-				30424A15FF625421E63F306D4DCA634A /* PrimerTheme+Colors.swift */,
-				6BC822C374C92D20C25D1DB80CE6930F /* PrimerTheme+Inputs.swift */,
-				BB21E1376352DE378AADDC08EFEF7AC3 /* PrimerTheme+TextStyles.swift */,
-				466113CEF6EAC19D866900CCB282BEC2 /* PrimerTheme+Views.swift */,
+				68A425DF08E1F6DC50BF7F38E3A29991 /* PrimerCardData.swift */,
+				F5AE547C4FAFF96DA5F59CEE5E4507F3 /* PrimerCardRedirectData.swift */,
+				EC9BE98AD0A498B74ABC35971CBB1EA3 /* PrimerInputElements.swift */,
+				71CB22A248E6C3F8A502B7539BBCF73C /* PrimerPhoneNumberData.swift */,
+				EF1C199E2CD2B5737740E1C24BC8AA47 /* PrimerRawCardDataRedirectTokenizationBuilder.swift */,
+				C05000A05B1C43ADBCB50A311617CC33 /* PrimerRawCardDataTokenizationBuilder.swift */,
+				2C3750940B2FA6D58AE93382E53D20C4 /* PrimerRawData.swift */,
 			);
-			path = Internal;
+			name = "Checkout Components";
+			path = "Checkout Components";
+			sourceTree = "<group>";
+		};
+		687139B7119FFC0E05937A5D927A8EEC /* Root */ = {
+			isa = PBXGroup;
+			children = (
+				AD516439159EAF2C4962E9E3EA8A9B41 /* PrimerCardFormViewController.swift */,
+			);
+			name = Root;
+			path = Root;
+			sourceTree = "<group>";
+		};
+		6AE9C37D11FE8544DEAEA811FF7937B4 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				372BA201AC4938F7D167D5060203BB85 /* PrimerAPIClient+3DS.swift */,
+			);
+			name = Networking;
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		6CED766219C30F55F140AFF4A9F9C7D5 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				12CA876226AACE3698AF07A0A1D48D31 /* ClientSessionAPIModel.swift */,
+				6A5084423FF5D474B7098BAF76BCC636 /* PaymentAPIModel.swift */,
+				DC965C17D86D28EEA7C1247831FB1B27 /* Request.swift */,
+				6DD3ECFAF50DF47E3F4EBE777CEF518B /* Response.swift */,
+				30AA83D4E70802B46864623386CDE15F /* VaultedPaymentMethods.swift */,
+			);
+			name = API;
+			path = API;
+			sourceTree = "<group>";
+		};
+		6EDD0122FB22E060263E2D1021B78751 /* PCI */ = {
+			isa = PBXGroup;
+			children = (
+				E8BAAB2CA6A44B0B15C464EE9CA8C7C5 /* TokenizationService.swift */,
+				619717D4B476631E943328D4C8CB3A72 /* Checkout Components */,
+				DCA00ECE502751A813523E9144302E6C /* Services */,
+				D03A4CD49DBF7EB487A73CAEA3CCB39F /* Tokenization View Models */,
+				C963B2F210C3843E381477E64931E009 /* User Interface */,
+			);
+			name = PCI;
+			path = Sources/PrimerSDK/Classes/PCI;
 			sourceTree = "<group>";
 		};
 		7247ACD97AB79769C7D29E910A7E0D09 /* Development Pods */ = {
@@ -1558,76 +1530,88 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
-		74841C71F346CBD84A52C5C58D5D3725 /* PrimerHeadlessUniversalCheckout */ = {
+		79E00D21CCE6D38E9EC33F8FD202075E /* Root */ = {
 			isa = PBXGroup;
 			children = (
-				D258EE2578C0D3E4396FE13FE69516DD /* PrimerHeadlessUniversalCheckout.swift */,
-				ED316D11AA35ACCF831DB7531099B3A4 /* PrimerHeadlessUniversalCheckoutProtocols.swift */,
-				76D63374FF815E04E0862E4533FE06D9 /* Managers */,
-				3657ECFC9B1AA39BA364A60C4F9D2BFB /* Models */,
+				16E4CE9C3AEBD32B0C6532B6E1D70771 /* PrimerAccountInfoPaymentViewController.swift */,
+				F0BDB02350A2F210BF098C93DAD877DB /* PrimerContainerViewController.swift */,
+				911B56AB0AD9B3D86A426EEAA4366161 /* PrimerFormViewController.swift */,
+				4E4142BE00050FEA8E2151E032C95729 /* PrimerInputViewController.swift */,
+				21E33DED88C753F774E07438BEFEA587 /* PrimerLoadingViewController.swift */,
+				3E4B086002167B86FB152200CB5F4C3F /* PrimerNavigationBar.swift */,
+				27FF8B3650A748481B91343F88669976 /* PrimerNavigationController.swift */,
+				463AC2D355BEA8F77BF070B1071D107D /* PrimerPaymentPendingInfoViewController.swift */,
+				0C0C538E168130A05D5F9FA9C3E1674E /* PrimerRootViewController.swift */,
+				D5CA8CA6BB86462451ED4D675CC1E279 /* PrimerUniversalCheckoutViewController.swift */,
+				9C68FFDC0DB7E31F13437D793D85EEA8 /* PrimerVaultManagerViewController.swift */,
+				36AAB1BDBB913DA8B0155AEC46064F30 /* PrimerVoucherInfoPaymentViewController.swift */,
 			);
-			path = PrimerHeadlessUniversalCheckout;
+			name = Root;
+			path = Root;
 			sourceTree = "<group>";
 		};
-		758D2F94AB5E8DEC05DF723F03CC7967 /* Banks */ = {
+		7B2833556746661F32A4785EAFBFD9E5 /* Parser */ = {
 			isa = PBXGroup;
 			children = (
-				20B0427E8C854C706F85DF8529F099FD /* BankSelectorViewController.swift */,
-				04CA368E1040DCDB874CFD05EB959664 /* BankTableViewCell.swift */,
+				FD04AC7556EEBF0E4FDF6EA25195760F /* JSON */,
 			);
-			path = Banks;
+			name = Parser;
+			path = Parser;
 			sourceTree = "<group>";
 		};
-		76D63374FF815E04E0862E4533FE06D9 /* Managers */ = {
+		7EAEC2C0FFDF115E81E2FBFAB6EE5E06 /* PromiseKit */ = {
 			isa = PBXGroup;
 			children = (
-				DA52BDA0E27F4AC98488EEB595A22985 /* AssetsManager.swift */,
-				1437FAD4E45E8929285D343D53E42338 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift */,
-				DBC487EDD403A3B04E9CE4657D379494 /* PrimerRawRetailerDataTokenizationBuilder.swift */,
-				7E576BDDB4E79A57CE3045FD25A4E450 /* VaultManager.swift */,
-				3A70404AA616BFD28BAC5A79415EAA24 /* Payment Method Managers */,
+				C5A025D9F91E2FF89B8464E303E74DB9 /* after.swift */,
+				DCCF5CAD3C150CA38CA653BB6AA19D1B /* Box.swift */,
+				FE7D6C0C6AC8F4A135668BDB6C1517CA /* Catchable.swift */,
+				E14DA91E266DC6F936AFBDDE4DE581DA /* Configuration.swift */,
+				294457E6EC1065D042CE94502D6F82B3 /* CustomStringConvertible.swift */,
+				E025A3E214DBB9676536F35385694E5E /* Dispatcher.swift */,
+				F528C392D992975CBA53BB67D7133282 /* Error.swift */,
+				7152E639D865A2AB5D0E967175881AA7 /* firstly.swift */,
+				8F17EDDF46611F1B4C439953451A6E50 /* Guarantee.swift */,
+				A16ADD8E6E4EC877AC44728F26B1DEBB /* hang.swift */,
+				F95A46947102FD5D1FF05FA25E6C3E59 /* LogEvent.swift */,
+				1AB77F315E45888534C0F141F1D8BA34 /* Promise.swift */,
+				8E9DE2E33E4E2B002220B36F21D5D087 /* race.swift */,
+				307663AD5935C039472F05A5DD7574B0 /* Resolver.swift */,
+				53BF9A4F2B75AA0E6AE8CD0E127A3C8B /* Thenable.swift */,
+				6E149402472998D402CC08A36B9ED04E /* when.swift */,
+				E3684FD04B3B3B3BE81032B553AC9F76 /* Cancellation */,
+				A12896011E2AE7B881A2DE2FF8970463 /* Dispatchers */,
+				1A20051D4248404A18F68417DC5A2D14 /* Wrappers */,
 			);
-			path = Managers;
+			name = PromiseKit;
+			path = PromiseKit;
 			sourceTree = "<group>";
 		};
-		799D8434AFED7808C162E6775B9B09EA /* TestPaymentMethods */ = {
+		7F0BE3AEE999CD8F2371B63666CD77FD /* Modules */ = {
 			isa = PBXGroup;
 			children = (
-				27ADB4294EBF96BDDC56D895E9C695F0 /* FlowDecisionTableViewCell.swift */,
-				2B2F07CE5498831C6E3A6EB73C38EE5E /* PrimerTestPaymentMethodViewController.swift */,
+				CE6A990031D4592237BFB5289337A600 /* CheckoutEventsNotifierModule.swift */,
+				52F16846F426A104F596734101DA7B30 /* ClientSessionActionsModule.swift */,
+				02DDEB4BFDD82D2B3C1999FC0D6C2F87 /* Downloader.swift */,
+				E7F8C0AB63EE61A11B45676E80D0BD10 /* ImageManager.swift */,
+				31878C04FDEA377DA4D75BACEDA06152 /* PollingModule.swift */,
+				2832A895415923855F604D702DFEB066 /* UserInterfaceModule.swift */,
 			);
-			path = TestPaymentMethods;
+			name = Modules;
+			path = Sources/PrimerSDK/Classes/Modules;
 			sourceTree = "<group>";
 		};
-		84B550C489920745A7B99D0AB780D467 /* FormsTokenizationViewModel */ = {
+		87A13BD67A76A56796714CF8D24B911A /* Internal */ = {
 			isa = PBXGroup;
 			children = (
-				424E17EAD5C6A4D0775B89D66167B1F3 /* CardFormPaymentMethodTokenizationViewModel.swift */,
-				F0237EB57F7AD1A4F815C165E0EFB038 /* FormPaymentMethodTokenizationViewModel.swift */,
-				26B15B62F11C383393F1DECF26A5DFF6 /* FormPaymentMethodTokenizationViewModel+FormViews.swift */,
-				F1D28C317BB17486018978978A329936 /* Fields */,
+				E232F12546E5C86663B55B942844EFBA /* PrimerTheme+Borders.swift */,
+				B30F920C49BE7B4AD210E011736F2818 /* PrimerTheme+Buttons.swift */,
+				36AE63293F2752157771515FEF5A232D /* PrimerTheme+Colors.swift */,
+				A88C932B6FC5FAE95C0C752509E0F898 /* PrimerTheme+Inputs.swift */,
+				FB24D04FD39B8B5319F6AD122E20A801 /* PrimerTheme+TextStyles.swift */,
+				8EB08C138B9B1F3AE0259F9F24B581AA /* PrimerTheme+Views.swift */,
 			);
-			path = FormsTokenizationViewModel;
-			sourceTree = "<group>";
-		};
-		85B6038EEA97F72CDA27A27CF70C1CEA /* Crypto */ = {
-			isa = PBXGroup;
-			children = (
-				3378FDE7CF6756B16256FFBF993DA91A /* AES256.swift */,
-			);
-			path = Crypto;
-			sourceTree = "<group>";
-		};
-		871B765E2AF32AED4056327D2AC28A8B /* Cancellation */ = {
-			isa = PBXGroup;
-			children = (
-				FA236D6CCC7FE519C6A4A34148702342 /* CancelContext.swift */,
-				DE4CA17ABBC956DFB5EBCB1FC341FEF2 /* Cancellable.swift */,
-				A96C1C2310EE6FE1A26F847E3F502237 /* CancellableCatchable.swift */,
-				A737E9A220CDE88BDFAFFDFCBB3E6FC8 /* CancellablePromise.swift */,
-				BD1AC8628545D02AF110941128880271 /* CancellableThenable.swift */,
-			);
-			path = Cancellation;
+			name = Internal;
+			path = Internal;
 			sourceTree = "<group>";
 		};
 		882EB5F10F588EA2B77CF1229CFC1455 /* Frameworks */ = {
@@ -1638,94 +1622,55 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		890548F6977869283AA5027CFCE508E3 /* Primer */ = {
+		88E0DA43ED8936BF3324BDFE7340081F /* Fields */ = {
 			isa = PBXGroup;
 			children = (
-				BF5AB512118494BC502B5323CFA02BF0 /* CardButton.swift */,
+				E2FB734F02E472954A35A5B040DA73DB /* AddressField.swift */,
+				825260542897EEC7C355908ED05D63EF /* CardholderNameField.swift */,
+				F7C89BF054E74D49332F76E03F4B2ECD /* CardNumberField.swift */,
+				8CE1CD4CA67633AB5538A06FE3789905 /* CityField.swift */,
+				3F5CC8C8A16059A657F0CADD5E61944F /* CountryField.swift */,
+				0052C9E5ED38BFDEB3318B8B276FDC32 /* CVVField.swift */,
+				631718A3A98AB5B6B06E017715D36CE9 /* ExpiryDateField.swift */,
+				D1A6FCB18ED6D61CB1B602B5C540367D /* Field.swift */,
+				FEFA1832ABD955A4B39AFD5E85F8D49F /* FirstNameField.swift */,
+				FF5BC25EC635A1BF75DD2781EE799554 /* LastNameField.swift */,
+				496A63B242FDB61ECDFCAFFACE55FFD7 /* PostalCodeField.swift */,
+				717DD5F963C60F4088A44B483EE5A52F /* StateField.swift */,
 			);
-			path = Primer;
+			name = Fields;
+			path = Fields;
 			sourceTree = "<group>";
 		};
-		8FF3D7F6CDF398D4989C5469994DE43C /* localized_countries */ = {
+		8B69713FE4714583F191334CF3C7E770 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				23008DCE30635C2A48179C8955173D36 /* af.json */,
-				F1E339730CCE3ED7B776D477C2269C47 /* am.json */,
-				0FBDA3A3F35DC75334856E3135A512A3 /* ar.json */,
-				46DF979C091AAEB2188A67A4E60973E0 /* az.json */,
-				19DF40448DACEAE8218A622C7ACADE84 /* be.json */,
-				091C52DB4E0BF544AAB20BF31610BE30 /* bg.json */,
-				CAFD03D52BC86E04D48749A8276E6435 /* bn.json */,
-				980024E63BCCDC799A4FB8E643F4B7EE /* bs.json */,
-				E6E126C004CE794EDFA7032CF6351974 /* ca.json */,
-				D7216679FBF84EF0B6A60C80BEE735FA /* cs.json */,
-				C2B4A5EC72F45CCBD072612DD8D0FFD8 /* cy.json */,
-				8504B12C19D5BE4EC28864CDA892D4EB /* da.json */,
-				3D5DD3A443EAFA64A6728D9623C32711 /* de.json */,
-				D5AA7F2B319372A3BCC38F1C1FA73FD2 /* dv.json */,
-				5183A3A34BBBB945AE29667C7553B603 /* el.json */,
-				BC6E909C3027887A486C44600B79E2C4 /* en.json */,
-				B72E54D3874156D1405A9599AAAD83E9 /* es.json */,
-				3EE5B0DBF4ADCE0BC50EFA7DCA887F8D /* et.json */,
-				442C27AA6E002EB3C377B9C4198AFAF3 /* eu.json */,
-				9DA99FE5EE965E84DBF481F457B7FBB8 /* fa.json */,
-				D9D7EA565E96F5A5809133ED8B30E4D3 /* fi.json */,
-				A6210190AB0CCA765D073F0650BDB241 /* fr.json */,
-				7E9EF19EBB79EF723BE66B549F0964B7 /* gl.json */,
-				971A091B046B3E3D91DE2A49AD38C415 /* ha.json */,
-				CDACA4B200F86A610702409F061A2342 /* he.json */,
-				3DCE173F1CCAF4B0D75CB8CC7AA5F677 /* hi.json */,
-				8E982532F5FBC7DEB03C0F6F70AC0AB7 /* hr.json */,
-				2D222B2A5D57E2055C9EF12BCAE26F26 /* hu.json */,
-				04DE2790F4BA934C8B330CE4A023A484 /* hy.json */,
-				8CE87FB7342A874BC723C9F2B2ED8AB3 /* id.json */,
-				E748D2D45994BFBE4E57575B230B0427 /* is.json */,
-				958DF5DC676C76B87FD38B6C4BE484F3 /* it.json */,
-				3830E414F3EB4A0C9C40924BC94F52B5 /* ja.json */,
-				C5892FD01BAD8F04E4AA744ED4E8DCD7 /* ka.json */,
-				12F049D553385B220511DA5324E73CAC /* kk.json */,
-				79B5FDC0D811DD22D438C8299147D10B /* km.json */,
-				09A090A65E85F0E260BBBC518FAFDD22 /* ko.json */,
-				7731D330DFFDE5BDB7262CBFE75CFA39 /* ku.json */,
-				F106E4972B36125362E0E9C48D144360 /* ky.json */,
-				D5E82976D4CF476DD8CD1853E13FE271 /* lt.json */,
-				67D4FB0F9B75B23896A5A80E46D02369 /* lv.json */,
-				DC4D8F2C4DC84A5D2246A81EF8201817 /* mk.json */,
-				5857FE9CD25823EAB3D2A307A82BE32A /* ml.json */,
-				B61DC9B4534E5B21A28E037B2A53A371 /* mn.json */,
-				3F61EEC23B1A888114C4C1ADF4A86673 /* ms.json */,
-				827092588059F50742C1CF6F40847E91 /* nb.json */,
-				FA140C6F6C4E7C0563354CB048666AAD /* nl.json */,
-				D3D99E723F3EFB3D2C3BE3BD7D65A31E /* nn.json */,
-				1DA399A7CEC10284AA5DFF7087AB1606 /* no.json */,
-				AFED0419F58810B094B045A94F42778F /* pl.json */,
-				9E30A8643A102CCE33849AEF658FA34B /* ps.json */,
-				01DCCECEF6DE0816459294F7D4E380B3 /* pt.json */,
-				A6EB9488B303B043EBC9D2CFC453B832 /* ro.json */,
-				16A13FF37400C98AB78552A82F345D3C /* ru.json */,
-				FCDF6C3A22A8FF7C96EEF514CD7A64D0 /* sd.json */,
-				56B368F810A2AB543CC374D7AC273A20 /* sk.json */,
-				C2E84F0E6CADC0D66E56DE50C04D9C1B /* sl.json */,
-				059A44FD4398BD3ECD3A33D1571C4CA0 /* so.json */,
-				30E5D8C43EE6F0E901F1F460DB736C49 /* sq.json */,
-				0CFE031BD7589055BFCEEB1119F8C153 /* sr.json */,
-				810EAC7B6BF98765F2675614D2007FF5 /* sv.json */,
-				5B711EB42C8FFABADACBF36D08837634 /* sw.json */,
-				559CE23A5F2B394A14101BA2F258C75A /* ta.json */,
-				5B0FE5BEF2FD855A8FF77C7511E26F6D /* tg.json */,
-				58D0B252742894B8F436E2D6226EE52E /* th.json */,
-				661B567C4810A935CFBA7E116438230C /* tr.json */,
-				5329A0B8367E43F6DE39ABE055E9D040 /* tt.json */,
-				F7443D3024DCD2FF2616FBE671774A2C /* ug.json */,
-				B79C83472C36ACC8CA5F9E1B0014E4A4 /* uk.json */,
-				AA9C05DD563B3DC1156264E53846CC54 /* ur.json */,
-				C15FF3302B2650F6B206E8C98C61B6A4 /* uz.json */,
-				5602C99E5A9BBF31FEE8709F61A81EF8 /* vi.json */,
-				70248D6685AE5AFEA64D59F62D4A16C8 /* zh.json */,
-				5536D76A02FB86E84689A5D3B051CBDA /* zh-KH.json */,
-				63C72E6699818410EB0A9F8081A9EC1E /* zh-TW.json */,
+				19783814363AE8875B4B3FA0F62B90B4 /* Icons.xcassets */,
+				511523BE2DE03BF88740C3B799E7E8E8 /* version.swift */,
+				35D217E337CBE5A779A90AC08B7362CE /* Core */,
+				2573DC7EE0659F315A93B19E8E28E0FD /* Data Models */,
+				9C3FBB61DA6BD8AFD2394D377A0BDAA0 /* Error Handler */,
+				B8551660D7AA8648973225E21B354CA4 /* Extensions & Utilities */,
+				494625B223770C4AA5DEF9615D259A8B /* JSONs */,
+				125BF7342515679E037239059190B1E5 /* Localizable */,
+				7F0BE3AEE999CD8F2371B63666CD77FD /* Modules */,
+				BCF80A97B30B0F2E56E6F04EE5409B3E /* Nibs */,
+				6EDD0122FB22E060263E2D1021B78751 /* PCI */,
+				37B1484349450C88EE64B3F13F7AFC9B /* Services */,
+				93B9DEDCBF236C767C4792434CDB2962 /* Third Party */,
+				EB903229F47F668CC72FD495CB4B395A /* User Interface */,
 			);
-			path = localized_countries;
+			name = Core;
+			sourceTree = "<group>";
+		};
+		8F43594A92617FA476940A0E5AA05840 /* Generic */ = {
+			isa = PBXGroup;
+			children = (
+				7D6972E4A97A6A938F9C2CC34E640F90 /* PrimerGenericTextFieldView.swift */,
+				FE4C5FEF5E78F5DB0590B5B665402F9E /* PrimerSimpleCardFormTextFieldView.swift */,
+			);
+			name = Generic;
+			path = Generic;
 			sourceTree = "<group>";
 		};
 		91D9ECEEBE4B18617FCB1A4D8F79C8CA /* Support Files */ = {
@@ -1744,6 +1689,15 @@
 			path = "../Target Support Files/Primer3DS";
 			sourceTree = "<group>";
 		};
+		93B9DEDCBF236C767C4792434CDB2962 /* Third Party */ = {
+			isa = PBXGroup;
+			children = (
+				7EAEC2C0FFDF115E81E2FBFAB6EE5E06 /* PromiseKit */,
+			);
+			name = "Third Party";
+			path = "Sources/PrimerSDK/Classes/Third Party";
+			sourceTree = "<group>";
+		};
 		987BBF73787C38018601EDE014539D37 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1752,62 +1706,58 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		9E309FBC005D816D0180B91229F0AC36 /* User Interface */ = {
+		9C3FBB61DA6BD8AFD2394D377A0BDAA0 /* Error Handler */ = {
 			isa = PBXGroup;
 			children = (
-				06EFDD6B847899803CDD6CEC7D495774 /* InternalCardComponentsManager.swift */,
-				A0FAE966BC79B9B16334FAED9F133131 /* Root */,
-				4EC1BD9CC6162D39D51B8D2310C702FA /* Text Fields */,
+				600403423B116C4F1A1383A4FAB1FED6 /* ErrorHandler.swift */,
+				F1ECA51C0DDC3F397B0C117FC191A099 /* Primer3DSErrorContainer.swift */,
+				747C2640DE0A63351A972AE55921A08F /* PrimerError.swift */,
 			);
-			path = "User Interface";
+			name = "Error Handler";
+			path = "Sources/PrimerSDK/Classes/Error Handler";
 			sourceTree = "<group>";
 		};
-		A0BB1A8B295DFB412F3F87C014FDB0D1 /* Mock */ = {
+		A12896011E2AE7B881A2DE2FF8970463 /* Dispatchers */ = {
 			isa = PBXGroup;
 			children = (
-				BF39310D7B33FA69131E4875E4A13290 /* Mock3DSService.swift */,
+				2B1C6967F9433EA11FDB7D0E230C1142 /* ConcurrencyLimitedDispatcher.swift */,
+				19AEAA7CE084F88A8F7A2CD0CEA5A653 /* CoreDataDispatcher.swift */,
+				BFB7686329605392FBCB2FE172FC6126 /* Queue.swift */,
+				2AEF45F7CBBDB26A5BF0FD2C893529F3 /* RateLimitedDispatcher.swift */,
+				300244607D16CA9353D9E8A3BC84638D /* RateLimitedDispatcherBase.swift */,
+				6AB959C423AD7C3414D505E8DEC2C0F6 /* StrictRateLimitedDispatcher.swift */,
 			);
-			path = Mock;
+			name = Dispatchers;
+			path = Dispatchers;
 			sourceTree = "<group>";
 		};
-		A0FAE966BC79B9B16334FAED9F133131 /* Root */ = {
+		A7EB55112B943CCB0BB2C9EB1E22F6C8 /* Theme */ = {
 			isa = PBXGroup;
 			children = (
-				08B07423AA82A0FE4FA4CCA0106C9DE4 /* PrimerCardFormViewController.swift */,
+				A01CB8FDA4F59661CDB4F887F79ED7B4 /* PrimerTheme.swift */,
+				87A13BD67A76A56796714CF8D24B911A /* Internal */,
+				CDE20084EA24A64E19D32AD1FC082641 /* Public */,
 			);
-			path = Root;
+			name = Theme;
+			path = Theme;
 			sourceTree = "<group>";
 		};
-		A78EF1336A166E295E7EDE56B19713B0 /* Components */ = {
+		ADEFAC5629B619378A55BE39999B6E3E /* PCI */ = {
 			isa = PBXGroup;
 			children = (
-				BBD82A811F119463D9AFE8CF7713F31E /* HeaderFooterLabelView.swift */,
-				9CEDC7C2CEA211E2F43BE2A99F644487 /* PrimerFormView.swift */,
-				D24CD24F268D7252CA8F3E99D6CAC1D2 /* PrimerNibView.swift */,
-				0CEA1480749C8D81B0FFB635BDEB4705 /* PrimerResultComponentView.swift */,
-				E559541AB9C303C0205C05EBBD2103B9 /* PrimerResultViewController.swift */,
-				B6BD7F4864DA4F3847A569AE1AC6892C /* PrimerSearchTextField.swift */,
+				D6A8A6E0DF6DAFCAFAB8BC61C6252B63 /* FormType.swift */,
 			);
-			path = Components;
-			sourceTree = "<group>";
-		};
-		AD0B889B9E8784572C27760EAD24028E /* Payment Services */ = {
-			isa = PBXGroup;
-			children = (
-				F91464987A23B4425A1988E1CBC420A3 /* CreateResumePaymentService.swift */,
-				816A780D0C2C1EFA953A2F9344D73E85 /* PayPalService.swift */,
-				BB51DD55C93705722B61C0C1C641F20C /* PrimerAPIConfigurationModule.swift */,
-				4DDCF00E3E0AD992D1C7DBDE77038D7C /* VaultService.swift */,
-			);
-			path = "Payment Services";
-			sourceTree = "<group>";
-		};
-		AFF98B27C22001A60C8C0EDD56933048 /* PCI */ = {
-			isa = PBXGroup;
-			children = (
-				D8A42D0CFF172D36E04B660BDEA23C9C /* FormType.swift */,
-			);
+			name = PCI;
 			path = PCI;
+			sourceTree = "<group>";
+		};
+		AF226B97AB588801EB2AB1120A1778AE /* API */ = {
+			isa = PBXGroup;
+			children = (
+				B4B0A8907FAEF873BEF70F1FA60D51F9 /* Primer */,
+			);
+			name = API;
+			path = API;
 			sourceTree = "<group>";
 		};
 		B11321628DE110303AE6F175D536C27E /* Products */ = {
@@ -1822,30 +1772,6 @@
 				A8B3BC107C2BDC3C03D961866F721265 /* PrimerSDK-PrimerResources */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		B1BB7587E588AB3D40D39783F44D8DCF /* Dispatchers */ = {
-			isa = PBXGroup;
-			children = (
-				812E080E981922506FDB77AB628466A0 /* ConcurrencyLimitedDispatcher.swift */,
-				8F8BFB4BF6C1343B4ACB13ACA968F483 /* CoreDataDispatcher.swift */,
-				80CA37C2FE6FB9EFDFFDD60DE151158B /* Queue.swift */,
-				8F42F8ED46021BBDDAE4541C3E02327C /* RateLimitedDispatcher.swift */,
-				5707CA8EF477DEEB8CB41B18726CB8E5 /* RateLimitedDispatcherBase.swift */,
-				97797B3A826695B50126CEBA1DF3D1C4 /* StrictRateLimitedDispatcher.swift */,
-			);
-			path = Dispatchers;
-			sourceTree = "<group>";
-		};
-		B2D815919F5AFA8A49486111E552EEAA /* JSONs */ = {
-			isa = PBXGroup;
-			children = (
-				9B1F3303C4C025BE383B9236FF4CCA51 /* currencies.json */,
-				54AB737F3043554978BCE0BD76000729 /* phone_number_country_codes.json */,
-				8FF3D7F6CDF398D4989C5469994DE43C /* localized_countries */,
-			);
-			name = JSONs;
-			path = Sources/PrimerSDK/Resources/JSONs;
 			sourceTree = "<group>";
 		};
 		B3770BD74A9165DBC013AC1357AEE513 /* Support Files */ = {
@@ -1875,109 +1801,234 @@
 			path = "../Target Support Files/PrimerIPay88MYSDK";
 			sourceTree = "<group>";
 		};
-		B854EF59AB1326AB7774184535098F45 /* Localizable */ = {
+		B4B0A8907FAEF873BEF70F1FA60D51F9 /* Primer */ = {
 			isa = PBXGroup;
 			children = (
-				3C63DD85A6A9E4C7DB5A148B98C37FE1 /* Localizable.strings */,
+				576786592FCD001C69C87A203233A0A3 /* PrimerAPI.swift */,
+				EAF4666584FA7A50B9E8A199F8D4CC3D /* PrimerAPIClient+PCI.swift */,
 			);
-			name = Localizable;
-			path = Sources/PrimerSDK/Resources/Localizable;
+			name = Primer;
+			path = Primer;
 			sourceTree = "<group>";
 		};
-		B8829AF0F07C22C996889FBFE116AD48 /* UI Delegates */ = {
+		B8551660D7AA8648973225E21B354CA4 /* Extensions & Utilities */ = {
 			isa = PBXGroup;
 			children = (
-				88BBFB31782058675116A1EF8DF9BD73 /* ReloadDelegate.swift */,
-			);
-			path = "UI Delegates";
-			sourceTree = "<group>";
-		};
-		B9026D51FBB9F2C480F9DFCAAD8EB5FE /* Extensions & Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				3BC65978AB3603D3CC369B2F3256AE3D /* AlertController.swift */,
-				3ED1DCCC3BE7EDEB962787A8E30A6F96 /* AnyCodable.swift */,
-				A02784547B176EA2ACAAD8AC90276D48 /* AnyDecodable.swift */,
-				18A9C0DF1386999EC3DF0E2399A99778 /* AnyEncodable.swift */,
-				8065232778925761294C43BC52D3166A /* ArrayExtension.swift */,
-				65EEC09164AC46A490D889A4B3A4E875 /* BundleExtension.swift */,
-				C5D152F5C198FFCC1BADCADFEE4A9DBB /* DataExtension.swift */,
-				3B52689B762A3CB52BD072A91E2EC1C1 /* DateExtension.swift */,
-				0828534D079454FFFF543D9866AA1AE1 /* DateFormatter+Extensions.swift */,
-				E1A8D570C8144D1E41B17235A8B0E377 /* EncodingDecodingContainerExtensions.swift */,
-				CF92DE9C2024A0DCE5088E1DC761A8A5 /* IntExtension.swift */,
-				9A959FADE6100F477E9A88FBF7BE17B5 /* Logger.swift */,
-				3ECCC38DA7558D2053B8F5633AAAAF79 /* Mask.swift */,
-				BA4A4667E5FDDAC93F09F3D2C931362F /* NSErrorExtension.swift */,
-				2F862A072948ABE92A6870DD4AD7B0FD /* NSObject+ClassName.swift */,
-				FAD89B0D3B0B712AE738025E0B73D538 /* Optional+Extensions.swift */,
-				931FEB5AEACA42D4B737383BBD69447D /* PostalCode.swift */,
-				2F76FB1A589EF365F1AEBAB99EBFA5F5 /* PresentationController.swift */,
-				CB2D76BD1B8AC84CA2D9720E5345DF1D /* PrimerButton.swift */,
-				7851B1E6D972B53FDD5C84DEA2B2BA94 /* PrimerCustomStyleTextField.swift */,
-				BA5F402AF26A5D15C068808791BA701A /* PrimerImage.swift */,
-				999B0869695391000743FA8993417DE1 /* PrimerImageView.swift */,
-				651FF45F7CE8B91761113CF106217967 /* PrimerScrollView.swift */,
-				18234F9225DD0A2D3272048CD6BE9FFA /* PrimerStackVIew.swift */,
-				666D95E8D4302FED5DF81F797FFBB301 /* PrimerTableViewCell.swift */,
-				4CD7B9DE66B36FC501E03FE83C88329D /* PrimerUIImage.swift */,
-				9376E09A9CF791A7E524DAE45024EE8D /* PrimerViewController.swift */,
-				3CCCFF6ACD3423689A805F7A41F456C6 /* PrimerViewExtensions.swift */,
-				BD91667428047551AF217B76A0AA3019 /* StringExtension.swift */,
-				932B912B4240B649996034B90C5C83CA /* TimerExtension.swift */,
-				A6411C49128C3CFB8AA377695C2104AE /* UIColorExtension.swift */,
-				2E7E40195DF13E27C66AAAFB4107A989 /* UIDeviceExtension.swift */,
-				F464B2AC0B131BFCE9FFBB964BBB9E21 /* UILocalizableUtil.swift */,
-				8553901DF5E05FEE1FD261595F9EA449 /* UINavigationController+Extensions.swift */,
-				57F087DB1B37A42AFDE479741B0685DB /* UIScreenExtension.swift */,
-				64B6B05ABD3E84D51BBFF140D357117F /* URLExtension.swift */,
-				75802316C029BB1D2F3FA33D0890975A /* UserAgent.swift */,
-				E43836F7676956C6AE724F137B96A47F /* UserDefaultsExtension.swift */,
-				B070035BEF45F872802D2C617B7BEE8F /* Weak.swift */,
-				BD241F41F82B185EBCCAE78E790C9528 /* WebViewUtil.swift */,
-				F03699522AC2DB5700E4179D /* VersionUtils.swift */,
+				5E793ED0ECBAA79C40A4F80E1E28E3B6 /* AlertController.swift */,
+				62C187F5DFF3075C9D1790B79AA29905 /* AnyCodable.swift */,
+				11E678F93CD7D86FF3DA682F680132F1 /* AnyDecodable.swift */,
+				6CDDAD82B1C38F0BE836D756E5A56CC7 /* AnyEncodable.swift */,
+				B5B8121BE683E18C1BD5CA7EE3581141 /* ArrayExtension.swift */,
+				F517C79AD2636FE2ED0CF5D63F1D294F /* BundleExtension.swift */,
+				12CB36C753AA3EFECA8803A4909B722D /* DataExtension.swift */,
+				FE5ECAD1D6B458C0AA5A316A31D577C1 /* DateExtension.swift */,
+				F52413C8A5C07398BBC5127429551597 /* DateFormatter+Extensions.swift */,
+				FFA1ACC3B92AF5E7BA2BD4CC83D6BBEE /* EncodingDecodingContainerExtensions.swift */,
+				6BA2A455CF52819239E4F86D36167A86 /* IntExtension.swift */,
+				BA2244D72F2463C99B2B8BEF584E38FE /* Logger.swift */,
+				8A4347B3D833934D076AC54429CC9C73 /* Mask.swift */,
+				2265FF9EA917CC753CDA43675489BBF9 /* NSErrorExtension.swift */,
+				4E8EFDD6D1662B6CC455CEC9599268B8 /* NSObject+ClassName.swift */,
+				861B719BB7AC6DCB3267D345ECEC120F /* Optional+Extensions.swift */,
+				2A3D3EB3C0B6EE702D3FFCF03F936666 /* PostalCode.swift */,
+				C82D3986D0793B70A06C3786EE4EA38F /* PresentationController.swift */,
+				34D5898376477D28E2A203F36651F59C /* PrimerButton.swift */,
+				001E05D511E77A6FA8C2963AC7FB50A5 /* PrimerCustomStyleTextField.swift */,
+				E3CBD0EBF5F5385E9855BC3BAB991474 /* PrimerImage.swift */,
+				929B7338F092F3735EFE03928AF9FD3D /* PrimerImageView.swift */,
+				F5ABAA71946AE923EBDB4FB83DD4E012 /* PrimerScrollView.swift */,
+				64E5CBA74B8AE23B563020A92BE93851 /* PrimerStackVIew.swift */,
+				0C74DCA6DE0FC3BECB04A1CD06D6A314 /* PrimerTableViewCell.swift */,
+				F076F54BD9CE05779AABC4D587EF7D1C /* PrimerUIImage.swift */,
+				8C1938219645ECD7444E7368C7AE41EC /* PrimerViewController.swift */,
+				76212726E96FAB1AEA9D22D13D8B2A26 /* PrimerViewExtensions.swift */,
+				F2601D30CBAD816B246C384DE0E6A35B /* StringExtension.swift */,
+				A501D3D16752F32AC3F057D2F8D47E79 /* TimerExtension.swift */,
+				1DAF0408BD674A9D72D801E98E502399 /* UIColorExtension.swift */,
+				B050FDD714CC6E742FD9B1C5431DE0A2 /* UIDeviceExtension.swift */,
+				ED3765E6101DD650B9FF36CD06892A83 /* UILocalizableUtil.swift */,
+				5929A82D3FF45FCDE5E499D31F7CC018 /* UINavigationController+Extensions.swift */,
+				AFEE19A51E07C151053E75A5335CA468 /* UIScreenExtension.swift */,
+				D31FFABD73529549DD0648E22237ED73 /* URLExtension.swift */,
+				DD49CD925E98AB5EEE20311B70F118A4 /* UserAgent.swift */,
+				903452C2F03311E9F54893E00CF2991F /* UserDefaultsExtension.swift */,
+				4C3E1CBC5614C1FA19A1770150551171 /* VersionUtils.swift */,
+				47F357409294319906FBAF58233E2080 /* Weak.swift */,
+				D8DAE5650418097986F7404E18C71541 /* WebViewUtil.swift */,
 			);
 			name = "Extensions & Utilities";
 			path = "Sources/PrimerSDK/Classes/Extensions & Utilities";
 			sourceTree = "<group>";
 		};
-		BBB9D1FE04554DB9AC20289D7535AED5 /* Networking */ = {
+		BA3F29A93470580D1A8E9A94278FC211 /* FormsTokenizationViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				CAAC1DC0B5F5979EF3D8E6494A9E5713 /* PrimerAPIClient+3DS.swift */,
+				9E13CEC6801594CE09EE0D4F92DAC184 /* CardFormPaymentMethodTokenizationViewModel.swift */,
+				BC7761C41E744E52D98D8B4B7759A821 /* FormPaymentMethodTokenizationViewModel.swift */,
+				AEEA3E008E64C1F5EE29412E44B180F9 /* FormPaymentMethodTokenizationViewModel+FormViews.swift */,
+				88E0DA43ED8936BF3324BDFE7340081F /* Fields */,
 			);
-			path = Networking;
+			name = FormsTokenizationViewModel;
+			path = FormsTokenizationViewModel;
 			sourceTree = "<group>";
 		};
-		BCA1F4FC261B5795F9EB66A41963E734 /* Nibs */ = {
+		BA432F27C0065F4F4D4B9EB85D8C3812 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
-				29A96B2E7EF83B15654E41E07CA9011B /* PrimerTextFieldView.xib */,
+				DC47390466729A45FC745790F6C0900D /* AssetsManager.swift */,
+				ACDC3243C2E4F76161D1FD8B607AB018 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift */,
+				565C2F154D3AF2C4CF0567D742493C93 /* PrimerRawRetailerDataTokenizationBuilder.swift */,
+				89CD109AF48504DEE37CFC24F53DACD2 /* VaultManager.swift */,
+				47168EB07A3F1F058FAEADD89AC0E4D0 /* Payment Method Managers */,
+			);
+			name = Managers;
+			path = Managers;
+			sourceTree = "<group>";
+		};
+		BB5618F527A1C462BAE9F22253E2C2F2 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				F22F17017930269FC0D4E88BB05BEC8E /* URLSessionStack.swift */,
+			);
+			name = Network;
+			path = Network;
+			sourceTree = "<group>";
+		};
+		BCF80A97B30B0F2E56E6F04EE5409B3E /* Nibs */ = {
+			isa = PBXGroup;
+			children = (
+				61A15B1951AF9CFA64C9A09F47AA0250 /* PrimerTextFieldView.xib */,
 			);
 			name = Nibs;
 			path = Sources/PrimerSDK/Resources/Nibs;
 			sourceTree = "<group>";
 		};
-		C5F9EF159569E8D0D992ACC9346871A0 /* Primer */ = {
+		BE579FF01542B5F8108BC1A46EAC1CB3 /* Text Fields */ = {
 			isa = PBXGroup;
 			children = (
-				70DE611C78184781092429D859F017EB /* PrimerAPI.swift */,
-				C29E21010341A1863EABED0426192B0C /* PrimerAPIClient+PCI.swift */,
+				38A824B2812F36EF238ACDF467425101 /* PrimerCardholderNameFieldView.swift */,
+				72CFC4735220124F1C27518F5795CCFF /* PrimerCardNumberFieldView.swift */,
+				798185C0AAF883967105163189763B53 /* PrimerCVVFieldView.swift */,
+				8743B83727ED04C6EEFB6676A7294731 /* PrimerExpiryDateFieldView.swift */,
+				318698473C98A0165F9B976398542408 /* PrimerTextField.swift */,
+				16E651F2EF0359212D2E8D44E6C814C2 /* PrimerTextFieldView.swift */,
 			);
-			path = Primer;
+			name = "Text Fields";
+			path = "Text Fields";
 			sourceTree = "<group>";
 		};
-		CD3FEE2C3E183D9F5AC9EA786D044581 /* PCI */ = {
+		C4849A8F6CC796B5F8E5A15636DB51F6 /* localized_countries */ = {
 			isa = PBXGroup;
 			children = (
-				A572AB697E2F05A71DD3D8B2776AD7DC /* TokenizationService.swift */,
-				578B46DC031EA0605CDCB031D67FBD70 /* Checkout Components */,
-				2ECB21BE2B2BF43072338AF867898037 /* Services */,
-				609EE354DA04651413B7D08AFB1C869B /* Tokenization View Models */,
-				9E309FBC005D816D0180B91229F0AC36 /* User Interface */,
+				E3F086A1612812EEB7F60FE75B9F764C /* af.json */,
+				C15B03C6068D04B239AB92399510FEB5 /* am.json */,
+				D6F90BB1D517FA485D4412B287CB3B0E /* ar.json */,
+				4FE10E4416F253ED2F8A7562226504A3 /* az.json */,
+				E3DA91531A79C93FB543A72149CB5D0F /* be.json */,
+				1A98363F99139D5B9B01EA53F46BBD85 /* bg.json */,
+				40FA715D84A8FF6F50AAF6E5C550461B /* bn.json */,
+				C4A936EA6139B2FA3457A56E75871EFB /* bs.json */,
+				A4DDC3E610AE18626518A71E64F31FD8 /* ca.json */,
+				E55D99380D990C8DCFB88B73AB599FBC /* cs.json */,
+				C28DA10BB82E4219207E02A998F75394 /* cy.json */,
+				973F4605FB509D06C59F6AB96ED9EDF0 /* da.json */,
+				D6BC88E1C31DC1249EF7119D251BA204 /* de.json */,
+				9F4DCEC4A50A61283DE3D94B7D7D83CE /* dv.json */,
+				4C9A28C3BCAEFE9BD5AB757E551C3293 /* el.json */,
+				BA9AB5993CC6ABCE0808A95D838BA535 /* en.json */,
+				68A1B21616905897DE02509A7829E281 /* es.json */,
+				7510600267C94A917C4B694DD9FC8A8B /* et.json */,
+				4832C2449FCB88FB90840BFAFD2F8920 /* eu.json */,
+				46B3EA56B0956E1AF30EDF2B734CE19C /* fa.json */,
+				3BE2983E904B9562D062C90EDB0F7369 /* fi.json */,
+				F887E16271844B36888D936B3045E36D /* fr.json */,
+				8A401D6CD84605D71981212A4D86A86B /* gl.json */,
+				637B454A256CADC4D8EFD5280ED58548 /* ha.json */,
+				A8C220F0252DF3030F67739D5D7CFC0C /* he.json */,
+				7E3829BFC4A103319826826E33060597 /* hi.json */,
+				1B8F0E0D1F895D7FBC080355D9E0D08B /* hr.json */,
+				22793AE5741A5F986FC0B459363EDB0D /* hu.json */,
+				213B5FDF3D6350724D0E3CB989DD6807 /* hy.json */,
+				A888A56ABB4E2264835636822B21D957 /* id.json */,
+				20F8C6339735F2D7EF116A79442C0A1C /* is.json */,
+				79FEB8CEBD39C9AEB4C37603C20372C4 /* it.json */,
+				CBA439F33C6B71CA66767C4D3C657DBF /* ja.json */,
+				3F4D40A84A2FD64608BF069DDCFB78B8 /* ka.json */,
+				409C1D1713CED34744C259E39762DA48 /* kk.json */,
+				0703C47FE2E57ECE50F82429DA4A5691 /* km.json */,
+				595EBEC18007F19642E3E4E4ACE00323 /* ko.json */,
+				97CA75D3D6AA933DE54DC8F409A234CA /* ku.json */,
+				7EA5F939D4E2AE50BF6269EDDAA890A4 /* ky.json */,
+				2AB885AFB60EE0C6B39062DFE30176AC /* lt.json */,
+				BD1470B97657B6C4BDBACC9E553269AD /* lv.json */,
+				A4545C55DFE17BDBA7005AED27FF9E22 /* mk.json */,
+				FD66BDF8CA86C83594B4B5985A5C5EFD /* ml.json */,
+				BEF5C2A116F901093DC28689676D0D7B /* mn.json */,
+				4E530B50E3299919F005E3567B4CA23E /* ms.json */,
+				F0BAAE6701EBBA54A56BC58E97505F84 /* nb.json */,
+				6B0806BEFC9CC9998C48890016E52486 /* nl.json */,
+				2E1E4D5287D1BC23822FF2515E9248AE /* nn.json */,
+				4B18BAA9E78106A09D434DF7792F0632 /* no.json */,
+				D13D585BB4F26D9D79CBE16CBD0B1362 /* pl.json */,
+				2D60F047DE49B9E1CB784CA58F775EAE /* ps.json */,
+				8943A0F753665E1CDE97043C6D0B5144 /* pt.json */,
+				26BF1DF0CF7272AD3242B7D5FCD7BF60 /* ro.json */,
+				AFAB69FA82453448447AE6944EE6B068 /* ru.json */,
+				6124368491C700E91F5E7FFF9F75ACC6 /* sd.json */,
+				794A84E32A1C21271E3B869D970535BB /* sk.json */,
+				D4C1587E41FF1F893688589214A1F24D /* sl.json */,
+				6EC48B5C87BC19DD44808313ED2011ED /* so.json */,
+				D9E3ED96959579BEEE7BAF7E4A95AF12 /* sq.json */,
+				C3E2546D6816E142BAD4DDA304274D32 /* sr.json */,
+				7CFCB01CA35903EB7665DB1CEE88F1CC /* sv.json */,
+				D8A78C9A95D42B03B85DE293D09C6831 /* sw.json */,
+				1FC60FD7327B5F605ACC509FDA36E3E3 /* ta.json */,
+				BAD688DF63876C2E1AE5B532F18C7D0D /* tg.json */,
+				FEE6C260E8DFD5CEB5C5BACDB1620BAB /* th.json */,
+				BBE9A4BD522623C67BCCB016D50A9029 /* tr.json */,
+				985AF13E3948D7D025AC1B019B99D045 /* tt.json */,
+				D6674E079526CF6D8F40E80278CC86A2 /* ug.json */,
+				4A976165D788F0CD483FCDE40AFD93D6 /* uk.json */,
+				2E125144112EB19BFE978F77064D400C /* ur.json */,
+				B597C18CE138C83C3EB07E587B1FEE92 /* uz.json */,
+				F0C5A3999803846187EAF8E85921D100 /* vi.json */,
+				5BA577DA087EFF27F914174F351FCCE6 /* zh.json */,
+				B22B51EE13746464F156E7AC3365C078 /* zh-KH.json */,
+				8391C5AC38DC9940E6C112E51A37E47C /* zh-TW.json */,
 			);
-			name = PCI;
-			path = Sources/PrimerSDK/Classes/PCI;
+			name = localized_countries;
+			path = localized_countries;
+			sourceTree = "<group>";
+		};
+		C6538C1100DDBCEB2EBA6BA118B998EE /* Countries */ = {
+			isa = PBXGroup;
+			children = (
+				2A70671F7AA0DE263FAE41BF52094283 /* CountrySelectorViewController.swift */,
+				FA811C7A05459AC87527FED5F1BD368E /* CountryTableViewCell.swift */,
+			);
+			name = Countries;
+			path = Countries;
+			sourceTree = "<group>";
+		};
+		C963B2F210C3843E381477E64931E009 /* User Interface */ = {
+			isa = PBXGroup;
+			children = (
+				2A98A4CC4194D2E133E1A93105BECAA7 /* InternalCardComponentsManager.swift */,
+				687139B7119FFC0E05937A5D927A8EEC /* Root */,
+				BE579FF01542B5F8108BC1A46EAC1CB3 /* Text Fields */,
+			);
+			name = "User Interface";
+			path = "User Interface";
+			sourceTree = "<group>";
+		};
+		CDE20084EA24A64E19D32AD1FC082641 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				F8EE2C72FA1F716181A3C2ED47540C02 /* PrimerThemeData.swift */,
+				26F7FF514DC158521EF4450F0BF89139 /* PrimerThemeData+Deprecated.swift */,
+			);
+			name = Public;
+			path = Public;
 			sourceTree = "<group>";
 		};
 		CF09FDEDD112D10516F31E67FE070F1D /* Pod */ = {
@@ -2002,78 +2053,83 @@
 			);
 			sourceTree = "<group>";
 		};
-		CF8D95340ADE9B69D22DF751EC3A7730 /* Theme */ = {
+		D03A4CD49DBF7EB487A73CAEA3CCB39F /* Tokenization View Models */ = {
 			isa = PBXGroup;
 			children = (
-				768DFADB4567BC5D42C0BE71D3D87CCA /* PrimerTheme.swift */,
-				680359D66F46C2951A78C19ED2AC9FD9 /* Internal */,
-				0C30A86041FA6C60519939331CCE5008 /* Public */,
+				BA3F29A93470580D1A8E9A94278FC211 /* FormsTokenizationViewModel */,
 			);
-			path = Theme;
+			name = "Tokenization View Models";
+			path = "Tokenization View Models";
 			sourceTree = "<group>";
 		};
-		D6566FD1F6220FDC81630314E152AB40 /* User Interface */ = {
+		D2C61E87F0C3E83CDCD7A89B7129341F /* Connectivity */ = {
 			isa = PBXGroup;
 			children = (
-				4FD32028FD5BF0AEA431D16151440339 /* Identifiable.swift */,
-				A5AAD964478E927406E375C8674D47C4 /* PaymentMethodsGroupView.swift */,
-				5C7DE3C637C159DD04B51F8624B44624 /* PrimerDemo3DSViewController.swift */,
-				F4F8BF23E74B8A9811AF0145DDF82D00 /* PrimerUIManager.swift */,
-				B7F35FC28E43595B3B10E170BB27463E /* UIUtils.swift */,
-				758D2F94AB5E8DEC05DF723F03CC7967 /* Banks */,
-				A78EF1336A166E295E7EDE56B19713B0 /* Components */,
-				E6A9BC1D267B9246A5A79C3F4E5D1077 /* Countries */,
-				F697BE3C0B7E966BD66EF62A53C708AC /* OAuth */,
-				890548F6977869283AA5027CFCE508E3 /* Primer */,
-				E7220B8E9987A9680E9659B17B468A30 /* Root */,
-				799D8434AFED7808C162E6775B9B09EA /* TestPaymentMethods */,
-				E3581C88BAFBCC958595EBC5D1F76385 /* Text Fields */,
-				F835790CD1F1A50AE0161831CD4F5688 /* TokenizationViewControllers */,
-				442144B2C1B83E433FC3F328010C8A8A /* TokenizationViewModels */,
-				B8829AF0F07C22C996889FBFE116AD48 /* UI Delegates */,
-				5BEEE2EE0882B7BC12D42B57A5DD8E55 /* Vault */,
+				2427D763745299B1B1C8A7A8F7166C90 /* Connectivity.swift */,
 			);
-			name = "User Interface";
-			path = "Sources/PrimerSDK/Classes/User Interface";
+			name = Connectivity;
+			path = Connectivity;
 			sourceTree = "<group>";
 		};
-		D6B6640B24BE844CED3F2D51BAD33B35 /* Data Models */ = {
+		D6467212D3521EA8354B4F63E88763FE /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				AC15F60DD4F3F7665ED569E4AE16ED4C /* 3DS.swift */,
+				61F7412D45858B66147EECAEDA4AD2F0 /* HeaderFooterLabelView.swift */,
+				A9EEC75B7B1B82C1B674974260346A05 /* PrimerFormView.swift */,
+				715B7A9737972FC4CFF322C9D09BA162 /* PrimerNibView.swift */,
+				7929645639832C86A4A793856AC218FC /* PrimerResultComponentView.swift */,
+				A6C00E0D3A4D85BDA30C8760990EE13C /* PrimerResultViewController.swift */,
+				1B4FE78145CB0E3CE9CA10F5B57E721B /* PrimerSearchTextField.swift */,
 			);
-			path = "Data Models";
+			name = Components;
+			path = Components;
 			sourceTree = "<group>";
 		};
-		DB4BDD64573B9E5913B9F61B1DFBC076 /* Modules */ = {
+		D70FEA4D9CCAA7B6265D085FA9053C90 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
-				B2B221963E70220E6B3394DEF7763AB4 /* CheckoutEventsNotifierModule.swift */,
-				F80AB2877BC6D8647D57A95FBA70289E /* ClientSessionActionsModule.swift */,
-				96245C913D414469B1B055FE759BCE36 /* Downloader.swift */,
-				7EC9E7DF45F1F430B386960FC32F8DE4 /* ImageManager.swift */,
-				F52B6F5E14121C09C0A1D067D35D33C2 /* PollingModule.swift */,
-				703B7306E142EC188CB5862A3386412B /* UserInterfaceModule.swift */,
+				3A0DE56B2DF2205BD309227E499DAC80 /* Analytics.swift */,
+				3967A27848CBD48A31BBE753FDD7AA39 /* AnalyticsEvent.swift */,
+				543B41C5C2EDE9AA3BB42EB5694F0714 /* AnalyticsService.swift */,
+				E4C51AE115C965E7B9FD010CCFF9695A /* Device.swift */,
 			);
-			name = Modules;
-			path = Sources/PrimerSDK/Classes/Modules;
+			name = Analytics;
+			path = Analytics;
 			sourceTree = "<group>";
 		};
-		E3581C88BAFBCC958595EBC5D1F76385 /* Text Fields */ = {
+		DCA00ECE502751A813523E9144302E6C /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				02E4F824F61AB7ED19B472516A3E9C8D /* PrimerAddressLineFieldView.swift */,
-				B7F1D9613A2366B3F5224FB667DD56DE /* PrimerCityFieldView.swift */,
-				C69E70953DB1701A8251042C30D374FD /* PrimerCountryFieldView.swift */,
-				E16B961BCEA56E1E787141DF5A81C0B3 /* PrimerFirstNameFieldView.swift */,
-				6A7BBE63AFAE496E1D588F9F8EE93954 /* PrimerLastNameFieldView.swift */,
-				27E0ADF57D15D16B4B09330F015DAC41 /* PrimerPostalCodeFieldView.swift */,
-				3E83B8F8F0ECE8ECEDC17E44428515C7 /* PrimerStateFieldView.swift */,
-				6942EEB75589F8096F31A852E985DC5A /* PrimerTextFieldView+Analytics.swift */,
-				1CDD75F8BD3124D3057BDBC8548F8B7F /* PrimerTextFieldView+CardFormFieldsAnalytics.swift */,
-				0680F97659B4FEEABFECADE8CF824132 /* Generic */,
+				AF226B97AB588801EB2AB1120A1778AE /* API */,
+				BB5618F527A1C462BAE9F22253E2C2F2 /* Network */,
+				7B2833556746661F32A4785EAFBFD9E5 /* Parser */,
 			);
-			path = "Text Fields";
+			name = Services;
+			path = Services;
+			sourceTree = "<group>";
+		};
+		DF167A1082C6AB9CFD477CDC162DB8DE /* Vault */ = {
+			isa = PBXGroup;
+			children = (
+				11E2A15227CF22FFC4B4C56AAE533118 /* VaultPaymentMethodView.swift */,
+				8F038A4E81716AB1E8C552E2504CF13C /* VaultPaymentMethodViewController.swift */,
+				1DA02A897C750507CA0849CE74B55431 /* VaultPaymentMethodViewModel.swift */,
+			);
+			name = Vault;
+			path = Vault;
+			sourceTree = "<group>";
+		};
+		E3684FD04B3B3B3BE81032B553AC9F76 /* Cancellation */ = {
+			isa = PBXGroup;
+			children = (
+				E25402AB502E293F91B86FCC719BE0EC /* CancelContext.swift */,
+				44162EBABABA5203CEA22C4AD66FDEA9 /* Cancellable.swift */,
+				0080C787E33A5BFA9E346142D3959DE3 /* CancellableCatchable.swift */,
+				7B53B2736E88AB8E197388914CF53DC8 /* CancellablePromise.swift */,
+				7DDA0306F9F9577B3D634F0D7564BDC5 /* CancellableThenable.swift */,
+			);
+			name = Cancellation;
+			path = Cancellation;
 			sourceTree = "<group>";
 		};
 		E59AE524338A66D328434373B5ECC4BD /* full */ = {
@@ -2084,32 +2140,20 @@
 			name = full;
 			sourceTree = "<group>";
 		};
-		E6A9BC1D267B9246A5A79C3F4E5D1077 /* Countries */ = {
+		E7205671470293C04694647D441B346B /* Primer */ = {
 			isa = PBXGroup;
 			children = (
-				3D803FB62A01F2DB010435FC0D6B72FE /* CountrySelectorViewController.swift */,
-				26238DDBA62CD3748B820A6A1EDE9B01 /* CountryTableViewCell.swift */,
+				1D6971C4F3174907CE296FE18125901E /* AppState.swift */,
+				25CFE7582EBED3AD762E268632D3C4DE /* DependencyInjection.swift */,
+				B425735AD0440C017E0D53AFB3789334 /* Primer.swift */,
+				F9CAB132F350CE2AA9EA91A1CCF60526 /* PrimerDelegate.swift */,
+				5695576113B7185E09733A9CD2E2F320 /* PrimerInternal.swift */,
+				4C87A27D9176D689333D6F72470419B6 /* PrimerSource.swift */,
+				AAA4A8CE5D93F1C448697BFBDB16C1AE /* ResumeHandlerProtocol.swift */,
+				3B4C8BC289127C1F940B60B4C68AFA93 /* Decision Handlers */,
 			);
-			path = Countries;
-			sourceTree = "<group>";
-		};
-		E7220B8E9987A9680E9659B17B468A30 /* Root */ = {
-			isa = PBXGroup;
-			children = (
-				167D824DCDED21787986848B8C99950E /* PrimerAccountInfoPaymentViewController.swift */,
-				6B5A8E285FB2A6884A07A5FF0B847E32 /* PrimerContainerViewController.swift */,
-				46BE40CF3D522E23F0A1AC4996C89EB1 /* PrimerFormViewController.swift */,
-				08D90FB6A5D795F4049AE61499E72F81 /* PrimerInputViewController.swift */,
-				2EA913A90FFF849E790BF1C22831A3E2 /* PrimerLoadingViewController.swift */,
-				B41878BCFFB2F0774673FAF76C845093 /* PrimerNavigationBar.swift */,
-				7E63F745E427E987E09670C63FFB0AAD /* PrimerNavigationController.swift */,
-				EE90A0AF7BD80B38DC3402043B60F5CD /* PrimerPaymentPendingInfoViewController.swift */,
-				4F6618008B201E5110B04678DF9385E9 /* PrimerRootViewController.swift */,
-				9D06A2CDE452ACD10D1C7D44B64CB297 /* PrimerUniversalCheckoutViewController.swift */,
-				CF62A4EBA4EDBA912B5ACEB9B84BA64A /* PrimerVaultManagerViewController.swift */,
-				3613D9723544DFCA6CB7871DA72A105D /* PrimerVoucherInfoPaymentViewController.swift */,
-			);
-			path = Root;
+			name = Primer;
+			path = Primer;
 			sourceTree = "<group>";
 		};
 		E8986BCA747D691F5B00D6934671BC95 /* Frameworks */ = {
@@ -2118,6 +2162,40 @@
 				E906FBDA07229BAB789B1402FE3C3585 /* libipay88sdk.xcframework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		EB903229F47F668CC72FD495CB4B395A /* User Interface */ = {
+			isa = PBXGroup;
+			children = (
+				AB0DE4CDFEDDADC6C799DCF98FA4027D /* Identifiable.swift */,
+				31FE9C6312D13374285B21F2E910631C /* PaymentMethodsGroupView.swift */,
+				7935484F6C5ED13DE9B756AD5CCA7A39 /* PrimerDemo3DSViewController.swift */,
+				86B1AACEEFA843EB2D72C63081EF0EAB /* PrimerUIManager.swift */,
+				F7400A013AEDEF44A971F11CAD1BA407 /* UIUtils.swift */,
+				2B467074626866293D5AB76562AC8C35 /* Banks */,
+				D6467212D3521EA8354B4F63E88763FE /* Components */,
+				C6538C1100DDBCEB2EBA6BA118B998EE /* Countries */,
+				1112231654CC821E058B32F7205A2EFE /* OAuth */,
+				2022DD36CA4DBFFF8F9BF513891BBA9F /* Primer */,
+				79E00D21CCE6D38E9EC33F8FD202075E /* Root */,
+				4AFE1E796B5610DEBCA14E5AF907ABF7 /* TestPaymentMethods */,
+				45D66F71B0186E3B289B1D2B9DC6A62E /* Text Fields */,
+				43F65EF49A7D5D75C503AB0FC0C8C6BB /* TokenizationViewControllers */,
+				597E64FB8AB4ED32F5AC7A323FA58417 /* TokenizationViewModels */,
+				2C610A58679C9117632C65D24E1FE255 /* UI Delegates */,
+				DF167A1082C6AB9CFD477CDC162DB8DE /* Vault */,
+			);
+			name = "User Interface";
+			path = "Sources/PrimerSDK/Classes/User Interface";
+			sourceTree = "<group>";
+		};
+		EEF26DE2DFC899951CC1B5BF293CA02D /* Crypto */ = {
+			isa = PBXGroup;
+			children = (
+				4D94D6F1EA8ABFBD1EC98BB93CF85248 /* AES256.swift */,
+			);
+			name = Crypto;
+			path = Crypto;
 			sourceTree = "<group>";
 		};
 		F104F0684750526EB9589A6F2EEE2481 /* Pods-Debug App */ = {
@@ -2137,39 +2215,16 @@
 			path = "Target Support Files/Pods-Debug App";
 			sourceTree = "<group>";
 		};
-		F183F4030364A6D6AA087BA35BB1A61F /* Network */ = {
+		F3995BD08F3DDE452A4FC53F2B16FA1D /* 3DS */ = {
 			isa = PBXGroup;
 			children = (
-				E13D715A28E38B1A41D9B3671C0F90CF /* URLSessionStack.swift */,
+				15CDBA87C49E2F7988858775788B6589 /* 3DSService.swift */,
+				1FF38A4AE39D2695460167BC06BA8B05 /* Data Models */,
+				40366A8866BC14D21EA7D254C235B47C /* Mock */,
+				6AE9C37D11FE8544DEAEA811FF7937B4 /* Networking */,
 			);
-			path = Network;
-			sourceTree = "<group>";
-		};
-		F1D28C317BB17486018978978A329936 /* Fields */ = {
-			isa = PBXGroup;
-			children = (
-				6C80A02EA38330B87DF2A01E76DA99CF /* AddressField.swift */,
-				A61E7B7CCD27CE3F5AFAF67768319512 /* CardholderNameField.swift */,
-				B1F7C27DA3C1925E73955990BEF67E0A /* CardNumberField.swift */,
-				72E7D5002DB55BB9F9632D427714BB4D /* CityField.swift */,
-				22E3B6E2350EC9C8A4FB2AB0DF81D119 /* CountryField.swift */,
-				F81B733AB83E11404DA41A994E6DF0E9 /* CVVField.swift */,
-				76E3578E4B628CC91F9BC1B6C5C4FC73 /* ExpiryDateField.swift */,
-				571542B6D7831B459B37FF0196AC9727 /* Field.swift */,
-				FC3AEB607A42E7813FA5CC05C2E22893 /* FirstNameField.swift */,
-				D81C1DB85FAF3F49403DF67E2C7D8A5E /* LastNameField.swift */,
-				38135FC951FDE8E3032F3CC26C45B06D /* PostalCodeField.swift */,
-				8B18397CD1BFAF65AECB88E78BAC0ADD /* StateField.swift */,
-			);
-			path = Fields;
-			sourceTree = "<group>";
-		};
-		F697BE3C0B7E966BD66EF62A53C708AC /* OAuth */ = {
-			isa = PBXGroup;
-			children = (
-				0A9BFD6F8F465F8A708FE03A17414427 /* PrimerWebViewController.swift */,
-			);
-			path = OAuth;
+			name = 3DS;
+			path = 3DS;
 			sourceTree = "<group>";
 		};
 		F70E7EBF8F4CB809EEDFCA9508D34317 /* PrimerKlarnaSDK */ = {
@@ -2179,15 +2234,8 @@
 				788823208848A5A159A527490F431C70 /* PrimerKlarnaViewController.swift */,
 				28CBDFB3C4CF4B13FFC4A89754308FEB /* Support Files */,
 			);
+			name = PrimerKlarnaSDK;
 			path = PrimerKlarnaSDK;
-			sourceTree = "<group>";
-		};
-		F835790CD1F1A50AE0161831CD4F5688 /* TokenizationViewControllers */ = {
-			isa = PBXGroup;
-			children = (
-				61E7AFAA58AAFA31C00BACCCF8559AC5 /* QRCodeViewController.swift */,
-			);
-			path = TokenizationViewControllers;
 			sourceTree = "<group>";
 		};
 		FB3082D82D5272776837FE77F7DA1CDC /* Primer3DS */ = {
@@ -2204,7 +2252,17 @@
 				987BBF73787C38018601EDE014539D37 /* Frameworks */,
 				91D9ECEEBE4B18617FCB1A4D8F79C8CA /* Support Files */,
 			);
+			name = Primer3DS;
 			path = Primer3DS;
+			sourceTree = "<group>";
+		};
+		FD04AC7556EEBF0E4FDF6EA25195760F /* JSON */ = {
+			isa = PBXGroup;
+			children = (
+				DFE48F48CCAA57BABEC5152F8FF0107F /* JSONParser.swift */,
+			);
+			name = JSON;
+			path = JSON;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2228,11 +2286,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		69E4183AE72B78E862ECC5980E09A0CF /* Headers */ = {
+		9E264EDD8BB2251ACB0DB09A70DBB128 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DF3A5CF67AF7D0DF6B3D4D22D6B74FB1 /* PrimerSDK-umbrella.h in Headers */,
+				8FF05675EA291968E2ECF69D02855186 /* PrimerSDK-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2275,7 +2333,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				9B83085B805A82859AC144401B7FEE66 /* PBXTargetDependency */,
+				CC662D5F08F04E5630AF3837C4B0F618 /* PBXTargetDependency */,
 			);
 			name = PrimerKlarnaSDK;
 			productName = PrimerKlarnaSDK;
@@ -2294,7 +2352,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				A7BC393349FFD7276F202FA19680299D /* PBXTargetDependency */,
+				7C7D76EA8EEAE9D76025A404DAD8F4D2 /* PBXTargetDependency */,
 			);
 			name = "Pods-Debug App Tests";
 			productName = Pods_Debug_App_Tests;
@@ -2303,11 +2361,11 @@
 		};
 		6E6525C7043FBA7BB34A249010AF5593 /* PrimerSDK-PrimerResources */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = A8EF881FD5A72A7DB048671BC29DB4D0 /* Build configuration list for PBXNativeTarget "PrimerSDK-PrimerResources" */;
+			buildConfigurationList = 2D377BA0A96E61EDE346C6F614B8DBC8 /* Build configuration list for PBXNativeTarget "PrimerSDK-PrimerResources" */;
 			buildPhases = (
-				51853750D945E1BD766C38D35F6E25A3 /* Sources */,
-				242555C7735855BCEB0673DF13F49FE1 /* Frameworks */,
-				B155E6B562D5834C23E99466C18D3289 /* Resources */,
+				A0BCFEAFD0BA3197FA6E6DE69FCB2607 /* Sources */,
+				7434B9BBD05C3F5210694B135C8A5A5D /* Frameworks */,
+				F60DF1FAB395C1BDBFF04187781A400B /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2349,11 +2407,11 @@
 			buildRules = (
 			);
 			dependencies = (
-				55FC62A60315FE126E3E0251A4BBF7C8 /* PBXTargetDependency */,
-				3DA1EAE2F57843839A24434589963E82 /* PBXTargetDependency */,
-				0AAAE37337CE79CC0775C3CB663C5D61 /* PBXTargetDependency */,
-				226BB79F1CA022474D3A40283B27AA17 /* PBXTargetDependency */,
-				BE88681C9DFDD6125B60EB7C26BDC415 /* PBXTargetDependency */,
+				6F32ED436AAF77B26CDF62B90DD2D1CB /* PBXTargetDependency */,
+				AE64B373B3E8699DA1EDBB0B90EA4C8B /* PBXTargetDependency */,
+				41239B3F8CFC01C2547DD4A76A755960 /* PBXTargetDependency */,
+				A522F090FEB8AF5501545E21B256A29F /* PBXTargetDependency */,
+				B928D73AB2B69C97970980760E2CA1A6 /* PBXTargetDependency */,
 			);
 			name = "Pods-Debug App";
 			productName = Pods_Debug_App;
@@ -2362,17 +2420,17 @@
 		};
 		F3BE9108C53B53949406218CEA55E0B2 /* PrimerSDK */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 3493B366F8D15A18C083F1DF7B22BC3A /* Build configuration list for PBXNativeTarget "PrimerSDK" */;
+			buildConfigurationList = A7AF6E72B65301242A39A130F132A530 /* Build configuration list for PBXNativeTarget "PrimerSDK" */;
 			buildPhases = (
-				69E4183AE72B78E862ECC5980E09A0CF /* Headers */,
-				7DF00B37D0BA9CB72D987626752CB0C0 /* Sources */,
-				D27CC70B1B10E399B8DC40ABF4DA146E /* Frameworks */,
-				B2A7FD0B4F2ADB29686863B6BC0519D8 /* Resources */,
+				9E264EDD8BB2251ACB0DB09A70DBB128 /* Headers */,
+				C868828A7552C705C65A473ACC97869D /* Sources */,
+				9884039CEB87EFE5BDE56F95FDB60079 /* Frameworks */,
+				F8ADCB4C939EE7E15CEE212E1D613099 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				6AD8591E40660D9097E0DF591DC18022 /* PBXTargetDependency */,
+				00E0A69F77F29BDCC2415C895DAE266B /* PBXTargetDependency */,
 			);
 			name = PrimerSDK;
 			productName = PrimerSDK;
@@ -2479,98 +2537,98 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B155E6B562D5834C23E99466C18D3289 /* Resources */ = {
+		F60DF1FAB395C1BDBFF04187781A400B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				983A0A82BDAD071D43676D836270DB95 /* af.json in Resources */,
-				D296953F1AB9EA6F48D8F0BA4823802C /* am.json in Resources */,
-				EB4196324EAF78474C515FD0221C7B18 /* ar.json in Resources */,
-				4364A26809CFE3BFF6D1C387F1D4B869 /* az.json in Resources */,
-				266CED9451AA8C03DCED9A3EBA68200B /* be.json in Resources */,
-				9F10A15F75EBA6E273788FA3FC62DF5D /* bg.json in Resources */,
-				A57869D5C44040198C89892DAC2F943D /* bn.json in Resources */,
-				A4FAC82BCDD056CC9D573F688F6FBC5F /* bs.json in Resources */,
-				B2069F3F63574996CD79F7A8E99F7B2E /* ca.json in Resources */,
-				42AD943772E9FEF6247E9A728D865240 /* cs.json in Resources */,
-				CB0B4C49754C3382583C3C530A41C67B /* currencies.json in Resources */,
-				25CCDBB8C347CAFBB8AD8B263B348E3F /* cy.json in Resources */,
-				669300183A9A0B6C31F1B5BAE80D6E4F /* da.json in Resources */,
-				FC4EEF009ADEFE96E61178DCB0461758 /* de.json in Resources */,
-				9EBF8AA4485C29D34CC5666C589A9621 /* dv.json in Resources */,
-				D665B0D13E8B2F0DE0B01ED16F3D1189 /* el.json in Resources */,
-				1F94A232CA204C37C0427CD6145E8E91 /* en.json in Resources */,
-				746BA51131AD06750526B1AD752B8AAC /* es.json in Resources */,
-				89F9A4C99F7456F9F26D259B908BAB2A /* et.json in Resources */,
-				CEB03B9A470236DE0FCD1BCF2A1E173C /* eu.json in Resources */,
-				9452A1B60059ED90AC149CBEA50166EB /* fa.json in Resources */,
-				DCACB5CDA5373A3EF2E2E7F18DD8078E /* fi.json in Resources */,
-				67B2CA1A7AD4D2F09E5E36479E2D40D3 /* fr.json in Resources */,
-				D7DDDC7B7EE5BCFDA9C8ECD6D8B4B283 /* gl.json in Resources */,
-				0CB5F72EEB51A1E60599A4429C955DFD /* ha.json in Resources */,
-				CD85771AE9473EF0813C04F1EB4A58F9 /* he.json in Resources */,
-				60503B86EEE1AFD14CBF990E5E60F944 /* hi.json in Resources */,
-				966AA40CF4E8B6078593931CDADEF06E /* hr.json in Resources */,
-				52F788E625802856465B4B2D5676CE07 /* hu.json in Resources */,
-				C7A74B0755EAEAA5C70A27E729210F05 /* hy.json in Resources */,
-				ECAF8BA773D686781DEDF814875D3851 /* Icons.xcassets in Resources */,
-				CC19CDC4D302359C586811C3F065E1C6 /* id.json in Resources */,
-				8B02449E7354A1EB1D770568A20021D1 /* is.json in Resources */,
-				74B2115BAAF64D321F97FB799725242E /* it.json in Resources */,
-				4B37EAF151154CBB216977928324F816 /* ja.json in Resources */,
-				B12634601C435E330B118EF3181EADD3 /* ka.json in Resources */,
-				6C5314ED927C8464E485C309DB83E554 /* kk.json in Resources */,
-				C2118EDDCD32F6B7524DCFEA24C77389 /* km.json in Resources */,
-				875EABC36D7C52A79ECF7C5EC4E517EA /* ko.json in Resources */,
-				973580F2C85ADB174A8B7787BBB16D2C /* ku.json in Resources */,
-				25274121CBE436BE5BD26B3937B43B9B /* ky.json in Resources */,
-				2711F8E08FDED2DA544FC5970F17FE7F /* Localizable.strings in Resources */,
-				67482175C339F66B108C5710090BC5E6 /* lt.json in Resources */,
-				12CF81BDA8626434B0942B8E448AD8D1 /* lv.json in Resources */,
-				0AC10349CDBDADC11503633C2E5B6602 /* mk.json in Resources */,
-				D2ECBF7F9F227AE9386B8648C917988A /* ml.json in Resources */,
-				128C1BEE9B19ABDA88D26B4181072C72 /* mn.json in Resources */,
-				7C83B7715B581A2D8D97FD8E31EF3427 /* ms.json in Resources */,
-				2FB3CA07F8C08C808C4D69EA96350823 /* nb.json in Resources */,
-				F9A1A369A8B0CE25DCD66CA2E45D220D /* nl.json in Resources */,
-				6DA37F26D380A1A52F6A7CDBB4B7E962 /* nn.json in Resources */,
-				18A170A1E091F4B100334BA1D56F470A /* no.json in Resources */,
-				840215AFA76EF6FE97DAD17EFBD84824 /* phone_number_country_codes.json in Resources */,
-				E623437DD5C7DA4259778303BC444391 /* pl.json in Resources */,
-				E632D526F53A35050E9CA5A547E1E3C1 /* PrimerTextFieldView.xib in Resources */,
-				014C524E29C473BFEDAE3AD78F5AAC3C /* ps.json in Resources */,
-				BBF17D69C53D70680F3F31528FA73D3D /* pt.json in Resources */,
-				9525C251ACCEA5EDAC1896B6AE7ACCD8 /* ro.json in Resources */,
-				6075CB00D12E3CB83A6B4471F2898483 /* ru.json in Resources */,
-				0FD069250A0316B0A6F03DE67A00D9F7 /* sd.json in Resources */,
-				EEB8C49A72E04185A67A9D7E9F8B6014 /* sk.json in Resources */,
-				5385DE76B7F00F80033BAA6CDB1EFE45 /* sl.json in Resources */,
-				540AEE941275FB770AC5A5236FD36B11 /* so.json in Resources */,
-				19ADDFD87EFAEDE49E31344D273345E8 /* sq.json in Resources */,
-				735AB4AE5A2FA7666B2F59725816D9CB /* sr.json in Resources */,
-				1A5EF02432234C27BD393DD2C5B83436 /* sv.json in Resources */,
-				1E7014216D3C80B146E4CF11B3276DF2 /* sw.json in Resources */,
-				2275211086B4218FFC05873534A8852F /* ta.json in Resources */,
-				391D5CE37A29CA1D38CA59CD609E5A33 /* tg.json in Resources */,
-				5DEC6214C32D1DBFFBD611AEE8EC5BB2 /* th.json in Resources */,
-				FE48C561A91EF1E78AA83681652EB36B /* tr.json in Resources */,
-				CB33E63CD85746176E34828238C59AE6 /* tt.json in Resources */,
-				41202FE114E26F23AB27C1C1DFFD9ECE /* ug.json in Resources */,
-				7AA027CD74DC030D017A0A32F3D744D3 /* uk.json in Resources */,
-				B07E70D5283CE2E696AE03409C6BFD9E /* ur.json in Resources */,
-				C3A51CC724A231C3851A3F891A98E472 /* uz.json in Resources */,
-				601008AD15B07A3502754F7905AD07BF /* vi.json in Resources */,
-				82915469183481164C4AF527615835DB /* zh.json in Resources */,
-				45D0E33FCBC1A929D1FB3BACF4E513EA /* zh-KH.json in Resources */,
-				42BCF68DB690C3AC2F2332505110B136 /* zh-TW.json in Resources */,
+				B29BB998854AA8268C9A7A14F138CB60 /* af.json in Resources */,
+				069044A430CED2722377537410FB0C49 /* am.json in Resources */,
+				F2531A0E5117149F13DEA91B634717E0 /* ar.json in Resources */,
+				D7118A0AB3D2B98C74F837A67FCAF142 /* az.json in Resources */,
+				166B3214F3930A766A23765378F44712 /* be.json in Resources */,
+				665E0721793376E6AB3F3BB1190E576B /* bg.json in Resources */,
+				DF71206C9759D436CD8CB377D170D96E /* bn.json in Resources */,
+				F460BA338614C0B143374D1D0C29C5A8 /* bs.json in Resources */,
+				AE2B8AA6C0CF1889F58DE49BE7D19E00 /* ca.json in Resources */,
+				CD3F73CD61A3A9E9A34A0988B357F51E /* cs.json in Resources */,
+				FF04CA26888FF4CC567AB5A5799A109B /* currencies.json in Resources */,
+				D0EE9958A36C558BCEAFF469BABE7906 /* cy.json in Resources */,
+				2D80F501AA10D68E6DB0EA622DAEE6F7 /* da.json in Resources */,
+				8E7C2E6C79F2C18A8B3F1B9E247E5266 /* de.json in Resources */,
+				D4C697D94B7E4281D150049E4A7FF372 /* dv.json in Resources */,
+				5EC3191DDCFD3FE210F1321958B4C0DA /* el.json in Resources */,
+				F2C5CF00B2908E7A6D53AEC8B9806C6D /* en.json in Resources */,
+				CD74C0CB1F62AC5204D6AC41A8AAEE3D /* es.json in Resources */,
+				F6CE947F106A72E09F4BC8E154EF981C /* et.json in Resources */,
+				E03406441CB9FE4E8B989BA20DC7495C /* eu.json in Resources */,
+				29B3C5276319AF781C5B071BFD91816E /* fa.json in Resources */,
+				106937FD9BAF7983249FBC5560D7706D /* fi.json in Resources */,
+				017854BE0483AC2B14F3508368CEE9F2 /* fr.json in Resources */,
+				DD534498256AD30A803B5CCB933D44E3 /* gl.json in Resources */,
+				0F653D74B38A8BB3B885AF79ADCD6075 /* ha.json in Resources */,
+				FED55746A9DBB0AD2F03FCF5804D63EA /* he.json in Resources */,
+				E660A089587BA639932F6BB8A81974C4 /* hi.json in Resources */,
+				8B47FA494AE86067A0A69052D20BC47A /* hr.json in Resources */,
+				E7C099E2899AD97D9CA1258A2AE5CA5A /* hu.json in Resources */,
+				0E907F1ED25E8430D07F613B069DC69D /* hy.json in Resources */,
+				B3E70FE8D44A299BDC7240BB4E8831BC /* Icons.xcassets in Resources */,
+				FBC66B851190E52896041216B08CE5FB /* id.json in Resources */,
+				14B35AF46143EDCAA071BDFCB9DDA13E /* is.json in Resources */,
+				32FDB09865EB81F57C1635AC8E30ACD7 /* it.json in Resources */,
+				A440311C648C82F03FDC4D3344632864 /* ja.json in Resources */,
+				0AA18B7E79D56919F0E67ED2F3D4FCA5 /* ka.json in Resources */,
+				B33AF23503661100A632AF4834CFE0B0 /* kk.json in Resources */,
+				E222A85074E9212F89CA7507CE83B1C2 /* km.json in Resources */,
+				F989AB35A74BE27E16C022F0B3D11910 /* ko.json in Resources */,
+				CC3850A078BB4CC97717463116A85BE0 /* ku.json in Resources */,
+				134855B0A05ABAEB971DDF30D199CBC6 /* ky.json in Resources */,
+				A75079A75A17F259A6AD440B844D3D3A /* Localizable.strings in Resources */,
+				3BDB0B2387E3F1C2523E355B60D1C636 /* lt.json in Resources */,
+				710C88B920EF2B8835FEABF45A0A6E2D /* lv.json in Resources */,
+				15E86FC99F9636F3A801993A83FCDEF6 /* mk.json in Resources */,
+				C44568C311EC81A90383E5D58AAC61A0 /* ml.json in Resources */,
+				9C8FBB8C6B16F1C440E9B7EC65EC9071 /* mn.json in Resources */,
+				0B7481462DB080AE7289E28332EBDAC3 /* ms.json in Resources */,
+				E179800124DE384C8ED5A9EAE4875B14 /* nb.json in Resources */,
+				246D7F69B91260D4B962C1B0182A760B /* nl.json in Resources */,
+				C2FCF781492656879AD51363B12C0F1E /* nn.json in Resources */,
+				E9154B0B9CF20E145509140A3C3B7214 /* no.json in Resources */,
+				4C8EBC2302679848450315CF3E15B765 /* phone_number_country_codes.json in Resources */,
+				6498ACFF45A6D29AA456C1CB90198BF9 /* pl.json in Resources */,
+				D28100BC16A8FDA4F1C14A51099CCA22 /* PrimerTextFieldView.xib in Resources */,
+				73B63C0A95EB7EEAE6FB4882D490E72F /* ps.json in Resources */,
+				E8BF65312DF50B2218C51C7656972A3F /* pt.json in Resources */,
+				DF415F70C769E65CEC31FF7A60757890 /* ro.json in Resources */,
+				CD35E5E0D792555AB997529C770F411D /* ru.json in Resources */,
+				ECFE457A75271F33C2F57145694D6A27 /* sd.json in Resources */,
+				D9A13D90FE6F39BEB45FEA1041333D6C /* sk.json in Resources */,
+				279CD4F2CBBA2D16C5A31B25649258CD /* sl.json in Resources */,
+				D539E01F14B01F4650A1674AEC7B4589 /* so.json in Resources */,
+				1C6E791714F0E609B788E83AA6CBA03C /* sq.json in Resources */,
+				3A6CC0C21C3BDEF6E33EB7272ED5D43B /* sr.json in Resources */,
+				B604B3529CBD09291BBE42512ED1E2A5 /* sv.json in Resources */,
+				746A5DE654FEA255F60F701F14BEA79F /* sw.json in Resources */,
+				C98B4AE5B8218FC2E3DE6E84DD6FC4C4 /* ta.json in Resources */,
+				2A330F0C41AC4E4063E40BEF83B7127F /* tg.json in Resources */,
+				3C894DBAEC1E5425BC891FA99AD937EC /* th.json in Resources */,
+				0230FD67B5771625664B73D962E2C74A /* tr.json in Resources */,
+				98D7CF09AF8506C5BB95D34410E31033 /* tt.json in Resources */,
+				F71CA7D762DE25EA50A2A40A258BAF99 /* ug.json in Resources */,
+				048BD37DFCDEB8637C9F29D6AF4536D6 /* uk.json in Resources */,
+				22E01854198F40F0589161F0E5A9FC8B /* ur.json in Resources */,
+				C79664FA579D7B3059F98F40848AD1BE /* uz.json in Resources */,
+				B593A88D9A95BC538E0A54C00A784D77 /* vi.json in Resources */,
+				FC68038AC11099228BC09136C5CE04C6 /* zh.json in Resources */,
+				D4C3596C0C2DAE6A0C210CDB1DB9D78C /* zh-KH.json in Resources */,
+				87C55EF8F9144348B0FAFD80D592E942 /* zh-TW.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B2A7FD0B4F2ADB29686863B6BC0519D8 /* Resources */ = {
+		F8ADCB4C939EE7E15CEE212E1D613099 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2D4BCBC60D6A9DA6E660BB5DD923BD31 /* PrimerSDK-PrimerResources in Resources */,
+				17B2AFE0C21A5187A4FC01A38800D667 /* PrimerSDK-PrimerResources in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2656,307 +2714,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		51853750D945E1BD766C38D35F6E25A3 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		7DF00B37D0BA9CB72D987626752CB0C0 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BAC1D1E35E1A8DD1707AE9ED384B20E7 /* 3DS.swift in Sources */,
-				C2A8A9155A6C5DA43F2774409659E721 /* 3DSService.swift in Sources */,
-				44722AAA42E7AA57010A9C110571D8BF /* _PaymentAPIModel.swift in Sources */,
-				2F80A714ACAE14E5EE60B937BCC9CDBD /* AddressField.swift in Sources */,
-				BFBB6FFA1690D623141CC894E2EBFB51 /* AdyenDotPay.swift in Sources */,
-				62DEF38F2A78274B2E28FAA523AF2F2C /* AES256.swift in Sources */,
-				B2D952BB3A9B7880FC85E1D08F8EFFB9 /* after.swift in Sources */,
-				9862FDA20AA52FA011F52DA8392722C8 /* AlertController.swift in Sources */,
-				F56CF1FA9C17BF9927E675F8825B083A /* Analytics.swift in Sources */,
-				8F4F784BAE3A358BC922A219346644CC /* AnalyticsEvent.swift in Sources */,
-				A16320AE4C50CA2B96C8017B5E115ACF /* AnalyticsService.swift in Sources */,
-				957CDE4F5C3C84976525CD591211501D /* AnyCodable.swift in Sources */,
-				6C38C147792DC9215861821F89E21751 /* AnyDecodable.swift in Sources */,
-				E789A66622141D4D7E1502CB0B9067E7 /* AnyEncodable.swift in Sources */,
-				BD0734B4C169F4FA88E8D6311BF78809 /* Apaya.swift in Sources */,
-				C4FB4A76740C1CA1FABF85653CC0BEE7 /* ApayaTokenizationViewModel.swift in Sources */,
-				3D6F530D8331C9039FCA2E3D42365771 /* ApplePay.swift in Sources */,
-				DDFFE0A634DF5706B39F4BB7A0A747F1 /* ApplePayTokenizationViewModel.swift in Sources */,
-				0B2D0F1F5A2D4BAE523E216BD2A1F8CF /* AppState.swift in Sources */,
-				8AFAAB65F988D72181C68200863D2E3A /* ArrayExtension.swift in Sources */,
-				B66BD240C9F0F783615C391AB9C0AA04 /* AssetsManager.swift in Sources */,
-				A779FDFDCA9D954447C2423A02435D3B /* BankSelectorTokenizationViewModel.swift in Sources */,
-				EB0F240939F2DC39D537FB05E7A72980 /* BankSelectorViewController.swift in Sources */,
-				2A34459350773A77479834CD960DCDD1 /* BankTableViewCell.swift in Sources */,
-				CB8B304640BEC8B9F5A36F2A557D683D /* Box.swift in Sources */,
-				FF0C26D15151E47E46AE60957C1D5DA8 /* BundleExtension.swift in Sources */,
-				60986774826B581EC079F37AC10AC96E /* CancelContext.swift in Sources */,
-				4F9C98C798275B4809F824CD1E0B5CFF /* Cancellable.swift in Sources */,
-				D7EACE861C11D105F007A281BA538B0C /* CancellableCatchable.swift in Sources */,
-				99373AEFC79F35130A5278872B48AFFB /* CancellablePromise.swift in Sources */,
-				F03699532AC2DB5700E4179D /* VersionUtils.swift in Sources */,
-				4A9E857059A73B4DE144ECF8569C17FE /* CancellableThenable.swift in Sources */,
-				A11411FF83DE56C6B4C61144E1F865CB /* CardButton.swift in Sources */,
-				0A4DFBDD664FEA2FC5641A638FB281E6 /* CardButtonViewModel.swift in Sources */,
-				B26247834F1D88963334E8BD9C537200 /* CardComponentsManager.swift in Sources */,
-				7B9C8FFA2658F7CAED064291F9904606 /* CardFormPaymentMethodTokenizationViewModel.swift in Sources */,
-				5E7431ECF9C516E46206F6B8183DE3FE /* CardholderNameField.swift in Sources */,
-				DAB4D685A784582B65B362FF483E9894 /* CardNetwork.swift in Sources */,
-				454CBAD1FBD8053E84D855AE0243A3A2 /* CardNumberField.swift in Sources */,
-				CF79C101A544A31D35961ABCB3469FBD /* Catchable.swift in Sources */,
-				C03208409B7A7C42DBC04FA3A979F815 /* CatchWrappers.swift in Sources */,
-				431F6F8F51B550EF3C8EA36797306F5B /* CheckoutEventsNotifierModule.swift in Sources */,
-				D389E728F4E971CCC87E84B123C3FDA5 /* CheckoutModule.swift in Sources */,
-				9653BCC12AD7465C6CA0FF63AE163DEB /* CheckoutWithVaultedPaymentMethodViewModel.swift in Sources */,
-				C6A2A57D5DB25341B764521F3E4C6434 /* CityField.swift in Sources */,
-				187EFC88FD260D9577A5C423E2BD84DA /* ClientSession.swift in Sources */,
-				8A9DE5459039C8A9D640DE47AD46D2E1 /* ClientSessionActionsModule.swift in Sources */,
-				0997BA5898D28DF3D707169207F523CE /* ClientSessionAPIModel.swift in Sources */,
-				0063DDF5EF039CCEF448CD2AED360274 /* ClientToken.swift in Sources */,
-				DE3C4C35AE75A535C5EA43B6D1203542 /* Colors.swift in Sources */,
-				7F809FADFA983E4CD80BE6857060D766 /* ConcurrencyLimitedDispatcher.swift in Sources */,
-				04AB8A1739E637B8937E370536B2D6EE /* Configuration.swift in Sources */,
-				8667E405A7FBA6C9816F833EA7697AE6 /* Connectivity.swift in Sources */,
-				D7265E0C55649147DE043E3B123A2E75 /* Consolable.swift in Sources */,
-				323114E92AD7B249AFC7D7D12B24021D /* Content.swift in Sources */,
-				EDB2A4C62E16581A08CF3385841E4BF8 /* CoreDataDispatcher.swift in Sources */,
-				264FFDBC9CD2A52D0C36B73C78F6E356 /* CountryCode.swift in Sources */,
-				49406745B6BAAB7578B5856F1042CFFA /* CountryField.swift in Sources */,
-				8E364F09CFE7E5C36E42748A0A3844A3 /* CountrySelectorViewController.swift in Sources */,
-				929519986E7EC1B2B79186340026F423 /* CountryTableViewCell.swift in Sources */,
-				6B98CC78B0B433580D5FB99C5AD4DC8A /* CreateResumePaymentService.swift in Sources */,
-				EB10D2BF28265550E0168BF7B5671807 /* Currency.swift in Sources */,
-				84BCDEBC9E53917DCDC895D62CDE7241 /* CustomStringConvertible.swift in Sources */,
-				EC7EA89FCA052FB2E030ECAF4F243408 /* CVVField.swift in Sources */,
-				6108382731B4A9CD2F7E240B404D09B4 /* DataExtension.swift in Sources */,
-				80FCA5A86BA0E93A4EA53B3FDD6F8EF5 /* DateExtension.swift in Sources */,
-				D8544E39442F1C28C5B47D2F2EA8B2F3 /* DateFormatter+Extensions.swift in Sources */,
-				06239314163E8B9A998CF74E64C0A0B7 /* Decisions.swift in Sources */,
-				3E2F20142F93D7731AD0FFBF0AB23CE5 /* DependencyInjection.swift in Sources */,
-				DF6DAA3D8B437577B1AD90929A698E35 /* Device.swift in Sources */,
-				C768ABABB25E6212C6B6E8E29C11D68F /* Dimensions.swift in Sources */,
-				7A80F5A95C8D78D8410BD45DCBE66A6E /* Dispatcher.swift in Sources */,
-				60166F35DB9B5FEC0F970EDEE04611D9 /* Downloader.swift in Sources */,
-				11AADCBE699813B2BF3D1326D4E6C688 /* EncodingDecodingContainerExtensions.swift in Sources */,
-				CFFCD08DAF54388A55523EE19CE046C5 /* Endpoint.swift in Sources */,
-				FFB2F495F4C53251F12D1CB996FE4C70 /* EnsureWrappers.swift in Sources */,
-				F873B1A2983553F28F9926B66ECBDE3F /* Error.swift in Sources */,
-				23BD510FA8AD2D6A773AFC4B870C4E10 /* ErrorHandler.swift in Sources */,
-				651C6737EB0BA2A743C23F7CC33DF460 /* ExpiryDateField.swift in Sources */,
-				8EB59290371F04C139482A787F9925D9 /* Field.swift in Sources */,
-				9E75CD03EB24E31AA4A726DD28DF2198 /* FinallyWrappers.swift in Sources */,
-				E29A6FB22D2E2628BBB772888A125CC1 /* firstly.swift in Sources */,
-				6D1C13F088C0C92E455455618DBFE41B /* FirstNameField.swift in Sources */,
-				963070261D5988FE5852A590443384FA /* FlowDecisionTableViewCell.swift in Sources */,
-				63F37738C45B82C6F97456589D11F8EA /* FormPaymentMethodTokenizationViewModel.swift in Sources */,
-				A1C2C6A7FE57E4D77CA87971217A9BDD /* FormPaymentMethodTokenizationViewModel+FormViews.swift in Sources */,
-				B34234FCC1A0D6D4A7C8DDD287A3D8E1 /* FormType.swift in Sources */,
-				125B9A0D45C0ECA16BA4FD56E8A34D6D /* Guarantee.swift in Sources */,
-				185B5CBD64C5DF783753A483A3E085E0 /* GuaranteeWrappers.swift in Sources */,
-				A857A5EF7C79D22301BB8A99A7A06596 /* hang.swift in Sources */,
-				F61BCA17069429B3154BCE97A1826259 /* HeaderFooterLabelView.swift in Sources */,
-				3831698229FE103843982AA1218C3ADB /* Identifiable.swift in Sources */,
-				C7F72861F4E85C3A49801F8BAA76922A /* ImageManager.swift in Sources */,
-				4FE8183A1E2DBC989A3B77719D547DCA /* ImageName.swift in Sources */,
-				1CDE557D6CB2436BB8161744B0DEEB94 /* InternalCardComponentsManager.swift in Sources */,
-				EC80644DB7761088F63AFC7FB021CAC8 /* IntExtension.swift in Sources */,
-				5A97C78BEABC8CB8216E8D856F244B22 /* IPay88TokenizationViewModel.swift in Sources */,
-				25A286907F09947F15B84606013518E3 /* JSONParser.swift in Sources */,
-				A1869358FCBF25E7BB241894C5768C94 /* Keychain.swift in Sources */,
-				2DF278C9F5CC65A2A76B2265B6B043E8 /* Klarna.swift in Sources */,
-				3D5F819E57B47ECCA17CDE0290F2054B /* KlarnaTokenizationViewModel.swift in Sources */,
-				7319016F79E9DA518388FBB3F8C69526 /* LastNameField.swift in Sources */,
-				9ACD87859E74D886FAC25AA89AA14294 /* LogEvent.swift in Sources */,
-				9E57D88D90F1E015D49D1EFEAB35BCE1 /* Logger.swift in Sources */,
-				14A47C330CAAF5A5DE0F22D98AFBB875 /* Mask.swift in Sources */,
-				BE7569ED27CE84C3AD5BD3FD003A95F4 /* Mock3DSService.swift in Sources */,
-				3CB900063BF1DF50D33DB6BFDCA10E5E /* NativeUIManager.swift in Sources */,
-				90BF90D2594E0B8EB02B0F5879BA8E31 /* NetworkService.swift in Sources */,
-				9615F418C13E6B019CA1FBCEE4634368 /* Notification.swift in Sources */,
-				6DCB9C1B91858FC3FE5592E6756D1055 /* NSErrorExtension.swift in Sources */,
-				2DE94B5CAFA5D0A595AFF3CCA45C0D57 /* NSObject+ClassName.swift in Sources */,
-				84D8DC7534E302AECB98BA589C40C854 /* Optional+Extensions.swift in Sources */,
-				211BCD0F16C3C01C852B8187FA257D1B /* OrderItem.swift in Sources */,
-				6FB3F69390BC961E5866FDC437FB3654 /* Parser.swift in Sources */,
-				42918D8C3EDA4381966EF347B2BDB5AD /* PaymentAPIModel.swift in Sources */,
-				BA87B76CD1988636692B3751022944F7 /* PaymentMethod.swift in Sources */,
-				D5126C666BEEC75D033292C551D999D9 /* PaymentMethodConfigurationOptions.swift in Sources */,
-				C984956292334CECAA52D4B6EC6D3393 /* PaymentMethodsGroupView.swift in Sources */,
-				2A958724141525BAEF326B49D4E07640 /* PaymentMethodTokenizationViewModel.swift in Sources */,
-				ACB2CE42E1568ABAC6C47CB883D055F5 /* PaymentMethodTokenizationViewModel+Logic.swift in Sources */,
-				73BE082FA9CDD65597D25B5910AF9016 /* PaymentResponse.swift in Sources */,
-				E654B4193C079AF9E0394EEA1813CDF9 /* PayPal.swift in Sources */,
-				319356506C1E7A4D390E46F53B6401BB /* PayPalService.swift in Sources */,
-				535CDAABFDB80965A0DF264C2E4FD6FC /* PayPalTokenizationViewModel.swift in Sources */,
-				312C974250B49255DA79E2E3BFD87E15 /* PollingModule.swift in Sources */,
-				C12E440189EC8403BEC7E4A735BABEBA /* PostalCode.swift in Sources */,
-				2F1643EABAF0D77D455206D2E1E59921 /* PostalCodeField.swift in Sources */,
-				527EFC230461EA5C15FA7962FF19AA84 /* PresentationController.swift in Sources */,
-				9C4B35E019D1720DEBCDAF69E3E2C689 /* Primer.swift in Sources */,
-				DED092689D57D4E60133CF48E8608F40 /* Primer3DSErrorContainer.swift in Sources */,
-				E01497CAF069AC89228080029603516B /* PrimerAccountInfoPaymentViewController.swift in Sources */,
-				EE0CCE61EE1909ECEF6F204B278CCD6C /* PrimerAddressLineFieldView.swift in Sources */,
-				D68009A69E66784C03B1BB64DA536F56 /* PrimerAPI.swift in Sources */,
-				B4E97335991CF743002AD88C1507E872 /* PrimerAPIClient.swift in Sources */,
-				91FA7BE4C9D94425610BD0DB3E3151A4 /* PrimerAPIClient+3DS.swift in Sources */,
-				BF69EE4430B749A3B4E91CA1C6A636C4 /* PrimerAPIClient+PCI.swift in Sources */,
-				56DA6251DE9EBB0BC6E29B6290C1432B /* PrimerAPIClient+Promises.swift in Sources */,
-				2CAADB525BA5B3ABB8A715DB8A5848A0 /* PrimerAPIConfigurationModule.swift in Sources */,
-				DE1B527B70CFB8FF2D921C7D5517FCCF /* PrimerButton.swift in Sources */,
-				BA4D2D268341237FE84ED147F10C8640 /* PrimerCardData.swift in Sources */,
-				FF368EEEA31FECCFD5F15896E5F9595E /* PrimerCardFormViewController.swift in Sources */,
-				E7CB5AEF296C838AB2F6846C7A394DBF /* PrimerCardholderNameFieldView.swift in Sources */,
-				0875C63487274992CBEF00E157525A9D /* PrimerCardNumberFieldView.swift in Sources */,
-				E73A65A74626A664BE1393D03BF6B9C0 /* PrimerCardRedirectData.swift in Sources */,
-				368300110598446595EC7467DFEB91BE /* PrimerCheckoutAdditionalInfo.swift in Sources */,
-				6C2A557E1A095CBA8E8325D6DAA84CA8 /* PrimerCheckoutQRCodeInfo.swift in Sources */,
-				54912066C003D58A6EB95128BEF91991 /* PrimerCheckoutVoucherAdditionalInfo.swift in Sources */,
-				774D920A9C2D5695C9E9828EBAAF039B /* PrimerCityFieldView.swift in Sources */,
-				F0436570ADD72DF65293A1A25FA25F30 /* PrimerConfiguration.swift in Sources */,
-				A14008C0A96ED637E95C920620618793 /* PrimerContainerViewController.swift in Sources */,
-				3B5A6B47B566362822E1EA34CE7A953D /* PrimerCountryFieldView.swift in Sources */,
-				CA152B107057FAFA2FA686EF5C4F4F76 /* PrimerCustomStyleTextField.swift in Sources */,
-				7AF17C27FDD1ED990159DEB114B44725 /* PrimerCVVFieldView.swift in Sources */,
-				6C588008FB9A067778A7839C86D1C39C /* PrimerDelegate.swift in Sources */,
-				9318CA1646A7401F4B6DF7F24B355CAF /* PrimerDemo3DSViewController.swift in Sources */,
-				5F66DDE8DB124E3CD2C81AF820B25C98 /* PrimerError.swift in Sources */,
-				2C4E730D919A7F3A88AFE37A349DCA63 /* PrimerExpiryDateFieldView.swift in Sources */,
-				8A61D0B062C84295CE16A367BD1975C0 /* PrimerFirstNameFieldView.swift in Sources */,
-				8661F5DC74EBE1B8F59CD1FF20C67A42 /* PrimerFlowEnums.swift in Sources */,
-				4F9AF0AC03CB91D2E6460A4C8D35AA1D /* PrimerFormView.swift in Sources */,
-				5204BAE23E4B036E1870B9BFC7B827A0 /* PrimerFormViewController.swift in Sources */,
-				66481EA2CBF7AFC8590263121AD7B1A4 /* PrimerGenericTextFieldView.swift in Sources */,
-				0C4F2A0575B460737338609780C51401 /* PrimerHeadlessUniversalCheckout.swift in Sources */,
-				19E2AB62A71504DD0095A79CAD85F7C0 /* PrimerHeadlessUniversalCheckoutInputElement.swift in Sources */,
-				A146CCA5BFB8855BAE251E271FCC7033 /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift in Sources */,
-				EC7E81943F96769CBFD9902C8E8409AC /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift in Sources */,
-				F22B0A82D3A11725346534EB86D0B76F /* PrimerHeadlessUniversalCheckoutProtocols.swift in Sources */,
-				E97345ED46A5F4CB3CDD5F58E5B002BA /* PrimerImage.swift in Sources */,
-				C4907BB571A6B78C8FAB12417A752B3D /* PrimerImageView.swift in Sources */,
-				122705E4F7AC7565303938843292B36E /* PrimerInitializationData.swift in Sources */,
-				81696D29BCA1E116786093E4DBED1974 /* PrimerInputElements.swift in Sources */,
-				F097A00591647AE1226DA32369F0D4E6 /* PrimerInputViewController.swift in Sources */,
-				9CF848F1F9AD50523AF5EBB908CEEDEC /* PrimerIntegrationOptions.swift in Sources */,
-				9741DF8F1E7FDECD2E973317BD802D6F /* PrimerInternal.swift in Sources */,
-				3969A93549D85A2FDD387538FFA999BA /* PrimerLastNameFieldView.swift in Sources */,
-				FF130CAEFD0454DFAA5F304B8AC5C0E6 /* PrimerLoadingViewController.swift in Sources */,
-				60994BCB481CA73588524AA590E08126 /* PrimerLocaleData.swift in Sources */,
-				6F4E73BBCE30AB6B5B7AB5E03C6FC1E7 /* PrimerMultibancoCheckoutAdditionalInfo.swift in Sources */,
-				F4C7A6049770CFAB2A664B28364F03EB /* PrimerNavigationBar.swift in Sources */,
-				832CD4420A092EB1F7F054925ECCDE44 /* PrimerNavigationController.swift in Sources */,
-				769353053EA80213EF441E5DE41DF823 /* PrimerNibView.swift in Sources */,
-				09319A1F89C2ECE4FEB39CE24DCAF0D9 /* PrimerPaymentMethodManager.swift in Sources */,
-				610672125FB39E76DB8392133A1DEC63 /* PrimerPaymentMethodType.swift in Sources */,
-				A6809D53B64CC470AC9347B59F769B46 /* PrimerPaymentPendingInfoViewController.swift in Sources */,
-				F7A51F5C092E54B9555330B7503DEA13 /* PrimerPhoneNumberData.swift in Sources */,
-				240DB8AB800EB3D8F5FE12E339A19E7D /* PrimerPostalCodeFieldView.swift in Sources */,
-				D1554E1834FD3DB8C1F4D3869C2087D9 /* PrimerRawCardDataRedirectTokenizationBuilder.swift in Sources */,
-				567000E6DA9A409C0F9EE94347135FF3 /* PrimerRawCardDataTokenizationBuilder.swift in Sources */,
-				711351EA81E43872032020A35C1545B7 /* PrimerRawData.swift in Sources */,
-				810EC0426A9F3F9A6AA97538B491FE99 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift in Sources */,
-				CBFB9998825BDE248B0273B5CB836D00 /* PrimerRawRetailerDataTokenizationBuilder.swift in Sources */,
-				28FA3E1C3A4AD6A84E60F1F9BBC1C45C /* PrimerResultComponentView.swift in Sources */,
-				8EF9F4599EDC147FAEFEB5D3D6580DA1 /* PrimerResultViewController.swift in Sources */,
-				F219167FF3FE3C20BD85C39A075903FF /* PrimerRetailerData.swift in Sources */,
-				E7DB067FCD1914E4340AD0CCC6427B65 /* PrimerRootViewController.swift in Sources */,
-				8A0237F193CF59410CDB8D0D1B9C1691 /* PrimerScrollView.swift in Sources */,
-				5F836E2EE4C4A059FB93E2AD183EC7C8 /* PrimerSDK-dummy.m in Sources */,
-				2D99BEE894D28B1FF73F4760A8337000 /* PrimerSDKIntegrationType.swift in Sources */,
-				A5F4BB9612668326188E6FB6E60EE912 /* PrimerSearchTextField.swift in Sources */,
-				A33FCE865A8BC4960CC5874F4023FA70 /* PrimerSettings.swift in Sources */,
-				AD164C6467AD8FDAED9FEC22B0E52BFD /* PrimerSimpleCardFormTextFieldView.swift in Sources */,
-				EA882876CC706E98990DBBB573218172 /* PrimerSource.swift in Sources */,
-				CC1E43E71993515CECCECC8B24287745 /* PrimerStackVIew.swift in Sources */,
-				8EBC4F9180AEF3A2ABB8B1405A538E5E /* PrimerStateFieldView.swift in Sources */,
-				A199F24A0A847471A5DA67CBA1473735 /* PrimerTableViewCell.swift in Sources */,
-				2F181CEC1B9E78FC9E8023EF2B3CF4E0 /* PrimerTestPaymentMethodTokenizationViewModel.swift in Sources */,
-				1C9DC1876CEE43ECF100BC9C5F7D09E1 /* PrimerTestPaymentMethodViewController.swift in Sources */,
-				F57E3DC185601E906C10CAFE7D32C332 /* PrimerTextField.swift in Sources */,
-				C9D69E0410251A2DF83198BDDE6A05BB /* PrimerTextFieldView.swift in Sources */,
-				6CDBE386A918159F9DBD3AC06F436BDD /* PrimerTextFieldView+Analytics.swift in Sources */,
-				6D1056B74A7C33A8AB9C67AC59A7590E /* PrimerTextFieldView+CardFormFieldsAnalytics.swift in Sources */,
-				380D48B7EDBF3209CFE15E69ABA9330A /* PrimerTheme.swift in Sources */,
-				1EB16A8D35751125308F7496BA3FFB85 /* PrimerTheme+Borders.swift in Sources */,
-				DF54F848D3EB18C1EB96AA3158BB9C43 /* PrimerTheme+Buttons.swift in Sources */,
-				5BE3D708EBC970C282B673F4A4D8920E /* PrimerTheme+Colors.swift in Sources */,
-				CABB070BDB8EAFE98DE010FBD0DD82AA /* PrimerTheme+Inputs.swift in Sources */,
-				5BD49609BA3C39DCE430160E18CC510A /* PrimerTheme+TextStyles.swift in Sources */,
-				525DC99947F2605886DDF0875358D5FA /* PrimerTheme+Views.swift in Sources */,
-				7E20082F41C80E00AA9CB734F9C63108 /* PrimerThemeData.swift in Sources */,
-				F7B1EC4A8897700E48B98DC1FF07E011 /* PrimerThemeData+Deprecated.swift in Sources */,
-				AA218DE90374491E229FC6F8DA291A4A /* PrimerUIImage.swift in Sources */,
-				78E9DE6814AD0B6CAD24E6E07E3EA1F9 /* PrimerUIManager.swift in Sources */,
-				B680DBCB4FA0E8BE1891A2563A7CD370 /* PrimerUniversalCheckoutViewController.swift in Sources */,
-				6ECE60EE09F8B72456125F748CE1891A /* PrimerVaultedCardAdditionalData.swift in Sources */,
-				555A59F7214CB9C907A8A975D2400430 /* PrimerVaultedPaymentMethodAdditionalData.swift in Sources */,
-				A92E54AB8466F171B6FF82E25B037C3A /* PrimerVaultManagerViewController.swift in Sources */,
-				39E30C3D9D239DA34BAE4402CED7C903 /* PrimerViewController.swift in Sources */,
-				D9D2FC875684F5902BB64C20CF4AC1A4 /* PrimerViewExtensions.swift in Sources */,
-				B680028AE15290BD492DC6967F3DC29D /* PrimerVoucherInfoPaymentViewController.swift in Sources */,
-				87F29E7DA43653C3719FE3070D1EDE32 /* PrimerWebViewController.swift in Sources */,
-				2726A5AB70D3EC9A8F9A59B37CF4EAC8 /* Promise.swift in Sources */,
-				0BB0E1196DFC9F551A9B59FAB6B08766 /* QRCodeTokenizationViewModel.swift in Sources */,
-				62EBE6572803AE2D7B4286B21F1EF6BA /* QRCodeViewController.swift in Sources */,
-				8FD9E9736E18EB88B8E425506A3CA7FF /* Queue.swift in Sources */,
-				9CE397E3EA1E6F920AACD4DC02B81C4E /* race.swift in Sources */,
-				770BE13A9D82192E3A58A21A9F3021DF /* RateLimitedDispatcher.swift in Sources */,
-				D92FB4D55C68D4001615D6D3C7F2F098 /* RateLimitedDispatcherBase.swift in Sources */,
-				4B3A306CBBFC00939662136388B5B575 /* RawDataManager.swift in Sources */,
-				1B8B20E53F8C220776B76F67122367DF /* RecoverWrappers.swift in Sources */,
-				A88B597299BDC3EB121E5A922450650E /* ReloadDelegate.swift in Sources */,
-				DFA23092A3569518357C9987EF736821 /* Request.swift in Sources */,
-				E6B2DCE00DBA478EF2F0A1BA3302D6CF /* Resolver.swift in Sources */,
-				EA8C2851AFD95208E20D0E180CDA4849 /* Response.swift in Sources */,
-				E86F08D8DE17AB43C03C1BFCC90FC311 /* ResumeHandlerProtocol.swift in Sources */,
-				61AB2516BA25047CF79BCE3DB4A684E2 /* RetailOutletsRetail.swift in Sources */,
-				CBFD4B33ECA7EFDB0B993B2C2335D230 /* SequenceWrappers.swift in Sources */,
-				CE1BB440ED4BB6FC9DFF9E32D8CD9684 /* StateField.swift in Sources */,
-				826AB5A88C1611E104B4B1600D767299 /* StrictRateLimitedDispatcher.swift in Sources */,
-				30FC34E9815ABDDFC082EC5F7A584498 /* StringExtension.swift in Sources */,
-				87C890C697BD6516C1127687C5376281 /* Strings.swift in Sources */,
-				9A6B059C3E1E53108B246E340BC56C58 /* SuccessMessage.swift in Sources */,
-				8E8091EF91DB17E367068EB0584D9997 /* SuccessResponse.swift in Sources */,
-				63E8656535F70CB23091FF23064835C5 /* Thenable.swift in Sources */,
-				833D04BCF4A56EFAEBDEB7AE603CB22D /* ThenableWrappers.swift in Sources */,
-				B24CC404D253425FB636C44C9BC52038 /* Throwable.swift in Sources */,
-				2C1D946C476290C7A21B0405873E4CF2 /* TimerExtension.swift in Sources */,
-				FA64A67C1F4DDB1CBCCE5E76456228BA /* TokenizationRequestBody.swift in Sources */,
-				8626B60C98BF2CA62298DD565BF126FB /* TokenizationRequestPaymentInstrument.swift in Sources */,
-				371EC33E8989AFCC8810B46216AE6801 /* TokenizationRequestPaymentSessionInfo.swift in Sources */,
-				238646B9826A9F6D4E81C6360AF08A25 /* TokenizationResponse.swift in Sources */,
-				866F2CE977080DDF05E6A02C95B00E5A /* TokenizationService.swift in Sources */,
-				1B7922891AB7A7893B74703078F1743F /* UIColorExtension.swift in Sources */,
-				A96E378A39B0BAC0598F3918136BAB50 /* UIDeviceExtension.swift in Sources */,
-				932ED4B25DD6AFAE979205B6E6A48BDC /* UILocalizableUtil.swift in Sources */,
-				B736CEDA4F4E630C1C5522255AA6D907 /* UINavigationController+Extensions.swift in Sources */,
-				7DB2346F02620ECBC0D057BF2CC5C436 /* UIScreenExtension.swift in Sources */,
-				491A4225D2D223D0F7625F914F9E42E8 /* UIUtils.swift in Sources */,
-				0DCB89E913FCA27A0BC821857F28E1FD /* UniversalCheckoutViewModel.swift in Sources */,
-				ABA4EF4502A2BC2A0BC3B08A7B02C445 /* URLExtension.swift in Sources */,
-				ACBAF8A7582940A39EA37145B6821728 /* URLSessionStack.swift in Sources */,
-				DD2BD6C3AFF47F17BBCB52A4D978D116 /* UserAgent.swift in Sources */,
-				2967858E7576797276258A886262E8D4 /* UserDefaultsExtension.swift in Sources */,
-				8DD3F8A314C8A9CCCC3ABBDF9CB867D6 /* UserInterfaceModule.swift in Sources */,
-				86E9A3F4A7B8E05FAA61E978393ED1A3 /* VaultedPaymentMethods.swift in Sources */,
-				79E09E6B6F18F2E3D31D7A76B8696D32 /* VaultManager.swift in Sources */,
-				71FF48FC4AFCA46B18DAD5403BEFB673 /* VaultPaymentMethodView.swift in Sources */,
-				4F83FED6407EA397E86AD8B9806E2AB2 /* VaultPaymentMethodViewController.swift in Sources */,
-				1BA14BE3A70732BD492CF0939060B0AB /* VaultPaymentMethodViewModel.swift in Sources */,
-				C2987619222467917FE9515C5E20CA0A /* VaultService.swift in Sources */,
-				FDF8BEA59D992C0E870098D3E0354FF4 /* version.swift in Sources */,
-				0416D0FB3FEC7A0564562E58EA704252 /* VoucherValue.swift in Sources */,
-				A209FCF1CBB9DEC05DC6A060108E02B3 /* Weak.swift in Sources */,
-				4DB4439507F12698585A300C026BABEE /* WebRedirectPaymentMethodTokenizationViewModel.swift in Sources */,
-				1E5D8E4DECCFB923EA11E82DA1615BA0 /* WebViewUtil.swift in Sources */,
-				CED8C4D1670D280D3F5038A2EDC776AC /* when.swift in Sources */,
-				BA00ECFFD78D8B7DED5E8BD60DF99C64 /* WrapperProtocols.swift in Sources */,
-				7F655860A1071864B0A6A691068925C7 /* XenditRetailOutlets.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		8C2C6A2D1336BC6D5F1CFB4A2BF70E1D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2981,6 +2738,307 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A0BCFEAFD0BA3197FA6E6DE69FCB2607 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C868828A7552C705C65A473ACC97869D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D72987636C92BD1A4245BD19ABA30C05 /* 3DS.swift in Sources */,
+				9910658DECB1E40CF4E2CD4FCA64A931 /* 3DSService.swift in Sources */,
+				1879BFFE78BC1D5AEAAF27346CF5A92E /* _PaymentAPIModel.swift in Sources */,
+				B62AD6900B78761449192DA9B50CDF22 /* AddressField.swift in Sources */,
+				2FD7A5B737B87210A606E81A4D44BF32 /* AdyenDotPay.swift in Sources */,
+				BFB43D872B19D6B06C0CB971E65619D6 /* AES256.swift in Sources */,
+				5379DE83ECE0F20EE0E8EEEB2C5BEFBE /* after.swift in Sources */,
+				DFA482384717834EE7A3542D57101B56 /* AlertController.swift in Sources */,
+				04DDA0CB6CB772E6B0B620695F65A746 /* Analytics.swift in Sources */,
+				D8DC8B901B0B768F60240969C67A627F /* AnalyticsEvent.swift in Sources */,
+				41F99066672B4CB84CA9F81BC4B2215B /* AnalyticsService.swift in Sources */,
+				365AD3F069149AC2DDC7BA04A42B42E8 /* AnyCodable.swift in Sources */,
+				68B7DA7338FAF48893A3159432B4E12D /* AnyDecodable.swift in Sources */,
+				E8E77747D51EC70140B8A7C08E916D38 /* AnyEncodable.swift in Sources */,
+				108DAA60EC83C905F227A6C829CF70E7 /* Apaya.swift in Sources */,
+				B9071E6561C46C7C3E0BBC9E5ABF93C6 /* ApayaTokenizationViewModel.swift in Sources */,
+				8610F300668A73B555A1692DBEECFA65 /* ApplePay.swift in Sources */,
+				A0D0B12282F17401E20BF7E6A817A5EB /* ApplePayTokenizationViewModel.swift in Sources */,
+				3BA7704C8CE75E8D1D0FFB1B05C6F76D /* AppState.swift in Sources */,
+				284E6C157330E4EE01FA454134B5B11C /* ArrayExtension.swift in Sources */,
+				EFDD9C8D7D2336B584F4AEAC4CBC78B9 /* AssetsManager.swift in Sources */,
+				D870640BE0F7F4D05A77324D8F778CAA /* BankSelectorTokenizationViewModel.swift in Sources */,
+				33D80B332E429634DCE82884C67D256B /* BankSelectorViewController.swift in Sources */,
+				DBB7304E4E54DC7109ED595F9FA39A91 /* BankTableViewCell.swift in Sources */,
+				62558304A5F51F14F6DA4CF11B787247 /* Box.swift in Sources */,
+				CD034D6F9EE4E597493FE17CB34D0F0B /* BundleExtension.swift in Sources */,
+				F1213C5E25D3BB57E7EB1DDF39BD9E56 /* CancelContext.swift in Sources */,
+				111DCA97CF2A019D06D2D0CC50B0096E /* Cancellable.swift in Sources */,
+				F40785CD2DBD47A08922298197A3393C /* CancellableCatchable.swift in Sources */,
+				137A3093F17FE67B5FE0304311CF3E9E /* CancellablePromise.swift in Sources */,
+				E1022A103B2D937E2E508B1A9EB01525 /* CancellableThenable.swift in Sources */,
+				62B26BDC8B6C86C7C53A41EEAB3B7944 /* CardButton.swift in Sources */,
+				3179D5F9CCD483BC06E3AC4D00D6A23F /* CardButtonViewModel.swift in Sources */,
+				42D20B1E2F0D0C9455294CABB8FF7C7E /* CardComponentsManager.swift in Sources */,
+				616CCEBD27A3EDD03FB2EC15DD1DDB28 /* CardFormPaymentMethodTokenizationViewModel.swift in Sources */,
+				8889364F8E43DA05CCD356A26D7F3273 /* CardholderNameField.swift in Sources */,
+				6A1E5BAAD92FC13481C0B3E205CA7452 /* CardNetwork.swift in Sources */,
+				861DCE334FC92AB4CEFB8138C2D1A90C /* CardNumberField.swift in Sources */,
+				AF5947F738E745254FCDB3F5AF67BD0B /* Catchable.swift in Sources */,
+				DC83DDF5FB1096173B04A7DB16BB0FE2 /* CatchWrappers.swift in Sources */,
+				8B314CBD511D76DE1718E369A718B74B /* CheckoutEventsNotifierModule.swift in Sources */,
+				874FC34E431B9401CEA26CEFFCB23EBB /* CheckoutModule.swift in Sources */,
+				BC67235BB1F43318E6A4066170253C65 /* CheckoutWithVaultedPaymentMethodViewModel.swift in Sources */,
+				F46E0DA88E8EC478E075359C442057EE /* CityField.swift in Sources */,
+				2F84899923D7679832F1FBA28B2B9190 /* ClientSession.swift in Sources */,
+				1C805B1E0817E26C3EA7CF89730B1301 /* ClientSessionActionsModule.swift in Sources */,
+				EE2AB4511296F36A85B2CA179B7A2BE3 /* ClientSessionAPIModel.swift in Sources */,
+				56833A8FCF855324404168991E37CEDF /* ClientToken.swift in Sources */,
+				2FA5A10DE6688A74B692CB69AF26E669 /* Colors.swift in Sources */,
+				AEE0B4493E680A5631B68F708EDCE130 /* ConcurrencyLimitedDispatcher.swift in Sources */,
+				70AF069FE09421FA59A463A9EA547450 /* Configuration.swift in Sources */,
+				D5ADD4CFEA25171C6A7E7AB611C79742 /* Connectivity.swift in Sources */,
+				63C751378CCFE26D0CA7A5D53F476488 /* Consolable.swift in Sources */,
+				E1F278BDE7B246AFCB80FEB50A63F49E /* Content.swift in Sources */,
+				924C31A2B8D8892E9AD9CA29B16BFDD7 /* CoreDataDispatcher.swift in Sources */,
+				E142908815AD1D9B0056CD10C34778FE /* CountryCode.swift in Sources */,
+				E749D59BC7283341382689C9EEE76A2C /* CountryField.swift in Sources */,
+				EB1327F3414A6780E304FD5DCEAF6FEF /* CountrySelectorViewController.swift in Sources */,
+				F5C7F80F06FC54E68372DED8D3E21B41 /* CountryTableViewCell.swift in Sources */,
+				C64001BFB7A576583E9806AE70428D26 /* CreateResumePaymentService.swift in Sources */,
+				307BF4B4DAD4C1ACC2BC36E0C368C3CB /* Currency.swift in Sources */,
+				30FE9E01D4020B25D8589108A668338A /* CustomStringConvertible.swift in Sources */,
+				CB4E92C96C1DD0FB49250640EFC41EAF /* CVVField.swift in Sources */,
+				8E2C7AE71DAE348904D2F065D8D2601C /* DataExtension.swift in Sources */,
+				E6DAE79409A54DAFD54D2CEF632E5595 /* DateExtension.swift in Sources */,
+				8B0F1327013B30F3861831F48C44CF17 /* DateFormatter+Extensions.swift in Sources */,
+				CD81A47B945C7055F79D96ADFBFB2231 /* Decisions.swift in Sources */,
+				87C41F5F698D3ADF39E2114C595FD3A8 /* DependencyInjection.swift in Sources */,
+				5BFC2FB36F5C2887C11A9F8151E28A86 /* Device.swift in Sources */,
+				517CD4047125CEAAC7232631C78418F8 /* Dimensions.swift in Sources */,
+				75729AE2A7738C353D22D1DA439D604F /* Dispatcher.swift in Sources */,
+				9C3C7FB8351E6D4CF035B08639DA405F /* Downloader.swift in Sources */,
+				232D2FB5A74E423D7F81356C87A407E8 /* EncodingDecodingContainerExtensions.swift in Sources */,
+				28B4C72C9CABE7AA765936A41FFFEF6C /* Endpoint.swift in Sources */,
+				B75ECA140FB730142FABDBFFCCD8F4C5 /* EnsureWrappers.swift in Sources */,
+				1140B0E9C7DAFC6131F04131BF2184EF /* Error.swift in Sources */,
+				D432A31ED03CB4A0614B603DE313BE4F /* ErrorHandler.swift in Sources */,
+				2A76C85858CC82770DB962B167EED755 /* ExpiryDateField.swift in Sources */,
+				01266976EABD22087B74AD1088FD2E2A /* Field.swift in Sources */,
+				DA92A8F98B228DA006464D3AE9281ED2 /* FinallyWrappers.swift in Sources */,
+				326AD2D6F55892152FD1E5F5D0E00DF3 /* firstly.swift in Sources */,
+				BDFDE885E132BCEE4A9A5ACA22AC0091 /* FirstNameField.swift in Sources */,
+				EFA1882A1393417477BDD8A64A252797 /* FlowDecisionTableViewCell.swift in Sources */,
+				E19EDD7D94F8370F7B30183E7EC0C84B /* FormPaymentMethodTokenizationViewModel.swift in Sources */,
+				D907BFEF7E8C0DDA1543FC51E07083E9 /* FormPaymentMethodTokenizationViewModel+FormViews.swift in Sources */,
+				160BC5B64C58B0FCBEF6E9AED0DA0907 /* FormType.swift in Sources */,
+				B2287C7924A7CC5DB594D4EC95994892 /* Guarantee.swift in Sources */,
+				93DDD3E6F43B0B582AEA0F51A5FAC345 /* GuaranteeWrappers.swift in Sources */,
+				0AE4507010624BD53BFE57DC8D58AD15 /* hang.swift in Sources */,
+				6D0A41B3B3CEA4A5F879D6F54EA7849F /* HeaderFooterLabelView.swift in Sources */,
+				505F38FBD69611077DF0A5515E281EA1 /* Identifiable.swift in Sources */,
+				B6CDD21A504E4EC3170DFFEF2C110829 /* ImageManager.swift in Sources */,
+				FE1AE3798E12D0992BB9F8E4FA176430 /* ImageName.swift in Sources */,
+				0BB2717D4F0F9D3BAB28907C198F36AA /* InternalCardComponentsManager.swift in Sources */,
+				2619F43D465820A75A94CD1A7312A25B /* IntExtension.swift in Sources */,
+				1E6491AE7451C22527030EC38E4A6EBA /* IPay88TokenizationViewModel.swift in Sources */,
+				AE3A3780267492B92D9D78FC726F1DB7 /* JSONParser.swift in Sources */,
+				22EB3B80DC4632A9C3D8F39A8A8632F4 /* Keychain.swift in Sources */,
+				66DEDA93DB0A1E016FC92E568E10B159 /* Klarna.swift in Sources */,
+				47CBA74E57F387AC617C78DDC0FECBED /* KlarnaTokenizationViewModel.swift in Sources */,
+				177FD231C69ACC3F2A6A909F4B3C92D3 /* LastNameField.swift in Sources */,
+				430128B993F1ED51292E2A837188AC72 /* LogEvent.swift in Sources */,
+				B16703121928EECE16278487A7F0CDFD /* Logger.swift in Sources */,
+				F34E27989E563A6D98AA351E7FFF010A /* Mask.swift in Sources */,
+				6161254769D1D2CA2AF37A89816B5CAA /* Mock3DSService.swift in Sources */,
+				5142CC524F7DB55C500E378D3D3B56B5 /* NativeUIManager.swift in Sources */,
+				39CB4A3E452C22D0F0EFB445941C4BD3 /* NetworkService.swift in Sources */,
+				A7357D9AFC7AAD55BDAAC8D0B9E5ED51 /* Notification.swift in Sources */,
+				2FCEADBC467212BBE7DE2FF3660A1452 /* NSErrorExtension.swift in Sources */,
+				D96340F2CD37420E0956C022CEEDA35B /* NSObject+ClassName.swift in Sources */,
+				AEFF9808E2B0B3B85D3638E9BC50BF77 /* Optional+Extensions.swift in Sources */,
+				A4DAA605C1A0CBB01CD307103D16DC3F /* OrderItem.swift in Sources */,
+				BA2867D40CDC47C32A6E7A6B7ADD8B0E /* Parser.swift in Sources */,
+				49170C629B41B4B013B6307A549AB5BD /* PaymentAPIModel.swift in Sources */,
+				00DC67712DC2F3FCADB3E78C98D20453 /* PaymentMethod.swift in Sources */,
+				0855FC2FA594BC4FA6A25C95E55AEC3A /* PaymentMethodConfigurationOptions.swift in Sources */,
+				55E378081852352525DC1017A401CCF1 /* PaymentMethodsGroupView.swift in Sources */,
+				B8506193F09E036A307173810C3BDC02 /* PaymentMethodTokenizationViewModel.swift in Sources */,
+				7B6C050C0706422EFEC6F957958C864A /* PaymentMethodTokenizationViewModel+Logic.swift in Sources */,
+				158DF5688F26F4313FDE615553B21DA0 /* PaymentResponse.swift in Sources */,
+				76741435B0939E7F5B64C17ED8FAA92D /* PayPal.swift in Sources */,
+				DA646B14FF3664645E2A99F299BB6A4B /* PayPalService.swift in Sources */,
+				52513ADEC23A6FDADDCE6B4D8541AC54 /* PayPalTokenizationViewModel.swift in Sources */,
+				5085F457670F7774BDA18C7EE2FE326E /* PollingModule.swift in Sources */,
+				BF6ABA7832162F51C875C329B4025559 /* PostalCode.swift in Sources */,
+				DB5A70CAC42F4DE6F78523F08EDCF587 /* PostalCodeField.swift in Sources */,
+				DF5AF56CFB80DC88A3BF163C1CC461D1 /* PresentationController.swift in Sources */,
+				60AA658765BF7371041F4D8A1A29B93C /* Primer.swift in Sources */,
+				D0FC42A70DC0111B814CFCFF67A2854F /* Primer3DSErrorContainer.swift in Sources */,
+				8734C3843CFBFCE5E0783B610348E174 /* PrimerAccountInfoPaymentViewController.swift in Sources */,
+				86D1903A1A4257CD70E188406BC4F489 /* PrimerAddressLineFieldView.swift in Sources */,
+				9CD9BCE5FDD4DF5C41473C0A63FFB2A4 /* PrimerAPI.swift in Sources */,
+				0582675A4147315A319BE9067D2C5AA4 /* PrimerAPIClient.swift in Sources */,
+				3DD29072DA7F2701E2DAC4174D061118 /* PrimerAPIClient+3DS.swift in Sources */,
+				95AD474739E2C9485658113EF70F7738 /* PrimerAPIClient+PCI.swift in Sources */,
+				47D91F38A5E41383DCA4F11BAE34EFFF /* PrimerAPIClient+Promises.swift in Sources */,
+				BB08AC80C2747AD10882553C802AA3D8 /* PrimerAPIConfigurationModule.swift in Sources */,
+				29922C5DC274B5DBD2E0AE32A1B72E04 /* PrimerButton.swift in Sources */,
+				C93869D5151D2D6F322AC763D4C74F66 /* PrimerCardData.swift in Sources */,
+				D4AEEBB700BD713533BFC14E562FB493 /* PrimerCardFormViewController.swift in Sources */,
+				18CBF4097EC2AAAEF24A704ABCFF7013 /* PrimerCardholderNameFieldView.swift in Sources */,
+				61624F1FDE241B8786142E5FCF878EF5 /* PrimerCardNumberFieldView.swift in Sources */,
+				D46507B03706B97C6C35CDFA7F71FD25 /* PrimerCardRedirectData.swift in Sources */,
+				160FF3F5E7D40DBD83C973F3D8799C45 /* PrimerCheckoutAdditionalInfo.swift in Sources */,
+				AE7E0E63239B62E7C1046E3F484A755A /* PrimerCheckoutQRCodeInfo.swift in Sources */,
+				5D9198FA6D079DE47A98EF155E9731D9 /* PrimerCheckoutVoucherAdditionalInfo.swift in Sources */,
+				398BC07833BC44F18EE2AC8536ACFA39 /* PrimerCityFieldView.swift in Sources */,
+				BB0E65F06E775A6B564B66CC08531964 /* PrimerConfiguration.swift in Sources */,
+				0853A7ED996225D3A9303B8D70CC424C /* PrimerContainerViewController.swift in Sources */,
+				35B0F46955D221BED20908E798CC1AC1 /* PrimerCountryFieldView.swift in Sources */,
+				4B852D34199682AD08222B044E8CB9E1 /* PrimerCustomStyleTextField.swift in Sources */,
+				750A5410E582D090A07B81F505F11DF3 /* PrimerCVVFieldView.swift in Sources */,
+				B6034449ACF8118BDA19C6BCB50845E0 /* PrimerDelegate.swift in Sources */,
+				C232CB3C9459C1311BE9D32C07191AE4 /* PrimerDemo3DSViewController.swift in Sources */,
+				3C8CF8C485E5FBB0591585904873E3A5 /* PrimerError.swift in Sources */,
+				798759292CC8F37C6DC6191315946811 /* PrimerExpiryDateFieldView.swift in Sources */,
+				826BA116192C52E349A7282DB602B967 /* PrimerFirstNameFieldView.swift in Sources */,
+				AC33EE124E866FD09D727DF5E23EBA79 /* PrimerFlowEnums.swift in Sources */,
+				93187FE69443EBA952AEFA9B6FCC6938 /* PrimerFormView.swift in Sources */,
+				75E17503A7FABAA4A72356895F537839 /* PrimerFormViewController.swift in Sources */,
+				CB997FFA9BC4DAF73E39D11B958577F0 /* PrimerGenericTextFieldView.swift in Sources */,
+				1103A16421D4EFB2DCAF49BD1DD35B95 /* PrimerHeadlessUniversalCheckout.swift in Sources */,
+				068D511A2D5AF97B73207AF444117599 /* PrimerHeadlessUniversalCheckoutInputElement.swift in Sources */,
+				3E9B4605720345FBA68419D0074CF886 /* PrimerHeadlessUniversalCheckoutInputElementDelegate.swift in Sources */,
+				BD646FA6B742558E00FDE8F2048D31C2 /* PrimerHeadlessUniversalCheckoutPaymentMethod.swift in Sources */,
+				D28CFF143F6E34FAE5F4DE67EB4E5F7E /* PrimerHeadlessUniversalCheckoutProtocols.swift in Sources */,
+				D671E78C1B3EE3856F0F3721B5E69571 /* PrimerImage.swift in Sources */,
+				0B4554175AD2C3AB8A7EA399DBD0FCAF /* PrimerImageView.swift in Sources */,
+				E744A5469C73D0C10B7325FE243F05BE /* PrimerInitializationData.swift in Sources */,
+				12F0B7F31E9C0CB055D964A743C4E218 /* PrimerInputElements.swift in Sources */,
+				D760AF181B9733AEA2A1868A59CFA16C /* PrimerInputViewController.swift in Sources */,
+				B684037856F57C85F5FB41523432E471 /* PrimerIntegrationOptions.swift in Sources */,
+				DF3D2365A243EBC0D230B252F36F67C4 /* PrimerInternal.swift in Sources */,
+				CD4F65001E86978876BC2FCF4142A769 /* PrimerLastNameFieldView.swift in Sources */,
+				8D85B2F3BC9C2410AFE245FDCC8AF354 /* PrimerLoadingViewController.swift in Sources */,
+				C94662E652FA3DC59B4A2976940A576F /* PrimerLocaleData.swift in Sources */,
+				CC68922C84F6EC6A8CEB0B917B6B8CA4 /* PrimerMultibancoCheckoutAdditionalInfo.swift in Sources */,
+				7EC57E10386C8DD31099002EB8A81782 /* PrimerNavigationBar.swift in Sources */,
+				DF153155CD623940BE0E0450E9B8D9CC /* PrimerNavigationController.swift in Sources */,
+				523B2D8586C398B62CAFACD182558E32 /* PrimerNibView.swift in Sources */,
+				F12627F8E793A5D4377B46506A1C09E6 /* PrimerPaymentMethodManager.swift in Sources */,
+				B98C8DBCA1CF7174135DFF8E56733ADA /* PrimerPaymentMethodType.swift in Sources */,
+				F6A382F5D66E86C1CB2B6D4DC9BFF7F2 /* PrimerPaymentPendingInfoViewController.swift in Sources */,
+				3E91783E8BE5E43164BD4ABB791DC06F /* PrimerPhoneNumberData.swift in Sources */,
+				70F9EF93D422C7D3942B4B072F140872 /* PrimerPostalCodeFieldView.swift in Sources */,
+				5E290CA468C68621963E82B3DA8431C8 /* PrimerRawCardDataRedirectTokenizationBuilder.swift in Sources */,
+				B399F7D2FFF9989C27F80B5FB648E7DF /* PrimerRawCardDataTokenizationBuilder.swift in Sources */,
+				2482BA1CA254F97C3E399B63C9F65C54 /* PrimerRawData.swift in Sources */,
+				57F73A2311AF02C4DC5A6CC60684C5E4 /* PrimerRawPhoneNumberDataTokenizationBuilder.swift in Sources */,
+				2CA2EE76A731273A1AC977DA229C5AB7 /* PrimerRawRetailerDataTokenizationBuilder.swift in Sources */,
+				7067DB8DE6C9923E8FC68F0268A5B1E6 /* PrimerResultComponentView.swift in Sources */,
+				24E5571F00D7574C36FE672E2D6575C6 /* PrimerResultViewController.swift in Sources */,
+				E605A012AAABF91FEBDA186A5577947A /* PrimerRetailerData.swift in Sources */,
+				BC2DAA3B604E03F31A9D4CC717071573 /* PrimerRootViewController.swift in Sources */,
+				32F5A3484817FDE0DB15C9A31553EEB6 /* PrimerScrollView.swift in Sources */,
+				FD05512CE2215CC619D395325D4AEEFA /* PrimerSDK-dummy.m in Sources */,
+				60766B2E178CF0A69EC093236389DFF6 /* PrimerSDKIntegrationType.swift in Sources */,
+				00D28CB035C060FC6264205886F77664 /* PrimerSearchTextField.swift in Sources */,
+				ABD82D493D7034BE7ED4C7E5295C7452 /* PrimerSettings.swift in Sources */,
+				BAD1E84AF2077DC809EF10E354400AFF /* PrimerSimpleCardFormTextFieldView.swift in Sources */,
+				13D25B5E61AF2EB068F96ACB661222C7 /* PrimerSource.swift in Sources */,
+				B4890981C3F2CBE2F592639C7657D25A /* PrimerStackVIew.swift in Sources */,
+				054526B68E9339989D17B8FCF531C8A9 /* PrimerStateFieldView.swift in Sources */,
+				92E286EA4FB846EFEBC230CC0A1CF5E2 /* PrimerTableViewCell.swift in Sources */,
+				8842F56D7D93F82438A4767AD842743F /* PrimerTestPaymentMethodTokenizationViewModel.swift in Sources */,
+				BD740D09D30C50EB641FC9986A501A55 /* PrimerTestPaymentMethodViewController.swift in Sources */,
+				207F743D2B6BD97FD11D6AD087C7D3FC /* PrimerTextField.swift in Sources */,
+				B9D090AAD04841F5DF878F554BE67DEF /* PrimerTextFieldView.swift in Sources */,
+				F57E0A392BC5C52EC886128ED83F6754 /* PrimerTextFieldView+Analytics.swift in Sources */,
+				F722A59AA15B5BDB0F5C5362B0734A13 /* PrimerTextFieldView+CardFormFieldsAnalytics.swift in Sources */,
+				3FC830AD4C485F517E1ADBF2BDEB33EE /* PrimerTheme.swift in Sources */,
+				9056D0BF2FF4FAE51B4BA8B5AD796D67 /* PrimerTheme+Borders.swift in Sources */,
+				67C42DC99CAB6FB5F70E1DEA35D50B0E /* PrimerTheme+Buttons.swift in Sources */,
+				79A5D1DD6812CC64723437B0519ACBC3 /* PrimerTheme+Colors.swift in Sources */,
+				9CD4DBEE36C2A732329EE14F555A4D0C /* PrimerTheme+Inputs.swift in Sources */,
+				83D436ADAFFC0C4AEE5C464104E185EA /* PrimerTheme+TextStyles.swift in Sources */,
+				80F800D5CB99614EF506AFF3F63B306F /* PrimerTheme+Views.swift in Sources */,
+				311CA7B281D44CF7ED2B9EF5001D749C /* PrimerThemeData.swift in Sources */,
+				C3131807367CE0D9F90C31B59AAB2F28 /* PrimerThemeData+Deprecated.swift in Sources */,
+				B3BB15F4274DF8A878EA1FFA043DC52F /* PrimerUIImage.swift in Sources */,
+				D6A501D515E864C816776F6095DC27AC /* PrimerUIManager.swift in Sources */,
+				423D733401241A30AE19FD0682D47448 /* PrimerUniversalCheckoutViewController.swift in Sources */,
+				F75595ADEF7DFD9660358955529C5BF7 /* PrimerVaultedCardAdditionalData.swift in Sources */,
+				DDB33AE363BB858324152DA3734D305E /* PrimerVaultedPaymentMethodAdditionalData.swift in Sources */,
+				3EC500D7BAB81C3873E1DEA57BF966D5 /* PrimerVaultManagerViewController.swift in Sources */,
+				534940DA47CE2B00A9498B25017B886E /* PrimerViewController.swift in Sources */,
+				C6048C6C4F82A56A71843B129A2EBF74 /* PrimerViewExtensions.swift in Sources */,
+				7C492879F072CD000DE5EC816AACA14A /* PrimerVoucherInfoPaymentViewController.swift in Sources */,
+				6FB35AE2668B5590FE8DE098DE348934 /* PrimerWebViewController.swift in Sources */,
+				D13CECF148E95EB4491E5B3FA3950EEB /* Promise.swift in Sources */,
+				026D9A82E011E1344A2BFDAFCBDD4965 /* QRCodeTokenizationViewModel.swift in Sources */,
+				E37B0E6775C5B84E1D5104F57E754A3E /* QRCodeViewController.swift in Sources */,
+				FFAD20E1275EB45E91BF20A1945638B1 /* Queue.swift in Sources */,
+				E78811539F47C57B52FAE803893EF61E /* race.swift in Sources */,
+				D2745D36D41AF170B354169CC388CE49 /* RateLimitedDispatcher.swift in Sources */,
+				2D6C3C0AE899231F313F2731B1F48EB0 /* RateLimitedDispatcherBase.swift in Sources */,
+				F9D4E56DE46B4C5BC8550D13396E2CD9 /* RawDataManager.swift in Sources */,
+				E36AB03FC42CB5436CB7FDDBE4110688 /* RecoverWrappers.swift in Sources */,
+				CCB04398206BC8362CC053F7E937FA63 /* ReloadDelegate.swift in Sources */,
+				39DEBF122D67CEC7F876D2067B5F17CE /* Request.swift in Sources */,
+				41BE82E48B02158234F9CC37428A95D0 /* Resolver.swift in Sources */,
+				4FA9664093FFC69CBEFEAC86BB6F5053 /* Response.swift in Sources */,
+				CA9494C0BDA37194743348D4125BE2F1 /* ResumeHandlerProtocol.swift in Sources */,
+				1C6F2D3FE87D0730CB21F682E11EDA3C /* RetailOutletsRetail.swift in Sources */,
+				46C0E408664E32E075A980113500F6C7 /* SequenceWrappers.swift in Sources */,
+				E549345AF63325A1EF5A957C7229D5DB /* StateField.swift in Sources */,
+				EE25841E65825D0CE2186AF42EB38061 /* StrictRateLimitedDispatcher.swift in Sources */,
+				EE7D8D77CBDA99D8A6C3EE5296FE13AC /* StringExtension.swift in Sources */,
+				C7B08653B65DC8D19DC48CCE9EA3F71E /* Strings.swift in Sources */,
+				167DEBF94CED26FE6B9ED4DDE3B48698 /* SuccessMessage.swift in Sources */,
+				155918B7996866F3D9DCDBD9704DA9F2 /* SuccessResponse.swift in Sources */,
+				6722B084ADD9DA4AC3DABA50F8C52BFF /* Thenable.swift in Sources */,
+				4BCF555BB378319B84938A268583EE89 /* ThenableWrappers.swift in Sources */,
+				15BBA5C2D14D9F340528B2771E70F8B7 /* Throwable.swift in Sources */,
+				9C069FBA6B0862F59BB0E224BCF8353C /* TimerExtension.swift in Sources */,
+				91AE90FCAAA605A5C8A3F8F45518FDF8 /* TokenizationRequestBody.swift in Sources */,
+				DAAD066AFDAAC2DD71A2D48BA1FC8F01 /* TokenizationRequestPaymentInstrument.swift in Sources */,
+				0047C55A24CDD0CCE0A0235D6688A894 /* TokenizationRequestPaymentSessionInfo.swift in Sources */,
+				D9913134A9B7ABDFA77DE4AEDA649C7D /* TokenizationResponse.swift in Sources */,
+				FE521007E0962259151A9C837BEBF576 /* TokenizationService.swift in Sources */,
+				D98A0DB4BF083ECEB3CA97B9AF563970 /* UIColorExtension.swift in Sources */,
+				938EB36DE7BF084D418AF662EB6A3BBB /* UIDeviceExtension.swift in Sources */,
+				2021E3E6A9A27B2E76241E8ACCC60E4E /* UILocalizableUtil.swift in Sources */,
+				929D946937DE8CA191B212FD5599A84F /* UINavigationController+Extensions.swift in Sources */,
+				94635F0350F5B14F1628CF4E21A57B31 /* UIScreenExtension.swift in Sources */,
+				49AE481684D585E4C8D6B6F2F3EA7BF9 /* UIUtils.swift in Sources */,
+				E20FD5C54202CE449897D4515460CFF0 /* UniversalCheckoutViewModel.swift in Sources */,
+				CF9D5B788A51C19C6DACCAFE0D2133A8 /* URLExtension.swift in Sources */,
+				7A803B561ED06FCCA76114EE49FCB9BE /* URLSessionStack.swift in Sources */,
+				BA19D8A0232B442731FA116A27089854 /* UserAgent.swift in Sources */,
+				7DB78C6B612412BC66841DD9D9CDEABF /* UserDefaultsExtension.swift in Sources */,
+				86A8876BAE5C57C36A2996C56BC36940 /* UserInterfaceModule.swift in Sources */,
+				95B522E9A0763F91B36E62600E85FE89 /* VaultedPaymentMethods.swift in Sources */,
+				46E111D8A06C7A28D9C51CB99D309043 /* VaultManager.swift in Sources */,
+				BBE0ABD67AB18C95447A44E66C2634D0 /* VaultPaymentMethodView.swift in Sources */,
+				20645148922EECD1763BF10979FB5AA0 /* VaultPaymentMethodViewController.swift in Sources */,
+				5C678B7E2D5D163822B3A0F2BF9766B9 /* VaultPaymentMethodViewModel.swift in Sources */,
+				3D3BF04386CD7C7876F019E23472CD03 /* VaultService.swift in Sources */,
+				A9AB53119611E2B0A61D29277B76BC79 /* version.swift in Sources */,
+				BEC4D0C8667FE08CB71D556157BB78BB /* VersionUtils.swift in Sources */,
+				239263C672FCEFFADABA2D4257682626 /* VoucherValue.swift in Sources */,
+				5EF5BC8F9F91271692A25668864EB240 /* Weak.swift in Sources */,
+				0EF5FB1C897C76FD7850DCB5852CC772 /* WebRedirectPaymentMethodTokenizationViewModel.swift in Sources */,
+				BF9D9399062FFF0EA8D3B741E0BFBA72 /* WebViewUtil.swift in Sources */,
+				97BE6E19021709989310C4FBABDA697E /* when.swift in Sources */,
+				89684057B1971C6FA6C89A5C4F2D8715 /* WrapperProtocols.swift in Sources */,
+				DA8E6CD15E71A439671D29CFB7556AB4 /* XenditRetailOutlets.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E892043F627C397AC25A7EAC61F66012 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2995,79 +3053,79 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0AAAE37337CE79CC0775C3CB663C5D61 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PrimerIPay88MYSDK;
-			target = F8E5FB3C062691E4A558AC2F38E07E63 /* PrimerIPay88MYSDK */;
-			targetProxy = F6B821012F73712BAA9216B41954A5D8 /* PBXContainerItemProxy */;
-		};
-		226BB79F1CA022474D3A40283B27AA17 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = PrimerKlarnaSDK;
-			target = 46078E413137E8360E17944FC2E93839 /* PrimerKlarnaSDK */;
-			targetProxy = 277D368223672865BA1AAF6BBB943E74 /* PBXContainerItemProxy */;
-		};
-		3DA1EAE2F57843839A24434589963E82 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Primer3DS;
-			target = 6F5F0A81CAE773CFE5371059A81B5B6A /* Primer3DS */;
-			targetProxy = 1ACC4A73A1487D1AC301C59D3DDEAE39 /* PBXContainerItemProxy */;
-		};
-		55FC62A60315FE126E3E0251A4BBF7C8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = KlarnaMobileSDK;
-			target = CED402C355914FFED9773C1549264B8C /* KlarnaMobileSDK */;
-			targetProxy = 5BB6C350E9383B50DFF1A6E8DD6760CB /* PBXContainerItemProxy */;
-		};
-		6AD8591E40660D9097E0DF591DC18022 /* PBXTargetDependency */ = {
+		00E0A69F77F29BDCC2415C895DAE266B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "PrimerSDK-PrimerResources";
 			target = 6E6525C7043FBA7BB34A249010AF5593 /* PrimerSDK-PrimerResources */;
-			targetProxy = E49D3DDF11F735CE913D6E8E1249E2BF /* PBXContainerItemProxy */;
+			targetProxy = 25543BDC4D05319E9EFEFD60058137C3 /* PBXContainerItemProxy */;
 		};
-		9B83085B805A82859AC144401B7FEE66 /* PBXTargetDependency */ = {
+		41239B3F8CFC01C2547DD4A76A755960 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PrimerIPay88MYSDK;
+			target = F8E5FB3C062691E4A558AC2F38E07E63 /* PrimerIPay88MYSDK */;
+			targetProxy = 636F9C9ED4C5676ECFA9F0BE24CF15C9 /* PBXContainerItemProxy */;
+		};
+		6F32ED436AAF77B26CDF62B90DD2D1CB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = KlarnaMobileSDK;
 			target = CED402C355914FFED9773C1549264B8C /* KlarnaMobileSDK */;
-			targetProxy = 581CA5B990D3DDFB0532F8131F541EE6 /* PBXContainerItemProxy */;
+			targetProxy = EBB0E0EDEEBE106737507CFDAA2FAB29 /* PBXContainerItemProxy */;
 		};
-		A7BC393349FFD7276F202FA19680299D /* PBXTargetDependency */ = {
+		7C7D76EA8EEAE9D76025A404DAD8F4D2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-Debug App";
 			target = AE0D1F6B2232EC9235B0E597AE598062 /* Pods-Debug App */;
-			targetProxy = 211BEB055EE4D700E332D9ECAA3E6173 /* PBXContainerItemProxy */;
+			targetProxy = 551DEBFCD56AD448C0BC804A24E6C93F /* PBXContainerItemProxy */;
 		};
-		BE88681C9DFDD6125B60EB7C26BDC415 /* PBXTargetDependency */ = {
+		A522F090FEB8AF5501545E21B256A29F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PrimerKlarnaSDK;
+			target = 46078E413137E8360E17944FC2E93839 /* PrimerKlarnaSDK */;
+			targetProxy = B15A4DC2F5082785774B48D5252ABDA5 /* PBXContainerItemProxy */;
+		};
+		AE64B373B3E8699DA1EDBB0B90EA4C8B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Primer3DS;
+			target = 6F5F0A81CAE773CFE5371059A81B5B6A /* Primer3DS */;
+			targetProxy = 7D303E8160F602C5CC1A3DEC2BDA81FC /* PBXContainerItemProxy */;
+		};
+		B928D73AB2B69C97970980760E2CA1A6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PrimerSDK;
 			target = F3BE9108C53B53949406218CEA55E0B2 /* PrimerSDK */;
-			targetProxy = 45AAF336FA4B87FA058691C0FBA0A82C /* PBXContainerItemProxy */;
+			targetProxy = FB2A023D65B0BE2FD4C38BBD1F866821 /* PBXContainerItemProxy */;
+		};
+		CC662D5F08F04E5630AF3837C4B0F618 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = KlarnaMobileSDK;
+			target = CED402C355914FFED9773C1549264B8C /* KlarnaMobileSDK */;
+			targetProxy = FC6E52886F3218093A3CB69EF1334B6C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		3C63DD85A6A9E4C7DB5A148B98C37FE1 /* Localizable.strings */ = {
+		F970CB7C0D80D515A6B60786C926E196 /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
-				C9A892EA6945752EE41ED16A748E8593 /* Localizable.strings */,
-				E2D9E5496CC150463B46FBF6BD4C5B77 /* Localizable.strings */,
-				33A68EB2935D68427FAB53A08D703711 /* Localizable.strings */,
-				D86DD8C26E739EFE60DD76F302B92D95 /* Localizable.strings */,
-				0DB7F2D5BB97649A588DE3F579C41081 /* Localizable.strings */,
-				F8CE6370124F3692D2A038ACE8DA4376 /* Localizable.strings */,
-				6098CE9116BFC3845DD96AD652C04E36 /* Localizable.strings */,
-				F0D277A20A55FD3777A8DB8968C43D82 /* Localizable.strings */,
-				3406163F77D2FB6CF057AA67D4E34DF9 /* Localizable.strings */,
-				5335514016E0A6B50E5A03D318A7CC71 /* Localizable.strings */,
-				D3A7E9C2363E309FB79C2CD38C041213 /* Localizable.strings */,
-				B866BC8CB195144C70D5613B2260BCFE /* Localizable.strings */,
-				F4BA008515B6E5DB751DCD7290E712B4 /* Localizable.strings */,
-				139D45FF1CFA7B8C5CE600B027FAB52E /* Localizable.strings */,
-				D03FF889913EE3797E582422BEFFC4E3 /* Localizable.strings */,
-				066A1F71DBE9D14ACDB2A63D48ADDF68 /* Localizable.strings */,
-				4D2ECACF0E03330C7C331270B918C78B /* Localizable.strings */,
-				CB83F002475DA8C34F8A8E93D336C3C4 /* Localizable.strings */,
-				8332AEB6F0EF946984EC5330A3BD7049 /* Localizable.strings */,
+				C804BEAF37C2336475DC11C3E7F65379 /* Localizable.strings */,
+				2ABDA4A40D9E4BB020FAE8D4159CD91F /* Localizable.strings */,
+				71AD1E849E719DD50A376226ECBBEED3 /* Localizable.strings */,
+				E1ADD94E9D154B6E0E2A53A5D06482DF /* Localizable.strings */,
+				31804F20060164582477B07E26D95BBA /* Localizable.strings */,
+				BC400E34349A965A8870B2ABCA6BB701 /* Localizable.strings */,
+				0B4F24B38DC7272A8BB20C6C3AB8911C /* Localizable.strings */,
+				016B82E8953680E3FDFB6CF99F8E820B /* Localizable.strings */,
+				4771BAAA633C309EACC1EB3E2FCD159F /* Localizable.strings */,
+				7204F6CB5015623899D7FD0266BAEC8A /* Localizable.strings */,
+				6ED7263654A9F15F9AA18ADCEDDFD5A6 /* Localizable.strings */,
+				C92CF359D03821C1FE9C01C1CB3D70A5 /* Localizable.strings */,
+				2AF1D4F681057F4721C0662C745E8E8D /* Localizable.strings */,
+				7715BCA22D1D7480C14034B239384E02 /* Localizable.strings */,
+				CA0A9B1EE87D12DD49DFECABE956A051 /* Localizable.strings */,
+				F925EFEDD853C9FB5AF827E90ED6C9D5 /* Localizable.strings */,
+				8501ED6EC044D3BD2043B3952D8123F5 /* Localizable.strings */,
+				978B4EC5FF8648A451F56A4CB9A64D62 /* Localizable.strings */,
+				54D981578A2AB7D51245C718C5A2981B /* Localizable.strings */,
 			);
 			name = Localizable.strings;
 			path = .;
@@ -3113,48 +3171,6 @@
 			};
 			name = Debug;
 		};
-		22C538E2473EBF1828D0D405AFAC575E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = F1188C3FC901946A1FDBE86766A5B95C /* PrimerSDK.debug.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_WEAK = NO;
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/PrimerSDK/PrimerSDK-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/PrimerSDK/PrimerSDK-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/PrimerSDK/PrimerSDK.modulemap";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-framework",
-					"\"Primer3DS\"",
-					"-framework",
-					"\"PrimerKlarnaSDK\"",
-				);
-				PRODUCT_MODULE_NAME = PrimerSDK;
-				PRODUCT_NAME = PrimerSDK;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 4.2;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		2D2E01887785B913C546F0B04C8A25FD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 967B58577CC95960D03E88A8367394BB /* KlarnaMobileSDK.debug.xcconfig */;
@@ -3172,7 +3188,7 @@
 			};
 			name = Debug;
 		};
-		48EE75B22F35A685C4633B398B30DF62 /* Release */ = {
+		52800BEA3112C7B780049AB036496065 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0432C455D98AF72FD6864C01E3E06BE5 /* PrimerSDK.release.xcconfig */;
 			buildSettings = {
@@ -3215,9 +3231,51 @@
 			};
 			name = Release;
 		};
-		5DDCD2D7B89B9A32375BA36AF1B5810D /* Debug */ = {
+		5DDAF9CDF899F746118B90531C1A2CD2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F1188C3FC901946A1FDBE86766A5B95C /* PrimerSDK.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/PrimerSDK/PrimerSDK-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/PrimerSDK/PrimerSDK-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/PrimerSDK/PrimerSDK.modulemap";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					"\"Primer3DS\"",
+					"-framework",
+					"\"PrimerKlarnaSDK\"",
+				);
+				PRODUCT_MODULE_NAME = PrimerSDK;
+				PRODUCT_NAME = PrimerSDK;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5FAB96B3EADA8CA0B4A95FC95F55029A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0432C455D98AF72FD6864C01E3E06BE5 /* PrimerSDK.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGNING_ALLOWED = NO;
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/PrimerSDK";
@@ -3231,7 +3289,7 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = bundle;
 			};
-			name = Debug;
+			name = Release;
 		};
 		60192E584E7615A352BDA38E45C35DC1 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -3477,24 +3535,6 @@
 			};
 			name = Release;
 		};
-		A3F2D962AF905F729ED734B6E16C5A66 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0432C455D98AF72FD6864C01E3E06BE5 /* PrimerSDK.release.xcconfig */;
-			buildSettings = {
-				CODE_SIGNING_ALLOWED = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/PrimerSDK";
-				DEVELOPMENT_TEAM = N8UN9TR5DY;
-				IBSC_MODULE = PrimerSDK;
-				INFOPLIST_FILE = "Target Support Files/PrimerSDK/ResourceBundle-PrimerResources-PrimerSDK-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				PRODUCT_NAME = PrimerResources;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Release;
-		};
 		B4EFE046ACF8F37157F6E322C7FCFC28 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3596,6 +3636,24 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		D017E03FFEB808F3F980E415D751826A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F1188C3FC901946A1FDBE86766A5B95C /* PrimerSDK.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/PrimerSDK";
+				DEVELOPMENT_TEAM = N8UN9TR5DY;
+				IBSC_MODULE = PrimerSDK;
+				INFOPLIST_FILE = "Target Support Files/PrimerSDK/ResourceBundle-PrimerResources-PrimerSDK-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				PRODUCT_NAME = PrimerResources;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
 		};
 		D8A6A789C0E3BF7BE03D7AD5F0A9DFA9 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -3744,11 +3802,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3493B366F8D15A18C083F1DF7B22BC3A /* Build configuration list for PBXNativeTarget "PrimerSDK" */ = {
+		2D377BA0A96E61EDE346C6F614B8DBC8 /* Build configuration list for PBXNativeTarget "PrimerSDK-PrimerResources" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				22C538E2473EBF1828D0D405AFAC575E /* Debug */,
-				48EE75B22F35A685C4633B398B30DF62 /* Release */,
+				D017E03FFEB808F3F980E415D751826A /* Debug */,
+				5FAB96B3EADA8CA0B4A95FC95F55029A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -3771,11 +3829,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A8EF881FD5A72A7DB048671BC29DB4D0 /* Build configuration list for PBXNativeTarget "PrimerSDK-PrimerResources" */ = {
+		A7AF6E72B65301242A39A130F132A530 /* Build configuration list for PBXNativeTarget "PrimerSDK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5DDCD2D7B89B9A32375BA36AF1B5810D /* Debug */,
-				A3F2D962AF905F729ED734B6E16C5A66 /* Release */,
+				5DDAF9CDF899F746118B90531C1A2CD2 /* Debug */,
+				52800BEA3112C7B780049AB036496065 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Debug App/Pods/Primer3DS/Sources/Primer3DS/Classes/Primer3DSStructures.swift
+++ b/Debug App/Pods/Primer3DS/Sources/Primer3DS/Classes/Primer3DSStructures.swift
@@ -8,7 +8,6 @@ public enum Environment: String, Codable {
     case staging = "STAGING"
     case sandbox = "SANDBOX"
     case local = "LOCAL"
-    case dev = "DEV"
 }
 
 @objc public enum ResponseCode: Int {

--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -57,9 +57,9 @@
 		961B5D18058EF4CFCD0185AE /* MockVaultCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3E75CD834937EF85DE1C14 /* MockVaultCheckoutViewModel.swift */; };
 		97F0B302DF965C1AD1EC6F4D /* PaymentMethodConfigServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743F107C464526926A34A433 /* PaymentMethodConfigServiceTests.swift */; };
 		9AB1ABF4E46A37766CDBF197 /* ApayaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F79B50111AC4161CFB1EFE8 /* ApayaTests.swift */; };
+		9BA207CBF62E6E3B931A6D69 /* Pods_Debug_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02AD8415F6A4CA38ABE76E50 /* Pods_Debug_App.framework */; };
 		A39750255D4C33527A3766A0 /* UserInterfaceModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B8CB5A11A44AA9F3D7FE356 /* UserInterfaceModuleTests.swift */; };
 		A61B9E61EDCE18D34438352E /* PayPalConfirmBillingAgreementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D122A0B71B707C2110AB7F5 /* PayPalConfirmBillingAgreementTests.swift */; };
-		A7C46717FEC8D8FB47A2252E /* Pods_Debug_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9543C140C2D099E34E95FDE /* Pods_Debug_App.framework */; };
 		AAE3B30B64B6822A20987FCA /* CreateClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229849A3DBE0858EE90673B9 /* CreateClientToken.swift */; };
 		AD9CF1073EE0676E6640481A /* MerchantHeadlessCheckoutRawDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B866FF13033A5CB8B4C3388E /* MerchantHeadlessCheckoutRawDataViewController.swift */; };
 		C0115AC7BC96FDF49EF8E530 /* PaymentMethodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E79C93EA805E87E1137A513 /* PaymentMethodCell.swift */; };
@@ -68,6 +68,7 @@
 		C6D7F7ECFD35B3DC3AFD6CB2 /* PayPalService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FD540BEA16ABBDFE7DE182 /* PayPalService.swift */; };
 		C75A11E6AEEFC2B7A29BBC04 /* TestScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AEF11B151368BF993C3EA9 /* TestScenario.swift */; };
 		C8A64A69AD55D9BF82F0D876 /* StringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872A0647D4136E27365FB7F8 /* StringTests.swift */; };
+		CC1A2ECF1BD5D023C4483B7C /* Pods_Debug_App_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47E44825FD53ECDA27E1B066 /* Pods_Debug_App_Tests.framework */; };
 		CE5E673A96BB5B96AE5EFC56 /* Range+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9128566126AA7F571FFECA3A /* Range+Extensions.swift */; };
 		D649870C2D022B4063BDC0B4 /* PrimerRawRetailerDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B266F9E1651BD20E45DCCF68 /* PrimerRawRetailerDataTests.swift */; };
 		D886D8E47D883304B505CE11 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC5687FF32E8661F1A00CE5 /* AppDelegate.swift */; };
@@ -82,7 +83,6 @@
 		F03699552AC2DCF100E4179D /* VersionUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03699542AC2DCF100E4179D /* VersionUtilsTests.swift */; };
 		F0C2147F6FA26527BE55549A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = FC701AFD94F96F0F1D108D1A /* LaunchScreen.xib */; };
 		F1A71C2E0D900FEB9AF1351C /* ThreeDSProtocolVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A00DEB01A46C876592575 /* ThreeDSProtocolVersionTests.swift */; };
-		F2E6C6BA5E1E367E862408E3 /* Pods_Debug_App_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D4A756EB43AB71D4C3270A7 /* Pods_Debug_App_Tests.framework */; };
 		F3B88F24999785898FE54C53 /* MerchantHeadlesVaultManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5698F95A8EC4DF45AFFDA783 /* MerchantHeadlesVaultManagerViewController.swift */; };
 		F99DAF50E86E6F8CCD127E5B /* ThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD381E7E16D01D8D743232F7 /* ThemeTests.swift */; };
 		FD5ADBCFA70DB606339F3AF2 /* TransactionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D3D6CF0F006A06B7CEC71B /* TransactionResponse.swift */; };
@@ -125,23 +125,23 @@
 		00E3C8FE62D22147335F2455 /* MerchantResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantResultViewController.swift; sourceTree = "<group>"; };
 		01C09DEAB07F42004B26A278 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		021A00DEB01A46C876592575 /* ThreeDSProtocolVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSProtocolVersionTests.swift; sourceTree = "<group>"; };
+		02AD8415F6A4CA38ABE76E50 /* Pods_Debug_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Debug App Tests-Info.plist"; sourceTree = "<group>"; };
 		0DA32ABCF07A4EBED014327B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		0ED746F8924E70AD868BC0F4 /* MerchantNewLineItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantNewLineItemViewController.swift; sourceTree = "<group>"; };
 		0FD08B8CE57A11D1E35A8684 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
-		106118796661236E7228680A /* Pods-Debug App Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App Tests.release.xcconfig"; path = "Target Support Files/Pods-Debug App Tests/Pods-Debug App Tests.release.xcconfig"; sourceTree = "<group>"; };
 		13FA89917603E4BA5BB66AFC /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		1594BC5C96ECC3F46C811B2F /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
+		163F31955FBDDFF30D869CBD /* Pods-Debug App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.debug.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.debug.xcconfig"; sourceTree = "<group>"; };
 		17476BFBED51F389FCE82F16 /* MockAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAPIClient.swift; sourceTree = "<group>"; };
 		1B8CB5A11A44AA9F3D7FE356 /* UserInterfaceModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInterfaceModuleTests.swift; sourceTree = "<group>"; };
-		1C3F188F928FF043952E4A46 /* Pods-Debug App Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App Tests.debug.xcconfig"; path = "Target Support Files/Pods-Debug App Tests/Pods-Debug App Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		1D05E65C196E6715D7D8B0C6 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Main.strings; sourceTree = "<group>"; };
 		1F4E35F809D3FAF4354D5B05 /* URLSessionStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionStackTests.swift; sourceTree = "<group>"; };
 		1F79B50111AC4161CFB1EFE8 /* ApayaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApayaTests.swift; sourceTree = "<group>"; };
 		229849A3DBE0858EE90673B9 /* CreateClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateClientToken.swift; sourceTree = "<group>"; };
 		25FD540BEA16ABBDFE7DE182 /* PayPalService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalService.swift; sourceTree = "<group>"; };
 		2A328E38DA586FFE0ED2894B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Main.strings; sourceTree = "<group>"; };
-		2D4A756EB43AB71D4C3270A7 /* Pods_Debug_App_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2CF8B35D6F82024B7101C245 /* Pods-Debug App Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App Tests.debug.xcconfig"; path = "Target Support Files/Pods-Debug App Tests/Pods-Debug App Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		2E64F057A39A91CA01CCB57F /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Main.strings; sourceTree = "<group>"; };
 		2E8F69253D85350BB7A1A761 /* TokenizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenizationService.swift; sourceTree = "<group>"; };
 		31CFA93A373A7DB78DA77283 /* ApplePayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayTests.swift; sourceTree = "<group>"; };
@@ -149,6 +149,8 @@
 		38DD0A9535544D446514124A /* CreateResumePaymentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateResumePaymentService.swift; sourceTree = "<group>"; };
 		39CCCB917D1881082ED75975 /* ViewController+Primer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Primer.swift"; sourceTree = "<group>"; };
 		404E173A513B986A36F835F7 /* MerchantHeadlessCheckoutRawPhoneNumberDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutRawPhoneNumberDataViewController.swift; sourceTree = "<group>"; };
+		4497DFC51EFD05EA805BD250 /* Pods-Debug App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.release.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.release.xcconfig"; sourceTree = "<group>"; };
+		47E44825FD53ECDA27E1B066 /* Pods_Debug_App_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		483D2036DE3F89CA2C244C4F /* Debug App Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Debug App Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49DFB1ACD5014BF28ED283B3 /* PollingModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingModuleTests.swift; sourceTree = "<group>"; };
 		4A5E3ACDA26D44F66B55766B /* HUC_TokenizationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUC_TokenizationViewModelTests.swift; sourceTree = "<group>"; };
@@ -195,6 +197,7 @@
 		994AE6760B506D02499AEC90 /* CardComponentManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardComponentManagerTests.swift; sourceTree = "<group>"; };
 		9D122A0B71B707C2110AB7F5 /* PayPalConfirmBillingAgreementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayPalConfirmBillingAgreementTests.swift; sourceTree = "<group>"; };
 		A1604A656AF654D7422A2A5E /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
+		A22B8720D253FE4DD06B13E9 /* Pods-Debug App Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App Tests.release.xcconfig"; path = "Target Support Files/Pods-Debug App Tests/Pods-Debug App Tests.release.xcconfig"; sourceTree = "<group>"; };
 		A6AEF11B151368BF993C3EA9 /* TestScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestScenario.swift; sourceTree = "<group>"; };
 		AD381E7E16D01D8D743232F7 /* ThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeTests.swift; sourceTree = "<group>"; };
 		AF07D2421252EA2AE5C2FC4F /* AnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
@@ -209,7 +212,6 @@
 		BF8639891B79E2FCCE10A510 /* ThreeDSErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSErrorTests.swift; sourceTree = "<group>"; };
 		C18C9664115CFDEB59FED19A /* MerchantSessionAndSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantSessionAndSettingsViewController.swift; sourceTree = "<group>"; };
 		C4DFE77F28AB538220A0F6EE /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = ka.lproj/Main.strings; sourceTree = "<group>"; };
-		C6745C430E163CD64B0C8705 /* Pods-Debug App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.debug.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.debug.xcconfig"; sourceTree = "<group>"; };
 		C7D8E1E91CA11EC6831ADEE4 /* EncodingDecodingContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodingDecodingContainerTests.swift; sourceTree = "<group>"; };
 		C7EB86C62BA46BF51C64ABC2 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		CA30891B2D5F9B6B97E56B99 /* WebViewUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewUtilTests.swift; sourceTree = "<group>"; };
@@ -229,11 +231,9 @@
 		E9899972360BCA5992CEE5BC /* PrimerBancontactCardDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerBancontactCardDataManagerTests.swift; sourceTree = "<group>"; };
 		EEB1E1B37192BF739461AFF1 /* PrimerRawCardDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerRawCardDataManagerTests.swift; sourceTree = "<group>"; };
 		F03699542AC2DCF100E4179D /* VersionUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionUtilsTests.swift; sourceTree = "<group>"; };
-		F09934A8E7076E1A2F606E9E /* Pods-Debug App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.release.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.release.xcconfig"; sourceTree = "<group>"; };
 		F4AC1EC0F98CB56DA4D075CA /* Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		F816A2444633C4336A7CB071 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		F9023841AFCE8E3205CB713A /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
-		F9543C140C2D099E34E95FDE /* Pods_Debug_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB1F71737862EF5D0F4FE5AB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		FC8A21D574BAEF7E0ED9E9CD /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Main.strings"; sourceTree = "<group>"; };
 		FEEF675F553A6AD99750CB0F /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -245,7 +245,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F2E6C6BA5E1E367E862408E3 /* Pods_Debug_App_Tests.framework in Frameworks */,
+				CC1A2ECF1BD5D023C4483B7C /* Pods_Debug_App_Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -253,7 +253,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A7C46717FEC8D8FB47A2252E /* Pods_Debug_App.framework in Frameworks */,
+				9BA207CBF62E6E3B931A6D69 /* Pods_Debug_App.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -290,9 +290,9 @@
 			isa = PBXGroup;
 			children = (
 				FBDF3F8B5F93A0EC28048640 /* Project */,
-				6EC17DC25908BCF71DE8B55E /* Frameworks */,
 				DF30711EB149C64C364BB79A /* Products */,
 				61E8D69DF93462D748F446DF /* Pods */,
+				F5DECA5C61674A1411273A00 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -376,10 +376,10 @@
 		61E8D69DF93462D748F446DF /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				C6745C430E163CD64B0C8705 /* Pods-Debug App.debug.xcconfig */,
-				F09934A8E7076E1A2F606E9E /* Pods-Debug App.release.xcconfig */,
-				1C3F188F928FF043952E4A46 /* Pods-Debug App Tests.debug.xcconfig */,
-				106118796661236E7228680A /* Pods-Debug App Tests.release.xcconfig */,
+				163F31955FBDDFF30D869CBD /* Pods-Debug App.debug.xcconfig */,
+				4497DFC51EFD05EA805BD250 /* Pods-Debug App.release.xcconfig */,
+				2CF8B35D6F82024B7101C245 /* Pods-Debug App Tests.debug.xcconfig */,
+				A22B8720D253FE4DD06B13E9 /* Pods-Debug App Tests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -399,15 +399,6 @@
 				77E08473D1DF8C47A6EB61B2 /* Networking+Models.swift */,
 			);
 			path = Network;
-			sourceTree = "<group>";
-		};
-		6EC17DC25908BCF71DE8B55E /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				F9543C140C2D099E34E95FDE /* Pods_Debug_App.framework */,
-				2D4A756EB43AB71D4C3270A7 /* Pods_Debug_App_Tests.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9EE81958BB2BB34183F6C0AB /* Modules */ = {
@@ -573,6 +564,15 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		F5DECA5C61674A1411273A00 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				02AD8415F6A4CA38ABE76E50 /* Pods_Debug_App.framework */,
+				47E44825FD53ECDA27E1B066 /* Pods_Debug_App_Tests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		FBDF3F8B5F93A0EC28048640 /* Project */ = {
 			isa = PBXGroup;
 			children = (
@@ -592,7 +592,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4700FFD06E10F0EE123A7B8B /* Build configuration list for PBXNativeTarget "Debug App Tests" */;
 			buildPhases = (
-				2C22E94DB713D3EA5A536EB1 /* [CP] Check Pods Manifest.lock */,
+				278034DFFCE0D37C58A4CC0F /* [CP] Check Pods Manifest.lock */,
 				1E0FCAD905F5F8F13B6A164B /* Sources */,
 				9CED4C4EFACB340F3C55B1F0 /* Resources */,
 				D11E367C3560C383BC4CA0A7 /* Embed Frameworks */,
@@ -612,12 +612,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CA98A6B11506835A81F6391A /* Build configuration list for PBXNativeTarget "Debug App" */;
 			buildPhases = (
-				DB1A13EF76206FE4666685CE /* [CP] Check Pods Manifest.lock */,
+				0617C8B715EF9B9B2F05997F /* [CP] Check Pods Manifest.lock */,
 				66BB6A7BADD3A9CDD6412CE2 /* Sources */,
 				10FBAAC827CE0E3983CD7597 /* Resources */,
 				73B416AD9A0CB3B0EA16AF79 /* Embed Frameworks */,
 				CB612F7DF16CD3190025327F /* Frameworks */,
-				B2FDCAA88E771FFCFC370B7A /* [CP] Embed Pods Frameworks */,
+				EAC047F570C459820F2DEF2E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -697,7 +697,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2C22E94DB713D3EA5A536EB1 /* [CP] Check Pods Manifest.lock */ = {
+		0617C8B715EF9B9B2F05997F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Debug App-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		278034DFFCE0D37C58A4CC0F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -719,7 +741,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B2FDCAA88E771FFCFC370B7A /* [CP] Embed Pods Frameworks */ = {
+		EAC047F570C459820F2DEF2E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -734,28 +756,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Debug App/Pods-Debug App-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DB1A13EF76206FE4666685CE /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Debug App-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -910,7 +910,7 @@
 /* Begin XCBuildConfiguration section */
 		313E094F25A94116E340B043 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C6745C430E163CD64B0C8705 /* Pods-Debug App.debug.xcconfig */;
+			baseConfigurationReference = 163F31955FBDDFF30D869CBD /* Pods-Debug App.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/ExampleApp.entitlements";
@@ -943,7 +943,7 @@
 		};
 		44381669975E0C07E78FA641 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F09934A8E7076E1A2F606E9E /* Pods-Debug App.release.xcconfig */;
+			baseConfigurationReference = 4497DFC51EFD05EA805BD250 /* Pods-Debug App.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/ExampleApp.entitlements";
@@ -975,7 +975,7 @@
 		};
 		5434DA74E34D2EBEBD3D74C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1C3F188F928FF043952E4A46 /* Pods-Debug App Tests.debug.xcconfig */;
+			baseConfigurationReference = 2CF8B35D6F82024B7101C245 /* Pods-Debug App Tests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1058,7 +1058,7 @@
 		};
 		F10A44A87CE1B40DAFF5D30F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 106118796661236E7228680A /* Pods-Debug App Tests.release.xcconfig */;
+			baseConfigurationReference = A22B8720D253FE4DD06B13E9 /* Pods-Debug App Tests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		E6F85ECD80B64754E7A6D35E /* RawDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7C082270CF1C6B7810F9B3 /* RawDataManagerTests.swift */; };
 		EA7FAA4F8476BD3711D628CB /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B18D7E7738BF86467B0F1465 /* Images.xcassets */; };
 		F02F496FD20B5291C044F62C /* MerchantResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E3C8FE62D22147335F2455 /* MerchantResultViewController.swift */; };
+		F03699552AC2DCF100E4179D /* VersionUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03699542AC2DCF100E4179D /* VersionUtilsTests.swift */; };
 		F0C2147F6FA26527BE55549A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = FC701AFD94F96F0F1D108D1A /* LaunchScreen.xib */; };
 		F1A71C2E0D900FEB9AF1351C /* ThreeDSProtocolVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A00DEB01A46C876592575 /* ThreeDSProtocolVersionTests.swift */; };
 		F2E6C6BA5E1E367E862408E3 /* Pods_Debug_App_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D4A756EB43AB71D4C3270A7 /* Pods_Debug_App_Tests.framework */; };
@@ -227,6 +228,7 @@
 		E90441E821B5FE76643B62A6 /* AnalyticsTests+Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsTests+Constants.swift"; sourceTree = "<group>"; };
 		E9899972360BCA5992CEE5BC /* PrimerBancontactCardDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerBancontactCardDataManagerTests.swift; sourceTree = "<group>"; };
 		EEB1E1B37192BF739461AFF1 /* PrimerRawCardDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerRawCardDataManagerTests.swift; sourceTree = "<group>"; };
+		F03699542AC2DCF100E4179D /* VersionUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionUtilsTests.swift; sourceTree = "<group>"; };
 		F09934A8E7076E1A2F606E9E /* Pods-Debug App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.release.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.release.xcconfig"; sourceTree = "<group>"; };
 		F4AC1EC0F98CB56DA4D075CA /* Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		F816A2444633C4336A7CB071 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
@@ -457,6 +459,7 @@
 				BD26E8C6074BB89ACBD5B8B9 /* MaskTests.swift */,
 				872A0647D4136E27365FB7F8 /* StringTests.swift */,
 				CA30891B2D5F9B6B97E56B99 /* WebViewUtilTests.swift */,
+				F03699542AC2DCF100E4179D /* VersionUtilsTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -786,6 +789,7 @@
 				583EBAA90902121CEA479416 /* VaultService.swift in Sources */,
 				961B5D18058EF4CFCD0185AE /* MockVaultCheckoutViewModel.swift in Sources */,
 				622A605DDEA98D981670B53F /* DropInUI_TokenizationViewModelTests.swift in Sources */,
+				F03699552AC2DCF100E4179D /* VersionUtilsTests.swift in Sources */,
 				208CA849F3187C2DA63CC17B /* HUC_TokenizationViewModelTests.swift in Sources */,
 				213196DEDF2A3A84037ED884 /* PollingModuleTests.swift in Sources */,
 				1589385B62C86DE7C735F3EC /* PrimerAPIConfigurationModuleTests.swift in Sources */,

--- a/Debug App/Tests/Unit Tests/Utils/VersionUtilsTests.swift
+++ b/Debug App/Tests/Unit Tests/Utils/VersionUtilsTests.swift
@@ -20,7 +20,7 @@ final class VersionUtilsTests: XCTestCase {
     }
 
     func test_reactNativeVersion() throws {
-        Primer.shared.integrationOptions = .init(reactNativeVersion: "1.0.0")
+        Primer.shared.integrationOptions = PrimerIntegrationOptions(reactNativeVersion: "1.0.0")
         XCTAssertEqual(VersionUtils.releaseVersionNumber, "1.0.0")
     }
 }

--- a/Debug App/Tests/Unit Tests/Utils/VersionUtilsTests.swift
+++ b/Debug App/Tests/Unit Tests/Utils/VersionUtilsTests.swift
@@ -1,0 +1,26 @@
+//
+//  VersionUtilsTests.swift
+//  Debug App Tests
+//
+//  Created by Niall Quinn on 26/09/23.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+final class VersionUtilsTests: XCTestCase {
+    
+    override func tearDown() {
+        Primer.shared.integrationOptions = nil
+    }
+    
+    func test_releaseVersionNumber() throws {
+        XCTAssertEqual(VersionUtils.releaseVersionNumber, PrimerSDKVersion)
+    }
+
+    func test_reactNativeVersion() throws {
+        Primer.shared.integrationOptions = .init(reactNativeVersion: "1.0.0")
+        XCTAssertEqual(VersionUtils.releaseVersionNumber, "1.0.0")
+    }
+}

--- a/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
@@ -53,7 +53,7 @@ class Analytics {
             self.properties = properties
             self.sdkSessionId = PrimerInternal.shared.sdkSessionId
             self.sdkType = Primer.shared.integrationOptions?.reactNativeVersion == nil ? "IOS_NATIVE" : "RN_IOS"
-            self.sdkVersion = Bundle.primerFramework.releaseVersionNumber
+            self.sdkVersion = VersionUtils.releaseVersionNumber
             self.sdkIntegrationType = PrimerInternal.shared.sdkIntegrationType
             self.sdkPaymentHandling = PrimerSettings.current.paymentHandling
             

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
@@ -552,7 +552,7 @@ struct SDKProperties: Codable {
         self.sdkSessionId = PrimerInternal.shared.checkoutSessionId
         
         self.sdkType = Primer.shared.integrationOptions?.reactNativeVersion == nil ? "IOS_NATIVE" : "RN_IOS"
-        self.sdkVersion = Bundle.primerFramework.releaseVersionNumber
+        self.sdkVersion = VersionUtils.releaseVersionNumber
         
         if let settingsData = try? JSONEncoder().encode(PrimerSettings.current) {
             let decoder = JSONDecoder()

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
@@ -102,12 +102,12 @@ internal class PrimerInternal {
                 severity: .error)))
 #endif
         
-        let bundleReleaseVersionNumber = Bundle.primerFramework.releaseVersionNumber
+        let releaseVersionNumber = VersionUtils.releaseVersionNumber
         events.append(
             Analytics.Event(
                 eventType: .message,
                 properties: MessageEventProperties(
-                    message: "Version number (\(bundleReleaseVersionNumber ?? "n/a")) detected.",
+                    message: "Version number (\(releaseVersionNumber ?? "n/a")) detected.",
                     messageType: .other,
                     severity: .info
                 )

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/BundleExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/BundleExtension.swift
@@ -27,19 +27,5 @@ internal extension Bundle {
     static var primerFrameworkIdentifier: String {
         return Bundle.primerFramework.bundleIdentifier ?? "org.cocoapods.PrimerSDK"
     }
-    
-    var releaseVersionNumber: String? {
-        if let reactNativeVersion = Primer.shared.integrationOptions?.reactNativeVersion {
-            return reactNativeVersion
-        }
-        
-        let version = Bundle.primerFramework.infoDictionary?["CFBundleShortVersionString"] as? String
-        return version
-    }
-    
-    var buildVersionNumber: String? {
-        return Bundle.primerFramework.infoDictionary?["CFBundleVersion"] as? String
-    }
+
 }
-
-

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/VersionUtils.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/VersionUtils.swift
@@ -1,0 +1,18 @@
+//
+//  VersionUtils.swift
+//  PrimerSDK
+//
+//  Created by Niall Quinn on 26/09/23.
+//
+
+import Foundation
+
+struct VersionUtils {
+    static var releaseVersionNumber: String? {
+        if let reactNativeVersion = Primer.shared.integrationOptions?.reactNativeVersion {
+            return reactNativeVersion
+        }
+    
+        return PrimerSDKVersion
+    }
+}

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/VersionUtils.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/VersionUtils.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 struct VersionUtils {
+    
+    /**
+     Returns the version string in the format `"major.minor.patch"`
+     
+     If `PrimerIntegrationOptions.reactNativeVersion` is set, it will be returned.
+     If not, the version specified as `PrimerSDKVersion` in the file `"sources/version.swift"` will be returned.
+     */
     static var releaseVersionNumber: String? {
         if let reactNativeVersion = Primer.shared.integrationOptions?.reactNativeVersion {
             return reactNativeVersion

--- a/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
@@ -85,7 +85,7 @@ internal extension PrimerAPI {
     
     static let headers: [String: String] = [
         "Content-Type": "application/json",
-        "Primer-SDK-Version": Bundle.primerFramework.releaseVersionNumber ?? "n/a",
+        "Primer-SDK-Version": VersionUtils.releaseVersionNumber ?? "n/a",
         "Primer-SDK-Client": PrimerSource.sdkSourceType.sourceType
     ]
     


### PR DESCRIPTION
# What this PR does
- Replaces all usage of `info.plist` for version reporting with the new `version.swift`
- Added a utility to wrap this number to preserve current react native version logic
- Added unit tests to this utility

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [x] I manually tested this with a demo application (real device)
- [x] I wrote unit tests for each new util-like function