### PR TITLE
chore: Report min deployment version as semver string with every event

### DIFF
--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
@@ -1491,31 +1491,6 @@ class AnalyticsTests: XCTestCase {
             Analytics.Service.deleteAnalyticsFile()
         }
     }
-    
-    func testMinDeploymentTargetParsesCorrectly() {
-        XCTAssertEqual(Analytics.deploymentTarget(for: 100000), "10.0.0")
-        XCTAssertEqual(Analytics.deploymentTarget(for: 123456), "12.34.56")
-        XCTAssertEqual(Analytics.deploymentTarget(for: 160500), "16.5.0")
-        XCTAssertEqual(Analytics.deploymentTarget(for: 170101), "17.1.1")
-    }
-    
-    func testMinDeploymentTargetCorrectOnEncodedEvent() {
-        let event = Analytics.Event(eventType: .message,
-                                    properties: MessageEventProperties.init(
-                                        message: "",
-                                        messageType: .other,
-                                        severity: .debug
-                                    )
-        )
-        
-        XCTAssertEqual(event.minDeploymentTarget, Analytics.deploymentTarget())
-        
-        let encodedEventData = try! JSONEncoder().encode(event)
-        
-        let decodedEvent = try! JSONDecoder().decode(Analytics.Event.self, from: encodedEventData)
-        
-        XCTAssertEqual(decodedEvent.minDeploymentTarget, Analytics.deploymentTarget())
-    }
 }
 
 

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
@@ -1491,6 +1491,31 @@ class AnalyticsTests: XCTestCase {
             Analytics.Service.deleteAnalyticsFile()
         }
     }
+    
+    func testMinDeploymentTargetParsesCorrectly() {
+        XCTAssertEqual(Analytics.deploymentTarget(for: 100000), "10.0.0")
+        XCTAssertEqual(Analytics.deploymentTarget(for: 123456), "12.34.56")
+        XCTAssertEqual(Analytics.deploymentTarget(for: 160500), "16.5.0")
+        XCTAssertEqual(Analytics.deploymentTarget(for: 170101), "17.1.1")
+    }
+    
+    func testMinDeploymentTargetCorrectOnEncodedEvent() {
+        let event = Analytics.Event(eventType: .message,
+                                    properties: MessageEventProperties.init(
+                                        message: "",
+                                        messageType: .other,
+                                        severity: .debug
+                                    )
+        )
+        
+        XCTAssertEqual(event.minDeploymentTarget, Analytics.deploymentTarget())
+        
+        let encodedEventData = try! JSONEncoder().encode(event)
+        
+        let decodedEvent = try! JSONDecoder().decode(Analytics.Event.self, from: encodedEventData)
+        
+        XCTAssertEqual(decodedEvent.minDeploymentTarget, Analytics.deploymentTarget())
+    }
 }
 
 

--- a/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
@@ -37,6 +37,7 @@ class Analytics {
         let sdkIntegrationType: PrimerSDKIntegrationType?
         let sdkPaymentHandling: PrimerPaymentHandling?
         let integrationType: String
+        let minDeploymentTarget: String
         
         init(eventType: Analytics.Event.EventType, properties: AnalyticsEventProperties?) {
             self.analyticsUrl = PrimerAPIConfigurationModule.decodedJWTToken?.analyticsUrlV2
@@ -56,6 +57,7 @@ class Analytics {
             self.sdkVersion = VersionUtils.releaseVersionNumber
             self.sdkIntegrationType = PrimerInternal.shared.sdkIntegrationType
             self.sdkPaymentHandling = PrimerSettings.current.paymentHandling
+            self.minDeploymentTarget = Analytics.deploymentTarget()
             
 #if COCOAPODS
             self.integrationType = "COCOAPODS"
@@ -81,7 +83,8 @@ class Analytics {
                  sdkVersion,
                  sdkIntegrationType,
                  sdkPaymentHandling,
-                 integrationType
+                 integrationType,
+                 minDeploymentTarget
         }
         
         func encode(to encoder: Encoder) throws {
@@ -101,6 +104,7 @@ class Analytics {
             try? container.encode(sdkVersion, forKey: .sdkVersion)
             try? container.encode(sdkIntegrationType?.rawValue, forKey: .sdkIntegrationType)
             try? container.encode(integrationType, forKey: .integrationType)
+            try? container.encode(minDeploymentTarget, forKey: .minDeploymentTarget)
             
             if sdkPaymentHandling == .auto {
                 try? container.encode("AUTO", forKey: .sdkPaymentHandling)
@@ -141,6 +145,7 @@ class Analytics {
             self.sdkType = try container.decode(String.self, forKey: .sdkType)
             self.sdkVersion = try container.decode(String.self, forKey: .sdkVersion)
             self.integrationType = try container.decode(String.self, forKey: .integrationType)
+            self.minDeploymentTarget = try container.decode(String.self, forKey: .minDeploymentTarget)
             
             if let sdkIntegrationTypeStr = try? container.decode(String.self, forKey: .sdkIntegrationType) {
                 self.sdkIntegrationType = PrimerSDKIntegrationType(rawValue: sdkIntegrationTypeStr)
@@ -178,6 +183,14 @@ class Analytics {
                 self.properties = nil
             }
         }
+    }
+    
+    static func deploymentTarget(for version: Int = Int(__IPHONE_OS_VERSION_MIN_REQUIRED)) -> String {
+        let majorVersion = version / 10000
+        let minorVersion = (version / 100) % 100
+        let patchVersion = version % 100
+        
+        return "\(majorVersion).\(minorVersion).\(patchVersion)"
     }
 }
 

--- a/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/Analytics.swift
@@ -57,7 +57,7 @@ class Analytics {
             self.sdkVersion = VersionUtils.releaseVersionNumber
             self.sdkIntegrationType = PrimerInternal.shared.sdkIntegrationType
             self.sdkPaymentHandling = PrimerSettings.current.paymentHandling
-            self.minDeploymentTarget = Analytics.deploymentTarget()
+            self.minDeploymentTarget = Bundle.main.minimumOSVersion ?? "Unknown"
             
 #if COCOAPODS
             self.integrationType = "COCOAPODS"
@@ -183,14 +183,6 @@ class Analytics {
                 self.properties = nil
             }
         }
-    }
-    
-    static func deploymentTarget(for version: Int = Int(__IPHONE_OS_VERSION_MIN_REQUIRED)) -> String {
-        let majorVersion = version / 10000
-        let minorVersion = (version / 100) % 100
-        let patchVersion = version % 100
-        
-        return "\(majorVersion).\(minorVersion).\(patchVersion)"
     }
 }
 

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/BundleExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/BundleExtension.swift
@@ -27,6 +27,10 @@ internal extension Bundle {
     static var primerFrameworkIdentifier: String {
         return Bundle.primerFramework.bundleIdentifier ?? "org.cocoapods.PrimerSDK"
     }
+    
+    var minimumOSVersion: String? {
+        return infoDictionary?["MinimumOSVersion"] as? String
+    }
 }
 
 


### PR DESCRIPTION
CHKT-1683

# What this PR does

Reports the minimum deployment target (i.e. min required OS version) of the integrating app.

# Instructions on how to test this

Inspect the event at runtime

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [x] I wrote unit tests for each new util-like function
