### PR TITLE
chore: Handle incoming livedemostore on physical device

### DIFF
--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.1.0)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerSDK (2.24.0):
-    - PrimerSDK/Core (= 2.24.0)
-  - PrimerSDK/Core (2.24.0)
+  - PrimerSDK (2.25.0):
+    - PrimerSDK/Core (= 2.25.0)
+  - PrimerSDK/Core (2.25.0)
 
 DEPENDENCIES:
   - IQKeyboardManagerSwift
@@ -34,7 +34,7 @@ SPEC CHECKSUMS:
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 83e9a1357a7247bf8fa2836fc945cf97644d601d
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerSDK: af09c3d815cda8b5dc815cb91b2a693e55c52677
+  PrimerSDK: 152a021dc6b47783d844b7770c14c843856f724f
 
 PODFILE CHECKSUM: 4070d0f559c86f4414e465a26e3de7b095420546
 

--- a/Debug App/Sources/AppDelegate.swift
+++ b/Debug App/Sources/AppDelegate.swift
@@ -27,6 +27,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      continue userActivity: NSUserActivity,
                      restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+        if let url = userActivity.webpageURL {
+            let handled = AppetizeUrlHandler.handleUrl(url)
+            if handled == true {
+                return handled
+            }
+        }
         return Primer.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
 

--- a/Debug App/Sources/Utilities/AppetizeConfigProvider.swift
+++ b/Debug App/Sources/Utilities/AppetizeConfigProvider.swift
@@ -50,3 +50,27 @@ extension UserDefaults: AppetizePayloadProviding {
         string(forKey: Self.configJwtKey)
     }
 }
+
+struct AppetizeUrlHandler {
+    // Handle incoming livedemostore url
+    static func handleUrl(_ url: URL) -> Bool {
+        if url.absoluteString.contains("livedemostore.common.primer.io"),
+           let p = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems?.first(where: { $0.name == "p"})
+        {
+            let DeeplinkConfigProvider = DeeplinkConfigProvider(isAppetize: true, configJwt: p.value)
+            NotificationCenter.default.post(name: .appetizeURLHandled, object: DeeplinkConfigProvider)
+            return true
+        } else {
+            return false
+        }
+    }
+}
+
+extension NSNotification.Name {
+    static let appetizeURLHandled = NSNotification.Name("appetizeURLHandled")
+}
+
+struct DeeplinkConfigProvider: AppetizePayloadProviding {
+    let isAppetize: Bool?
+    let configJwt: String?
+}

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -190,12 +190,23 @@ class MerchantSessionAndSettingsViewController: UIViewController {
 
         customerIdTextField.addTarget(self, action: #selector(customerIdChanged(_:)), for: .editingDidEnd)
 
-        let configProvider = AppetizeConfigProvider()
+        handleAppetizeIfNeeded(AppetizeConfigProvider())
+
+        render()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAppetizeConfig), name: NSNotification.Name.appetizeURLHandled, object: nil)
+    }
+
+    @objc func handleAppetizeConfig(_ notification: NSNotification) {
+        if let payloadProvider = notification.object as? DeeplinkConfigProvider {
+            handleAppetizeIfNeeded(AppetizeConfigProvider(payloadProvider: payloadProvider))
+        }
+    }
+
+    private func handleAppetizeIfNeeded(_ configProvider: AppetizeConfigProvider) {
         if let config = configProvider.fetchConfig() {
             updateUI(for: config)
         }
-
-        render()
     }
 
     @objc func viewTapped() {


### PR DESCRIPTION
This enabled incoming Universal Links to be handled on the Debug app on a physical device.

To test:
- Run this build on a physical device.
- On the device, navigate to the single test account site: https://primer-io.gitlab.io/connections/qa-tools/test-scenario-docs/
- Use any livedemostore link in any scenario
- Observe the Debug app is pre populated with the scenario config
