### PR TITLE
chore: use version.swift file

### DIFF
--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		E6F85ECD80B64754E7A6D35E /* RawDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7C082270CF1C6B7810F9B3 /* RawDataManagerTests.swift */; };
 		EA7FAA4F8476BD3711D628CB /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B18D7E7738BF86467B0F1465 /* Images.xcassets */; };
 		F02F496FD20B5291C044F62C /* MerchantResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E3C8FE62D22147335F2455 /* MerchantResultViewController.swift */; };
+		F03699592AC2E63700E4179D /* VersionUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03699582AC2E63700E4179D /* VersionUtilsTests.swift */; };
 		F0C2147F6FA26527BE55549A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = FC701AFD94F96F0F1D108D1A /* LaunchScreen.xib */; };
 		F1A71C2E0D900FEB9AF1351C /* ThreeDSProtocolVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021A00DEB01A46C876592575 /* ThreeDSProtocolVersionTests.swift */; };
 		F2E6C6BA5E1E367E862408E3 /* Pods_Debug_App_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D4A756EB43AB71D4C3270A7 /* Pods_Debug_App_Tests.framework */; };
@@ -227,6 +228,7 @@
 		E90441E821B5FE76643B62A6 /* AnalyticsTests+Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsTests+Constants.swift"; sourceTree = "<group>"; };
 		E9899972360BCA5992CEE5BC /* PrimerBancontactCardDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerBancontactCardDataManagerTests.swift; sourceTree = "<group>"; };
 		EEB1E1B37192BF739461AFF1 /* PrimerRawCardDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimerRawCardDataManagerTests.swift; sourceTree = "<group>"; };
+		F03699582AC2E63700E4179D /* VersionUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionUtilsTests.swift; sourceTree = "<group>"; };
 		F09934A8E7076E1A2F606E9E /* Pods-Debug App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.release.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.release.xcconfig"; sourceTree = "<group>"; };
 		F4AC1EC0F98CB56DA4D075CA /* Mocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mocks.swift; sourceTree = "<group>"; };
 		F816A2444633C4336A7CB071 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
@@ -457,6 +459,7 @@
 				BD26E8C6074BB89ACBD5B8B9 /* MaskTests.swift */,
 				872A0647D4136E27365FB7F8 /* StringTests.swift */,
 				CA30891B2D5F9B6B97E56B99 /* WebViewUtilTests.swift */,
+				F03699582AC2E63700E4179D /* VersionUtilsTests.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -786,6 +789,7 @@
 				583EBAA90902121CEA479416 /* VaultService.swift in Sources */,
 				961B5D18058EF4CFCD0185AE /* MockVaultCheckoutViewModel.swift in Sources */,
 				622A605DDEA98D981670B53F /* DropInUI_TokenizationViewModelTests.swift in Sources */,
+				F03699592AC2E63700E4179D /* VersionUtilsTests.swift in Sources */,
 				208CA849F3187C2DA63CC17B /* HUC_TokenizationViewModelTests.swift in Sources */,
 				213196DEDF2A3A84037ED884 /* PollingModuleTests.swift in Sources */,
 				1589385B62C86DE7C735F3EC /* PrimerAPIConfigurationModuleTests.swift in Sources */,

--- a/Debug App/Tests/Unit Tests/Utils/VersionUtilsTests.swift
+++ b/Debug App/Tests/Unit Tests/Utils/VersionUtilsTests.swift
@@ -1,0 +1,26 @@
+//
+//  VersionUtilsTests.swift
+//  Debug App Tests
+//
+//  Created by Niall Quinn on 26/09/23.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+final class VersionUtilsTests: XCTestCase {
+    
+    override func tearDown() {
+        Primer.shared.integrationOptions = nil
+    }
+    
+    func test_releaseVersionNumber() throws {
+        XCTAssertEqual(VersionUtils.releaseVersionNumber, PrimerSDKVersion)
+    }
+
+    func test_reactNativeVersion() throws {
+        Primer.shared.integrationOptions = PrimerIntegrationOptions(reactNativeVersion: "1.0.0")
+        XCTAssertEqual(VersionUtils.releaseVersionNumber, "1.0.0")
+    }
+}

--- a/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
@@ -53,7 +53,7 @@ class Analytics {
             self.properties = properties
             self.sdkSessionId = PrimerInternal.shared.sdkSessionId
             self.sdkType = Primer.shared.integrationOptions?.reactNativeVersion == nil ? "IOS_NATIVE" : "RN_IOS"
-            self.sdkVersion = Bundle.primerFramework.releaseVersionNumber
+            self.sdkVersion = VersionUtils.releaseVersionNumber
             self.sdkIntegrationType = PrimerInternal.shared.sdkIntegrationType
             self.sdkPaymentHandling = PrimerSettings.current.paymentHandling
             

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
@@ -552,7 +552,7 @@ struct SDKProperties: Codable {
         self.sdkSessionId = PrimerInternal.shared.checkoutSessionId
         
         self.sdkType = Primer.shared.integrationOptions?.reactNativeVersion == nil ? "IOS_NATIVE" : "RN_IOS"
-        self.sdkVersion = Bundle.primerFramework.releaseVersionNumber
+        self.sdkVersion = VersionUtils.releaseVersionNumber
         
         if let settingsData = try? JSONEncoder().encode(PrimerSettings.current) {
             let decoder = JSONDecoder()

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
@@ -102,12 +102,12 @@ internal class PrimerInternal {
                 severity: .error)))
 #endif
         
-        let bundleReleaseVersionNumber = Bundle.primerFramework.releaseVersionNumber
+        let releaseVersionNumber = VersionUtils.releaseVersionNumber
         events.append(
             Analytics.Event(
                 eventType: .message,
                 properties: MessageEventProperties(
-                    message: "Version number (\(bundleReleaseVersionNumber ?? "n/a")) detected.",
+                    message: "Version number (\(releaseVersionNumber ?? "n/a")) detected.",
                     messageType: .other,
                     severity: .info
                 )

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/BundleExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/BundleExtension.swift
@@ -27,19 +27,6 @@ internal extension Bundle {
     static var primerFrameworkIdentifier: String {
         return Bundle.primerFramework.bundleIdentifier ?? "org.cocoapods.PrimerSDK"
     }
-    
-    var releaseVersionNumber: String? {
-        if let reactNativeVersion = Primer.shared.integrationOptions?.reactNativeVersion {
-            return reactNativeVersion
-        }
-        
-        let version = Bundle.primerFramework.infoDictionary?["CFBundleShortVersionString"] as? String
-        return version
-    }
-    
-    var buildVersionNumber: String? {
-        return Bundle.primerFramework.infoDictionary?["CFBundleVersion"] as? String
-    }
 }
 
 

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/VersionUtils.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/VersionUtils.swift
@@ -1,0 +1,8 @@
+//
+//  VersionUtils.swift
+//  PrimerSDK
+//
+//  Created by Niall Quinn on 26/09/23.
+//
+
+import Foundation

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/VersionUtils.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/VersionUtils.swift
@@ -6,3 +6,20 @@
 //
 
 import Foundation
+
+struct VersionUtils {
+    
+    /**
+     Returns the version string in the format `"major.minor.patch"`
+     
+     If `PrimerIntegrationOptions.reactNativeVersion` is set, it will be returned.
+     If not, the version specified as `PrimerSDKVersion` in the file `"sources/version.swift"` will be returned.
+     */
+    static var releaseVersionNumber: String? {
+        if let reactNativeVersion = Primer.shared.integrationOptions?.reactNativeVersion {
+            return reactNativeVersion
+        }
+    
+        return PrimerSDKVersion
+    }
+}

--- a/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
@@ -85,7 +85,7 @@ internal extension PrimerAPI {
     
     static let headers: [String: String] = [
         "Content-Type": "application/json",
-        "Primer-SDK-Version": Bundle.primerFramework.releaseVersionNumber ?? "n/a",
+        "Primer-SDK-Version": VersionUtils.releaseVersionNumber ?? "n/a",
         "Primer-SDK-Client": PrimerSource.sdkSourceType.sourceType
     ]
     


### PR DESCRIPTION
# What this PR does
- Replaces all usage of `info.plist` for version reporting with the new `version.swift`
- Added a utility to wrap this number to preserve current react native version logic
- Added unit tests to this utility

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [x] I manually tested this with a demo application (real device)
- [x] I wrote unit tests for each new util-like function
