### PR TITLE
fix: Ensure card network is updated correctly in drop-in card form

### DIFF
--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.1.0)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerSDK (2.21.0):
-    - PrimerSDK/Core (= 2.21.0)
-  - PrimerSDK/Core (2.21.0)
+  - PrimerSDK (2.22.0):
+    - PrimerSDK/Core (= 2.22.0)
+  - PrimerSDK/Core (2.22.0)
 
 DEPENDENCIES:
   - IQKeyboardManagerSwift
@@ -34,7 +34,7 @@ SPEC CHECKSUMS:
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 83e9a1357a7247bf8fa2836fc945cf97644d601d
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerSDK: ee8781b2ecb4ecf578d9329ec5fc22083eb24f43
+  PrimerSDK: 9795618b058c6a88ed53ba33e606d2c028bf4075
 
 PODFILE CHECKSUM: 2165f25bdca4c31e764947a29b616b0ebe1a5034
 

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/CardFormPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/CardFormPaymentMethodTokenizationViewModel.swift
@@ -877,7 +877,7 @@ extension CardFormPaymentMethodTokenizationViewModel: PrimerTextFieldViewDelegat
         var network = self.cardNetwork?.rawValue.uppercased()
         let clientSessionActionsModule: ClientSessionActionsProtocol = ClientSessionActionsModule()
 
-        if let cardNetwork = cardNetwork, cardNetwork != .unknown, cardNumberContainerView.rightImage2 == nil && cardNetwork.icon != nil {
+        if let cardNetwork = cardNetwork, cardNetwork != .unknown, cardNumberContainerView.rightImage2 != cardNetwork.icon {
             if network == nil || network == "UNKNOWN" {
                 network = "OTHER"
             }
@@ -891,7 +891,7 @@ extension CardFormPaymentMethodTokenizationViewModel: PrimerTextFieldViewDelegat
                 self.updateButtonUI()
             }
             .catch { _ in }
-        } else if cardNumberContainerView.rightImage2 != nil && cardNetwork?.icon == nil {
+        } else if cardNumberContainerView.rightImage2 != nil && (cardNetwork?.icon == nil || cardNetwork == .unknown) {
             cardNumberContainerView.rightImage2 = nil
 
             firstly {


### PR DESCRIPTION
# Description

CHKT-2150

These changes ensure that the correct card badge is shown at all times on the drop-in checkout UI 

# Manual Testing

Tested a variety of inputs and input overwrites in the debug app

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)