### PR TITLE
chore: Correct syntax for post-pr merge

### DIFF
--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -1,16 +1,12 @@
 name: Post Release PR Merge
 
-on: 
-  workflow_dispatch:
+on:
   pull_request:
-    # Patterns matched against refs/heads
-    branches:
-      - release/next
     types: [ closed ]
 
 jobs:
   release_merge:
-    if: github.event.pull_request.merged == true
+    if: github.head_ref == 'release/next' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Git - Checkout
@@ -34,6 +30,7 @@ jobs:
         with:
           title: Release ${{ env.RELEASE_VERSION }}
   build-and-upload-to-appetize:
+    if: github.head_ref == 'release/next' && github.event.pull_request.merged == true
     runs-on: macos-latest
     timeout-minutes: 20
     name: "Build and upload app to Appetize"


### PR DESCRIPTION
The workflow didnt run as expected yesterday. I did some testing on [another repo](https://github.com/NQuinn27/TestActions) and this syntax will get us where we want to be,

The workflow will run if:
- a PR is **closed** and **merged**
- the head_ref is `release/next`
