### PR TITLE
fix: Fix parsing of the API response

### DIFF
--- a/Debug App/Sources/View Controllers/Merchant Helpers/MerchantHelpers.swift
+++ b/Debug App/Sources/View Controllers/Merchant Helpers/MerchantHelpers.swift
@@ -81,7 +81,7 @@ struct MerchantMockDataManager {
     static var genericPaymentMethod = ClientSessionRequestBody.PaymentMethod(
         vaultOnSuccess: false,
         options: nil,
-        descriptor: nil,
+        descriptor: "Random descriptor",
         paymentType: nil
     )
 

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayLinkedCardsComponent.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/NolPay/NolPayLinkedCardsComponent.swift
@@ -24,7 +24,9 @@ public class NolPayLinkedCardsComponent {
     var phoneMetadataService: NolPayPhoneMetadataProviding?
     var apiClient: PrimerAPIClientProtocol?
 
-    public init() {}
+    public init() {
+        self.apiClient = PrimerAPIClient()
+    }
 
     public func getLinkedCardsFor(mobileNumber: String, completion: @escaping (Result<[PrimerNolPaymentCard], PrimerError>) -> Void) {
 

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/PrimerHeadlessComposable.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/PrimerHeadlessComposable.swift
@@ -76,7 +76,7 @@ extension PrimerHeadlessCollectDataComponent {
         let error = PrimerError.invalidValue(key: key,
                                              value: nil,
                                              userInfo: .errorUserInfoDictionary(),
-        diagnosticsId: UUID().uuidString)
+                                             diagnosticsId: UUID().uuidString)
         ErrorHandler.handle(error: error)
         self.errorDelegate?.didReceiveError(error: error)
     }

--- a/Sources/PrimerSDK/Classes/PCI/Services/Network/NetworkReportingService.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/Network/NetworkReportingService.swift
@@ -15,8 +15,8 @@ enum NetworkEventType {
     var endpoint: Endpoint {
         switch self {
         case .requestStart(_, let endpoint, _),
-                .requestEnd(_, let endpoint, _),
-                .networkConnectivity(let endpoint):
+             .requestEnd(_, let endpoint, _),
+             .networkConnectivity(let endpoint):
             return endpoint
         }
     }
@@ -78,7 +78,7 @@ class DefaultNetworkReportingService: NetworkReportingService {
             return false
         }
         guard let baseURL = primerAPI.baseURL, let url = URL(string: baseURL),
-                !disallowedTrackingPaths.contains(url.path) else {
+              !disallowedTrackingPaths.contains(url.path) else {
             return false
         }
         return true

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
@@ -25,7 +25,7 @@ internal class PrimerAPIClient: PrimerAPIClientProtocol {
 
     func genericAPICall(clientToken: DecodedJWTToken, url: URL, completion: @escaping APICompletion<Bool>) {
         let endpoint = PrimerAPI.redirect(clientToken: clientToken, url: url)
-        networkService.request(endpoint) { (result: Result<SuccessResponse, Error>) in
+        networkService.request(endpoint) { (result: Result<String, Error>) in
             switch result {
             case .success:
                 completion(.success(true))


### PR DESCRIPTION
This PR fixes a parsing problem for the only case where we have a pure string as a response (HTML). This is mostly for @jnewc since you were working on the API layer refactor. Make sure I did everything as you would do it and feel free to change the implementation if you don't like it. 

We are currently waiting for confirmation from Lime that this is working (they are testing from the branch), if we get it while I am away, please make a new release with this fix.

Thanks!

PS: If you need more context, please ping Semir.