### PR TITLE
fix: Add local empty phone validation

### DIFF
--- a/Debug App/Sources/View Controllers/New UI/MerchantHeadlessCheckoutNolPayViewController.swift
+++ b/Debug App/Sources/View Controllers/New UI/MerchantHeadlessCheckoutNolPayViewController.swift
@@ -241,13 +241,7 @@ class MerchantHeadlessCheckoutNolPayViewController: UIViewController {
     }
     
     @objc func submitPhoneNumberTapped() {
-        guard let mobileNumber = linkMobileNumberTextField.text, !mobileNumber.isEmpty
-        else {
-            showAlert(title: "Error", message: "Please enter phone number.")
-            return
-        }
-        
-        linkCardComponent.updateCollectedData(collectableData: NolPayLinkCollectableData.phoneData(mobileNumber: mobileNumber))
+        linkCardComponent.updateCollectedData(collectableData: NolPayLinkCollectableData.phoneData(mobileNumber: linkMobileNumberTextField.text ?? ""))
     }
     
     @objc func submitLinkOTPTapped() {
@@ -269,16 +263,15 @@ class MerchantHeadlessCheckoutNolPayViewController: UIViewController {
     }
     
     @objc func submitUnlinkPhoneNumberTapped() {
-        guard let mobileNumber = unlinkPhoneNumberTextField.text, !mobileNumber.isEmpty,
-              let card = selectedCardForUnlinking
+        guard let card = selectedCardForUnlinking
         else {
-            showAlert(title: "Error", message: "Please enter phone number.")
+            showAlert(title: "Error", message: "Please select the card for unlinking.")
             return
         }
         
         unlinkCardComponent.updateCollectedData(
             collectableData: .cardAndPhoneData(nolPaymentCard: card,
-                                               mobileNumber: mobileNumber)
+                                               mobileNumber: unlinkPhoneNumberTextField.text ?? "")
         )
     }
     
@@ -294,14 +287,7 @@ class MerchantHeadlessCheckoutNolPayViewController: UIViewController {
     
     // MARK: - Listing of the linked cards
     @objc private func getLinkedCards() {
-        
-        guard let phoneNumber = self.listCardsPhoneNumberTextField.text, !phoneNumber.isEmpty
-        else {
-            showAlert(title: "Error", message: "Invalid phone number or country code")
-            return
-        }
-        
-        getLinkedCardsComponent.getLinkedCardsFor(mobileNumber: phoneNumber) { result in
+        getLinkedCardsComponent.getLinkedCardsFor(mobileNumber: listCardsPhoneNumberTextField.text ?? "") { result in
             switch result {
                 
             case .success(let cards):
@@ -324,15 +310,9 @@ class MerchantHeadlessCheckoutNolPayViewController: UIViewController {
     }
     
     @objc func submitPaymentPhoneNumberButtonTapped() {
-        guard let phoneNumber = startPaymentPhoneNumberTextField.text, !phoneNumber.isEmpty
-        else {
-            showAlert(title: "Error", message: "Please enter phone number.")
-            return
-        }
-        
         paymentComponent.updateCollectedData(collectableData: NolPayPaymentCollectableData.paymentData(
             cardNumber: selectedCardForPayment?.cardNumber ?? "",
-            mobileNumber: phoneNumber))
+            mobileNumber: startPaymentPhoneNumberTextField.text ?? ""))
     }
         
     // MARK: - Helper

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayPhoneMetadataService.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayPhoneMetadataService.swift
@@ -29,6 +29,22 @@ struct NolPayPhoneMetadataService: NolPayPhoneMetadataProviding {
                 completion(.failure(err))
                 return
             }
+            
+            guard !mobileNumber.isEmpty else {
+                let validationError = PrimerValidationError.invalidPhoneNumber(
+                    message: "Phone number cannot be blank.",
+                    userInfo: [
+                        "file": #file,
+                        "class": "\(Self.self)",
+                        "function": #function,
+                        "line": "\(#line)"
+                    ],
+                    diagnosticsId: UUID().uuidString)
+                ErrorHandler.handle(error: validationError)
+
+                completion(.success((.invalid(errors: [validationError]), nil, nil)))
+                return
+            }
 
             let urlSessionConfiguration = URLSessionConfiguration.default
             urlSessionConfiguration.requestCachePolicy = .returnCacheDataElseLoad


### PR DESCRIPTION
We were not checking against an empty string before sending the phone string to the server for validation. Server returned 404 if you send it empty string.