### PR TITLE
chore: Remove canImport(UIKit) from all tests

### DIFF
--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -1270,5 +1268,3 @@ class AnalyticsTests: XCTestCase {
     }    
 }
 
-
-#endif

--- a/Debug App/Tests/Unit Tests/Data Models/ApayaTests.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/ApayaTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -109,5 +107,3 @@ class ApayaDataModelTests: XCTestCase {
     
 }
 
-
-#endif

--- a/Debug App/Tests/Unit Tests/Data Models/ApplePayTests.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/ApplePayTests.swift
@@ -7,8 +7,6 @@
 //
 
 
-#if canImport(UIKit)
-
 import PassKit
 import XCTest
 @testable import PrimerSDK
@@ -321,5 +319,3 @@ class ApplePayTests: XCTestCase {
         }
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Data Models/IPay88Tests.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/IPay88Tests.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
 #if canImport(PrimerIPay88MYSDK)
 import XCTest
 @testable import PrimerIPay88MYSDK
@@ -245,5 +244,4 @@ class IPay88Tests: XCTestCase {
 #endif
 }
 
-#endif
 #endif

--- a/Debug App/Tests/Unit Tests/Data Models/PayPalConfirmBillingAgreementTests.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/PayPalConfirmBillingAgreementTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -102,5 +100,3 @@ class PayPalConfirmBillingAgreementTests: XCTestCase {
         XCTAssert(response["billingAgreementId"] as? String == confirmBillingAgreement.billingAgreementId)
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Data Models/PaymentMethodConfigTests.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/PaymentMethodConfigTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -273,5 +271,3 @@ class PaymentMethodConfigTests: XCTestCase {
     
 }
 
-
-#endif

--- a/Debug App/Tests/Unit Tests/Data Models/PrimerCheckoutTheme.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/PrimerCheckoutTheme.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 import UIKit
@@ -72,5 +70,3 @@ class PrimerCheckoutThemeTests: XCTestCase {
         XCTAssert(storedSettings.uiOptions.theme.mainButton.text.color == tropical4, "Main button's enabled color should be 'tropical8'")
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Data Models/ThemeTests.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/ThemeTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2021 CocoaPods. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -98,6 +96,4 @@ class PrimerThemeTests: XCTestCase {
     }
 }
 
-
-#endif
 

--- a/Debug App/Tests/Unit Tests/Data Models/ThreeDSErrorTests.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/ThreeDSErrorTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 @testable import Primer3DS
@@ -158,5 +156,3 @@ class ThreeDSErrorTests: XCTestCase {
                 threeDsErrorDetail: primer3DSError.threeDsErrorDetail))
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Data Models/ThreeDSProtocolVersionTests.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/ThreeDSProtocolVersionTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -111,5 +109,3 @@ class ThreeDSProtocolVersionTests: XCTestCase {
         XCTAssert(threeDSProtocolVersion == nil)
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Data Models/TokenizationResponseTests.swift
+++ b/Debug App/Tests/Unit Tests/Data Models/TokenizationResponseTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -136,5 +134,3 @@ class TokenizationResponseTests: XCTestCase {
         XCTAssert(primerPaymentMethodToken.threeDSecureAuthentication?.reasonText == threeDSecureAuthentication?["reasonText"] as? String, "threeDSecureAuthentication?.protocolVersion is \(primerPaymentMethodToken.threeDSecureAuthentication?.protocolVersion) when it should be \(threeDSecureAuthentication?["protocolVersion"] as? String ?? "n/a")")
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Extensions/EncodingDecodingContainerTests.swift
+++ b/Debug App/Tests/Unit Tests/Extensions/EncodingDecodingContainerTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -81,5 +79,3 @@ class EncodingTests: XCTestCase {
         }
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Helpers/CardData.swift
+++ b/Debug App/Tests/Unit Tests/Helpers/CardData.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import Foundation
 @testable import PrimerSDK
 
@@ -57,5 +55,3 @@ class Constants {
         ]
     ]
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Mocks.swift
+++ b/Debug App/Tests/Unit Tests/Mocks.swift
@@ -5,8 +5,6 @@
 //  Created by Carl Eriksson on 03/01/2021.
 //
 
-#if canImport(UIKit)
-
 @testable import PrimerSDK
 import XCTest
 
@@ -553,5 +551,3 @@ class MockPrimerAPIConfigurationModule: PrimerAPIConfigurationModuleProtocol {
         }
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Mocks/MockPaymentMethodTokenizationViewModel.swift
+++ b/Debug App/Tests/Unit Tests/Mocks/MockPaymentMethodTokenizationViewModel.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -269,6 +267,4 @@ class MockPaymentMethodTokenizationViewModel: NSObject, PaymentMethodTokenizatio
         self.didFinishPayment = nil
     }
 }
-
-#endif
 

--- a/Debug App/Tests/Unit Tests/Mocks/Services/PayPalService.swift
+++ b/Debug App/Tests/Unit Tests/Mocks/Services/PayPalService.swift
@@ -5,8 +5,6 @@
 //  Created by Carl Eriksson on 16/01/2021.
 //
 
-#if canImport(UIKit)
-
 @testable import PrimerSDK
 
 class MockPayPalService: PayPalServiceProtocol {
@@ -38,5 +36,3 @@ class MockPayPalService: PayPalServiceProtocol {
         
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Mocks/Services/VaultService.swift
+++ b/Debug App/Tests/Unit Tests/Mocks/Services/VaultService.swift
@@ -5,8 +5,6 @@
 //  Created by Carl Eriksson on 16/01/2021.
 //
 
-#if canImport(UIKit)
-
 @testable import PrimerSDK
 
 class MockVaultService: VaultServiceProtocol {
@@ -21,5 +19,3 @@ class MockVaultService: VaultServiceProtocol {
         return Promise()
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Mocks/ViewModels/MockVaultCheckoutViewModel.swift
+++ b/Debug App/Tests/Unit Tests/Mocks/ViewModels/MockVaultCheckoutViewModel.swift
@@ -5,8 +5,6 @@
 //  Created by Carl Eriksson on 16/01/2021.
 //
 
-#if canImport(UIKit)
-
 @testable import PrimerSDK
 import XCTest
 
@@ -18,5 +16,3 @@ class MockVaultCheckoutViewModel: UniversalCheckoutViewModelProtocol {
         return nil
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Modules/HUC_TokenizationViewModelTests.swift
+++ b/Debug App/Tests/Unit Tests/Modules/HUC_TokenizationViewModelTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -546,5 +544,3 @@ extension HUC_TokenizationViewModelTests: PrimerHeadlessUniversalCheckoutRawData
         
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Modules/PollingModuleTests.swift
+++ b/Debug App/Tests/Unit Tests/Modules/PollingModuleTests.swift
@@ -1,5 +1,3 @@
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -101,5 +99,3 @@ class PollingModuleTests: XCTestCase {
     }
 }
 
-
-#endif

--- a/Debug App/Tests/Unit Tests/Modules/PrimerAPIConfigurationModuleTests.swift
+++ b/Debug App/Tests/Unit Tests/Modules/PrimerAPIConfigurationModuleTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -51,5 +49,3 @@ class PrimerAPIConfigurationModuleTests: XCTestCase {
     }
 }
 
-
-#endif

--- a/Debug App/Tests/Unit Tests/Modules/UserInterfaceModuleTests.swift
+++ b/Debug App/Tests/Unit Tests/Modules/UserInterfaceModuleTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -82,5 +80,3 @@ class UserInterfaceModuleTests: XCTestCase {
     }
     
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Network/URLSessionStackTests.swift
+++ b/Debug App/Tests/Unit Tests/Network/URLSessionStackTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -97,4 +95,3 @@ final class URLSessionStackTests: XCTestCase {
     }
     
 }
-#endif

--- a/Debug App/Tests/Unit Tests/Primer/PrimerBancontactCardDataManagerTests.swift
+++ b/Debug App/Tests/Unit Tests/Primer/PrimerBancontactCardDataManagerTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -369,6 +367,4 @@ class PrimerBancontactCardDataManagerTests: XCTestCase {
         wait(for: [exp], timeout: Self.expectationTimeout)
     }
 }
-
-#endif
 

--- a/Debug App/Tests/Unit Tests/Primer/PrimerRawCardDataManagerTests.swift
+++ b/Debug App/Tests/Unit Tests/Primer/PrimerRawCardDataManagerTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -335,5 +333,3 @@ class PrimerRawCardDataManagerTests: XCTestCase {
         wait(for: [exp], timeout: Self.validationTimeout)
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Primer/PrimerRawRetailerDataTests.swift
+++ b/Debug App/Tests/Unit Tests/Primer/PrimerRawRetailerDataTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -58,5 +56,3 @@ class PrimerRawRetailerDataTests: XCTestCase {
     }
 
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Services/PayPalServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Services/PayPalServiceTests.swift
@@ -5,8 +5,6 @@
 //  Created by Carl Eriksson on 17/01/2021.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -268,5 +266,3 @@ class PayPalServiceTests: XCTestCase {
         wait(for: [expectation], timeout: 30.0)
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Services/PaymentMethodConfigServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Services/PaymentMethodConfigServiceTests.swift
@@ -5,8 +5,6 @@
 //  Created by Carl Eriksson on 03/01/2021.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -42,5 +40,3 @@ class PaymentMethodConfigServiceTests: XCTestCase {
         XCTAssertEqual(state.apiConfiguration?.coreUrl, "coreUrl")
     }
 }
-
-#endif

--- a/Debug App/Tests/Unit Tests/Services/TokenizationServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Services/TokenizationServiceTests.swift
@@ -5,13 +5,9 @@
 //  Created by Carl Eriksson on 07/01/2021.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
 //class TokenizationServiceTests: XCTestCase {
 //    
 //}
-
-#endif

--- a/Debug App/Tests/Unit Tests/Utils/DateTests.swift
+++ b/Debug App/Tests/Unit Tests/Utils/DateTests.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 import XCTest
 @testable import PrimerSDK
 
@@ -123,6 +121,4 @@ private extension RangeReplaceableCollection where Self: StringProtocol {
         return repeatElement(element, count: Swift.max(0, length-count)) + suffix(Swift.max(count, count-length))
     }
 }
-
-#endif
 

--- a/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
+++ b/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Primer API Ltd. All rights reserved.
 //
 
-#if canImport(UIKit)
-
 @testable import PrimerSDK
 import XCTest
 
@@ -909,5 +907,3 @@ extension MockPrimerAPIClient {
 
     }
 }
-
-#endif

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/NolPayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/NolPayTokenizationViewModel.swift
@@ -4,8 +4,6 @@
 //
 //  Created by Boris on 28.8.23..
 //
-#if canImport(UIKit)
-
 import Foundation
 import SafariServices
 import UIKit
@@ -269,4 +267,3 @@ class NolPayTokenizationViewModel: PaymentMethodTokenizationViewModel {
         // no-op
     }
 }
-#endif


### PR DESCRIPTION
# What this PR does

We previously removed these from the SDK. This is aligning the tests with that.

# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)