### PR TITLE
chore: Danger fails when conventional commit title is not used

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -77,6 +77,10 @@ if pr.assignees?.count == 0 {
     warn("Please assign someone aside from CODEOWNERS (@checkout-pci-reviewers) to review this PR.")
 }
 
+if !isConventionalCommitTitle() {
+    error("Please use a conventional commit title for this PR. See [Conventional Commits and SemVer](https://www.notion.so/primerio/Automating-Version-Bumping-and-Changelog-Creation-c13e32fea11447069dea76f966f4b0fb?pvs=4#c55764aa2f2748eb988d581a456e61e7)")
+}
+
 // MARK: - SwiftLint
 
 // Use a different path for SwiftLint
@@ -89,3 +93,13 @@ if pr.assignees?.count == 0 {
 
 //Coverage.xcodeBuildCoverage(.derivedDataFolder("Build"),
 //                            minimumCoverage: 30)
+
+func isConventionalCommitTitle() -> Bool {
+    // Commitizen-conpatible conventional commit titles
+    ["BREAKING CHANGE:", "feat:", "fix:", "chore:"].forEach { prefix in
+        if pr.title.hasPrefix(prefix) {
+            return true
+        }
+    }
+    return false
+}

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -52,17 +52,6 @@ if (additions + deletions > bigPRThreshold) {
     warn("> Pull Request size seems relatively large. If this Pull Request contains multiple changes, please split each into separate PR will helps faster, easier review.");
 }
 
-// MARK: - PR Title
-
-// The PR title needs to start with any of the following prefixes contained
-// in the array
-
-let ticketPrefixes = ["DEVX-", "CHKT-", "DXS-"]
-
-if !isReleasePr && ticketPrefixes.first(where: { pr.title.hasPrefix($0) }) != nil {
-    warn("Please add ticket number prefix to the PR")
-}
-
 // MARK: - PR WIP
 
 if pr.title.contains("WIP") || pr.draft == true {

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -94,10 +94,10 @@ if pr.assignees?.count == 0 {
 // MARK: - Conventional Commit Title
 func isConventionalCommitTitle() -> Bool {
     // Commitizen-compatible conventional commit titles
-    prTitle.hasPrefix("BREAKING CHANGE:") ||
-    prTitle.hasPrefix("chore:") ||
-    prTitle.hasPrefix("fix:") ||
-    prTitle.hasPrefix("feat:")
+    pr.title.hasPrefix("BREAKING CHANGE:") ||
+    pr.title.hasPrefix("chore:") ||
+    pr.title.hasPrefix("fix:") ||
+    pr.title.hasPrefix("feat:")
 }
 
 if !isConventionalCommitTitle() {

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -77,9 +77,6 @@ if pr.assignees?.count == 0 {
     warn("Please assign someone aside from CODEOWNERS (@checkout-pci-reviewers) to review this PR.")
 }
 
-if !isConventionalCommitTitle() {
-    error("Please use a conventional commit title for this PR. See [Conventional Commits and SemVer](https://www.notion.so/primerio/Automating-Version-Bumping-and-Changelog-Creation-c13e32fea11447069dea76f966f4b0fb?pvs=4#c55764aa2f2748eb988d581a456e61e7)")
-}
 
 // MARK: - SwiftLint
 
@@ -94,12 +91,16 @@ if !isConventionalCommitTitle() {
 //Coverage.xcodeBuildCoverage(.derivedDataFolder("Build"),
 //                            minimumCoverage: 30)
 
+// MARK: - Conventional Commit Title
 func isConventionalCommitTitle() -> Bool {
-    // Commitizen-conpatible conventional commit titles
-    ["BREAKING CHANGE:", "feat:", "fix:", "chore:"].forEach { prefix in
-        if pr.title.hasPrefix(prefix) {
-            return true
-        }
-    }
-    return false
+    // Commitizen-compatible conventional commit titles
+    prTitle.hasPrefix("BREAKING CHANGE:") ||
+    prTitle.hasPrefix("chore:") ||
+    prTitle.hasPrefix("fix:") ||
+    prTitle.hasPrefix("feat:")
 }
+
+if !isConventionalCommitTitle() {
+    fail("Please use a conventional commit title for this PR. See [Conventional Commits and SemVer](https://www.notion.so/primerio/Automating-Version-Bumping-and-Changelog-Creation-c13e32fea11447069dea76f966f4b0fb?pvs=4#c55764aa2f2748eb988d581a456e61e7)")
+}
+


### PR DESCRIPTION
This PR adds a failure when a [commitizen-compatible conventional commit](https://www.notion.so/primerio/Automating-Version-Bumping-and-Changelog-Creation-c13e32fea11447069dea76f966f4b0fb?pvs=4#c55764aa2f2748eb988d581a456e61e7) prefix is not used for the PR title.

Example of failure:
<img width="898" alt="Screenshot 2023-09-29 at 12 09 57" src="https://github.com/primer-io/primer-sdk-ios/assets/3179752/6b63ed55-d14c-43f8-a323-7629b95cf2cf">
