### PR TITLE
fix: Add UIKit import to Mock3DSService.swift

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/3DS/Mock/Mock3DSService.swift
+++ b/Sources/PrimerSDK/Classes/Core/3DS/Mock/Mock3DSService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 class Mock3DSService: ThreeDSServiceProtocol {
     static var apiClient: PrimerAPIClientProtocol?


### PR DESCRIPTION
# What this PR does

This PR fixes this issue: https://github.com/primer-io/primer-sdk-ios/issues/695 

# Notable decisions & other stuff

We will add an SPM build step to the CI pipeline in another PR

# Instructions on how to test this

Test this in an SPM-integrated app

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [x] I manually tested this with a demo application (real device)


