### PR TITLE
fix: release workflow - update branch name

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,8 +15,8 @@ jobs:
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
       - name: Create release branch
         run: |
-          git checkout -b release
-          git push -u origin release
+          git checkout -b release/next
+          git push -u origin release/next
       - id: cz
         name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
@@ -30,7 +30,7 @@ jobs:
         with:
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
           base: master
-          branch: release
+          branch: release/next
           delete-branch: true
           title: Release ${{ steps.cz.outputs.version }}
           body: ''


### PR DESCRIPTION
We cannot create a new branch named `release` because `release/xx` branches exist.

` ! [remote rejected]   release -> release (cannot lock ref 'refs/heads/release': 'refs/heads/release/2.13.2'`

https://github.com/primer-io/primer-sdk-ios/actions/runs/6325635960/job/17177564321