### PR TITLE
fix: Reduce memory usage for analytics service

### DIFF
--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		041295AA2AB9E25D00A4F243 /* MerchantHeadlessCheckoutNolPayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041295A92AB9E25D00A4F243 /* MerchantHeadlessCheckoutNolPayViewController.swift */; };
 		041295AD2AB9E2C100A4F243 /* PrimerHeadlessNolPayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041295AB2AB9E2A900A4F243 /* PrimerHeadlessNolPayManagerTests.swift */; };
 		04769C152B1A680C0051581C /* Promises+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04769C142B1A680C0051581C /* Promises+Helper.swift */; };
+		049298012B1DD466002E04B8 /* AnalyticsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049298002B1DD466002E04B8 /* AnalyticsServiceTests.swift */; };
 		04DFAADC2AAA01E60030FECE /* Debug App Tests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */; };
 		04F6EF722AE69FC500115D05 /* AnalyticsTests+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F6EF712AE69FC500115D05 /* AnalyticsTests+Helpers.swift */; };
 		04F6EF742AE6A06200115D05 /* AnalyticsEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F6EF732AE6A06200115D05 /* AnalyticsEventsTests.swift */; };
@@ -140,6 +141,7 @@
 		041295A92AB9E25D00A4F243 /* MerchantHeadlessCheckoutNolPayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutNolPayViewController.swift; sourceTree = "<group>"; };
 		041295AB2AB9E2A900A4F243 /* PrimerHeadlessNolPayManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessNolPayManagerTests.swift; sourceTree = "<group>"; };
 		04769C142B1A680C0051581C /* Promises+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promises+Helper.swift"; sourceTree = "<group>"; };
+		049298002B1DD466002E04B8 /* AnalyticsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceTests.swift; sourceTree = "<group>"; };
 		04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Debug App Tests-Info.plist"; sourceTree = "<group>"; };
 		04F6EF712AE69FC500115D05 /* AnalyticsTests+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsTests+Helpers.swift"; sourceTree = "<group>"; };
 		04F6EF732AE6A06200115D05 /* AnalyticsEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEventsTests.swift; sourceTree = "<group>"; };
@@ -584,6 +586,7 @@
 				E90441E821B5FE76643B62A6 /* AnalyticsTests+Constants.swift */,
 				04F6EF712AE69FC500115D05 /* AnalyticsTests+Helpers.swift */,
 				04F6EF732AE6A06200115D05 /* AnalyticsEventsTests.swift */,
+				049298002B1DD466002E04B8 /* AnalyticsServiceTests.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -860,6 +863,7 @@
 				208CA849F3187C2DA63CC17B /* HUC_TokenizationViewModelTests.swift in Sources */,
 				213196DEDF2A3A84037ED884 /* PollingModuleTests.swift in Sources */,
 				04F6EF742AE6A06200115D05 /* AnalyticsEventsTests.swift in Sources */,
+				049298012B1DD466002E04B8 /* AnalyticsServiceTests.swift in Sources */,
 				1589385B62C86DE7C735F3EC /* PrimerAPIConfigurationModuleTests.swift in Sources */,
 				A39750255D4C33527A3766A0 /* UserInterfaceModuleTests.swift in Sources */,
 				3EE90DEB1DB7BE9270FB17BF /* URLSessionStackTests.swift in Sources */,

--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		041295AA2AB9E25D00A4F243 /* MerchantHeadlessCheckoutNolPayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041295A92AB9E25D00A4F243 /* MerchantHeadlessCheckoutNolPayViewController.swift */; };
 		041295AD2AB9E2C100A4F243 /* PrimerHeadlessNolPayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041295AB2AB9E2A900A4F243 /* PrimerHeadlessNolPayManagerTests.swift */; };
+		04769C152B1A680C0051581C /* Promises+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04769C142B1A680C0051581C /* Promises+Helper.swift */; };
 		04DFAADC2AAA01E60030FECE /* Debug App Tests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */; };
 		04F6EF722AE69FC500115D05 /* AnalyticsTests+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F6EF712AE69FC500115D05 /* AnalyticsTests+Helpers.swift */; };
 		04F6EF742AE6A06200115D05 /* AnalyticsEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F6EF732AE6A06200115D05 /* AnalyticsEventsTests.swift */; };
@@ -138,6 +139,7 @@
 		021A00DEB01A46C876592575 /* ThreeDSProtocolVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDSProtocolVersionTests.swift; sourceTree = "<group>"; };
 		041295A92AB9E25D00A4F243 /* MerchantHeadlessCheckoutNolPayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutNolPayViewController.swift; sourceTree = "<group>"; };
 		041295AB2AB9E2A900A4F243 /* PrimerHeadlessNolPayManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessNolPayManagerTests.swift; sourceTree = "<group>"; };
+		04769C142B1A680C0051581C /* Promises+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promises+Helper.swift"; sourceTree = "<group>"; };
 		04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Debug App Tests-Info.plist"; sourceTree = "<group>"; };
 		04F6EF712AE69FC500115D05 /* AnalyticsTests+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsTests+Helpers.swift"; sourceTree = "<group>"; };
 		04F6EF732AE6A06200115D05 /* AnalyticsEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEventsTests.swift; sourceTree = "<group>"; };
@@ -463,6 +465,7 @@
 			children = (
 				D3D9154BF1E011FED6799CD5 /* CardData.swift */,
 				D038BDB23C062D362AAA09BE /* Networking.swift */,
+				04769C142B1A680C0051581C /* Promises+Helper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -835,6 +838,7 @@
 				8064B65A8F83D5B004D081FD /* PaymentMethodConfigTests.swift in Sources */,
 				4BD7794627267B40E9E10686 /* PrimerCheckoutTheme.swift in Sources */,
 				F99DAF50E86E6F8CCD127E5B /* ThemeTests.swift in Sources */,
+				04769C152B1A680C0051581C /* Promises+Helper.swift in Sources */,
 				24C060A48D4A2670FFC3426F /* ThreeDSErrorTests.swift in Sources */,
 				F1A71C2E0D900FEB9AF1351C /* ThreeDSProtocolVersionTests.swift in Sources */,
 				04FAF9EC2AE7B33E002E4BAE /* StringExtensionTests.swift in Sources */,

--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		041295AD2AB9E2C100A4F243 /* PrimerHeadlessNolPayManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041295AB2AB9E2A900A4F243 /* PrimerHeadlessNolPayManagerTests.swift */; };
 		04769C152B1A680C0051581C /* Promises+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04769C142B1A680C0051581C /* Promises+Helper.swift */; };
 		049298012B1DD466002E04B8 /* AnalyticsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049298002B1DD466002E04B8 /* AnalyticsServiceTests.swift */; };
+		049298072B1E1F4D002E04B8 /* AnalyticsStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049298062B1E1F4D002E04B8 /* AnalyticsStorageTests.swift */; };
 		04DFAADC2AAA01E60030FECE /* Debug App Tests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */; };
 		04F6EF722AE69FC500115D05 /* AnalyticsTests+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F6EF712AE69FC500115D05 /* AnalyticsTests+Helpers.swift */; };
 		04F6EF742AE6A06200115D05 /* AnalyticsEventsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F6EF732AE6A06200115D05 /* AnalyticsEventsTests.swift */; };
@@ -142,6 +143,7 @@
 		041295AB2AB9E2A900A4F243 /* PrimerHeadlessNolPayManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimerHeadlessNolPayManagerTests.swift; sourceTree = "<group>"; };
 		04769C142B1A680C0051581C /* Promises+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promises+Helper.swift"; sourceTree = "<group>"; };
 		049298002B1DD466002E04B8 /* AnalyticsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsServiceTests.swift; sourceTree = "<group>"; };
+		049298062B1E1F4D002E04B8 /* AnalyticsStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsStorageTests.swift; sourceTree = "<group>"; };
 		04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Debug App Tests-Info.plist"; sourceTree = "<group>"; };
 		04F6EF712AE69FC500115D05 /* AnalyticsTests+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsTests+Helpers.swift"; sourceTree = "<group>"; };
 		04F6EF732AE6A06200115D05 /* AnalyticsEventsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEventsTests.swift; sourceTree = "<group>"; };
@@ -587,6 +589,7 @@
 				04F6EF712AE69FC500115D05 /* AnalyticsTests+Helpers.swift */,
 				04F6EF732AE6A06200115D05 /* AnalyticsEventsTests.swift */,
 				049298002B1DD466002E04B8 /* AnalyticsServiceTests.swift */,
+				049298062B1E1F4D002E04B8 /* AnalyticsStorageTests.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -842,6 +845,7 @@
 				4BD7794627267B40E9E10686 /* PrimerCheckoutTheme.swift in Sources */,
 				F99DAF50E86E6F8CCD127E5B /* ThemeTests.swift in Sources */,
 				04769C152B1A680C0051581C /* Promises+Helper.swift in Sources */,
+				049298072B1E1F4D002E04B8 /* AnalyticsStorageTests.swift in Sources */,
 				24C060A48D4A2670FFC3426F /* ThreeDSErrorTests.swift in Sources */,
 				F1A71C2E0D900FEB9AF1351C /* ThreeDSProtocolVersionTests.swift in Sources */,
 				04FAF9EC2AE7B33E002E4BAE /* StringExtensionTests.swift in Sources */,

--- a/Debug App/Sources/AppDelegate.swift
+++ b/Debug App/Sources/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         customizeAppearance()
-        PrimerLogging.shared.logger = DefaultLogger(logLevel: .info)
+        PrimerLogging.shared.logger = DefaultLogger(logLevel: .debug)
         return true
     }
     

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
@@ -68,11 +68,7 @@ final class AnalyticsServiceTests: XCTestCase {
         (0..<5).forEach { _ in
             sendEvents(numberOfEvents: 5, delay: 0.1)
         }
-        let expectRemainingEvents = self.expectation(description: "Remaining events are recorded")
-        expectRemainingEvents.expectedFulfillmentCount = 4
-        sendEvents(numberOfEvents: 4, delay: 0.5) {
-            expectRemainingEvents.fulfill()
-        }
+        sendEvents(numberOfEvents: 4, delay: 0.5)
 
         waitForExpectations(timeout: 15.0)
         

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
@@ -123,8 +123,9 @@ final class AnalyticsServiceTests: XCTestCase {
         events.forEach { event in
             let _callback = {
                 print(">>>>> Reporting event on queue")
-                _ = self.service.record(event: event)
-                callback()
+                _ = self.service.record(event: event).ensure {
+                    callback()
+                }
             }
             if let delay = delay {
                 queue.asyncAfter(deadline: .now() + delay, execute: _callback)

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
@@ -93,11 +93,7 @@ final class AnalyticsServiceTests: XCTestCase {
         (0..<3).forEach { _ in
             sendEvents(numberOfEvents: 5, delay: 0.5)
         }
-        let expectRemainingEvents = self.expectation(description: "Remaining events are recorded")
-        expectRemainingEvents.expectedFulfillmentCount = 4
-        sendEvents(numberOfEvents: 4, delay: 0.5) {
-            expectRemainingEvents.fulfill()
-        }
+        sendEvents(numberOfEvents: 4, delay: 0.5)
         
         waitForExpectations(timeout: 15.0)
         
@@ -119,11 +115,14 @@ final class AnalyticsServiceTests: XCTestCase {
         let events = (0..<numberOfEvents).map { num in messageEvent(withMessage: "Test #\(num + 1)") }
         
         print(">>>>> About to report \(events.count) events")
-        
-        events.forEach { event in
+
+
+        events.forEach { (event: Analytics.Event) in
+            let expectEventToRecord = self.expectation(description: "event is recorded - \(event.localId)")
             let _callback = {
                 print(">>>>> Reporting event on queue")
                 _ = self.service.record(event: event).ensure {
+                    expectEventToRecord.fulfill()
                     callback()
                 }
             }

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
@@ -106,20 +106,13 @@ final class AnalyticsServiceTests: XCTestCase {
     
     func sendEvents(numberOfEvents: Int,
                     delay: TimeInterval? = nil,
-                    onQueue queue: DispatchQueue = AnalyticsServiceTests.createQueue(),
-                    callback: @escaping () -> Void = {}) {
+                    onQueue queue: DispatchQueue = AnalyticsServiceTests.createQueue()) {
         let events = (0..<numberOfEvents).map { num in messageEvent(withMessage: "Test #\(num + 1)") }
-        
-        print(">>>>> About to report \(events.count) events")
-
-
         events.forEach { (event: Analytics.Event) in
             let expectEventToRecord = self.expectation(description: "event is recorded - \(event.localId)")
             let _callback = {
-                print(">>>>> Reporting event on queue")
                 _ = self.service.record(event: event).ensure {
                     expectEventToRecord.fulfill()
-                    callback()
                 }
             }
             if let delay = delay {

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
@@ -186,8 +186,6 @@ class MockPrimerAPIAnalyticsClient: PrimerAPIClientAnalyticsProtocol {
         } else {
             completion(.failure(PrimerError.generic(message: "", userInfo: nil, diagnosticsId: "")))
         }
-        DispatchQueue.global(qos: .background).async {
-            self.onSendAnalyticsEvent?(body)
-        }
+        self.onSendAnalyticsEvent?(body)
     }
 }

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
@@ -70,9 +70,7 @@ final class AnalyticsServiceTests: XCTestCase {
         }
         sendEvents(numberOfEvents: 4, delay: 0.1)
         
-        waitForExpectations(timeout: 15.0) { _ in
-            print(" >>>> ERROR: batches found: \(self.apiClient.batches.count), events total: \(self.apiClient.batches.joined().count)")
-        }
+        waitForExpectations(timeout: 15.0)
         
         XCTAssertEqual(apiClient.batches.count, 5)
         XCTAssertEqual(apiClient.batches.joined().count, 25)
@@ -93,9 +91,7 @@ final class AnalyticsServiceTests: XCTestCase {
         }
         sendEvents(numberOfEvents: 4, delay: 0.5)
         
-        waitForExpectations(timeout: 15.0) { _ in
-            print(" >>>> ERROR: batches found: \(self.apiClient.batches.count), events total: \(self.apiClient.batches.joined().count)")
-        }
+        waitForExpectations(timeout: 15.0)
         
         XCTAssertEqual(apiClient.batches.count, 3)
         XCTAssertEqual(apiClient.batches.joined().count, 15)
@@ -175,11 +171,11 @@ class MockPrimerAPIAnalyticsClient: PrimerAPIClientAnalyticsProtocol {
         }
         print(">>>>> Received batch of: \(body.count)")
         batches.append(body)
-        onSendAnalyticsEvent?(body)
         if shouldSucceed {
             completion(.success(.init(id: nil, result: nil)))
         } else {
             completion(.failure(PrimerError.generic(message: "", userInfo: nil, diagnosticsId: "")))
         }
+        onSendAnalyticsEvent?(body)
     }
 }

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsServiceTests.swift
@@ -1,0 +1,185 @@
+//
+//  AnalyticsServiceTests.swift
+//  Debug App Tests
+//
+//  Created by Jack Newcombe on 04/12/2023.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+final class AnalyticsServiceTests: XCTestCase {
+    
+    var apiClient: MockPrimerAPIAnalyticsClient!
+
+    var storage: Analytics.Storage!
+    
+    var service: Analytics.Service!
+    
+    override func setUpWithError() throws {
+        apiClient = MockPrimerAPIAnalyticsClient()
+        storage = MockAnalyticsStorage()
+        service = Analytics.Service(sdkLogsUrl: URL(string: "http://localhost/")!, 
+                                    batchSize: 5,
+                                    storage: storage,
+                                    apiClient: apiClient)
+    }
+
+    override func tearDownWithError() throws {
+        service = nil
+        storage = nil
+        apiClient = nil
+    }
+
+    func testSimpleBatchSend() throws {
+        
+        // Setup API Client
+        
+        let expectation = self.expectation(description: "Batch of five events are sent")
+        
+        apiClient.onSendAnalyticsEvent = { events in
+            XCTAssertNotNil(events)
+            XCTAssertEqual(events?.count, 5)
+             
+            let messages = events!.enumerated().compactMap { (index, event) in
+                return (event.properties as? MessageEventProperties)?.message
+            }.sorted()
+            XCTAssertEqual(messages, ["Test #1", "Test #2", "Test #3", "Test #4", "Test #5"])
+            expectation.fulfill()
+        }
+        
+        // Send Events
+        
+        sendEvents(numberOfEvents: 5)
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testComplexMultiBatchFastSend() throws {
+        
+        let expectation = self.expectation(description: "Called expected number of times")
+        
+        apiClient.onSendAnalyticsEvent = { _ in
+            guard self.apiClient.batches.joined().count >= 25 else { return }
+            expectation.fulfill()
+        }
+        
+        (0..<5).forEach { _ in
+            sendEvents(numberOfEvents: 5, delay: 0.1)
+        }
+        sendEvents(numberOfEvents: 4, delay: 0.1)
+        
+        waitForExpectations(timeout: 15.0) { _ in
+            print(" >>>> ERROR: batches found: \(self.apiClient.batches.count), events total: \(self.apiClient.batches.joined().count)")
+        }
+        
+        XCTAssertEqual(apiClient.batches.count, 5)
+        XCTAssertEqual(apiClient.batches.joined().count, 25)
+        XCTAssertEqual(storage.loadEvents().count, 4)
+    }
+    
+    func testComplexMultiBatchSlowSend() throws {
+        
+        let expectation = self.expectation(description: "Called expected number of times")
+        
+        apiClient.onSendAnalyticsEvent = { _ in
+            guard self.apiClient.batches.joined().count == 15 else { return }
+            expectation.fulfill()
+        }
+        
+        (0..<3).forEach { _ in
+            sendEvents(numberOfEvents: 5, delay: 0.5)
+        }
+        sendEvents(numberOfEvents: 4, delay: 0.5)
+        
+        waitForExpectations(timeout: 15.0) { _ in
+            print(" >>>> ERROR: batches found: \(self.apiClient.batches.count), events total: \(self.apiClient.batches.joined().count)")
+        }
+        
+        XCTAssertEqual(apiClient.batches.count, 3)
+        XCTAssertEqual(apiClient.batches.joined().count, 15)
+        XCTAssertEqual(storage.loadEvents().count, 4)
+    }
+    
+    // MARK: Helpers
+    
+    static func createQueue() -> DispatchQueue {
+        DispatchQueue(label: "AnalyticsServiceTestsQueue-\(UUID().uuidString)", qos: .background, attributes: .concurrent)
+    }
+    
+    func sendEvents(numberOfEvents: Int,
+                    delay: TimeInterval? = nil,
+                    onQueue queue: DispatchQueue = AnalyticsServiceTests.createQueue()) {
+        let events = (0..<numberOfEvents).map { num in messageEvent(withMessage: "Test #\(num + 1)") }
+        
+        print(">>>>> About to report \(events.count) events")
+        
+        events.forEach { event in
+            let callback = {
+                print(">>>>> Reporting event on queue")
+                _ = self.service.record(event: event)
+            }
+            if let delay = delay {
+                queue.asyncAfter(deadline: .now() + delay, execute: callback)
+            } else {
+                queue.async(execute: callback)
+            }
+        }
+    }
+    
+    func messageEvent(withMessage message: String) -> Analytics.Event {
+        Analytics.Event(eventType: .message, properties: MessageEventProperties(message: message, messageType: .other, severity: .info))
+    }
+}
+
+class MockAnalyticsStorage: Analytics.Storage {
+    
+    var events: [Analytics.Event] = []
+    
+    func loadEvents() -> [Analytics.Event] {
+        return events
+    }
+    
+    func save(_ events: [Analytics.Event]) throws {
+        self.events = events
+    }
+    
+    func delete(_ eventsToDelete: [Analytics.Event]?) {
+        guard let eventsToDelete = eventsToDelete else { return }
+        let idsToDelete = eventsToDelete.map { $0.localId }
+        print(">>>> Delete events (before): \(self.events.count)")
+        self.events = self.events.filter { event in
+            !idsToDelete.contains(event.localId)
+        }
+        
+        print(">>>> Delete events (after): \(self.events.count)")
+    }
+    
+    func deleteAnalyticsFile() {
+        events = []
+    }
+}
+
+class MockPrimerAPIAnalyticsClient: PrimerAPIClientAnalyticsProtocol {
+    
+    var shouldSucceed: Bool = true
+    
+    var onSendAnalyticsEvent: (([PrimerSDK.Analytics.Event]?) -> Void)?
+    
+    var batches: [[Analytics.Event]] = []
+    
+    func sendAnalyticsEvents(clientToken: DecodedJWTToken?, url: URL, body: [Analytics.Event]?, completion: @escaping ResponseHandler) {
+        guard let body = body else {
+            XCTFail(); return
+        }
+        print(">>>>> Received batch of: \(body.count)")
+        batches.append(body)
+        onSendAnalyticsEvent?(body)
+        if shouldSucceed {
+            completion(.success(.init(id: nil, result: nil)))
+        } else {
+            completion(.failure(PrimerError.generic(message: "", userInfo: nil, diagnosticsId: "")))
+        }
+    }
+}

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsStorageTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsStorageTests.swift
@@ -1,0 +1,63 @@
+//
+//  AnalyticsStorageTests.swift
+//  Debug App Tests
+//
+//  Created by Jack Newcombe on 04/12/2023.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+final class AnalyticsStorageTests: XCTestCase {
+
+    var storage: Analytics.Storage!
+    
+    let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("analytics")
+    
+    let events = [
+        Analytics.Event(eventType: .message, properties: MessageEventProperties(message: "Test #1", messageType: .other, severity: .info)),
+        Analytics.Event(eventType: .message, properties: MessageEventProperties(message: "Test #2", messageType: .other, severity: .info)),
+        Analytics.Event(eventType: .message, properties: MessageEventProperties(message: "Test #3", messageType: .other, severity: .info)),
+    ]
+    
+    override func setUpWithError() throws {
+        storage = Analytics.DefaultStorage(fileURL: url)
+    }
+
+    override func tearDownWithError() throws {
+        storage = nil
+    }
+
+    func testSaveLoadDelete() throws {
+        try storage.save(events)
+        
+        let loadedEvents = storage.loadEvents()
+        XCTAssertEqual(Set(events), Set(loadedEvents))
+        
+        storage.delete(events)
+        
+        let reloadedEvents = storage.loadEvents()
+        
+        XCTAssert(reloadedEvents.isEmpty)
+    }
+    
+    func testDeleteFile() throws {
+        try storage.save(events)
+        
+        let loadedEvents = storage.loadEvents()
+        XCTAssertEqual(Set(events), Set(loadedEvents))
+        
+        XCTAssert(FileManager.default.fileExists(atPath: url.path))
+        
+        storage.deleteAnalyticsFile()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+}
+
+extension Analytics.Event: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(localId)
+    }
+}

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
@@ -199,10 +199,10 @@ extension AnalyticsTests {
     func syncAnalyticsFile(fromQueue queue: DispatchQueue, batchSize: UInt = 100, completion: @escaping (() -> Void)) {
         queue.async {
             firstly {
-                Analytics.Service.sync(batchSize: batchSize)
-            }
-            .done {
-                
+                Promise<Void> { seal in
+                    Analytics.Service.flush()
+                    seal.fulfill()
+                }
             }
             .ensure {
                 completion()

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
@@ -17,10 +17,10 @@ extension AnalyticsTests {
             
             do {
                 let eventsData = randomStr.data(using: .utf8)!
-                try eventsData.write(to: Analytics.Service.filepath)
+                try eventsData.write(to: storage.fileURL)
                 seal.fulfill()
             } catch {
-                XCTFail("Failed to write '\(randomStr)' in '\(Analytics.Service.filepath.absoluteString)'")
+                XCTFail("Failed to write '\(randomStr)' in '\(storage.fileURL.absoluteString)'")
                 seal.reject(error)
             }
         }
@@ -160,7 +160,7 @@ extension AnalyticsTests {
     func createAnalyticsFileForRC3() {
         do {
             let eventsData = AnalyticsTestsConstants.analytics_v_2_17_0_rc_3_Events.data(using: .utf8)!
-            try eventsData.write(to: Analytics.Service.filepath)
+            try eventsData.write(to: storage.fileURL)
             
         } catch {
             XCTFail("Failed to create analytics file for RC3 - error message: \(error.localizedDescription)")
@@ -198,7 +198,7 @@ extension AnalyticsTests {
         Analytics.Service.clear()
     }
     
-    var storage: Analytics.Storage {
+    var storage: Analytics.DefaultStorage {
         return _storage
     }
 }

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
@@ -174,7 +174,7 @@ extension AnalyticsTests {
         }
     }
     
-    func syncAnalyticsFile(fromQueue queue: DispatchQueue, batchSize: UInt = 100, completion: @escaping (() -> Void)) {
+    func syncAnalyticsFile(fromQueue queue: DispatchQueue, completion: @escaping (() -> Void)) {
         queue.async {
             firstly {
                 Analytics.Service.flush()
@@ -200,6 +200,15 @@ extension AnalyticsTests {
     
     var storage: Analytics.DefaultStorage {
         return _storage
+    }
+    
+    func recreateService() {
+        Analytics.Service.shared = {
+            Analytics.Service(sdkLogsUrl: Analytics.Service.defaultSdkLogsUrl,
+                              batchSize: Analytics.Service.maximumBatchSize,
+                              storage: Analytics.storage,
+                              apiClient: Analytics.apiClient ?? PrimerAPIClient())
+        }()
     }
 }
 

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
@@ -127,22 +127,6 @@ extension AnalyticsTests {
                 DependencyContainer.register(appState as AppStateProtocol)
                 seal.fulfill(MockAppState.mockClientToken)
             }
-//            let networking = Networking()
-//            networking.requestClientSession(
-//                clientSessionRequestBody: ClientSessionRequestBody.demoClientSessionRequestBody) { clientToken, err in
-//                    if let err = err {
-//                        seal.reject(err)
-//                    } else if let clientToken = clientToken {
-//                        let settings = PrimerSettings()
-//                        DependencyContainer.register(settings as PrimerSettingsProtocol)
-//                        let appState = AppState()
-//                        appState.clientToken = clientToken
-//                        DependencyContainer.register(appState as AppStateProtocol)
-//                        seal.fulfill(clientToken)
-//                    } else {
-//                        fatalError()
-//                    }
-//                }
         }
     }
     
@@ -164,17 +148,11 @@ extension AnalyticsTests {
     
     func writeEvents(_ events: [Analytics.Event], fromQueue queue: DispatchQueue, completion: @escaping (() -> Void)) {
         queue.async {
-            firstly {
+            _ = firstly {
                 Analytics.Service.record(events: events)
-            }
-            .done {
-                
             }
             .ensure {
                 completion()
-            }
-            .catch { _ in
-                
             }
         }
     }
@@ -199,10 +177,7 @@ extension AnalyticsTests {
     func syncAnalyticsFile(fromQueue queue: DispatchQueue, batchSize: UInt = 100, completion: @escaping (() -> Void)) {
         queue.async {
             firstly {
-                Promise<Void> { seal in
-                    Analytics.Service.flush()
-                    seal.fulfill()
-                }
+                Analytics.Service.flush()
             }
             .ensure {
                 completion()
@@ -215,13 +190,11 @@ extension AnalyticsTests {
     
     func cleanUpAnalytics() {
         self.deleteAnalyticsFileSynchonously()
-        let storedEvents = (try? Analytics.Service.loadEvents()) ?? []
+        let storedEvents = Analytics.Service.loadEvents()
         XCTAssert(storedEvents.count == 0, "Analytics events should be empty")
     }
     
     func deleteAnalyticsFileSynchonously() {
-        Analytics.queue.sync {
-            Analytics.Service.deleteAnalyticsFile()
-        }
+        Analytics.Service.deleteAnalyticsFile()
     }
 }

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
@@ -190,11 +190,17 @@ extension AnalyticsTests {
     
     func cleanUpAnalytics() {
         self.deleteAnalyticsFileSynchonously()
-        let storedEvents = Analytics.Service.loadEvents()
+        let storedEvents = storage.loadEvents()
         XCTAssert(storedEvents.count == 0, "Analytics events should be empty")
     }
     
     func deleteAnalyticsFileSynchonously() {
-        Analytics.Service.deleteAnalyticsFile()
+        Analytics.Service.clear()
+    }
+    
+    var storage: Analytics.Storage {
+        return _storage
     }
 }
+
+fileprivate let _storage = Analytics.DefaultStorage()

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests+Helpers.swift
@@ -215,7 +215,7 @@ extension AnalyticsTests {
     
     func cleanUpAnalytics() {
         self.deleteAnalyticsFileSynchonously()
-        let storedEvents = (try? Analytics.Service.loadEventsSynchronously()) ?? []
+        let storedEvents = (try? Analytics.Service.loadEvents()) ?? []
         XCTAssert(storedEvents.count == 0, "Analytics events should be empty")
     }
     

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
@@ -272,8 +272,8 @@ class AnalyticsTests: XCTestCase {
 
         waitForExpectations(timeout: 10)
         
-        if FileManager.default.fileExists(atPath: Analytics.Service.filepath.path) {
-            XCTFail("Failed to delete analytics file at '\(Analytics.Service.filepath.absoluteString)'")
+        if FileManager.default.fileExists(atPath: storage.fileURL.path) {
+            XCTFail("Failed to delete analytics file at '\(storage.fileURL.absoluteString)'")
         }
     }
     

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
@@ -11,6 +11,10 @@ import XCTest
 
 class AnalyticsTests: XCTestCase {
     
+    override func tearDown() {
+        self.cleanUpAnalytics()
+    }
+    
     var newEvents: [Analytics.Event] {
         return [
             Analytics.Event(
@@ -206,6 +210,7 @@ class AnalyticsTests: XCTestCase {
         let mockApiClient = MockPrimerAPIClient()
         mockApiClient.sendAnalyticsEventsResult = (Analytics.Service.Response(id: "mock-d", result: "success"), nil)
         Analytics.apiClient = mockApiClient
+        recreateService()
         
         self.createAnalyticsFileForRC3()
         
@@ -489,7 +494,8 @@ class AnalyticsTests: XCTestCase {
         let mockApiClient = MockPrimerAPIClient()
         mockApiClient.mockSuccessfulResponses()
         Analytics.apiClient = mockApiClient
-        
+        recreateService()
+
         self.cleanUpAnalytics()
         self.createAnalyticsFileForRC3()
         

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
@@ -97,24 +97,14 @@ class AnalyticsTests: XCTestCase {
         }
         .then { events -> Promise<[Analytics.Event]> in
             newEvents.append(contentsOf: events)
-
-            do {
-                let storedEvents = try Analytics.Service.loadEvents()
-                return Promise { seal in
-                    seal.fulfill(storedEvents)
-                }
-
-            } catch {
-                return Promise { seal in
-                    seal.reject(error)
-                }
-            }
+            return Promise.fulfilled(Analytics.Service.loadEvents())
         }
         .done { events in
             storedEvents = events
             exp.fulfill()
         }
         .catch { _ in
+            XCTFail()
             exp.fulfill()
         }
 
@@ -216,7 +206,7 @@ class AnalyticsTests: XCTestCase {
         
         wait(for: expectationsToBeFulfilled, timeout: 30)
         
-        var storedEvents = (try? Analytics.Service.loadEvents()) ?? []
+        var storedEvents = Analytics.Service.loadEvents()
         XCTAssert(storedEvents.count == 10, "storedEvents should be 10")
     }
     
@@ -230,7 +220,6 @@ class AnalyticsTests: XCTestCase {
         let exp = expectation(description: "Await")
         
         var storedEvents: [Analytics.Event]?
-        let batchSize: UInt = 4
         
         self.deleteAnalyticsFileSynchonously()
         
@@ -238,49 +227,26 @@ class AnalyticsTests: XCTestCase {
             // Create events without having a client token yet
             self.createEvents()
         }
-        .then { events -> Promise<Void> in
-            return Analytics.Service.record(events: events)
+        .then { events in
+            Analytics.Service.record(events: events)
         }
-        .then { () -> Promise<String> in
-            self.createDemoClientSessionAndSetAppState()
+        .then {
+            Analytics.Service.flush()
         }
-        .then { _ -> Promise<[Analytics.Event]> in
-            return self.createEvents()
+        .then {
+            self.createEvents()
         }
-        .then { events -> Promise<Void> in
-            return Analytics.Service.record(events: events)
+        .then { events in
+            Analytics.Service.record(events: events)
         }
-        .then { () -> Promise<[Analytics.Event]> in
-            do {
-                let storedEvents = try Analytics.Service.loadEvents()
-                return Promise { seal in
-                    seal.fulfill(storedEvents)
-                }
-                
-            } catch {
-                return Promise { seal in
-                    seal.reject(error)
-                }
-            }
+        .then {
+            Promise.fulfilled(Analytics.Service.loadEvents())
         }
-        .then { _ -> Promise<Void> in
-            Promise<Void> {
-                Analytics.Service.flush()
-                $0.fulfill()
-            }
+        .then { _ in
+            Analytics.Service.flush()
         }
-        .then { () -> Promise<[Analytics.Event]> in
-            do {
-                let storedEvents = try Analytics.Service.loadEvents()
-                return Promise { seal in
-                    seal.fulfill(storedEvents)
-                }
-                
-            } catch {
-                return Promise { seal in
-                    seal.reject(error)
-                }
-            }
+        .then {
+            Promise.fulfilled(Analytics.Service.loadEvents())
         }
         .done { events in
             storedEvents = events
@@ -354,7 +320,7 @@ class AnalyticsTests: XCTestCase {
         
         wait(for: [recordEvent], timeout: 10)
         
-        let events = (try? Analytics.Service.loadEvents()) ?? []
+        let events = Analytics.Service.loadEvents()
         let errorEvents = events.filter({ ($0.properties as? MessageEventProperties)?.diagnosticsId == diagnosticsId })
         let errorEvent = errorEvents.first
         
@@ -375,7 +341,8 @@ class AnalyticsTests: XCTestCase {
     func test_recording_race_conditions() throws {
         self.cleanUpAnalytics()
         self.createAnalyticsFileForRC3()
-        var storedEvents = (try? Analytics.Service.loadEvents()) ?? []
+        
+        var storedEvents = Analytics.Service.loadEvents()
         XCTAssert(storedEvents.count == 0, "Analytics events should be empty")
         
         let serialQueue     = DispatchQueue(label: "Serial Queue")
@@ -386,6 +353,20 @@ class AnalyticsTests: XCTestCase {
         let writeEventsOnSerialQueueExpectation2 = expectation(description: "Write events on \(serialQueue.label) 2")
         let writeEventsOnConcurrentQueueExpectation1 = expectation(description: "Write events on \(concurrentQueue.label) 1")
         let writeEventsOnConcurrentQueueExpectation2 = expectation(description: "Write events on \(concurrentQueue.label) 2")
+        
+        // Setup app state
+        
+        let appStateExpectation = self.expectation(description: "App state setup")
+        
+        firstly {
+            self.createDemoClientSessionAndSetAppState().erase()
+        }.done {
+            appStateExpectation.fulfill()
+        }.catch {
+            XCTFail("Failed to setup app state: \($0.localizedDescription)")
+        }
+        
+        wait(for: [appStateExpectation], timeout: 5.0)
         
         // Record events from different queues
         
@@ -405,11 +386,11 @@ class AnalyticsTests: XCTestCase {
             .done {
                 eventsIds.append(e1_1.localId)
             }
-            .ensure {
-                writeEventsOnSerialQueueExpectation1.fulfill()
-            }
             .catch { err in
-                XCTAssert(false, err.localizedDescription)
+                XCTFail(err.localizedDescription)
+            }
+            .finally {
+                writeEventsOnSerialQueueExpectation1.fulfill()
             }
         }
         
@@ -427,11 +408,11 @@ class AnalyticsTests: XCTestCase {
             .done {
                 eventsIds.append(e1_2.localId)
             }
-            .ensure {
-                writeEventsOnSerialQueueExpectation2.fulfill()
-            }
             .catch { err in
-                XCTAssert(false, err.localizedDescription)
+                XCTFail(err.localizedDescription)
+            }
+            .finally {
+                writeEventsOnSerialQueueExpectation2.fulfill()
             }
         }
         
@@ -449,12 +430,13 @@ class AnalyticsTests: XCTestCase {
             .done {
                 eventsIds.append(e2_1.localId)
             }
-            .ensure {
+            .catch { err in
+                XCTFail(err.localizedDescription)
+            }
+            .finally {
                 writeEventsOnConcurrentQueueExpectation1.fulfill()
             }
-            .catch { err in
-                XCTAssert(false, err.localizedDescription)
-            }
+
         }
         
         concurrentQueue.async {
@@ -471,11 +453,11 @@ class AnalyticsTests: XCTestCase {
             .done {
                 eventsIds.append(e2_2.localId)
             }
-            .ensure {
-                writeEventsOnConcurrentQueueExpectation2.fulfill()
-            }
             .catch { err in
-                XCTAssert(false, err.localizedDescription)
+                XCTFail(err.localizedDescription)
+            }
+            .finally {
+                writeEventsOnConcurrentQueueExpectation2.fulfill()
             }
         }
         
@@ -492,13 +474,13 @@ class AnalyticsTests: XCTestCase {
         .done {
             eventsIds.append(e3.localId)
         }
-        .ensure {
+        .catch { err in
+            XCTFail(err.localizedDescription)
+        }
+        .finally {
             writeEventsOnMainQueueExpectation1.fulfill()
         }
-        .catch { err in
-            XCTAssert(false, err.localizedDescription)
-        }
-        
+
         wait(for: [
             writeEventsOnMainQueueExpectation1,
             writeEventsOnSerialQueueExpectation1,
@@ -507,431 +489,8 @@ class AnalyticsTests: XCTestCase {
             writeEventsOnConcurrentQueueExpectation2
         ], timeout: 20)
                 
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        XCTAssert(storedEvents.count == eventsIds.count, "Analytics file should contain \(eventsIds.count) events")
-    }
-    
-    func test_race_conditions_on_recording_and_deleting_events() throws {
-        let mockApiClient = MockPrimerAPIClient()
-        mockApiClient.sendAnalyticsEventsResult = (Analytics.Service.Response(id: "mock-d", result: "success"), nil)
-        Analytics.apiClient = mockApiClient
-        
-        self.cleanUpAnalytics()
-        self.createAnalyticsFileForRC3()
-        var storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        
-        self.createAnalyticsFileForRC3()
-
-        let createClientSessionExpectation = expectation(description: "Create client session")
-        let expectationsToBeFulfilled = [createClientSessionExpectation]
-        
-        firstly {
-            self.createDemoClientSessionAndSetAppState()
-        }
-        .done { _ in
-            createClientSessionExpectation.fulfill()
-        }
-        .catch { err in
-            XCTAssert(false, err.localizedDescription)
-        }
-        
-        wait(for: expectationsToBeFulfilled, timeout: 30)
-        
-        let serialQueue     = DispatchQueue(label: "Serial Queue")
-        let concurrentQueue = DispatchQueue(label: "Concurrent Queue", attributes: .concurrent)
-        
-        let writeEventsOnMainQueueExpectation1 = expectation(description: "Write events on main queue 1")
-        let writeEventsOnSerialQueueExpectation1 = expectation(description: "Write events on \(serialQueue.label) 1")
-        let writeEventsOnSerialQueueExpectation2 = expectation(description: "Write events on \(serialQueue.label) 2")
-        let writeEventsOnConcurrentQueueExpectation1 = expectation(description: "Write events on \(concurrentQueue.label) 1")
-        let writeEventsOnConcurrentQueueExpectation2 = expectation(description: "Write events on \(concurrentQueue.label) 2")
-        
-        // Record events from different threads/queues
-        
-        var eventsIds: [String] = []
-        
-        var e1_1: Analytics.Event!
-        var e1_2: Analytics.Event!
-        var e2_1: Analytics.Event!
-        var e2_2: Analytics.Event!
-        var e3: Analytics.Event!
-        
-        serialQueue.async {
-            e1_1 = Analytics.Event(
-                eventType: .message,
-                properties: MessageEventProperties(
-                    message: "An error message 1.1",
-                    messageType: .error,
-                    severity: .error))
-            
-            firstly {
-                Analytics.Service.record(events: [e1_1])
-            }
-            .done {
-                eventsIds.append(e1_1.localId)
-            }
-            .ensure {
-                writeEventsOnSerialQueueExpectation1.fulfill()
-            }
-            .catch { err in
-                XCTAssert(false, err.localizedDescription)
-            }
-        }
-        
-        serialQueue.async {
-            e1_2 = Analytics.Event(
-                eventType: .message,
-                properties: MessageEventProperties(
-                    message: "An error message 1.2",
-                    messageType: .error,
-                    severity: .error))
-            
-            firstly {
-                Analytics.Service.record(events: [e1_2])
-            }
-            .done {
-                eventsIds.append(e1_2.localId)
-            }
-            .ensure {
-                writeEventsOnSerialQueueExpectation2.fulfill()
-            }
-            .catch { err in
-                XCTAssert(false, err.localizedDescription)
-            }
-        }
-        
-        concurrentQueue.async {
-            e2_1 = Analytics.Event(
-                eventType: .message,
-                properties: MessageEventProperties(
-                    message: "An error message 2_1",
-                    messageType: .error,
-                    severity: .error))
-            
-            firstly {
-                Analytics.Service.record(events: [e2_1])
-            }
-            .done {
-                eventsIds.append(e2_1.localId)
-            }
-            .ensure {
-                writeEventsOnConcurrentQueueExpectation1.fulfill()
-            }
-            .catch { err in
-                XCTAssert(false, err.localizedDescription)
-            }
-        }
-        
-        concurrentQueue.async {
-            e2_2 = Analytics.Event(
-                eventType: .message,
-                properties: MessageEventProperties(
-                    message: "An error message 2.2",
-                    messageType: .error,
-                    severity: .error))
-            
-            firstly {
-                Analytics.Service.record(events: [e2_2])
-            }
-            .done {
-                eventsIds.append(e2_2.localId)
-            }
-            .ensure {
-                writeEventsOnConcurrentQueueExpectation2.fulfill()
-            }
-            .catch { err in
-                XCTAssert(false, err.localizedDescription)
-            }
-        }
-        
-        e3 = Analytics.Event(
-            eventType: .message,
-            properties: MessageEventProperties(
-                message: "An error message 3",
-                messageType: .error,
-                severity: .error))
-        
-        firstly {
-            Analytics.Service.record(events: [e3])
-        }
-        .done {
-            eventsIds.append(e3.localId)
-        }
-        .ensure {
-            writeEventsOnMainQueueExpectation1.fulfill()
-        }
-        .catch { err in
-            XCTAssert(false, err.localizedDescription)
-        }
-        
-        wait(for: [
-            writeEventsOnMainQueueExpectation1,
-            writeEventsOnSerialQueueExpectation1,
-            writeEventsOnSerialQueueExpectation2,
-            writeEventsOnConcurrentQueueExpectation1,
-            writeEventsOnConcurrentQueueExpectation2
-        ], timeout: 20)
-                
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        let storedEventsIds = storedEvents.compactMap({ $0.localId })
-        
-        XCTAssert(storedEventsIds.contains(e1_1.localId), "Analytics file should contain event \(e1_1.localId)")
-        XCTAssert(storedEventsIds.contains(e1_2.localId), "Analytics file should contain event \(e1_2.localId)")
-        XCTAssert(storedEventsIds.contains(e2_2.localId), "Analytics file should contain event \(e2_2.localId)")
-        XCTAssert(storedEventsIds.contains(e3.localId), "Analytics file should contain event \(e3.localId)")
-        XCTAssert(storedEvents.count == eventsIds.count, "Analytics file should contain \(eventsIds.count) events")
-
-        // Delete events from different queues
-
-        Analytics.Service.delete([e3])
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        var deletedEvent3 = storedEvents.first(where: { $0.localId == e3.localId })
-        XCTAssert(deletedEvent3 == nil, "Stored events should not contain event \(deletedEvent3?.localId ?? "n/a")")
-        eventsIds = eventsIds.filter({ $0 != e3.localId })
-
-        // Now let's delete different events by dispatching async on the same serial queue
-
-        let deleteEvent1OnSerialQueueExpectation = expectation(description: "Delete event e1_1 on serial queue")
-        let deleteEvent2OnSerialQueueExpectation = expectation(description: "Delete event e1_2 on serial queue")
-
-        serialQueue.async {
-            Analytics.Service.delete([e1_1])
-            eventsIds = eventsIds.filter({ $0 != e1_1.localId })
-            deleteEvent1OnSerialQueueExpectation.fulfill()
-        }
-
-        serialQueue.async {
-            Analytics.Service.delete([e1_2])
-            eventsIds = eventsIds.filter({ $0 != e1_2.localId })
-            deleteEvent2OnSerialQueueExpectation.fulfill()
-        }
-
-        wait(for: [deleteEvent1OnSerialQueueExpectation, deleteEvent2OnSerialQueueExpectation], timeout: 10)
-
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-
-        var deletedEvent1_1 = storedEvents.first(where: { $0.localId == e1_1.localId })
-        var deletedEvent1_2 = storedEvents.first(where: { $0.localId == e1_2.localId })
-
-        XCTAssert(deletedEvent1_1 == nil && deletedEvent1_2 == nil, "Stored events should not contain events \(deletedEvent1_1?.localId ?? "n/a") and \(deletedEvent1_2?.localId ?? "n/a")")
-
-        let storedE2_1 = storedEvents.first(where: { $0.localId == e2_1.localId })
-        let storedE2_2 = storedEvents.first(where: { $0.localId == e2_2.localId })
-        XCTAssert(storedE2_1 != nil && storedE2_2 != nil, "e2_1 and e2_2 should still be stored")
-
-        // Now let's delete different events by dispatching async on the same concurrent queue
-
-        let deleteEvent1OnConcurrentQueueExpectation = expectation(description: "Delete event e2_1 on concurrent queue")
-        let deleteEvent2OnConcurrentQueueExpectation = expectation(description: "Delete event e2_2 on concurrent queue")
-
-        concurrentQueue.async {
-            Analytics.Service.delete([e2_1])
-            eventsIds = eventsIds.filter({ $0 != e2_1.localId })
-            deleteEvent1OnConcurrentQueueExpectation.fulfill()
-        }
-
-        concurrentQueue.async {
-            Analytics.Service.delete([e2_2])
-            eventsIds = eventsIds.filter({ $0 != e2_2.localId })
-            deleteEvent2OnConcurrentQueueExpectation.fulfill()
-        }
-
-        wait(for: [
-            deleteEvent1OnConcurrentQueueExpectation,
-            deleteEvent2OnConcurrentQueueExpectation
-        ], timeout: 10)
-
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-
-        var deletedEvent2_1 = storedEvents.first(where: { $0.localId == e2_1.localId })
-        var deletedEvent2_2 = storedEvents.first(where: { $0.localId == e2_2.localId })
-
-        XCTAssert(deletedEvent2_1 == nil && deletedEvent2_2 == nil, "Stored events should not contain events \(deletedEvent2_1?.localId ?? "n/a") and \(deletedEvent2_2?.localId ?? "n/a")")
-        XCTAssert(storedEvents.isEmpty, "Stored events should be empty")
-
-        // Rewrite some events
-        
-        let rewriteEventsFromMainQueueExpectation = expectation(description: "Rewrite events from the main queue")
-        
-        e1_1 = Analytics.Event(
-            eventType: .message,
-            properties: MessageEventProperties(
-                message: "An error message 1.1",
-                messageType: .error,
-                severity: .error))
-        e1_2 = Analytics.Event(
-            eventType: .message,
-            properties: MessageEventProperties(
-                message: "An error message 1.2",
-                messageType: .error,
-                severity: .error))
-        e2_1 = Analytics.Event(
-            eventType: .message,
-            properties: MessageEventProperties(
-                message: "An error message 2.1",
-                messageType: .error,
-                severity: .error))
-        e2_2 = Analytics.Event(
-            eventType: .message,
-            properties: MessageEventProperties(
-                message: "An error message 2.2",
-                messageType: .error,
-                severity: .error))
-        e3 = Analytics.Event(
-            eventType: .message,
-            properties: MessageEventProperties(
-                message: "An error message 3",
-                messageType: .error,
-                severity: .error))
-        
-        let events = [e1_1!, e1_2!, e2_1!, e2_2!, e3!]
-        
-        firstly {
-            Analytics.Service.record(events: events)
-        }
-        .done {
-            storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-            eventsIds = events.compactMap({ $0.localId })
-        }
-        .ensure {
-            rewriteEventsFromMainQueueExpectation.fulfill()
-        }
-        .catch { err in
-            XCTAssert(false, err.localizedDescription)
-        }
-        
-        wait(for: [rewriteEventsFromMainQueueExpectation], timeout: 10)
-        
-        let deleteEvent3OnMainQueueExpectation2       = expectation(description: "Delete event e3 on main queue")
-        let deleteEvent1OnSerialQueueExpectation2     = expectation(description: "Delete event e1_1 on serial queue")
-        let deleteEvent1OnConcurrentQueueExpectation2 = expectation(description: "Delete event e2_1 on concurrent queue")
-        
-        serialQueue.async {
-            Analytics.Service.delete([e1_1])
-            eventsIds = eventsIds.filter({ $0 != e1_1.localId })
-            deleteEvent1OnSerialQueueExpectation2.fulfill()
-        }
-        
-        concurrentQueue.async {
-            Analytics.Service.delete([e2_1])
-            eventsIds = eventsIds.filter({ $0 != e2_1.localId })
-            deleteEvent1OnConcurrentQueueExpectation2.fulfill()
-        }
-        
-        // I'm having so much fun, so let's delete an event from the main queue
-        
-        Analytics.Service.delete([e3])
-        deleteEvent3OnMainQueueExpectation2.fulfill()
-        eventsIds = eventsIds.filter({ $0 != e3.localId })
-        
-        wait(for: [
-            deleteEvent1OnSerialQueueExpectation2,
-            deleteEvent1OnConcurrentQueueExpectation2,
-            deleteEvent3OnMainQueueExpectation2
-        ], timeout: 10)
-        
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        deletedEvent1_1 = storedEvents.first(where: { $0.localId == e1_1.localId })
-        deletedEvent2_1 = storedEvents.first(where: { $0.localId == e2_1.localId })
-        deletedEvent3 = storedEvents.first(where: { $0.localId == e3.localId })
-        
-        XCTAssert(deletedEvent1_1 == nil && deletedEvent2_1 == nil && deletedEvent3 == nil, "Stored events should not contain events \(deletedEvent1_1?.localId ?? "n/a") and \(deletedEvent2_1?.localId ?? "n/a")")
-        XCTAssert(storedEvents.count == eventsIds.count, "Stored events should be empty")
-        
-        // At this point e1_2 and e2_2 are still in the stored events.
-        // Test recording a new event (e3), while deleting the other 2
-
-        let writeEvent1OnSerialQueueExpectation3      = expectation(description: "Write event e1_1 on serial queue")
-        let writeEvent1OnConcurrentQueueExpectation3  = expectation(description: "Write event e2_1 on concurrent queue")
-        let deleteEvent2OnSerialQueueExpectation3     = expectation(description: "Delete event e1_2 on serial queue")
-        let deleteEvent2OnConcurrentQueueExpectation3 = expectation(description: "Delete event e2_2 on concurrent queue")
-
-        e1_1 = Analytics.Event(
-            eventType: .message,
-            properties: MessageEventProperties(
-                message: "An error message 1.1",
-                messageType: .error,
-                severity: .error))
-        e2_1 = Analytics.Event(
-            eventType: .message,
-            properties: MessageEventProperties(
-                message: "An error message 2.1",
-                messageType: .error,
-                severity: .error))
-        
-        serialQueue.async {
-            firstly {
-                Analytics.Service.record(events: [e1_1])
-            }
-            .done {
-                eventsIds.append(e1_1.localId)
-            }
-            .ensure {
-                writeEvent1OnSerialQueueExpectation3.fulfill()
-            }
-            .catch { err in
-                XCTAssert(false, err.localizedDescription)
-            }
-        }
-        
-        serialQueue.async {
-            Analytics.Service.delete([e1_2])
-            eventsIds = eventsIds.filter({ $0 != e1_2.localId })
-            deleteEvent2OnSerialQueueExpectation3.fulfill()
-        }
-
-        concurrentQueue.async {
-            firstly {
-                Analytics.Service.record(events: [e2_1])
-            }
-            .done {
-                eventsIds.append(e2_1.localId)
-            }
-            .ensure {
-                writeEvent1OnConcurrentQueueExpectation3.fulfill()
-            }
-            .catch { err in
-                XCTAssert(false, err.localizedDescription)
-            }
-        }
-        
-        concurrentQueue.async {
-            Analytics.Service.delete([e2_2])
-            eventsIds = eventsIds.filter({ $0 != e2_2.localId })
-            deleteEvent2OnConcurrentQueueExpectation3.fulfill()
-        }
-        
-        wait(for: [
-            writeEvent1OnSerialQueueExpectation3,
-            writeEvent1OnConcurrentQueueExpectation3,
-            deleteEvent2OnSerialQueueExpectation3,
-            deleteEvent2OnConcurrentQueueExpectation3
-        ], timeout: 10)
-        
-        // Now events e1_1, e2_1 and e3 should still be in
-        
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        let storedEvent1_1 = storedEvents.first(where: { $0.localId == e1_1.localId })
-        let storedEvent2_1 = storedEvents.first(where: { $0.localId == e2_1.localId })
-        deletedEvent1_2 = storedEvents.first(where: { $0.localId == e1_2.localId })
-        deletedEvent2_2 = storedEvents.first(where: { $0.localId == e2_2.localId })
-        
-        XCTAssert(
-            storedEvent1_1?.localId != nil &&
-            storedEvent1_1?.localId == e1_1.localId &&
-            eventsIds.contains(storedEvent1_1!.localId),
-            "Analytics file should contain event \(e1_1.localId)"
-        )
-        
-        XCTAssert(
-            storedEvent2_1?.localId != nil &&
-            storedEvent2_1?.localId == e2_1.localId &&
-            eventsIds.contains(storedEvent2_1!.localId),
-            "Analytics file should contain event \(e2_1.localId)"
-        )
-        
-        XCTAssert(deletedEvent1_2 == nil, "Event \(e1_2.localId) should be deleted")
-        XCTAssert(deletedEvent2_2 == nil, "Event \(e2_2.localId) should be deleted")
+        storedEvents = Analytics.Service.loadEvents()
+        XCTAssert(storedEvents.count == eventsIds.count, "Analytics file should contain \(eventsIds.count) events but found \(storedEvents.count)")
     }
     
     func test_race_conditions_on_syncing() throws {
@@ -942,7 +501,7 @@ class AnalyticsTests: XCTestCase {
         self.cleanUpAnalytics()
         self.createAnalyticsFileForRC3()
         
-        var storedEvents = (try? Analytics.Service.loadEvents()) ?? []
+        var storedEvents = Analytics.Service.loadEvents()
         
         let events = self.createEvents(1000, withMessage: "A message")
         var eventsIds: [String] = []
@@ -967,7 +526,7 @@ class AnalyticsTests: XCTestCase {
         }
         
         wait(for: expectationsToBeFulfilled, timeout: 20)
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
+        storedEvents = Analytics.Service.loadEvents()
         XCTAssert(storedEvents.count == eventsIds.count, "Analytics file should contain \(eventsIds.count) events")
         
         let createClientSessionExpectation    = expectation(description: "Create client session")
@@ -1023,241 +582,35 @@ class AnalyticsTests: XCTestCase {
         }
         
         wait(for: expectationsToBeFulfilled, timeout: 60)
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
+        storedEvents = Analytics.Service.loadEvents()
         let nonNetworkEvents = storedEvents.filter({ $0.eventType != .networkCall && $0.eventType != .networkConnectivity })
         XCTAssert(nonNetworkEvents.count == 0, "nonNetworkEvents: \(nonNetworkEvents.count)")
     }
+}
+
+
+extension Promise {
+    static func fulfilled(_ value: T) -> Promise<T> {
+        return Promise<T> { $0.fulfill(value) }
+    }
     
-    func test_race_conditions_on_creating_events_and_deleting_analytics_file() throws {
-        self.cleanUpAnalytics()
-        self.createAnalyticsFileForRC3()
-        
-        self.createAnalyticsFileForRC3()
-        
-        var storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        XCTAssert(storedEvents.isEmpty, "storedEvents should be empty since load should delete migration events")
-        
-        let serialQueue     = DispatchQueue(label: "Serial Queue")
-        let concurrentQueue = DispatchQueue(label: "Concurrent Queue", attributes: .concurrent)
-        
-        var expectationsToBeFulfilled: [XCTestExpectation] = []
-        
-        let writeEventsOnMainQueueExpectation = expectation(description: "Write events from main queue")
-        var writeEventsOnSerialQueueExpectation1 = expectation(description: "Write events on \(serialQueue.label) [1]")
-        let writeEventsOnSerialQueueExpectation2 = expectation(description: "Write events on \(serialQueue.label) 2")
-        var writeEventsOnConcurrentQueueExpectation1 = expectation(description: "Write events on \(concurrentQueue.label) 1")
-        let writeEventsOnConcurrentQueueExpectation2 = expectation(description: "Write events on \(concurrentQueue.label) 2")
-        expectationsToBeFulfilled = [
-            writeEventsOnMainQueueExpectation,
-            writeEventsOnSerialQueueExpectation1,
-            writeEventsOnSerialQueueExpectation2,
-            writeEventsOnConcurrentQueueExpectation1,
-            writeEventsOnConcurrentQueueExpectation2
-        ]
-        
-        // Record events from different queues
-        
-        var eventsIds: [String] = []
-        
-        var serialQueueEvents1 = self.createEvents(2, withMessage: "Serial queue 1")
-        let serialQueueEvents2 = self.createEvents(2, withMessage: "Serial queue 2")
-        var concurrentQueueEvents1 = self.createEvents(2, withMessage: "Concurrent queue 1")
-        let concurrentQueueEvents2 = self.createEvents(2, withMessage: "Concurrent queue 2")
-        var mainQueueEvents = self.createEvents(2, withMessage: "Main queue")
-        
-        self.writeEvents(serialQueueEvents1, fromQueue: serialQueue) {
-            eventsIds.append(contentsOf: serialQueueEvents1.compactMap({ $0.localId }))
-            writeEventsOnSerialQueueExpectation1.fulfill()
+    static func rejected(_ error: Error) -> Promise<T> {
+        return Promise<T> { $0.reject(error) }
+    }
+    
+    static func resolved(_ closure: () throws -> T) -> Promise<T> {
+        Promise<T> { seal in
+            do {
+                seal.fulfill(try closure())
+            } catch {
+                seal.reject(error)
+            }
         }
-        
-        self.writeEvents(serialQueueEvents2, fromQueue: serialQueue) {
-            eventsIds.append(contentsOf: serialQueueEvents2.compactMap({ $0.localId }))
-            writeEventsOnSerialQueueExpectation2.fulfill()
+    }
+    
+    func erase() -> Promise<Void> {
+        then { _ in
+            Promise<Void>.fulfilled(())
         }
-        
-        self.writeEvents(concurrentQueueEvents1, fromQueue: concurrentQueue) {
-            eventsIds.append(contentsOf: concurrentQueueEvents1.compactMap({ $0.localId }))
-            writeEventsOnConcurrentQueueExpectation1.fulfill()
-        }
-        
-        self.writeEvents(concurrentQueueEvents2, fromQueue: concurrentQueue) {
-            eventsIds.append(contentsOf: concurrentQueueEvents2.compactMap({ $0.localId }))
-            writeEventsOnConcurrentQueueExpectation2.fulfill()
-        }
-        
-        self.writeEvents(mainQueueEvents, fromQueue: DispatchQueue.main) {
-            eventsIds.append(contentsOf: mainQueueEvents.compactMap({ $0.localId }))
-            writeEventsOnMainQueueExpectation.fulfill()
-        }
-        
-        wait(for: expectationsToBeFulfilled, timeout: 20)
-        expectationsToBeFulfilled = []
-                
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        XCTAssert(storedEvents.count == eventsIds.count, "Analytics file should contain \(eventsIds.count) events")
-        
-        for event in storedEvents {
-            XCTAssert(eventsIds.contains(event.localId), "Analytics file should contain event \(event.localId)")
-        }
-        
-        // Delete analytics file from different queues
-        
-        let deleteFileOnMainQueueExpectation1 = expectation(description: "Delete analytics file on main queue 1")
-        let deleteFileOnSerialQueueExpectation1 = expectation(description: "Delete analytics file on \(serialQueue.label) 1")
-        var deleteFileOnSerialQueueExpectation2 = expectation(description: "Delete analytics file on \(serialQueue.label) 2")
-        var deleteFileOnConcurrentQueueExpectation1 = expectation(description: "Delete analytics file on \(concurrentQueue.label) 1")
-        var deleteFileOnConcurrentQueueExpectation2 = expectation(description: "Delete analytics file on \(concurrentQueue.label) 2")
-        expectationsToBeFulfilled = [
-            deleteFileOnMainQueueExpectation1,
-            deleteFileOnSerialQueueExpectation1,
-            deleteFileOnSerialQueueExpectation2,
-            deleteFileOnConcurrentQueueExpectation1,
-            deleteFileOnConcurrentQueueExpectation2
-        ]
-        
-        self.deleteAnalyticsFile(fromQueue: serialQueue) {
-            deleteFileOnSerialQueueExpectation1.fulfill()
-        }
-        
-        self.deleteAnalyticsFile(fromQueue: serialQueue) {
-            deleteFileOnSerialQueueExpectation2.fulfill()
-        }
-        
-        self.deleteAnalyticsFile(fromQueue: serialQueue) {
-            deleteFileOnConcurrentQueueExpectation1.fulfill()
-        }
-        
-        self.deleteAnalyticsFile(fromQueue: serialQueue) {
-            deleteFileOnConcurrentQueueExpectation2.fulfill()
-        }
-        
-        self.deleteAnalyticsFile(fromQueue: serialQueue) {
-            deleteFileOnMainQueueExpectation1.fulfill()
-        }
-        
-        wait(for: expectationsToBeFulfilled, timeout: 20)
-        expectationsToBeFulfilled = []
-        
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        XCTAssert(storedEvents.isEmpty, "Stored events in analytics file should be 0")
-     
-        // Rewrite some events
-        
-        let rewriteEventsFromMainQueueExpectation = expectation(description: "Rewrite events from the main queue")
-        expectationsToBeFulfilled = [rewriteEventsFromMainQueueExpectation]
-        
-        mainQueueEvents = self.createEvents(5, withMessage: "A message")
-        
-        self.writeEvents(mainQueueEvents, fromQueue: DispatchQueue.main) {
-            eventsIds = mainQueueEvents.compactMap({ $0.localId })
-            rewriteEventsFromMainQueueExpectation.fulfill()
-        }
-        
-        wait(for: expectationsToBeFulfilled, timeout: 20)
-        expectationsToBeFulfilled = []
-        
-        // TEST
-        // - Write events from serial queue
-        // - Delete analytics file from serial queue
-        
-        writeEventsOnSerialQueueExpectation1 = expectation(description: "Write events on \(serialQueue.label) [1]")
-        deleteFileOnSerialQueueExpectation2 = expectation(description: "Delete analytics file on \(serialQueue.label) [2]")
-        expectationsToBeFulfilled = [writeEventsOnSerialQueueExpectation1, deleteFileOnSerialQueueExpectation2]
-        
-        serialQueueEvents1 = self.createEvents(2, withMessage: "Serial queue 1")
-                
-        self.writeEvents(serialQueueEvents1, fromQueue: serialQueue) {
-            eventsIds.append(contentsOf: serialQueueEvents1.compactMap({ $0.localId }))
-            writeEventsOnSerialQueueExpectation1.fulfill()
-        }
-        
-        self.deleteAnalyticsFile(fromQueue: serialQueue) {
-            eventsIds = []
-            deleteFileOnSerialQueueExpectation2.fulfill()
-        }
-        
-        wait(for: expectationsToBeFulfilled, timeout: 20)
-        expectationsToBeFulfilled = []
-        
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        XCTAssert(storedEvents.count == eventsIds.count, "Analytics file should contain \(eventsIds.count) events")
-        
-        // TEST
-        // - Write events from serial queue
-        // - Delete analytics file from serial queue
-        
-        writeEventsOnConcurrentQueueExpectation1 = expectation(description: "Write events on \(concurrentQueue.label) [1]")
-        deleteFileOnConcurrentQueueExpectation2 = expectation(description: "Delete analytics file on \(concurrentQueue.label) [2]")
-        expectationsToBeFulfilled = [writeEventsOnConcurrentQueueExpectation1, deleteFileOnConcurrentQueueExpectation2]
-        
-        concurrentQueueEvents1 = self.createEvents(2, withMessage: "Concurrent queue 1")
-                
-        self.writeEvents(concurrentQueueEvents1, fromQueue: concurrentQueue) {
-            eventsIds.append(contentsOf: concurrentQueueEvents1.compactMap({ $0.localId }))
-            writeEventsOnConcurrentQueueExpectation1.fulfill()
-        }
-        
-        self.deleteAnalyticsFile(fromQueue: concurrentQueue) {
-            eventsIds = []
-            deleteFileOnConcurrentQueueExpectation2.fulfill()
-        }
-        
-        wait(for: expectationsToBeFulfilled, timeout: 20)
-        expectationsToBeFulfilled = []
-        
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        XCTAssert(storedEvents.count == eventsIds.count, "Analytics file should contain \(eventsIds.count) events")
-        
-        // TEST
-        // - Write events from serial queue
-        // - Delete analytics file from concurrent queue
-        
-        writeEventsOnSerialQueueExpectation1 = expectation(description: "Write events on \(serialQueue.label) [1]")
-        deleteFileOnConcurrentQueueExpectation1 = expectation(description: "Delete analytics file on \(concurrentQueue.label) [1]")
-        expectationsToBeFulfilled = [writeEventsOnSerialQueueExpectation1, deleteFileOnConcurrentQueueExpectation1]
-        
-        serialQueueEvents1 = self.createEvents(2, withMessage: "Serial queue 1")
-                
-        self.writeEvents(serialQueueEvents1, fromQueue: serialQueue) {
-            eventsIds.append(contentsOf: serialQueueEvents1.compactMap({ $0.localId }))
-            writeEventsOnSerialQueueExpectation1.fulfill()
-        }
-        
-        self.deleteAnalyticsFile(fromQueue: concurrentQueue) {
-            eventsIds = []
-            deleteFileOnConcurrentQueueExpectation1.fulfill()
-        }
-        
-        wait(for: expectationsToBeFulfilled, timeout: 20)
-        expectationsToBeFulfilled = []
-        
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        XCTAssert(storedEvents.count == eventsIds.count, "Analytics file should contain \(eventsIds.count) events")
-        
-        // TEST
-        // - Write events from concurrent queue
-        // - Delete analytics file from serial queue
-        
-        let deleteEventsOnSerialQueueExpectation1 = expectation(description: "Write events on \(serialQueue.label) [1]")
-        let writeFileOnConcurrentQueueExpectation1 = expectation(description: "Delete analytics file on \(concurrentQueue.label) [1]")
-        expectationsToBeFulfilled = [deleteEventsOnSerialQueueExpectation1, writeFileOnConcurrentQueueExpectation1]
-        
-        concurrentQueueEvents1 = self.createEvents(2, withMessage: "Concurrent queue 1")
-            
-        self.deleteAnalyticsFile(fromQueue: serialQueue) {
-            eventsIds = []
-            deleteEventsOnSerialQueueExpectation1.fulfill()
-        }
-        
-        self.writeEvents(concurrentQueueEvents1, fromQueue: concurrentQueue) {
-            eventsIds.append(contentsOf: concurrentQueueEvents1.compactMap({ $0.localId }))
-            writeFileOnConcurrentQueueExpectation1.fulfill()
-        }
-        
-        wait(for: expectationsToBeFulfilled, timeout: 20)
-        expectationsToBeFulfilled = []
-        
-        storedEvents = (try? Analytics.Service.loadEvents()) ?? []
-        XCTAssert(storedEvents.count == eventsIds.count, "Analytics file should contain \(eventsIds.count) events")
-    }    
+    }
 }

--- a/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
+++ b/Debug App/Tests/Unit Tests/Analytics/AnalyticsTests.swift
@@ -206,12 +206,7 @@ class AnalyticsTests: XCTestCase {
         
         let newEvents = self.createEvents(10, withMessage: "A message")
         
-        firstly {
-            Analytics.Service.record(events: newEvents)
-        }
-        .done {
-            
-        }
+        Analytics.Service.record(events: newEvents)
         .ensure {
             writeEventExpectation.fulfill()
         }
@@ -269,7 +264,10 @@ class AnalyticsTests: XCTestCase {
             }
         }
         .then { _ -> Promise<Void> in
-            return Analytics.Service.sync(batchSize: batchSize)
+            Promise<Void> {
+                Analytics.Service.flush()
+                $0.fulfill()
+            }
         }
         .then { () -> Promise<[Analytics.Event]> in
             do {

--- a/Debug App/Tests/Unit Tests/Helpers/Promises+Helper.swift
+++ b/Debug App/Tests/Unit Tests/Helpers/Promises+Helper.swift
@@ -18,16 +18,6 @@ extension Promise {
         return Promise<T> { $0.reject(error) }
     }
     
-    static func resolved(_ closure: () throws -> T) -> Promise<T> {
-        Promise<T> { seal in
-            do {
-                seal.fulfill(try closure())
-            } catch {
-                seal.reject(error)
-            }
-        }
-    }
-    
     func erase() -> Promise<Void> {
         then { _ in
             Promise<Void>.fulfilled(())

--- a/Debug App/Tests/Unit Tests/Helpers/Promises+Helper.swift
+++ b/Debug App/Tests/Unit Tests/Helpers/Promises+Helper.swift
@@ -1,0 +1,36 @@
+//
+//  Promises+Helper.swift
+//  Debug App Tests
+//
+//  Created by Jack Newcombe on 01/12/2023.
+//  Copyright © 2023 Primer API Ltd. All rights reserved.
+//
+
+import Foundation
+@testable import PrimerSDK
+
+extension Promise {
+    static func fulfilled(_ value: T) -> Promise<T> {
+        return Promise<T> { $0.fulfill(value) }
+    }
+    
+    static func rejected(_ error: Error) -> Promise<T> {
+        return Promise<T> { $0.reject(error) }
+    }
+    
+    static func resolved(_ closure: () throws -> T) -> Promise<T> {
+        Promise<T> { seal in
+            do {
+                seal.fulfill(try closure())
+            } catch {
+                seal.reject(error)
+            }
+        }
+    }
+    
+    func erase() -> Promise<Void> {
+        then { _ in
+            Promise<Void>.fulfilled(())
+        }
+    }
+}

--- a/Debug App/Tests/Unit Tests/Network/URLSessionStackTests.swift
+++ b/Debug App/Tests/Unit Tests/Network/URLSessionStackTests.swift
@@ -81,7 +81,7 @@ final class URLSessionStackTests: XCTestCase {
     func testAnalyticsReportingForOmitted() {
         // Test endpoints that shouldn't cause a network event to be reported
         XCTAssertFalse(sut.shouldReportNetworkEvents(for: .poll(clientToken: nil, url: "")))
-        XCTAssertFalse(sut.shouldReportNetworkEvents(for: .sendAnalyticsEvents(clientToken: nil, url: Analytics.Service.sdkLogsUrl, body: nil)))
+        XCTAssertFalse(sut.shouldReportNetworkEvents(for: .sendAnalyticsEvents(clientToken: nil, url: Analytics.Service.defaultSdkLogsUrl, body: nil)))
         XCTAssertFalse(sut.shouldReportNetworkEvents(for: .sendAnalyticsEvents(clientToken: nil, url: URL(string: "https://anything-that-ends.with/sdk-logs")!, body: nil)))
 
         // Test selection of endpoints that should cause a network event to be reported

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
@@ -11,12 +11,6 @@ extension Analytics {
 
     internal class Service: LogReporter {
 
-        static var filepath: URL = {
-            let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("analytics")
-            logger.debug(message: "Analytics URL: \(url)")
-            return url
-        }()
-
         static let sdkLogsUrl = URL(string: "https://analytics.production.data.primer.io/sdk-logs")!
         
         static let maximumBatchSize: UInt = 100

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
@@ -70,9 +70,9 @@ extension Analytics {
                     do {
                         try self.storage.save(combinedEvents)
                         
-                        if combinedEvents.count >= batchSize {
-                            let batchSizeExceeded = combinedEvents.count > batchSize
-                            self.logger.debug(message: "📚 Analytics: Minimum batch size of \(batchSize) \(batchSizeExceeded ? "exceeded" : "reached") (\(combinedEvents.count) events present). Attempting sync ...")
+                        if combinedEvents.count >= self.batchSize {
+                            let batchSizeExceeded = combinedEvents.count > self.batchSize
+                            self.logger.debug(message: "📚 Analytics: Minimum batch size of \(self.batchSize) \(batchSizeExceeded ? "exceeded" : "reached") (\(combinedEvents.count) events present). Attempting sync ...")
                             self.sync(events: combinedEvents)
                         }
 
@@ -116,7 +116,7 @@ extension Analytics {
                 Analytics.queue.async(flags: .barrier) { [weak self] in
                     guard let self = self else { return }
                     
-                    let events = isFlush ? events : Array(events.prefix(Int(batchSize)))
+                    let events = isFlush ? events : Array(events.prefix(Int(self.batchSize)))
 
                     self.logger.debug(message: "📚 Analytics: \(syncType.capitalized)ing \(events.count) events ...")
 

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
@@ -45,7 +45,7 @@ extension Analytics {
                     guard let self = self else { return }
 
                     self.logger.debug(message: "📚 Analytics: Recording \(events.count) events")
-                    let storedEvents: [Analytics.Event] = storage.loadEvents()
+                    let storedEvents: [Analytics.Event] = self.storage.loadEvents()
 
                     let storedEventsIds = storedEvents.compactMap({ $0.localId })
                     var eventsToAppend: [Analytics.Event] = []
@@ -59,7 +59,7 @@ extension Analytics {
                     combinedEvents.append(contentsOf: storedEvents)
                     
                     do {
-                        try storage.save(combinedEvents)
+                        try self.storage.save(combinedEvents)
                         
                         if combinedEvents.count > 100 {
                             self.sync(events: combinedEvents)

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
@@ -11,22 +11,40 @@ extension Analytics {
 
     internal class Service: LogReporter {
 
-        static let sdkLogsUrl = URL(string: "https://analytics.production.data.primer.io/sdk-logs")!
+        static let defaultSdkLogsUrl = URL(string: "https://analytics.production.data.primer.io/sdk-logs")!
         
         static let maximumBatchSize: UInt = 100
         
-        static private var isSyncing: Bool = false
-
-        @discardableResult
-        internal static func record(event: Analytics.Event) -> Promise<Void> {
-            Analytics.Service.record(events: [event])
+        static let shared = Service(sdkLogsUrl: Service.defaultSdkLogsUrl,
+                                    batchSize: Service.maximumBatchSize,
+                                    storage: Analytics.storage)
+        
+        let sdkLogsUrl: URL
+        
+        let batchSize: UInt
+        
+        let storage: Storage
+        
+        private var isSyncing: Bool = false
+        
+        init(sdkLogsUrl: URL, batchSize: UInt, storage: Storage) {
+            self.sdkLogsUrl = sdkLogsUrl
+            self.batchSize = batchSize
+            self.storage = storage
         }
 
         @discardableResult
-        internal static func record(events: [Analytics.Event]) -> Promise<Void> {
+        internal func record(event: Analytics.Event) -> Promise<Void> {
+            self.record(events: [event])
+        }
+
+        @discardableResult
+        internal func record(events: [Analytics.Event]) -> Promise<Void> {
             return Promise { seal in
-                Analytics.queue.async(flags: .barrier) {
-                    logger.debug(message: "📚 Analytics: Recording \(events.count) events")
+                Analytics.queue.async(flags: .barrier) { [weak self] in
+                    guard let self = self else { return }
+
+                    self.logger.debug(message: "📚 Analytics: Recording \(events.count) events")
                     let storedEvents: [Analytics.Event] = storage.loadEvents()
 
                     let storedEventsIds = storedEvents.compactMap({ $0.localId })
@@ -44,7 +62,7 @@ extension Analytics {
                         try storage.save(combinedEvents)
                         
                         if combinedEvents.count > 100 {
-                            sync(events: combinedEvents)
+                            self.sync(events: combinedEvents)
                         }
 
                         seal.fulfill()
@@ -56,7 +74,7 @@ extension Analytics {
         }
         
         @discardableResult
-        internal static func flush() -> Promise<Void> {
+        internal func flush() -> Promise<Void> {
             Promise { seal in
                 let events = storage.loadEvents()
                 sync(events: events, isFlush: true)
@@ -69,70 +87,71 @@ extension Analytics {
         }
 
         @discardableResult
-        private static func sync(events: [Analytics.Event]? = nil, isFlush: Bool = false) -> Promise<Void> {
+        private func sync(events: [Analytics.Event]? = nil, isFlush: Bool = false) -> Promise<Void> {
             if !isFlush {
                 guard !isSyncing else { return Promise<Void> { $0.fulfill() } }
                 isSyncing = true
             }
             return Promise<Void> { seal in
-                Analytics.queue.async(flags: .barrier) {
-                    logger.debug(message: "📚 Analytics : Syncing...")
+                Analytics.queue.async(flags: .barrier) { [weak self] in
+                    guard let self = self else { return }
+                    self.logger.debug(message: "📚 Analytics : Syncing...")
                     
                     var events = events ?? []
                     guard events.count > 0 else {
-                        logger.warn(message: "📚 Analytics [sync]: Attempted to sync but had no events")
+                        self.logger.warn(message: "📚 Analytics [sync]: Attempted to sync but had no events")
                         return
                     }
                     
-                    events = isFlush ? events : Array(events.prefix(Int(maximumBatchSize)))
+                    events = isFlush ? events : Array(events.prefix(Int(batchSize)))
                     
                     let promises: [Promise<Void>] = [
-                        Analytics.Service.sendSkdLogEvents(events: events),
-                        Analytics.Service.sendSkdAnalyticsEvents(events: events)
+                        self.sendSkdLogEvents(events: events),
+                        self.sendSkdAnalyticsEvents(events: events)
                     ]
                     
                     when(fulfilled: promises)
                         .done { _ in
-                            logger.debug(message: "📚 Analytics: All events synced...")
+                            self.logger.debug(message: "📚 Analytics: All events synced...")
                         }
                         .ensure {
                         }
                         .catch { err in
-                            logger.error(message: "📚 Analytics: Failed to sync events with error \(err.localizedDescription)")
+                            self.logger.error(message: "📚 Analytics: Failed to sync events with error \(err.localizedDescription)")
                         }
                         .finally {
-                            let remainingEvents = storage.loadEvents()
-                            logger.debug(message: "📚 Analytics: Sync completed. \(remainingEvents.count) events present after sync.")
-                            isSyncing = false
+                            let remainingEvents = self.storage.loadEvents()
+                            self.logger.debug(message: "📚 Analytics: Sync completed. \(remainingEvents.count) events present after sync.")
+                            self.isSyncing = false
                             seal.fulfill()
                         }
                 }
             }
         }
         
-        static func clear() {
+        func clear() {
             storage.deleteAnalyticsFile()
         }
 
-        private static func sendSkdLogEvents(events: [Analytics.Event]) -> Promise<Void> {
+        private func sendSkdLogEvents(events: [Analytics.Event]) -> Promise<Void> {
             let storedEvents = events
             let sdkLogEvents = storedEvents.filter({ $0.analyticsUrl == nil })
-            let sdkLogEventsBatches = sdkLogEvents.toBatches(of: maximumBatchSize)
+            let sdkLogEventsBatches = sdkLogEvents.toBatches(of: batchSize)
 
             var promises: [Promise<Void>] = []
 
             for sdkLogEventsBatch in sdkLogEventsBatches {
-                let p = Analytics.Service.sendEvents(sdkLogEventsBatch, to: Analytics.Service.sdkLogsUrl)
+                let p = self.sendEvents(sdkLogEventsBatch, to: self.sdkLogsUrl)
                 promises.append(p)
             }
 
             return when(fulfilled: promises)
         }
 
-        private static func sendSkdAnalyticsEvents(events: [Analytics.Event]) -> Promise<Void> {
+        private func sendSkdAnalyticsEvents(events: [Analytics.Event]) -> Promise<Void> {
             let storedEvents = events
             let analyticsEvents = storedEvents.filter({ $0.analyticsUrl != nil })
-            let analyticsEventsBatches = analyticsEvents.toBatches(of: maximumBatchSize)
+            let analyticsEventsBatches = analyticsEvents.toBatches(of: batchSize)
 
             var promises: [Promise<Void>] = []
 
@@ -147,12 +166,12 @@ extension Analytics {
             return when(fulfilled: promises)
         }
 
-        private static func sendEvents(
+        private func sendEvents(
             _ events: [Analytics.Event],
             to url: URL
         ) -> Promise<Void> {
             return Promise { seal in
-                Analytics.Service.sendEvents(events, to: url) { err in
+                self.sendEvents(events, to: url) { err in
                     if let err = err {
                         seal.reject(err)
                     } else {
@@ -162,7 +181,7 @@ extension Analytics {
             }
         }
 
-        private static func sendEvents(
+        private func sendEvents(
             _ events: [Analytics.Event],
             to url: URL,
             completion: @escaping (Error?) -> Void
@@ -172,7 +191,7 @@ extension Analytics {
                 return
             }
 
-            if url.absoluteString != Analytics.Service.sdkLogsUrl.absoluteString, PrimerAPIConfigurationModule.clientToken?.decodedJWTToken == nil {
+            if url.absoluteString != self.sdkLogsUrl.absoluteString, PrimerAPIConfigurationModule.clientToken?.decodedJWTToken == nil {
                 // Sync another time
                 completion(nil)
                 return
@@ -191,12 +210,12 @@ extension Analytics {
             ) { result in
                 switch result {
                 case .success:
-                    logger.debug(message: "📚 Analytics: Finished syncing \(events.count) events on URL: \(url.absoluteString)")
-                    storage.delete(events)
+                    self.logger.debug(message: "📚 Analytics: Finished syncing \(events.count) events on URL: \(url.absoluteString)")
+                    self.storage.delete(events)
                     completion(nil)
 
                 case .failure(let err):
-                    logger.error(message: "📚 Analytics: Failed to sync \(events.count) events on URL \(url.absoluteString) with error \(err)")
+                    self.logger.error(message: "📚 Analytics: Failed to sync \(events.count) events on URL \(url.absoluteString) with error \(err)")
                     ErrorHandler.handle(error: err)
                     completion(err)
                 }
@@ -209,3 +228,22 @@ extension Analytics {
         }
     }
 }
+
+extension Analytics.Service {
+    static func record(event: Analytics.Event) -> Promise<Void> {
+        shared.record(event: event)
+    }
+
+    static func record(events: [Analytics.Event]) -> Promise<Void> {
+        shared.record(events: events)
+    }
+    
+    static func flush() -> Promise<Void> {
+        shared.flush()
+    }
+    
+    static func clear() {
+        shared.clear()
+    }
+}
+

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
@@ -18,6 +18,8 @@ extension Analytics {
         }()
 
         static let sdkLogsUrl = URL(string: "https://analytics.production.data.primer.io/sdk-logs")!
+        
+        static let maximumBatchSize: UInt = 100
 
         @discardableResult
         internal static func record(event: Analytics.Event) -> Promise<Void> {
@@ -55,7 +57,7 @@ extension Analytics {
         }
 
         @discardableResult
-        internal static func sync(batchSize: UInt = 300) -> Promise<Void> {
+        internal static func sync(batchSize: UInt = maximumBatchSize) -> Promise<Void> {
             return Promise { seal in
                 Analytics.queue.async {
                     logger.debug(message: "📚 Analytics: Syncing...")
@@ -222,6 +224,7 @@ extension Analytics {
                 let eventsData = try Data(contentsOf: Analytics.Service.filepath)
                 let events = try JSONDecoder().decode([Analytics.Event].self, from: eventsData)
                 let sortedEvents = events.sorted(by: { $0.createdAt > $1.createdAt })
+                logger.debug(message: "📚 Loaded events: \(sortedEvents.count)")
                 return sortedEvents
 
             } catch {

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsStorage.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsStorage.swift
@@ -1,0 +1,110 @@
+//
+//  AnalyticsStorage.swift
+//  PrimerSDK
+//
+//  Created by Jack Newcombe on 01/12/2023.
+//
+
+import Foundation
+
+protocol AnalyticsStorage {
+    
+    func loadEvents() -> [Analytics.Event]
+    
+    func save(_ events: [Analytics.Event]) throws
+    
+    func delete(_ events: [Analytics.Event]?)
+    
+    func deleteAnalyticsFile()
+}
+
+extension Analytics {
+    
+    typealias Storage = AnalyticsStorage
+    
+    static let storage: Storage = DefaultStorage()
+    
+    class DefaultStorage: AnalyticsStorage, LogReporter {
+        
+        func loadEvents() -> [Analytics.Event] {
+            do {
+                guard FileManager.default.fileExists(atPath: Analytics.Service.filepath.path) else {
+                    return []
+                }
+
+                let eventsData = try Data(contentsOf: Analytics.Service.filepath)
+                let events = try JSONDecoder().decode([Analytics.Event].self, from: eventsData)
+                let sortedEvents = events.sorted(by: { $0.createdAt > $1.createdAt })
+                return sortedEvents
+
+            } catch {
+                deleteAnalyticsFile()
+                return []
+            }
+        }
+
+        func save(_ events: [Analytics.Event]) throws {
+            do {
+                let eventsData = try JSONEncoder().encode(events)
+                try eventsData.write(to: Analytics.Service.filepath)
+                //                    logger.debug(message: "📚 Analytics: Saved \(events.count) events")
+            } catch {
+                logger.error(message: "📚 Analytics: Failed to save file \(error.localizedDescription)")
+                throw error
+            }
+        }
+
+        func delete(_ events: [Analytics.Event]?) {
+            logger.debug(message: "📚 Analytics: Deleting \(events == nil ? "all" : "\(events!.count)") events")
+
+            do {
+                if let events = events {
+                    let storedEvents = loadEvents()
+                    let eventsLocalIds = events.compactMap({ $0.localId })
+                    let remainingEvents = storedEvents.filter({ !eventsLocalIds.contains($0.localId )})
+                    
+                    logger.debug(message: "📚 Analytics: Deleted \(eventsLocalIds.count) events, saving remaining \(remainingEvents.count)")
+                    
+                    try save(remainingEvents)
+                } else {
+                    deleteAnalyticsFile()
+                }
+            } catch {
+                logger.error(message: "📚 Analytics: Failed to save partial events before deleting file. Deleting file anyway.")
+                deleteAnalyticsFile()
+            }
+        }
+
+        func deleteAnalyticsFile() {
+            logger.debug(message: "📚 Analytics: Deleting analytics file at \(Analytics.Service.filepath.absoluteString)")
+
+            if #available(iOS 16.0, *) {
+                if FileManager.default.fileExists(atPath: Analytics.Service.filepath.path()) {
+                    do {
+                        try FileManager.default.removeItem(at: Analytics.Service.filepath)
+
+                    } catch {
+                        let err = PrimerError.underlyingErrors(
+                            errors: [error],
+                            userInfo: nil,
+                            diagnosticsId: UUID().uuidString)
+                        ErrorHandler.handle(error: err)
+                    }
+                }
+            } else {
+                if FileManager.default.fileExists(atPath: Analytics.Service.filepath.path) {
+                    do {
+                        try FileManager.default.removeItem(at: Analytics.Service.filepath)
+
+                    } catch {
+                        let err = PrimerError.underlyingErrors(
+                            errors: [error],
+                            userInfo: nil,
+                            diagnosticsId: UUID().uuidString)
+                        ErrorHandler.handle(error: err)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsStorage.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsStorage.swift
@@ -46,6 +46,7 @@ extension Analytics {
                 return sortedEvents
 
             } catch {
+                logger.error(message: "📚 Analytics: Failed to load analytics file. Deleting file")
                 deleteAnalyticsFile()
                 return []
             }
@@ -55,7 +56,6 @@ extension Analytics {
             do {
                 let eventsData = try JSONEncoder().encode(events)
                 try eventsData.write(to: fileURL)
-                //                    logger.debug(message: "📚 Analytics: Saved \(events.count) events")
             } catch {
                 logger.error(message: "📚 Analytics: Failed to save file \(error.localizedDescription)")
                 throw error

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsStorage.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsStorage.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-private let analyticsURL: URL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("analytics")
+private let analyticsFileURL: URL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("analytics")
 
 protocol AnalyticsStorage {
     
@@ -30,7 +30,7 @@ extension Analytics {
         
         let fileURL: URL
         
-        init(fileURL: URL = analyticsURL) {
+        init(fileURL: URL = analyticsFileURL) {
             self.fileURL = fileURL
         }
         

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
@@ -169,7 +169,7 @@ internal class PrimerDelegateProxy: LogReporter {
                             id: timingEventId))
 
                     Analytics.Service.record(events: [timingEndEvent])
-                    Analytics.Service.sync()
+                    Analytics.Service.flush()
                 }
 
                 PrimerUIManager.dismissPrimerUI(animated: true)

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
@@ -77,7 +77,7 @@ internal class PrimerInternal: LogReporter {
 
     @objc
     private func onAppStateChange() {
-        Analytics.Service.sync()
+        Analytics.Service.flush()
     }
 
     // MARK: - CONFIGURATION
@@ -291,7 +291,7 @@ internal class PrimerInternal: LogReporter {
                 id: self.timingEventId))
 
         Analytics.Service.record(events: [sdkEvent, timingEvent])
-        Analytics.Service.sync()
+        Analytics.Service.flush()
 
         self.checkoutSessionId = nil
         self.selectedPaymentMethodType = nil

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
@@ -41,7 +41,7 @@ public class PrimerHeadlessUniversalCheckout: LogReporter {
     ]
 
     fileprivate init() {
-        Analytics.Service.sync()
+        Analytics.Service.flush()
     }
 
     public func start(

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol PrimerAPIClientProtocol {
+protocol PrimerAPIClientProtocol: PrimerAPIClientAnalyticsProtocol {
 
     func genericAPICall(clientToken: DecodedJWTToken,
                         url: URL,
@@ -100,7 +100,6 @@ protocol PrimerAPIClientProtocol {
 
     func requestPrimerConfigurationWithActions(clientToken: DecodedJWTToken, request: ClientSessionUpdateRequest, completion: @escaping (_ result: Result<PrimerAPIConfiguration, Error>) -> Void)
 
-    func sendAnalyticsEvents(clientToken: DecodedJWTToken?, url: URL, body: [Analytics.Event]?, completion: @escaping (_ result: Result<Analytics.Service.Response, Error>) -> Void)
     func fetchPayPalExternalPayerInfo(clientToken: DecodedJWTToken, payPalExternalPayerInfoRequestBody: Request.Body.PayPal.PayerInfo, completion: @escaping (Result<Response.Body.PayPal.PayerInfo, Error>) -> Void)
 
     // Payment

--- a/Sources/PrimerSDK/Classes/Services/Network/Protocols/PrimerAPIClientAnalyticsProtocol.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/Protocols/PrimerAPIClientAnalyticsProtocol.swift
@@ -1,6 +1,6 @@
 //
 //  PrimerAPIClientAnalyticsProtocol.swift
-//  IQKeyboardManagerSwift
+//  PrimerSDK
 //
 //  Created by Jack Newcombe on 04/12/2023.
 //

--- a/Sources/PrimerSDK/Classes/Services/Network/Protocols/PrimerAPIClientAnalyticsProtocol.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/Protocols/PrimerAPIClientAnalyticsProtocol.swift
@@ -1,0 +1,19 @@
+//
+//  PrimerAPIClientAnalyticsProtocol.swift
+//  IQKeyboardManagerSwift
+//
+//  Created by Jack Newcombe on 04/12/2023.
+//
+
+import Foundation
+
+protocol PrimerAPIClientAnalyticsProtocol {
+    
+    typealias ResponseHandler = (_ result: Result<Analytics.Service.Response, Error>) -> Void
+    
+    func sendAnalyticsEvents(clientToken: DecodedJWTToken?,
+                             url: URL,
+                             body: [Analytics.Event]?,
+                             completion: @escaping ResponseHandler)
+
+}


### PR DESCRIPTION
# Description

CHKT-1963

Rework of the analytics service

1. Refactor service to simplify use of concurrency and promises
2. Ensure batches are sent once a limit is reached (currently 100 events)
3. Split service into isolated storage and reporting services

# Manual Testing

Run debug app, filter console on "Analytics", then go through drop-in or headless checkout

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [x]  I have correctly prefixed one of the following conventional commit titles:
    - [ ]  chore - no version update
    - [x]  fix - patch version update
    - [ ]  feat - minor version update
    - [ ]  BREAKING CHANGE - major version update
- [x]  I have added unit tests to a reasonable level of coverage where suitable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)