### PR TITLE
chore: add acceptance merchant Ids

### DIFF
--- a/Debug App/ExampleApp.entitlements
+++ b/Debug App/ExampleApp.entitlements
@@ -8,9 +8,12 @@
 	</array>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
+		<string>merchant.acceptance.team</string>
+		<string>merchant.acceptance.team.sandbox</string>
+		<string>merchant.acceptance.team.staging</string>
 		<string>merchant.checkout.team</string>
 		<string>merchant.dx.team</string>
-		<string>merchant.acceptance.team</string>
+		<string>merchant.acceptance.team.dev</string>
 	</array>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>

--- a/Debug App/ExampleApp.entitlements
+++ b/Debug App/ExampleApp.entitlements
@@ -10,6 +10,7 @@
 	<array>
 		<string>merchant.checkout.team</string>
 		<string>merchant.dx.team</string>
+		<string>merchant.acceptance.team</string>
 	</array>
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>


### PR DESCRIPTION
This PR adds Apple Pay merchant IDs for acceptance team in all environments