### PR TITLE
chore: Constrain remote validation logic to eight-digit BIN only

### DIFF
--- a/Debug App/Tests/Unit Tests/Services/CardValidationServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Services/CardValidationServiceTests.swift
@@ -140,7 +140,7 @@ final class CardValidationServiceTests: XCTestCase {
                 expectation2.fulfill()
             }
             if self.delegate.onMetadataForCardValidationStateCount == (self.maxBinLength * 2) {
-                XCTAssertEqual(cardState.cardNumber, String(cardNumber.prefix(self.maxBinLength)))
+                XCTAssertEqual(cardState.cardNumber, String(altCardNumber.prefix(self.maxBinLength)))
                 XCTAssertEqual(networks.availableCardNetworks[0].displayName, "Network #3")
                 XCTAssertEqual(networks.availableCardNetworks[0].networkIdentifier, "NETWORK_3")
                 XCTAssertEqual(networks.availableCardNetworks[1].displayName, "Network #4")

--- a/Debug App/Tests/Unit Tests/Services/CardValidationServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Services/CardValidationServiceTests.swift
@@ -130,7 +130,6 @@ final class CardValidationServiceTests: XCTestCase {
         
         let expectation2 = self.expectation(description: "onMetadataForCardValidationState is called")
         delegate.onMetadataForCardValidationState = { rawDataManager, networks, cardState in
-            print(">> COUNT: \(self.delegate.onMetadataForCardValidationStateCount)")
             XCTAssertEqual(networks.availableCardNetworks.count, 1)
             if self.delegate.onMetadataForCardValidationStateCount == self.maxBinLength {
                 expectation2.fulfill()

--- a/Debug App/Tests/Unit Tests/Services/CardValidationServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Services/CardValidationServiceTests.swift
@@ -112,6 +112,8 @@ final class CardValidationServiceTests: XCTestCase {
         waitForExpectations(timeout: 5)
     }
     
+    
+    
     func testReceiveError() throws {
         
         let cardNumber = "552266117788"
@@ -128,8 +130,9 @@ final class CardValidationServiceTests: XCTestCase {
         
         let expectation2 = self.expectation(description: "onMetadataForCardValidationState is called")
         delegate.onMetadataForCardValidationState = { rawDataManager, networks, cardState in
+            print(">> COUNT: \(self.delegate.onMetadataForCardValidationStateCount)")
             XCTAssertEqual(networks.availableCardNetworks.count, 1)
-            if self.delegate.onMetadataForCardValidationStateCount == 6 {
+            if self.delegate.onMetadataForCardValidationStateCount == self.maxBinLength {
                 expectation2.fulfill()
             }
         }

--- a/Debug App/Tests/Unit Tests/Services/CardValidationServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Services/CardValidationServiceTests.swift
@@ -143,8 +143,8 @@ final class CardValidationServiceTests: XCTestCase {
                 XCTAssertEqual(cardState.cardNumber, String(cardNumber.prefix(self.maxBinLength)))
                 XCTAssertEqual(networks.availableCardNetworks[0].displayName, "Network #3")
                 XCTAssertEqual(networks.availableCardNetworks[0].networkIdentifier, "NETWORK_3")
-                XCTAssertEqual(networks.availableCardNetworks[1].displayName, "Network #3")
-                XCTAssertEqual(networks.availableCardNetworks[1].networkIdentifier, "NETWORK_3")
+                XCTAssertEqual(networks.availableCardNetworks[1].displayName, "Network #4")
+                XCTAssertEqual(networks.availableCardNetworks[1].networkIdentifier, "NETWORK_4")
                 expectation3.fulfill()
             }
         }

--- a/Debug App/Tests/Unit Tests/Test Utilities/StringTyper.swift
+++ b/Debug App/Tests/Unit Tests/Test Utilities/StringTyper.swift
@@ -31,35 +31,35 @@ class StringTyper {
     ///   - string: The string that should be types
     ///   - result: The string that is being written to (do not provide this by default, used for recursion)
     ///   - delay: The interval between appending characters to the result string
-    func type(_ string: String, _ result: String = "", delay: Double = 0.1) {
+    func type(_ string: String, _ result: String = "", delay: Double = 0.1, completion: @escaping () -> Void = {}) {
         var string = string
         let result = "\(result)\(string.removeFirst())"
+        print(">> TYPE: \(result)")
         receiver(result)
-        guard !string.isEmpty else { return }
+        guard !string.isEmpty else {
+            queue.asyncAfter(deadline: .now() + 1) {
+                completion()
+            }
+            return
+        }
         queue.asyncAfter(deadline: .now() + delay) {
-            self.type(string, result, delay: delay)
+            self.type(string, result, delay: delay, completion: completion)
         }
     }
     
-    
-    /// As per `type(string:result:delay:) but with individual delay intervals for each character`
-    /// - Parameters:
-    ///   - string:
-    ///   - result: The string that is being written to (do not provide this by default, used for recursion)
-    ///   - delays: an array of delay times, must be equal to one less than the length of `string`
-    func type(_ string: String, _ result: String = "", delays: [Double]) {
-        assert(delays.count == string.count)
+    func delete(_ string: String, delay: Double = 0.1, completion: @escaping () -> Void = {}) {
         var string = string
-        let result = "\(result)\(string.removeFirst())"
-        
-        var delays = delays
-        let delay = delays.removeFirst()
-        
-        receiver(result)
-
-        guard !string.isEmpty else { return }
+        _ = string.removeFirst()
+        print(">> DELETE: \(string)")
+        receiver(string)
+        guard !string.isEmpty else {
+            queue.asyncAfter(deadline: .now() + 1) {
+                completion()
+            }
+            return
+        }
         queue.asyncAfter(deadline: .now() + delay) {
-            self.type(string, result, delays: delays)
+            self.type(string, string, delay: delay, completion: completion)
         }
     }
     

--- a/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
+++ b/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
@@ -38,19 +38,29 @@ class DefaultCardValidationService: CardValidationService, LogReporter {
         
     func validateCardNetworks(withCardNumber cardNumber: String) {
         let sanitizedCardNumber = cardNumber.replacingOccurrences(of: " ", with: "")
-        guard !sanitizedCardNumber.isEmpty, sanitizedCardNumber != mostRecentCardNumber else {
+        // Don't validate empty string
+        guard !sanitizedCardNumber.isEmpty else {
             return
         }
+        // Don't validate if the BIN (first eight digits) hasn't changed
+        if let mostRecentCardNumber = mostRecentCardNumber, mostRecentCardNumber.prefix(8) == cardNumber.prefix(8) {
+            return
+        }
+        let isFirstTimeRemoteValidation = mostRecentCardNumber == nil
         mostRecentCardNumber = sanitizedCardNumber
         
         let cardState = PrimerCardNumberEntryState(cardNumber: sanitizedCardNumber)
-        guard sanitizedCardNumber.count >= 6 else {
+        guard sanitizedCardNumber.count >= 8 else {
             useLocalValidation(withCardState: cardState)
             return
         }
         
-        debouncer.debounce { [weak self] in
-            self?.useRemoteValidation(withCardState: cardState)
+        if isFirstTimeRemoteValidation {
+            useRemoteValidation(withCardState: cardState)
+        } else {
+            debouncer.debounce { [weak self] in
+                self?.useRemoteValidation(withCardState: cardState)
+            }
         }
     }
     

--- a/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
+++ b/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
@@ -38,23 +38,26 @@ class DefaultCardValidationService: CardValidationService, LogReporter {
         
     func validateCardNetworks(withCardNumber cardNumber: String) {
         let sanitizedCardNumber = cardNumber.replacingOccurrences(of: " ", with: "")
+        let cardState = PrimerCardNumberEntryState(cardNumber: sanitizedCardNumber)
+
         // Don't validate empty string
         guard !sanitizedCardNumber.isEmpty else {
             return
         }
-        // Don't validate if the BIN (first eight digits) hasn't changed
-        if let mostRecentCardNumber = mostRecentCardNumber, mostRecentCardNumber.prefix(8) == cardNumber.prefix(8) {
+        // Don't validate if incomplete BIN (less than eight digits)
+        if sanitizedCardNumber.count < 8 {
+            useLocalValidation(withCardState: cardState)
             return
         }
-        let isFirstTimeRemoteValidation = mostRecentCardNumber == nil
-        mostRecentCardNumber = sanitizedCardNumber
-        
-        let cardState = PrimerCardNumberEntryState(cardNumber: sanitizedCardNumber)
-        guard sanitizedCardNumber.count >= 8 else {
+        // Don't validate if the BIN (first eight digits) hasn't changed
+        if let mostRecentCardNumber = mostRecentCardNumber, mostRecentCardNumber.prefix(8) == cardNumber.prefix(8) {
             useLocalValidation(withCardState: cardState)
             return
         }
         
+        let isFirstTimeRemoteValidation = mostRecentCardNumber == nil
+        mostRecentCardNumber = sanitizedCardNumber
+                
         if isFirstTimeRemoteValidation {
             useRemoteValidation(withCardState: cardState)
         } else {


### PR DESCRIPTION
CHKT-1885

# What this PR does

Previously we triggered debounced validation on 6-8 characters, now we will trigger it:
1. When less than eight digits are entered, on eighth digit being entered 
2. After eight digits have been entered, only if the first eight digits change.

# Notable decisions & other stuff

* The first request is no longer debounced to ensure that we make an early request for the most common use case (i.e. straight entry without user error)

# Before merging

_QA_

- [ ] I manually tested this with a demo application (simulator)
- [ ] I wrote unit tests for each new util-like function