### PR TITLE
ci: Add more conventional commit titles

### DIFF
--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -82,7 +82,7 @@ if pr.assignees?.count == 0 {
 // MARK: - Conventional Commit Title
 let validPrefixes = ["fix", "feat", "chore", "ci", "refactor", "docs", 
                     "perf", "test", "build", "revert", "style", "BREAKING CHANGE"]
-let isConventionalCommitTitle = prefixes.contains { pr.title.hasPrefix($0) }
+let isConventionalCommitTitle = validPrefixes.contains { pr.title.hasPrefix($0) }
 
 if !pr.head.ref.hasPrefix("release") && !isConventionalCommitTitle {
     fail("Please use a conventional commit title for this PR. See [Conventional Commits and SemVer](https://www.notion.so/primerio/Automating-Version-Bumping-and-Changelog-Creation-c13e32fea11447069dea76f966f4b0fb?pvs=4#c55764aa2f2748eb988d581a456e61e7)")

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -80,14 +80,10 @@ if pr.assignees?.count == 0 {
 //                            minimumCoverage: 30)
 
 // MARK: - Conventional Commit Title
-func isConventionalCommitTitle() -> Bool {
-    // Commitizen-compatible conventional commit titles
-    pr.title.hasPrefix("BREAKING CHANGE:") ||
-    pr.title.hasPrefix("chore:") ||
-    pr.title.hasPrefix("fix:") ||
-    pr.title.hasPrefix("feat:")
-}
+let validPrefixes = ["fix", "feat", "chore", "ci", "refactor", "docs", 
+                    "perf", "test", "build", "revert", "style", "BREAKING CHANGE"]
+let isConventionalCommitTitle = prefixes.contains { pr.title.hasPrefix($0) }
 
-if !pr.head.ref.hasPrefix("release") && !isConventionalCommitTitle() {
+if !pr.head.ref.hasPrefix("release") && !isConventionalCommitTitle {
     fail("Please use a conventional commit title for this PR. See [Conventional Commits and SemVer](https://www.notion.so/primerio/Automating-Version-Bumping-and-Changelog-Creation-c13e32fea11447069dea76f966f4b0fb?pvs=4#c55764aa2f2748eb988d581a456e61e7)")
 }

--- a/Debug App/Tests/Unit Tests/Extensions/StringExtensionTests.swift
+++ b/Debug App/Tests/Unit Tests/Extensions/StringExtensionTests.swift
@@ -198,7 +198,7 @@ final class StringExtensionTests: XCTestCase {
         XCTAssertThrowsError(try "".validateExpiryDateString())
         XCTAssertThrowsError(try "01/2022".validateExpiryDateString())
         XCTAssertThrowsError(try "08/2022".validateExpiryDateString())
-        XCTAssertNoThrow(try "01/2023".validateExpiryDateString())
+        XCTAssertNoThrow(try almostOneYearAgoDateString().validateExpiryDateString())
         XCTAssertNoThrow(try "01/2028".validateExpiryDateString())
         XCTAssertNoThrow(try "02/2028".validateExpiryDateString())
         XCTAssertNoThrow(try "12/2028".validateExpiryDateString())
@@ -250,5 +250,12 @@ final class StringExtensionTests: XCTestCase {
         XCTAssertFalse("12345".isValidOTP)
         XCTAssertFalse("1234567".isValidOTP)
         XCTAssertFalse("".isValidOTP)
+    }
+
+    private func almostOneYearAgoDateString(format: String = "MM/YY") -> String {
+        let date = Date() - 364
+        let df = DateFormatter()
+        df.dateFormat = "MM/YYYY"
+        return df.string(from: date)
     }
 }


### PR DESCRIPTION
This adds more allowed conventional commit titles to the danger checks. Valid examples taken from the commitizen guides:

<img width="783" alt="Screenshot 2024-02-01 at 10 00 27" src="https://github.com/primer-io/primer-sdk-ios/assets/3179752/5af7e89a-9177-46aa-b957-4b899468822c">
