### PR TITLE
chore: fix broken UI Tests

### DIFF
--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -33,7 +33,7 @@ jobs:
           bodyFile: "release.md"
   build-and-upload-to-appetize:
     if: github.head_ref == 'release/next' && github.event.pull_request.merged == true
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 20
     name: "Build and upload app to Appetize"
     steps:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-upload-to-appetize:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 20
     name: "Build and upload app to Appetize"
     steps:


### PR DESCRIPTION
The recent changes to upgrade the Appetize build to Xcode 15 broke UI tests and post-release merge, as I forgot to update those.