### PR TITLE
fix: Fix state machine to allow going back in steps

### DIFF
--- a/Debug App/Sources/View Controllers/New UI/MerchantHeadlessCheckoutNolPayViewController.swift
+++ b/Debug App/Sources/View Controllers/New UI/MerchantHeadlessCheckoutNolPayViewController.swift
@@ -245,7 +245,7 @@ class MerchantHeadlessCheckoutNolPayViewController: UIViewController {
     @objc func submitPhoneNumberTapped() {
         guard let mobileNumber = linkMobileNumberTextField.text, !mobileNumber.isEmpty
         else {
-            showAlert(title: "Error", message: "Please enter both country code and phone number.")
+            showAlert(title: "Error", message: "Please enter phone number.")
             return
         }
         
@@ -274,7 +274,7 @@ class MerchantHeadlessCheckoutNolPayViewController: UIViewController {
         guard let mobileNumber = unlinkPhoneNumberTextField.text, !mobileNumber.isEmpty,
               let card = selectedCardForUnlinking
         else {
-            showAlert(title: "Error", message: "Please enter both country code and phone number.")
+            showAlert(title: "Error", message: "Please enter phone number.")
             return
         }
         
@@ -329,7 +329,7 @@ class MerchantHeadlessCheckoutNolPayViewController: UIViewController {
     @objc func submitPaymentPhoneNumberButtonTapped() {
         guard let phoneNumber = startPaymentPhoneNumberTextField.text, !phoneNumber.isEmpty
         else {
-            showAlert(title: "Error", message: "Please enter both country code and phone number.")
+            showAlert(title: "Error", message: "Please enter phone number.")
             return
         }
         

--- a/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayLinkCardComponentTest.swift
+++ b/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayLinkCardComponentTest.swift
@@ -119,5 +119,31 @@ final class NolPayLinkCardComponentTest: XCTestCase {
         sut.start()
         XCTAssertTrue(mockErrorDelegate.errorReceived is PrimerError)
     }
+    
+    func testUpdateCollectedDataWithPhoneData() {
+        // Given
+        let phoneData = NolPayLinkCollectableData.phoneData(mobileNumber: "1234567890")
+        
+        // When
+        sut.updateCollectedData(collectableData: phoneData)
+        
+        // Then
+        let expectedStep = String(describing: NolPayLinkCardStep.collectPhoneData(cardNumber: ""))
+        let actualStep = String(describing: sut.nextDataStep)
+        XCTAssertEqual(actualStep, expectedStep, "The nextDataStep should be .collectPhoneData after updating with phoneData")
+    }
+
+    func testUpdateCollectedDataWithOtpData() {
+        // Given
+        let otpData = NolPayLinkCollectableData.otpData(otpCode: "123456")
+        
+        // When
+        sut.updateCollectedData(collectableData: otpData)
+        
+        // Then
+        let expectedStep = String(describing: NolPayLinkCardStep.collectOtpData(phoneNumber: ""))
+        let actualStep = String(describing: sut.nextDataStep)
+        XCTAssertEqual(actualStep, expectedStep, "The nextDataStep should be .collectOtpData after updating with otpData")
+    }
 }
 #endif

--- a/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayPaymentComponentTests.swift
+++ b/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayPaymentComponentTests.swift
@@ -125,5 +125,17 @@ class NolPayPaymentComponentTests: XCTestCase {
         XCTAssertTrue(mockErrorDelegate.errorReceived is PrimerError, "Expected error type to be PrimerError.")
     }
     
+    func testUpdateCollectedDataWithPaymentData() {
+        // Given
+        let paymentData = NolPayPaymentCollectableData.paymentData(cardNumber: "1234567890123456", mobileNumber: "1234567890")
+        
+        // When
+        sut.updateCollectedData(collectableData: paymentData)
+        
+        // Then
+        let expectedStep = String(describing: NolPayPaymentStep.collectCardAndPhoneData)
+        let actualStep = String(describing: sut.nextDataStep)
+        XCTAssertEqual(actualStep, expectedStep, "The nextDataStep should be .collectCardAndPhoneData after updating with paymentData")
+    }
 }
 #endif

--- a/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayUnlinkCardComponentTest.swift
+++ b/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayUnlinkCardComponentTest.swift
@@ -191,5 +191,33 @@ final class NolPayUnlinkCardComponentTest: XCTestCase {
         
         XCTAssertNotNil(mockErrorDelegate.errorReceived, "Expected an error when there's no card number.")
     }
+    
+    func testUpdateCollectedDataWithCardAndPhoneData() {
+        // Given
+        let mockCard = PrimerNolPaymentCard(cardNumber: "1234567890123456", expiredTime: "") // Replace with the correct initializer
+        let cardAndPhoneData = NolPayUnlinkCollectableData.cardAndPhoneData(nolPaymentCard: mockCard, mobileNumber: "+1234567890")
+
+        // When
+        sut.updateCollectedData(collectableData: cardAndPhoneData)
+
+        // Then
+        let expectedStep = String(describing: NolPayUnlinkDataStep.collectCardAndPhoneData)
+        let actualStep = String(describing: sut.nextDataStep)
+        XCTAssertEqual(actualStep, expectedStep, "The nextDataStep should be .collectCardAndPhoneData after updating with cardAndPhoneData")
+    }
+    
+    func testUpdateCollectedDataWithOtpData() {
+        // Given
+        let otpData = NolPayUnlinkCollectableData.otpData(otpCode: "123456")
+        
+        // When
+        sut.updateCollectedData(collectableData: otpData)
+        
+        // Then
+        let expectedStep = String(describing: NolPayUnlinkDataStep.collectOtpData)
+        let actualStep = String(describing: sut.nextDataStep)
+        XCTAssertEqual(actualStep, expectedStep, "The nextDataStep should be .collectOtpData after updating with otpData")
+    }
+
 }
 #endif

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayLinkCardComponent.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayLinkCardComponent.swift
@@ -51,8 +51,10 @@ public class NolPayLinkCardComponent: PrimerHeadlessCollectDataComponent {
 
         switch collectableData {
         case .phoneData(let mobileNumber):
+            nextDataStep = .collectPhoneData(cardNumber: self.cardNumber ?? "")
             self.mobileNumber = mobileNumber
         case .otpData(let otpCode):
+            nextDataStep = .collectOtpData(phoneNumber: self.mobileNumber ?? "")
             self.otpCode = otpCode
         }
         

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayPaymentComponent.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayPaymentComponent.swift
@@ -41,6 +41,7 @@ public class NolPayPaymentComponent: PrimerHeadlessCollectDataComponent {
     public func updateCollectedData(collectableData: NolPayPaymentCollectableData) {
         switch collectableData {
         case let .paymentData(cardNumber, mobileNumber):
+            nextDataStep = .collectCardAndPhoneData
             self.cardNumber = cardNumber
             self.mobileNumber = mobileNumber
         }

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayUnlinkCardComponent.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayUnlinkCardComponent.swift
@@ -58,11 +58,11 @@ public class NolPayUnlinkCardComponent: PrimerHeadlessCollectDataComponent {
         
         case .cardAndPhoneData(nolPaymentCard: let nolPaymentCard,
                                mobileNumber: let mobileNumber):
-            
+            nextDataStep = .collectCardAndPhoneData
             cardNumber = nolPaymentCard.cardNumber
             self.mobileNumber = mobileNumber
-
         case .otpData(otpCode: let otpCode):
+            nextDataStep = .collectOtpData
             self.otpCode = otpCode
         }
         


### PR DESCRIPTION
This PR fixes a bug with Nol state machine. If a user wants to change the phone number after sending it for validation an error is returned. `submit()` was handling wrong step.

[JIRA](https://primerapi.atlassian.net/browse/CHKT-1928)
[SLACK](https://primerapi.slack.com/archives/C05DJ5LV309/p1699871603945539)