### PR TITLE
chore: Add toggle in the Debug application for Legacy-Workflows at session creation

### DIFF
--- a/Debug App/Primer.io Debug App SPM.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App SPM.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E1AB44D02AFE139600639DC5 /* URL+NetworkHeaders.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB44CF2AFE139600639DC5 /* URL+NetworkHeaders.swift */; };
 		F00C65F82ACC67FA00187028 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC5687FF32E8661F1A00CE5 /* AppDelegate.swift */; };
 		F00C65F92ACC67FA00187028 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1594BC5C96ECC3F46C811B2F /* Data+Extensions.swift */; };
 		F00C65FA2ACC67FA00187028 /* Range+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9128566126AA7F571FFECA3A /* Range+Extensions.swift */; };
@@ -150,6 +151,7 @@
 		DAC5687FF32E8661F1A00CE5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DBC8EA85D1CBC1EC4AB3EB8C /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		DECCDC4079DC6471CEDDEA84 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		E1AB44CF2AFE139600639DC5 /* URL+NetworkHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+NetworkHeaders.swift"; sourceTree = "<group>"; };
 		E1C3EF0BA039C0A50EDE13A5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Main.strings; sourceTree = "<group>"; };
 		E63F5C5C1FD2F3E6CB02EC5A /* HeadlessUniversalCheckoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlessUniversalCheckoutTests.swift; sourceTree = "<group>"; };
 		E7640DB186F9638C2F556F77 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 			isa = PBXGroup;
 			children = (
 				E8DE1E4FB055B60582977315 /* Networking.swift */,
+				E1AB44CF2AFE139600639DC5 /* URL+NetworkHeaders.swift */,
 				77E08473D1DF8C47A6EB61B2 /* Networking+Models.swift */,
 			);
 			path = Network;
@@ -599,6 +602,7 @@
 				F00C66012ACC67FA00187028 /* CreateClientToken.swift in Sources */,
 				F00C66022ACC67FA00187028 /* TestScenario.swift in Sources */,
 				F00C66032ACC67FA00187028 /* TransactionResponse.swift in Sources */,
+				E1AB44D02AFE139600639DC5 /* URL+NetworkHeaders.swift in Sources */,
 				F00C66042ACC67FA00187028 /* Networking+Models.swift in Sources */,
 				F00C66052ACC67FA00187028 /* Networking.swift in Sources */,
 				F00C66062ACC67FA00187028 /* MerchantDropInUIViewController.swift in Sources */,

--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		DB1A2989DDE0928C62B15303 /* PayPalServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7EC742DEB5BE12252E3E5B /* PayPalServiceTests.swift */; };
 		DC98712939835FB79A20BD63 /* IntExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9314E0A4E884A8228611A030 /* IntExtensionTests.swift */; };
 		DE53DA2D0AD108306C92E198 /* UIViewController+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD8065D40A2D691F643F3B /* UIViewController+API.swift */; };
+		E130C3D72AFD19EA00AC3E7C /* URL+NetworkHeaders.swift in Sources */ = {isa = PBXBuildFile; fileRef = E130C3D62AFD19EA00AC3E7C /* URL+NetworkHeaders.swift */; };
+		E130C3D92AFD19FF00AC3E7C /* NetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E130C3D82AFD19FF00AC3E7C /* NetworkTests.swift */; };
 		E4DF956CABAE0633980D5B89 /* AnalyticsTests+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90441E821B5FE76643B62A6 /* AnalyticsTests+Constants.swift */; };
 		E52B5646C4E1E712FEDE06CB /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF07D2421252EA2AE5C2FC4F /* AnalyticsTests.swift */; };
 		E6F85ECD80B64754E7A6D35E /* RawDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7C082270CF1C6B7810F9B3 /* RawDataManagerTests.swift */; };
@@ -247,6 +249,8 @@
 		DBC8EA85D1CBC1EC4AB3EB8C /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		DD2EC8A195C6BB1D85F1D805 /* Pods_Debug_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DECCDC4079DC6471CEDDEA84 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		E130C3D62AFD19EA00AC3E7C /* URL+NetworkHeaders.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+NetworkHeaders.swift"; sourceTree = "<group>"; };
+		E130C3D82AFD19FF00AC3E7C /* NetworkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTests.swift; sourceTree = "<group>"; };
 		E1C3EF0BA039C0A50EDE13A5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Main.strings; sourceTree = "<group>"; };
 		E63F5C5C1FD2F3E6CB02EC5A /* HeadlessUniversalCheckoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlessUniversalCheckoutTests.swift; sourceTree = "<group>"; };
 		E7640DB186F9638C2F556F77 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
@@ -340,6 +344,7 @@
 		2F23D3C9CC9CBC1B95329B1C /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				E130C3D82AFD19FF00AC3E7C /* NetworkTests.swift */,
 				1F4E35F809D3FAF4354D5B05 /* URLSessionStackTests.swift */,
 			);
 			path = Network;
@@ -431,6 +436,7 @@
 			children = (
 				E8DE1E4FB055B60582977315 /* Networking.swift */,
 				77E08473D1DF8C47A6EB61B2 /* Networking+Models.swift */,
+				E130C3D62AFD19EA00AC3E7C /* URL+NetworkHeaders.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -841,6 +847,7 @@
 				213196DEDF2A3A84037ED884 /* PollingModuleTests.swift in Sources */,
 				04F6EF742AE6A06200115D05 /* AnalyticsEventsTests.swift in Sources */,
 				1589385B62C86DE7C735F3EC /* PrimerAPIConfigurationModuleTests.swift in Sources */,
+				E130C3D92AFD19FF00AC3E7C /* NetworkTests.swift in Sources */,
 				A39750255D4C33527A3766A0 /* UserInterfaceModuleTests.swift in Sources */,
 				3EE90DEB1DB7BE9270FB17BF /* URLSessionStackTests.swift in Sources */,
 				2C98B33ECA68109C7A6AA134 /* PrimerBancontactCardDataManagerTests.swift in Sources */,
@@ -883,6 +890,7 @@
 				5E24CD5B3084FE3E8A3E85EC /* CheckoutTheme.swift in Sources */,
 				AAE3B30B64B6822A20987FCA /* CreateClientToken.swift in Sources */,
 				C75A11E6AEEFC2B7A29BBC04 /* TestScenario.swift in Sources */,
+				E130C3D72AFD19EA00AC3E7C /* URL+NetworkHeaders.swift in Sources */,
 				FD5ADBCFA70DB606339F3AF2 /* TransactionResponse.swift in Sources */,
 				8B51ABC1C475342A047D5FA6 /* Networking+Models.swift in Sources */,
 				53E3182FFC4E5F05D866CFAE /* Networking.swift in Sources */,

--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -87,8 +87,8 @@
 		DB1A2989DDE0928C62B15303 /* PayPalServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7EC742DEB5BE12252E3E5B /* PayPalServiceTests.swift */; };
 		DC98712939835FB79A20BD63 /* IntExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9314E0A4E884A8228611A030 /* IntExtensionTests.swift */; };
 		DE53DA2D0AD108306C92E198 /* UIViewController+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD8065D40A2D691F643F3B /* UIViewController+API.swift */; };
-		E130C3D72AFD19EA00AC3E7C /* URL+NetworkHeaders.swift in Sources */ = {isa = PBXBuildFile; fileRef = E130C3D62AFD19EA00AC3E7C /* URL+NetworkHeaders.swift */; };
 		E130C3D92AFD19FF00AC3E7C /* NetworkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E130C3D82AFD19FF00AC3E7C /* NetworkTests.swift */; };
+		E1AB44D22AFE13AF00639DC5 /* URL+NetworkHeaders.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB44D12AFE13AF00639DC5 /* URL+NetworkHeaders.swift */; };
 		E4DF956CABAE0633980D5B89 /* AnalyticsTests+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E90441E821B5FE76643B62A6 /* AnalyticsTests+Constants.swift */; };
 		E52B5646C4E1E712FEDE06CB /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF07D2421252EA2AE5C2FC4F /* AnalyticsTests.swift */; };
 		E6F85ECD80B64754E7A6D35E /* RawDataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7C082270CF1C6B7810F9B3 /* RawDataManagerTests.swift */; };
@@ -249,8 +249,8 @@
 		DBC8EA85D1CBC1EC4AB3EB8C /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		DD2EC8A195C6BB1D85F1D805 /* Pods_Debug_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DECCDC4079DC6471CEDDEA84 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
-		E130C3D62AFD19EA00AC3E7C /* URL+NetworkHeaders.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+NetworkHeaders.swift"; sourceTree = "<group>"; };
 		E130C3D82AFD19FF00AC3E7C /* NetworkTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkTests.swift; sourceTree = "<group>"; };
+		E1AB44D12AFE13AF00639DC5 /* URL+NetworkHeaders.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+NetworkHeaders.swift"; sourceTree = "<group>"; };
 		E1C3EF0BA039C0A50EDE13A5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Main.strings; sourceTree = "<group>"; };
 		E63F5C5C1FD2F3E6CB02EC5A /* HeadlessUniversalCheckoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadlessUniversalCheckoutTests.swift; sourceTree = "<group>"; };
 		E7640DB186F9638C2F556F77 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
@@ -436,7 +436,7 @@
 			children = (
 				E8DE1E4FB055B60582977315 /* Networking.swift */,
 				77E08473D1DF8C47A6EB61B2 /* Networking+Models.swift */,
-				E130C3D62AFD19EA00AC3E7C /* URL+NetworkHeaders.swift */,
+				E1AB44D12AFE13AF00639DC5 /* URL+NetworkHeaders.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -890,7 +890,7 @@
 				5E24CD5B3084FE3E8A3E85EC /* CheckoutTheme.swift in Sources */,
 				AAE3B30B64B6822A20987FCA /* CreateClientToken.swift in Sources */,
 				C75A11E6AEEFC2B7A29BBC04 /* TestScenario.swift in Sources */,
-				E130C3D72AFD19EA00AC3E7C /* URL+NetworkHeaders.swift in Sources */,
+				E1AB44D22AFE13AF00639DC5 /* URL+NetworkHeaders.swift in Sources */,
 				FD5ADBCFA70DB606339F3AF2 /* TransactionResponse.swift in Sources */,
 				8B51ABC1C475342A047D5FA6 /* Networking+Models.swift in Sources */,
 				53E3182FFC4E5F05D866CFAE /* Networking.swift in Sources */,

--- a/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
+++ b/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
@@ -2,7 +2,6 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YLF-5Z-Vka">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -177,10 +176,10 @@
                                 <rect key="frame" x="0.0" y="163" width="414" height="561"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="Yce-hH-uhX">
-                                        <rect key="frame" x="20" y="20" width="374" height="3455"/>
+                                        <rect key="frame" x="20" y="20" width="374" height="3506"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="oCT-9e-d89" userLabel="Environment Stack View">
-                                                <rect key="frame" x="0.0" y="0.0" width="374" height="240.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="291.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Environment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yLn-q9-pMX">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="33.5"/>
@@ -232,10 +231,27 @@
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="a0D-Pg-RVk" userLabel="Use New Workflows Stack View">
+                                                        <rect key="frame" x="0.0" y="260.5" width="374" height="31"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use New Workflows" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O64-8M-PSK" userLabel="Apply theming">
+                                                                <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="PCb-Hh-UuC">
+                                                                <rect key="frame" x="325" y="0.0" width="51" height="31"/>
+                                                                <connections>
+                                                                    <action selector="useNewWorkflowsSwitchValueChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="lVV-7E-cJF"/>
+                                                                </connections>
+                                                            </switch>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="n1R-Ky-ifJ" userLabel="Test Params Stack View">
-                                                <rect key="frame" x="0.0" y="280.5" width="374" height="424.5"/>
+                                                <rect key="frame" x="0.0" y="331.5" width="374" height="424.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Test" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5m9-J2-Vfy">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="33.5"/>
@@ -330,7 +346,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="f7f-4e-ZPN" userLabel="SDK Settings Stack View">
-                                                <rect key="frame" x="0.0" y="745" width="374" height="454.5"/>
+                                                <rect key="frame" x="0.0" y="796" width="374" height="454.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SDK Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HZ9-hO-miI">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="33.5"/>
@@ -444,7 +460,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Wmb-0A-wCB" userLabel="Order Stack View">
-                                                <rect key="frame" x="0.0" y="1239.5" width="374" height="461"/>
+                                                <rect key="frame" x="0.0" y="1290.5" width="374" height="461"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Order" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rhW-8E-83f">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="33.5"/>
@@ -555,7 +571,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="cka-yb-xqD" userLabel="Customer Stack View">
-                                                <rect key="frame" x="0.0" y="1740.5" width="374" height="1565.5"/>
+                                                <rect key="frame" x="0.0" y="1791.5" width="374" height="1565.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3y1-pX-UrW">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="33.5"/>
@@ -956,7 +972,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="32O-OV-0ey" userLabel="Surcharge Group Stack View">
-                                                <rect key="frame" x="0.0" y="3346" width="374" height="109"/>
+                                                <rect key="frame" x="0.0" y="3397" width="374" height="109"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hmO-CL-ebG">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="31"/>
@@ -1125,6 +1141,7 @@
                         <outlet property="testScenarioTextField" destination="1I5-Ez-Jqq" id="Rvd-za-0f6"/>
                         <outlet property="testingModeSegmentedControl" destination="hgd-Bd-Btv" id="Skc-l2-RBn"/>
                         <outlet property="totalAmountLabel" destination="Lx7-hC-lz7" id="pOX-nF-EWM"/>
+                        <outlet property="useNewWorkflowsStackView" destination="a0D-Pg-RVk" id="9Re-cu-NP8"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="19K-SE-wqb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Debug App/Sources/Network/Networking.swift
+++ b/Debug App/Sources/Network/Networking.swift
@@ -81,10 +81,6 @@ class Networking {
             request.addValue(customDefinedApiKey, forHTTPHeaderField: "x-api-key")
         }
 
-        if useNewWorkflows, let urlAbsoluteString = request.url?.absoluteString, urlAbsoluteString.hasSuffix("client-session") {
-            request.addValue("false", forHTTPHeaderField: "Legacy-Workflows")
-        }
-        
         if let headers = headers {
             // We have a dedicated argument that takes x-api-key into account
             // in case a custom one gets defined before SDK initialization
@@ -278,7 +274,7 @@ class Networking {
             apiVersion: .v2_2,
             url: url,
             method: .post,
-            headers: nil,
+            headers: URL.requestSessionHTTPHeaders(useNewWorkflows: useNewWorkflows),
             queryParameters: nil,
             body: bodyData
         ) { result in

--- a/Debug App/Sources/Network/Networking.swift
+++ b/Debug App/Sources/Network/Networking.swift
@@ -80,6 +80,10 @@ class Networking {
         if let customDefinedApiKey = customDefinedApiKey {
             request.addValue(customDefinedApiKey, forHTTPHeaderField: "x-api-key")
         }
+
+        if useNewWorkflows, let urlAbsoluteString = request.url?.absoluteString, urlAbsoluteString.hasSuffix("client-session") {
+            request.addValue("false", forHTTPHeaderField: "Legacy-Workflows")
+        }
         
         if let headers = headers {
             // We have a dedicated argument that takes x-api-key into account

--- a/Debug App/Sources/Network/URL+NetworkHeaders.swift
+++ b/Debug App/Sources/Network/URL+NetworkHeaders.swift
@@ -1,0 +1,14 @@
+//
+//  URL+NetworkHeaders.swift
+//  Debug App
+//
+//  Created by Alexandra Lovin on 09.11.2023.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import Foundation
+extension URL {
+    static func requestSessionHTTPHeaders(useNewWorkflows: Bool) -> [String: String]? {
+        useNewWorkflows ? ["Legacy-Workflows": "false"] : nil
+    }
+}

--- a/Debug App/Sources/Network/URL+NetworkHeaders.swift
+++ b/Debug App/Sources/Network/URL+NetworkHeaders.swift
@@ -9,6 +9,6 @@
 import Foundation
 extension URL {
     static func requestSessionHTTPHeaders(useNewWorkflows: Bool) -> [String: String]? {
-        useNewWorkflows ? ["Legacy-Wrkflows": "false"] : nil
+        useNewWorkflows ? ["Legacy-Workflows": "false"] : nil
     }
 }

--- a/Debug App/Sources/Network/URL+NetworkHeaders.swift
+++ b/Debug App/Sources/Network/URL+NetworkHeaders.swift
@@ -9,6 +9,6 @@
 import Foundation
 extension URL {
     static func requestSessionHTTPHeaders(useNewWorkflows: Bool) -> [String: String]? {
-        useNewWorkflows ? ["Legacy-Workflows": "false"] : nil
+        useNewWorkflows ? ["Legacy-Wrkflows": "false"] : nil
     }
 }

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 var environment: Environment = .sandbox
 var customDefinedApiKey: String?
 var performPaymentAfterVaulting: Bool = false
+var useNewWorkflows = false
 
 class MerchantSessionAndSettingsViewController: UIViewController {
     

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 var environment: Environment = .sandbox
 var customDefinedApiKey: String?
 var performPaymentAfterVaulting: Bool = false
-var useNewWorkflows = false
+var useNewWorkflows = true
 
 class MerchantSessionAndSettingsViewController: UIViewController {
     
@@ -27,6 +27,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
     @IBOutlet weak var environmentStackView: UIStackView!
     @IBOutlet weak var testParamsGroupStackView: UIStackView!
     @IBOutlet weak var apiKeyStackView: UIStackView!
+    @IBOutlet weak var useNewWorkflowsStackView: UIStackView!
     @IBOutlet weak var clientTokenStackView: UIStackView!
     @IBOutlet weak var sdkSettingsStackView: UIStackView!
     @IBOutlet weak var orderStackView: UIStackView!
@@ -64,7 +65,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
     @IBOutlet weak var disableSuccessScreenSwitch: UISwitch!
     @IBOutlet weak var disableErrorScreenSwitch: UISwitch!
     @IBOutlet weak var disableInitScreenSwitch: UISwitch!
-    
+
     
     // MARK: Order Inputs
     
@@ -279,6 +280,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
             orderStackView.isHidden = false
             customerStackView.isHidden = false
             surchargeGroupStackView.isHidden = false
+            useNewWorkflowsStackView.isHidden = false
             
         case .clientToken:
             environmentStackView.isHidden = false
@@ -289,6 +291,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
             orderStackView.isHidden = true
             customerStackView.isHidden = true
             surchargeGroupStackView.isHidden = true
+            useNewWorkflowsStackView.isHidden = true
             
         case .testScenario:
             environmentStackView.isHidden = true
@@ -299,6 +302,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
             orderStackView.isHidden = false
             customerStackView.isHidden = false
             surchargeGroupStackView.isHidden = false
+            useNewWorkflowsStackView.isHidden = true
             
             
             testParamsStackView.isHidden = (selectedTestScenario == nil)
@@ -429,6 +433,10 @@ class MerchantSessionAndSettingsViewController: UIViewController {
     
     @IBAction func surchargeSwitchValueChanged(_ sender: UISwitch) {
         surchargeStackView.isHidden = !sender.isOn
+    }
+
+    @IBAction func useNewWorkflowsSwitchValueChanged(_ sender: UISwitch) {
+        useNewWorkflows = sender.isOn
     }
     
     @IBAction func primerSDKButtonTapped(_ sender: Any) {

--- a/Debug App/Tests/Unit Tests/Network/NetworkTests.swift
+++ b/Debug App/Tests/Unit Tests/Network/NetworkTests.swift
@@ -1,0 +1,17 @@
+//
+//  NetworkTests.swift
+//  Debug App Tests
+//
+//  Created by Alexandra Lovin on 09.11.2023.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Debug_App
+final class NetworkTests: XCTestCase {
+
+    func test_http_headers_new_workflows() {
+        XCTAssertNil(URL.requestSessionHTTPHeaders(useNewWorkflows: false))
+        XCTAssertEqual(URL.requestSessionHTTPHeaders(useNewWorkflows: true), ["Legacy-Workflows": "false"])
+    }
+}


### PR DESCRIPTION
[TWS-37](https://primer-ext.atlassian.net/browse/TWS-37)

# What this PR does

As a developer of the primer iOS SDK the Debug App
I want to be able to see a toggle labelled “Enable New Workflows“ 
So that I can switch to using the new workflows for the session creation.

Other clients, eg: Android and Web have this toggle/checkbox.

# Notable decisions & other stuff

Add Toggle UI inside the Debug App Setup Screen for the “Create Session” Tab.
Default toggle state is off
When toggle is on, the request for /client-session contains the HTTP header Legacy-Workflows: false
When toggle is off, the request for /client-session contains doesn’t contain the HTTP header Legacy-Workflows
Toggle state doesn’t affect any other HTTP requests on different methods
Payments are successful under the new workflows for iDeal under development environment when toggle is on

# Instructions on how to test this

![Simulator Screenshot - iPhone 14 Pro - 2023-11-09 at 15 34 37](https://github.com/primer-io/primer-sdk-ios/assets/149569710/abc49e2c-8fa3-429e-9faf-dd64afe40df9)


# Before merging

_QA_

- [x] I manually tested this with a demo application (simulator)
- [x] I manually tested this with a demo application (real device)
- [x] I wrote unit tests for each new util-like function
- [ ] I wrote at least basic e2e tests for the new functionalities or new paths
- [x] If this PR introduces UI changes, I manually tested this PR on iPhone 8 (iOS 10, 12, 14), iPhone 12, and iPhone 12 Max
- [ ] If this PR modifies the behavior of an API, I did my best to make my new API backward compatible
- [ ] If this PR modifies the API, I attempted to implement the feature with an example

_Documentation_

- [ ] If this PR modifies the API, I updated the API Reference.
- [ ] If this PR adds new options to the API, I wrote some documentation or guide in the online documentation
- [ ] If the PR modifies the API, I wrote some documentation to deprecate it

# After merging

- Make sure a new release has been pushed to Cocoapods trunk
