### PR TITLE
Make the CVV recapture flag available on Headless

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
@@ -5,12 +5,25 @@
 //  Created by Evangelos on 27/9/22.
 //
 
+// swiftlint:disable nesting
+
 import Foundation
 import PassKit
 
 extension PrimerHeadlessUniversalCheckout {
 
     public class PaymentMethod: NSObject {
+
+        /// To enhance your experience and provide consistent functionality across our services,
+        /// some features are available in both our Headless and Drop-In interfaces.
+        /// While Drop-In automatically utilizes these features through predefined settings,
+        /// the Headless interface offers you the flexibility to enable these features manually.
+        /// This is made possible through the introduction of the "PrimerAvailablePaymentMethodsOptions".
+        /// This option allows you to customize your Headless setup by enabling specific features
+        /// that align with the capabilities available in the Drop-In interface.
+        public struct PrimerAvailablePaymentMethodsOptions {
+            let captureVaultedCardCvv: Bool?
+        }
 
         static var availablePaymentMethods: [PrimerHeadlessUniversalCheckout.PaymentMethod] {
             var availablePaymentMethods = PrimerAPIConfiguration.paymentMethodConfigs?
@@ -33,6 +46,7 @@ extension PrimerHeadlessUniversalCheckout {
         public private(set) var supportedPrimerSessionIntents: [PrimerSessionIntent] = []
         public private(set) var paymentMethodManagerCategories: [PrimerPaymentMethodManagerCategory]
         public private(set) var requiredInputDataClass: PrimerRawData.Type?
+        public private(set) var options: PrimerHeadlessUniversalCheckout.PaymentMethod.PrimerAvailablePaymentMethodsOptions
 
         init?(paymentMethodType: String) {
             guard let paymentMethod = PrimerAPIConfiguration.paymentMethodConfigs?
@@ -54,14 +68,17 @@ extension PrimerHeadlessUniversalCheckout {
             guard let paymentMethodManagerCategories = paymentMethod.paymentMethodManagerCategories else {
                 return nil
             }
-
             self.paymentMethodManagerCategories = paymentMethodManagerCategories
 
             if PrimerPaymentMethodType.paymentCard.rawValue == paymentMethodType {
                 requiredInputDataClass = PrimerCardData.self
             }
 
+            let captureVaultedCardCvv = (paymentMethod.options as? CardOptions)?.captureVaultedCardCvv ?? false
+            options = PrimerAvailablePaymentMethodsOptions(captureVaultedCardCvv: captureVaultedCardCvv)
+
             super.init()
         }
     }
 }
+// swiftlint:enable nesting


### PR DESCRIPTION
We want to make the CVV Recapture backend flag available for merchants who are using Headless as well. This is a proposal of how we could do it.

I made this draft PR instead of writing an RFC for better understanding.
WDYT?