### PR TITLE
fix: Fix NOL pay bug - fetching of the cards

### DIFF
--- a/Debug App/Sources/View Controllers/MerchantDropInUIViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantDropInUIViewController.swift
@@ -11,8 +11,11 @@ import UIKit
 
 class MerchantDropInUIViewController: UIViewController, PrimerDelegate {
     
-    class func instantiate(settings: PrimerSettings, clientSession: ClientSessionRequestBody?, clientToken: String?) -> MerchantDropInUIViewController {
-        let mcvc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "MerchantCheckoutViewController") as! MerchantDropInUIViewController
+    class func instantiate(settings: PrimerSettings, 
+                           clientSession: ClientSessionRequestBody?,
+                           clientToken: String?) -> MerchantDropInUIViewController {
+        let mcvc = UIStoryboard(name: "Main", 
+                                bundle: nil).instantiateViewController(withIdentifier: "MerchantCheckoutViewController") as! MerchantDropInUIViewController
         mcvc.settings = settings
         mcvc.clientSession = clientSession
         mcvc.clientToken = clientToken

--- a/Debug App/Tests/Unit Tests/Extensions/StringExtensionTests.swift
+++ b/Debug App/Tests/Unit Tests/Extensions/StringExtensionTests.swift
@@ -198,7 +198,7 @@ final class StringExtensionTests: XCTestCase {
         XCTAssertThrowsError(try "".validateExpiryDateString())
         XCTAssertThrowsError(try "01/2022".validateExpiryDateString())
         XCTAssertThrowsError(try "08/2022".validateExpiryDateString())
-        XCTAssertNoThrow(try "01/2023".validateExpiryDateString())
+        XCTAssertNoThrow(try "01/2024".validateExpiryDateString())
         XCTAssertNoThrow(try "01/2028".validateExpiryDateString())
         XCTAssertNoThrow(try "02/2028".validateExpiryDateString())
         XCTAssertNoThrow(try "12/2028".validateExpiryDateString())

--- a/Debug App/Tests/Unit Tests/Mocks.swift
+++ b/Debug App/Tests/Unit Tests/Mocks.swift
@@ -99,7 +99,8 @@ class Mocks {
             static var adyenGiroPayRedirectPaymentMethodId = "mock_adyen_giropay_payment_method_id"
             static var klarnaPaymentMethodId = "mock_klarna_payment_method_id"
             static var paymentCardPaymentMethodId = "mock_payment_card_payment_method_id"
-            
+            static var nolPaymentMethodId = "mock_nol_payment_method_id"
+
             static var webRedirectPaymentMethodType = "MOCK_WEB_REDIRECT_PAYMENT_METHOD_TYPE"
             static var adyenGiroPayRedirectPaymentMethodType = "MOCK_ADYEN_GIROPAY_PAYMENT_METHOD_TYPE"
             static var klarnaPaymentMethodType = "MOCK_KLARNA_PAYMENT_METHOD_TYPE"
@@ -109,7 +110,8 @@ class Mocks {
             static var adyenGiroPayRedirectPaymentMethodName = "Mock Adyen GiroPay Payment Method"
             static var klarnaPaymentMethodName = "Mock Klarna Payment Method"
             static var paymentCardPaymentMethodName = "Mock Payment Card Payment Method"
-            
+            static var nolPaymentMethodName = "Mock NOL Payment Method"
+
             static var processorConfigId = "mock_processor_config_id"
             static var idealPaymentMethodId = "ADYEN_IDEAL"
             static var idealPaymentMethodName = "Mock Ideal Payment Method"
@@ -136,6 +138,16 @@ class Mocks {
             processorConfigId: Mocks.Static.Strings.processorConfigId,
             surcharge: 0,
             options: nil,
+            displayMetadata: nil)
+        
+        static var nolPaymentMethod = PrimerPaymentMethod(
+            id: Mocks.Static.Strings.nolPaymentMethodId,
+            implementationType: .nativeSdk,
+            type: "NOL_PAY", // Mocks.Static.Strings.paymentCardPaymentMethodType,
+            name: Mocks.Static.Strings.nolPaymentMethodName,
+            processorConfigId: Mocks.Static.Strings.processorConfigId,
+            surcharge: 0,
+            options: MerchantOptions(merchantId: "user8", merchantAccountId: "123", appId: "test"),
             displayMetadata: nil)
         
         static var adyenGiroPayRedirectPaymentMethod = PrimerPaymentMethod(

--- a/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayLinkCardComponentTest.swift
+++ b/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayLinkCardComponentTest.swift
@@ -103,14 +103,6 @@ final class NolPayLinkCardComponentTest: XCTestCase {
         XCTAssertTrue(mockErrorDelegate.errorReceived is PrimerError)
     }
 
-    func testStart_NoNolAppID() {
-        let mockErrorDelegate = MockErrorDelegate()
-        sut.errorDelegate = mockErrorDelegate
-        // Assuming PrimerAPIConfiguration.current?.paymentMethods? does not contain valid Nol AppID
-        sut.start()
-        XCTAssertTrue(mockErrorDelegate.errorReceived is PrimerError)
-    }
-
     func testStart_NoClientToken() {
         let mockErrorDelegate = MockErrorDelegate()
         sut.errorDelegate = mockErrorDelegate

--- a/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayUnlinkCardComponentTest.swift
+++ b/Debug App/Tests/Unit Tests/Primer/NolPay/NolPayUnlinkCardComponentTest.swift
@@ -152,13 +152,7 @@ final class NolPayUnlinkCardComponentTest: XCTestCase {
     }
     
     // MARK: - Tests for start() function
-    func testStart_NoNolAppID() {
-        let mockErrorDelegate = MockErrorDelegate()
-        sut.errorDelegate = mockErrorDelegate
-        sut.start()
-        XCTAssertTrue(mockErrorDelegate.errorReceived is PrimerError)
-    }
-        
+    
     func testUpdateCollectedData_EmptyOTPCode() {
         let mockValidationDelegate = MockValidationDelegate()
         sut.validationDelegate = mockValidationDelegate
@@ -169,7 +163,6 @@ final class NolPayUnlinkCardComponentTest: XCTestCase {
         } else {
             XCTFail("Expected validation error")
         }
-
     }
         
     func testSubmit_NoDataForOTP() {

--- a/Debug App/Tests/Unit Tests/Primer/NolPay/NolTestsMocks.swift
+++ b/Debug App/Tests/Unit Tests/Primer/NolPay/NolTestsMocks.swift
@@ -52,7 +52,11 @@ class MockPrimerNolPay: PrimerNolPayProtocol {
     }
     
     func getAvailableCards(for mobileNumber: String, with countryCode: String, completion: @escaping (Result<[PrimerNolPayCard], PrimerNolPayError>) -> Void) {
-        completion(.success(mockCards))
+        if mockCards.count > 0 {
+            completion(.success(mockCards))
+        } else {
+            completion(.failure(PrimerNolPayError.nolPaySdkError(message: "Failed")))
+        }
     }
 }
 

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayLinkedCardsComponent.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayLinkedCardsComponent.swift
@@ -13,14 +13,15 @@ public class NolPayLinkedCardsComponent: PrimerHeadlessComponent {
 
     var nolPay: PrimerNolPayProtocol?
 
-    public var errorDelegate: PrimerHeadlessErrorableDelegate?
+    public weak var errorDelegate: PrimerHeadlessErrorableDelegate?
     public weak var validationDelegate: PrimerHeadlessValidatableDelegate?
     var mobileNumber: String?
     var countryCode: String?
     var phoneMetadataService: NolPayPhoneMetadataProviding?
 
-    public func getLinkedCardsFor(mobileNumber: String,
-                                  completion: @escaping (Result<[PrimerNolPaymentCard], PrimerError>) -> Void) {
+    public init() {}
+
+    public func getLinkedCardsFor(mobileNumber: String, completion: @escaping (Result<[PrimerNolPaymentCard], PrimerError>) -> Void) {
 
         let dispatchGroup = DispatchGroup()
         dispatchGroup.enter()  // Enter the dispatch group

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethod.swift
@@ -163,7 +163,8 @@ class PrimerPaymentMethod: Codable, LogReporter {
         switch internalPaymentMethodType {
         case PrimerPaymentMethodType.apaya,
             PrimerPaymentMethodType.goCardless,
-            PrimerPaymentMethodType.googlePay:
+            PrimerPaymentMethodType.googlePay,
+            PrimerPaymentMethodType.nolPay:
             return false
         default:
             return true

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerFormViewController.swift
@@ -26,7 +26,8 @@ class PrimerFormViewController: PrimerViewController {
         verticalStackView.pin(view: view, leading: 20, top: 20, trailing: -20, bottom: -20)
     }
 
-    static func renderPaymentMethods(_ paymentMethodTokenizationViewModels: [PaymentMethodTokenizationViewModelProtocol], on stackView: UIStackView) {
+    static func renderPaymentMethods(_ paymentMethodTokenizationViewModels: [PaymentMethodTokenizationViewModelProtocol],
+                                     on stackView: UIStackView) {
         let theme: PrimerThemeProtocol = DependencyContainer.resolve()
 
         let availablePaymentMethodsContainerStackView = UIStackView()
@@ -112,5 +113,4 @@ class PrimerFormViewController: PrimerViewController {
             stackView.addArrangedSubview(availablePaymentMethodsContainerStackView)
         }
     }
-
 }


### PR DESCRIPTION
Make sure fetching of the card is being called after fetching of the secret key is finished

# Description

[CHKT-2121](https://primerapi.atlassian.net/browse/CHKT-2121)

- Fix a bug in the case where fetching of the cards was called right after init() of the NolPayLinkedCardsComponent.
Fetching of the card was called before fetching the nolSdk secret key from the backend, I added these two requests into the DispatchGroup() 

There were no changes in the public nol API and no changes in the documentation are needed.

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [ ]  I have correctly prefixed one of the following conventional commit titles:
    - [ ]  chore - no version update
    - [x]  fix - patch version update
    - [ ]  feat - minor version update
    - [ ]  BREAKING CHANGE - major version update
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [x]  If introducing a breaking change, I have communicated it internally
- [x]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)

[CHKT-2121]: https://primerapi.atlassian.net/browse/CHKT-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ