### PR TITLE
chore: Use last stable version of activesupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "fastlane"
 gem "cocoapods"
+gem 'activesupport', '~> 7.0', '<= 7.0.8'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,6 +291,7 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
+  activesupport (~> 7.0, <= 7.0.8)
   cocoapods
   fastlane
   fastlane-plugin-browserstack


### PR DESCRIPTION
Addressing the failure on gitlab CI.
See this SO answer: https://stackoverflow.com/questions/77236339/after-updating-cocoapods-to-1-13-0-it-throws-error

Cocoapods issue: https://github.com/CocoaPods/CocoaPods/issues/12081