### PR TITLE
chore: Ensures ui test slack reports are sent even when not on PR

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -100,7 +100,7 @@ jobs:
             path: /var/tmp
 
         - name: Setup node
-          uses: actions/setup-node@v1
+          uses: actions/setup-node@v4
           with:
             node-version: 18.3.0
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -71,7 +71,7 @@ jobs:
           APPETIZE_API_TOKEN: ${{ secrets.APPETIZE_API_TOKEN }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          SOURCE_BRANCH: ${{ github.head_ref }}
+          SOURCE_BRANCH: ${{ github.ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Save Browserstack ID

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -118,10 +118,12 @@ jobs:
             npx wdio config/wdio.ios.bs.conf.js
             
         - name: Create Slack Report
+          if: ${{ success() || failure() }}
           run: |
             node report-script/slack-report-script.js createSlackReport iOS
 
         - name: Post summary message to a Slack channel
+          if: ${{ success() || failure() }}
           id: slack
           uses: slackapi/slack-github-action@v1.23.0
           with:
@@ -149,6 +151,7 @@ jobs:
             SLACK_BOT_TOKEN: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
 
         - name: Create and post Github summary
+          if: ${{ success() || failure() }}
           run: |
             node report-script/github-tests-summary-script.js createGithubSummaryReport
   

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -118,12 +118,10 @@ jobs:
             npx wdio config/wdio.ios.bs.conf.js
             
         - name: Create Slack Report
-          if: ${{ (success() ||  failure()) && github.event.pull_request.base.ref == 'master'  }}
           run: |
             node report-script/slack-report-script.js createSlackReport iOS
 
         - name: Post summary message to a Slack channel
-          if: ${{ (success() ||  failure()) && github.event.pull_request.base.ref == 'master' }}
           id: slack
           uses: slackapi/slack-github-action@v1.23.0
           with:
@@ -133,7 +131,7 @@ jobs:
             SLACK_BOT_TOKEN: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
 
         - name: Create Slack Failed Summary Report
-          if: ${{ failure() && github.event.pull_request.base.ref == 'master' }}
+          if: ${{ failure() }}
           run: |
             node report-script/slack-failed-report-script.js createSlackFailedSummaryReport ${{ steps.slack.outputs.thread_ts }}
           env:
@@ -141,7 +139,7 @@ jobs:
             BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
 
         - name: Post detailed summary to Slack channel thread
-          if: ${{ failure() && github.event.pull_request.base.ref == 'master' }}
+          if: ${{ failure() }}
           id: slack_thread
           uses: slackapi/slack-github-action@v1.23.0
           with:
@@ -151,7 +149,6 @@ jobs:
             SLACK_BOT_TOKEN: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
 
         - name: Create and post Github summary
-          if: ${{ success() || failure() }}
           run: |
             node report-script/github-tests-summary-script.js createGithubSummaryReport
   

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,7 +95,7 @@ platform :ios do
       service_credentials_file: "firebase_credentials.json",
       app: "1:1024117832450:ios:d8c2e74c66341d8cf3201b",
       groups: ENV["FIREBASE_COMMA_SEPARATED_TEST_GROUPS"],
-      release_notes: "QA release: #{sdk_version_name_source_branch} PR number: #{pr_number}"
+      release_notes: "QA release: #{sdk_version_name_source_branch}"
     )
 
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,6 +26,7 @@ app_output_archive_path = "/var/tmp/Primer.io_Debug_App.xcarchive"
 
 # Utils
 sdk_version_name_source_branch = ENV['SOURCE_BRANCH']
+source_branch_trimmed = ENV['SOURCE_BRANCH'].gsub("refs/heads/", "")
 pr_number = ENV['PR_NUMBER']
 
 podfile_path = "Debug App/Podfile"
@@ -95,7 +96,7 @@ platform :ios do
       service_credentials_file: "firebase_credentials.json",
       app: "1:1024117832450:ios:d8c2e74c66341d8cf3201b",
       groups: ENV["FIREBASE_COMMA_SEPARATED_TEST_GROUPS"],
-      release_notes: "QA release: #{sdk_version_name_source_branch}"
+      release_notes: "QA release: #{source_branch_trimmed}"
     )
 
   end


### PR DESCRIPTION
Removes the stipulation that Slack reports are only sent for PRs pointing to master
