### PR TITLE
fix: Adyen IDeal banks request failing

### DIFF
--- a/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
+++ b/Debug App/Tests/Unit Tests/v2/MockAPIClient.swift
@@ -28,7 +28,7 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
     var exchangePaymentMethodTokenResult: (PrimerPaymentMethodTokenData?, Error?)?
     var begin3DSAuthResult: (ThreeDS.BeginAuthResponse?, Error?)?
     var continue3DSAuthResult: (ThreeDS.PostAuthResponse?, Error?)?
-    var listAdyenBanksResult: ([Response.Body.Adyen.Bank]?, Error?)?
+    var listAdyenBanksResult: (BanksListSessionResponse?, Error?)?
     var listRetailOutletsResult: (RetailOutletsList?, Error?)?
     var paymentResult: (Response.Body.Payment?, Error?)?
     var sendAnalyticsEventsResult: (Analytics.Service.Response?, Error?)?
@@ -340,12 +340,12 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             }
         }
     }
-
+    
     func listAdyenBanks(
         clientToken: DecodedJWTToken,
         request: Request.Body.Adyen.BanksList,
-        completion: @escaping (_ result: Result<[Response.Body.Adyen.Bank], Error>) -> Void
-    ) {
+        completion: @escaping APICompletion<PrimerSDK.BanksListSessionResponse>)
+       {
         guard let result = listAdyenBanksResult,
               result.0 != nil || result.1 != nil
         else {
@@ -833,13 +833,14 @@ extension MockPrimerAPIClient {
             token: MockPrimerAPIClient.Samples.mockTokenizePaymentMethod,
             resumeToken: "mock-resume-token",
             authentication: nil)
-        static let mockAdyenBanks = [
-            Response.Body.Adyen.Bank(
-                id: "mock-bank-id",
-                name: "mock-bank-name",
-                iconUrlStr: "https://primer.io/bank-logo",
-                disabled: false)
-        ]
+        static let mockAdyenBanks = BanksListSessionResponse(
+            result: [
+                Response.Body.Adyen.Bank(
+                    id: "mock-bank-id",
+                    name: "mock-bank-name",
+                    iconUrlStr: "https://primer.io/bank-logo",
+                    disabled: false)
+            ])
         static let mockListRetailOutlets = RetailOutletsList(
             result: [
                 RetailOutletsRetail(

--- a/Sources/PrimerSDK/Classes/Core/Models/BanksTokenizationComponent.swift
+++ b/Sources/PrimerSDK/Classes/Core/Models/BanksTokenizationComponent.swift
@@ -85,7 +85,7 @@ final class BanksTokenizationComponent: NSObject, LogReporter {
                     seal.reject(err)
 
                 case .success(let banks):
-                    seal.fulfill(banks)
+                    seal.fulfill(banks.result)
                 }
             }
         }

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
@@ -125,7 +125,7 @@ internal class PrimerAPIClient: PrimerAPIClientProtocol {
     func listAdyenBanks(
         clientToken: DecodedJWTToken,
         request: Request.Body.Adyen.BanksList,
-        completion: @escaping (Result<[Response.Body.Adyen.Bank], Error>) -> Void) {
+        completion: @escaping APICompletion<BanksListSessionResponse>) {
         let endpoint = PrimerAPI.listAdyenBanks(clientToken: clientToken, request: request)
         execute(endpoint, completion: completion)
     }

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClientProtocol.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClientProtocol.swift
@@ -107,7 +107,7 @@ protocol PrimerAPIClientProtocol: PrimerAPIClientAnalyticsProtocol, PrimerAPICli
     func listAdyenBanks(
         clientToken: DecodedJWTToken,
         request: Request.Body.Adyen.BanksList,
-        completion: @escaping APICompletion<[Response.Body.Adyen.Bank]>)
+        completion: @escaping APICompletion<BanksListSessionResponse>)
 
     // MARK: Retail Outlets
 

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/BankSelectorTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/BankSelectorTokenizationViewModel.swift
@@ -234,7 +234,7 @@ class BankSelectorTokenizationViewModel: WebRedirectPaymentMethodTokenizationVie
                     seal.reject(err)
 
                 case .success(let banks):
-                    seal.fulfill(banks)
+                    seal.fulfill(banks.result)
                 }
             }
         }


### PR DESCRIPTION
# Description

[TWS-231](https://primer-ext.atlassian.net/browse/TWS-231)

Fix for retrieve banks request that is failing to decode.

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)