### PR TITLE
feat: add card networks endpoint to network and API services

### DIFF
--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		041F52092ADE92A300A1D702 /* ListCardNetworksEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041F52082ADE92A300A1D702 /* ListCardNetworksEndpointTests.swift */; };
+		047D8E892ADEA4C700A5E7BD /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 047D8E882ADEA4C700A5E7BD /* NetworkService.swift */; };
 		04DFAADC2AAA01E60030FECE /* Debug App Tests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */; };
 		05FAC0D894B841B52E9E0A9A /* PrimerRawCardDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB1E1B37192BF739461AFF1 /* PrimerRawCardDataManagerTests.swift */; };
 		088961D00784BD296EA9745C /* EncodingDecodingContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7D8E1E91CA11EC6831ADEE4 /* EncodingDecodingContainerTests.swift */; };
@@ -125,6 +127,8 @@
 		00E3C8FE62D22147335F2455 /* MerchantResultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantResultViewController.swift; sourceTree = "<group>"; };
 		01C09DEAB07F42004B26A278 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		021A00DEB01A46C876592575 /* ThreeDSProtocolVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSProtocolVersionTests.swift; sourceTree = "<group>"; };
+		041F52082ADE92A300A1D702 /* ListCardNetworksEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCardNetworksEndpointTests.swift; sourceTree = "<group>"; };
+		047D8E882ADEA4C700A5E7BD /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Debug App Tests-Info.plist"; sourceTree = "<group>"; };
 		0DA32ABCF07A4EBED014327B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		0ED746F8924E70AD868BC0F4 /* MerchantNewLineItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantNewLineItemViewController.swift; sourceTree = "<group>"; };
@@ -309,6 +313,7 @@
 			isa = PBXGroup;
 			children = (
 				1F4E35F809D3FAF4354D5B05 /* URLSessionStackTests.swift */,
+				041F52082ADE92A300A1D702 /* ListCardNetworksEndpointTests.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -369,6 +374,7 @@
 				25FD540BEA16ABBDFE7DE182 /* PayPalService.swift */,
 				2E8F69253D85350BB7A1A761 /* TokenizationService.swift */,
 				5E8D7F3C53F8CCE4A03C975E /* VaultService.swift */,
+				047D8E882ADEA4C700A5E7BD /* NetworkService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -778,6 +784,8 @@
 				24C060A48D4A2670FFC3426F /* ThreeDSErrorTests.swift in Sources */,
 				F1A71C2E0D900FEB9AF1351C /* ThreeDSProtocolVersionTests.swift in Sources */,
 				C29B625B5698094691227852 /* TokenizationResponseTests.swift in Sources */,
+				047D8E892ADEA4C700A5E7BD /* NetworkService.swift in Sources */,
+				041F52092ADE92A300A1D702 /* ListCardNetworksEndpointTests.swift in Sources */,
 				088961D00784BD296EA9745C /* EncodingDecodingContainerTests.swift in Sources */,
 				800B92A57CAAC6471D01A89D /* CardData.swift in Sources */,
 				3BB02CA24B6B3EF458326B7D /* Networking.swift in Sources */,

--- a/Debug App/Tests/Unit Tests/Mocks.swift
+++ b/Debug App/Tests/Unit Tests/Mocks.swift
@@ -524,7 +524,7 @@ class MockPrimerAPIConfigurationModule: PrimerAPIConfigurationModuleProtocol {
                 return
             }
             
-            Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
                 PrimerAPIConfigurationModule.clientToken = clientToken
                 PrimerAPIConfigurationModule.apiConfiguration = mockedAPIConfiguration
                 seal.fulfill()
@@ -539,7 +539,7 @@ class MockPrimerAPIConfigurationModule: PrimerAPIConfigurationModuleProtocol {
                 return
             }
             
-            Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
                 PrimerAPIConfigurationModule.apiConfiguration = mockedAPIConfiguration
             }
         }
@@ -547,7 +547,7 @@ class MockPrimerAPIConfigurationModule: PrimerAPIConfigurationModuleProtocol {
     
     func storeRequiredActionClientToken(_ newClientToken: String) -> Promise<Void> {
         return Promise { seal in
-            Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
                 PrimerAPIConfigurationModule.clientToken = newClientToken
             }
         }

--- a/Debug App/Tests/Unit Tests/Mocks/Services/NetworkService.swift
+++ b/Debug App/Tests/Unit Tests/Mocks/Services/NetworkService.swift
@@ -31,7 +31,6 @@ class MockNetworkService: NetworkService {
             } else {
                 XCTFail("Failed to produce either a valid result or an error for requested endpoint")
             }
-            
         }
     }
 }

--- a/Debug App/Tests/Unit Tests/Mocks/Services/NetworkService.swift
+++ b/Debug App/Tests/Unit Tests/Mocks/Services/NetworkService.swift
@@ -1,0 +1,37 @@
+//
+//  NetworkService.swift
+//  Debug App Tests
+//
+//  Created by Jack Newcombe on 17/10/2023.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+class MockNetworkService: NetworkService {
+    
+    var mockedResult: Decodable? = nil
+    
+    var mockedError: Error? = nil
+    
+    let mockedNetworkDelay: TimeInterval = Double.random(in: 0...2)
+    
+    var onReceiveEndpoint: ((Endpoint) -> Void)?
+    
+    func request<T>(_ endpoint: PrimerSDK.Endpoint, completion: @escaping PrimerSDK.ResultCallback<T>) where T : Decodable {
+        
+        onReceiveEndpoint?(endpoint)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + mockedNetworkDelay) {
+            if let error = self.mockedError {
+                completion(.failure(error))
+            } else if let result = self.mockedResult as? T {
+                completion(.success(result))
+            } else {
+                XCTFail("Failed to produce either a valid result or an error for requested endpoint")
+            }
+            
+        }
+    }
+}

--- a/Debug App/Tests/Unit Tests/Network/ListCardNetworksEndpointTests.swift
+++ b/Debug App/Tests/Unit Tests/Network/ListCardNetworksEndpointTests.swift
@@ -1,0 +1,98 @@
+//
+//  ListCardNetworksEndpointTests.swift
+//  Debug App Tests
+//
+//  Created by Jack Newcombe on 17/10/2023.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+final class ListCardNetworksEndpointTests: XCTestCase {
+    
+    var networkService: MockNetworkService!
+    
+    var apiClient: PrimerAPIClientProtocol!
+
+    override func setUp() {
+        super.setUp()
+        networkService = MockNetworkService()
+        apiClient = PrimerAPIClient(networkService: networkService)
+    }
+
+    override func tearDown() {
+        apiClient = nil
+        networkService = nil
+        super.tearDown()
+    }
+
+    func testValidRequestWithSuccessResponse() throws {
+        
+        let bin = "1234 5678 1234"
+        let network = Response.Body.Bin.Networks.Network(displayName: "Test", value: "Test")
+        
+        let expectSuccessfulResponse = self.expectation(description: "Expect request to complete successfully")
+        
+        let expectValidEndpointReceived = self.expectation(description: "Expect endpoint to be valid")
+        
+        networkService.onReceiveEndpoint = { endpoint in
+            XCTAssertEqual(endpoint.path, "/bin-data/\(bin)/networks")
+            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.1")
+            XCTAssertEqual(endpoint.headers?["Primer-Client-Token"], mockClientToken.accessToken)
+            expectValidEndpointReceived.fulfill()
+        }
+        
+        networkService.mockedResult = Response.Body.Bin.Networks(networks: [network])
+        
+        apiClient.listCardNetworks(clientToken: mockClientToken, bin: bin) { result in
+            switch result {
+            case .success(let result):
+                XCTAssertEqual(result.networks, [network])
+                expectSuccessfulResponse.fulfill()
+            case .failure:
+                XCTFail("Expected successful response")
+            }
+        }
+        
+        waitForExpectations(timeout: 2.0)
+    }
+    
+    func testValidRequestWithErrorResponse() throws {
+        
+        let bin = "1234 5678 1234"
+        
+        let expectSuccessfulResponse = self.expectation(description: "Expect request to complete successfully")
+        
+        let expectValidEndpointReceived = self.expectation(description: "Expect endpoint to be valid")
+        
+        networkService.onReceiveEndpoint = { endpoint in
+            XCTAssertEqual(endpoint.path, "/bin-data/\(bin)/networks")
+            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.1")
+            XCTAssertEqual(endpoint.headers?["Primer-Client-Token"], mockClientToken.accessToken)
+            expectValidEndpointReceived.fulfill()
+        }
+        
+        networkService.mockedError = NSError(domain: "", code: 123)
+        
+        apiClient.listCardNetworks(clientToken: mockClientToken, bin: bin) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure with error response")
+            case .failure(let error):
+                XCTAssertEqual((error as NSError).code, 123)
+                expectSuccessfulResponse.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 2.0)
+    }
+
+}
+
+extension Response.Body.Bin.Networks.Network: Equatable {
+    public static func == (lhs: PrimerSDK.Response.Body.Bin.Networks.Network, rhs: PrimerSDK.Response.Body.Bin.Networks.Network) -> Bool {
+        return lhs.displayName == rhs.displayName &&
+        lhs.value == rhs.value
+    }
+}

--- a/Debug App/Tests/Unit Tests/Network/ListCardNetworksEndpointTests.swift
+++ b/Debug App/Tests/Unit Tests/Network/ListCardNetworksEndpointTests.swift
@@ -38,7 +38,7 @@ final class ListCardNetworksEndpointTests: XCTestCase {
         
         networkService.onReceiveEndpoint = { endpoint in
             XCTAssertEqual(endpoint.path, "/bin-data/\(bin)/networks")
-            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.1")
+            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.2")
             XCTAssertEqual(endpoint.headers?["Primer-Client-Token"], mockClientToken.accessToken)
             expectValidEndpointReceived.fulfill()
         }
@@ -68,7 +68,7 @@ final class ListCardNetworksEndpointTests: XCTestCase {
         
         networkService.onReceiveEndpoint = { endpoint in
             XCTAssertEqual(endpoint.path, "/bin-data/\(bin)/networks")
-            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.1")
+            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.2")
             XCTAssertEqual(endpoint.headers?["Primer-Client-Token"], mockClientToken.accessToken)
             expectValidEndpointReceived.fulfill()
         }

--- a/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
+++ b/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
@@ -38,6 +38,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
     var fetchPayPalExternalPayerInfoResult: (Response.Body.PayPal.PayerInfo?, Error?)?
     var resumePaymentResult: (Response.Body.Payment?, Error?)?
     var testFinalizePollingResult: (Void?, Error?)?
+    var listCardNetworksResult: (Response.Body.Bin.Networks?, Error?)?
     
     private var currentPollingIteration: Int = 0
     
@@ -573,6 +574,23 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
                     completion(.failure(err))
                 } else {
                     completion(.success(()))
+                }
+            }
+        }
+    }
+    
+    func listCardNetworks(clientToken: DecodedJWTToken, bin: String, completion: @escaping (Result<Response.Body.Bin.Networks, Error>) -> Void) {
+        guard let result = listCardNetworksResult, (result.0 != nil || result.1 != nil) else {
+            XCTFail("Set 'listCardNetworksResult' on your MockPrimerAPIClient")
+            return
+        }
+        
+        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+            DispatchQueue.main.async {
+                if let err = result.1 {
+                    completion(.failure(err))
+                } else if let res = result.0 {
+                    completion(.success(res))
                 }
             }
         }

--- a/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
+++ b/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
@@ -53,7 +53,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) { 
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -74,7 +74,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -94,7 +94,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -126,7 +126,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else {
@@ -148,7 +148,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -169,7 +169,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -190,7 +190,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -212,7 +212,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -233,7 +233,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -254,7 +254,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -276,7 +276,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -298,7 +298,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -317,7 +317,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
             if let err = result.1 {
                 completion(.failure(err))
             } else if let successResult = result.0 {
@@ -334,13 +334,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else if let successResult = result.0 {
-                    completion(.success(successResult))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else if let successResult = result.0 {
+                completion(.success(successResult))
             }
         }
     }
@@ -358,13 +356,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else if let successResult = result.0 {
-                    completion(.success(successResult))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else if let successResult = result.0 {
+                completion(.success(successResult))
             }
         }
     }
@@ -381,13 +377,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else if let successResult = result.0 {
-                    completion(.success(successResult))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else if let successResult = result.0 {
+                completion(.success(successResult))
             }
         }
     }
@@ -404,13 +398,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else if let successResult = result.0 {
-                    completion(.success(successResult))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else if let successResult = result.0 {
+                completion(.success(successResult))
             }
         }
     }
@@ -427,27 +419,25 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                let pollingResult = pollingResults[self.currentPollingIteration]
-                self.currentPollingIteration += 1
-                
-                if pollingResult.0 == nil && pollingResult.1 == nil {
-                    XCTAssert(false, "Each 'pollingResult' must have a response or an error.")
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            let pollingResult = pollingResults[self.currentPollingIteration]
+            self.currentPollingIteration += 1
+            
+            if pollingResult.0 == nil && pollingResult.1 == nil {
+                XCTAssert(false, "Each 'pollingResult' must have a response or an error.")
+            }
+            
+            if let err = pollingResult.1 {
+                if self.currentPollingIteration == pollingResults.count {
+                    XCTAssert(false, "Polling finished with error")
+                } else {
+                    self.poll(clientToken: clientToken, url: url, completion: completion)
                 }
-                
-                if let err = pollingResult.1 {
-                    if self.currentPollingIteration == pollingResults.count {
-                        XCTAssert(false, "Polling finished with error")
-                    } else {
-                        self.poll(clientToken: clientToken, url: url, completion: completion)
-                    }
-                } else if let res = pollingResult.0 {
-                    if res.status == .complete {
-                        completion(.success(res))
-                    } else {
-                        self.poll(clientToken: clientToken, url: url, completion: completion)
-                    }
+            } else if let res = pollingResult.0 {
+                if res.status == .complete {
+                    completion(.success(res))
+                } else {
+                    self.poll(clientToken: clientToken, url: url, completion: completion)
                 }
             }
         }
@@ -465,13 +455,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else if let successResult = result.0 {
-                    completion(.success(successResult))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else if let successResult = result.0 {
+                completion(.success(successResult))
             }
         }
     }
@@ -505,13 +493,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else if let successResult = result.0 {
-                    completion(.success(successResult))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else if let successResult = result.0 {
+                completion(.success(successResult))
             }
         }
     }
@@ -530,13 +516,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else if let successResult = result.0 {
-                    completion(.success(successResult))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else if let successResult = result.0 {
+                completion(.success(successResult))
             }
         }
     }
@@ -549,13 +533,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else if let successResult = result.0 {
-                    completion(.success(successResult))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else if let successResult = result.0 {
+                completion(.success(successResult))
             }
         }
     }
@@ -568,13 +550,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else {
-                    completion(.success(()))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else {
+                completion(.success(()))
             }
         }
     }
@@ -585,13 +565,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return
         }
         
-        Timer.scheduledTimer(withTimeInterval: self.mockedNetworkDelay, repeats: false) { _ in
-            DispatchQueue.main.async {
-                if let err = result.1 {
-                    completion(.failure(err))
-                } else if let res = result.0 {
-                    completion(.success(res))
-                }
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.mockedNetworkDelay) {
+            if let err = result.1 {
+                completion(.failure(err))
+            } else if let res = result.0 {
+                completion(.success(res))
             }
         }
     }

--- a/Sources/PrimerSDK/Classes/Data Models/Bin.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Bin.swift
@@ -1,0 +1,34 @@
+//
+//  Bin.swift
+//  PrimerSDK
+//
+//  Created by Jack Newcombe on 17/10/2023.
+//
+
+import Foundation
+
+extension Response.Body {
+    class Bin {}
+}
+
+extension Response.Body.Bin {
+    class Networks: Decodable {
+        let networks: [Network]
+        
+        init(networks: [Network]) {
+            self.networks = networks
+        }
+    }
+}
+
+extension Response.Body.Bin.Networks {
+    class Network: Decodable {
+        let displayName: String
+        let value: String
+        
+        init(displayName: String, value: String) {
+            self.displayName = displayName
+            self.value = value
+        }
+    }
+}

--- a/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
@@ -196,7 +196,7 @@ internal extension PrimerAPI {
         case .testFinalizePolling:
             break
         case .listCardNetworks:
-            tmpHeaders["X-Api-Version"] = "2.1"
+            tmpHeaders["X-Api-Version"] = "2.2"
         }
         
         return tmpHeaders

--- a/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
@@ -76,6 +76,9 @@ enum PrimerAPI: Endpoint, Equatable {
     case resumePayment(clientToken: DecodedJWTToken, paymentId: String, paymentResumeRequest: Request.Body.Payment.Resume)
     
     case testFinalizePolling(clientToken: DecodedJWTToken, testId: String)
+    
+    // BIN Data
+    case listCardNetworks(clientToken: DecodedJWTToken, bin: String)
 
 }
 
@@ -116,7 +119,8 @@ internal extension PrimerAPI {
                 .fetchPayPalExternalPayerInfo(let clientToken, _),
                 .createPayment(let clientToken, _),
                 .resumePayment(let clientToken, _, _),
-                .testFinalizePolling(let clientToken, _):
+                .testFinalizePolling(let clientToken, _),
+                .listCardNetworks(let clientToken, _):
             if let token = clientToken.accessToken {
                 tmpHeaders["Primer-Client-Token"] = token
             }
@@ -191,6 +195,8 @@ internal extension PrimerAPI {
             tmpHeaders["X-Api-Version"] = "2.2"
         case .testFinalizePolling:
             break
+        case .listCardNetworks:
+            tmpHeaders["X-Api-Version"] = "2.1"
         }
         
         return tmpHeaders
@@ -209,7 +215,8 @@ internal extension PrimerAPI {
                 .listAdyenBanks(let clientToken, _),
                 .listRetailOutlets(let clientToken, _),
                 .fetchPayPalExternalPayerInfo(let clientToken, _),
-                .testFinalizePolling(let clientToken, _):
+                .testFinalizePolling(let clientToken, _),
+                .listCardNetworks(let clientToken, _):
             guard let urlStr = clientToken.coreUrl else { return nil }
             return urlStr
         case .deleteVaultedPaymentMethod(let clientToken, _),
@@ -286,6 +293,8 @@ internal extension PrimerAPI {
             return "/payments/\(paymentId)/resume"
         case .testFinalizePolling(_, _):
             return "/finalize-polling"
+        case .listCardNetworks(_, let bin):
+            return "/bin-data/\(bin)/networks"
         }
     }
     
@@ -304,7 +313,8 @@ internal extension PrimerAPI {
             return .delete
         case .fetchConfiguration,
                 .fetchVaultedPaymentMethods,
-                .listRetailOutlets:
+                .listRetailOutlets,
+                .listCardNetworks:
             return .get
         case .createPayPalOrderSession,
                 .createPayPalBillingAgreementSession,
@@ -393,7 +403,7 @@ internal extension PrimerAPI {
             return try? JSONEncoder().encode(paymentCreateRequestBody)
         case .resumePayment(_, _, let paymentResumeRequestBody):
             return try? JSONEncoder().encode(paymentResumeRequestBody)
-        case .testFinalizePolling:
+        case .testFinalizePolling, .listCardNetworks:
             return nil
         }
     }

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
@@ -117,6 +117,12 @@ protocol PrimerAPIClientProtocol {
         clientToken: DecodedJWTToken,
         testId: String,
         completion: @escaping (_ result: Result<Void, Error>) -> Void)
+    
+    // BIN Data
+    func listCardNetworks(
+        clientToken: DecodedJWTToken,
+        bin: String,
+        completion: @escaping (_ result: Result<Response.Body.Bin.Networks, Error>) -> Void)
 }
 
 internal class PrimerAPIClient: PrimerAPIClientProtocol {
@@ -526,6 +532,16 @@ internal class PrimerAPIClient: PrimerAPIClientProtocol {
             }
         }
     }
+    
+    func listCardNetworks(clientToken: DecodedJWTToken, bin: String, completion: @escaping (Result<Response.Body.Bin.Networks, Error>) -> Void) {
+        let endpoint = PrimerAPI.listCardNetworks(clientToken: clientToken, bin: bin)
+        networkService.request(endpoint) { (result: Result<Response.Body.Bin.Networks, Error>) in
+            switch result {
+            case .success(let res):
+                completion(.success(res))
+            case .failure(let err):
+                completion(.failure(err))
+            }
+        }
+    }
 }
-
-


### PR DESCRIPTION
CHKT-1751

# What this PR does

* Adds the new endpoint based on the open API spec to the Primer API service
* Adds tests for the new endpoint
* Introduces some new networking mocks that allow appropriate testing 

# Notable decisions & other stuff

We were using a mix of `Timer.scheduledTimer` and `DispatchQueue.main.async` across the mocks, and not consistently in any one place. I've replaced them all with `DispatchQueue.main.asyncAfter`

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [x] I wrote unit tests where appropriate
