### PR TITLE
chore: Disable nol pay unit tests

### DIFF
--- a/Debug App/Tests/UnitTestsTestPlan.xctestplan
+++ b/Debug App/Tests/UnitTestsTestPlan.xctestplan
@@ -13,6 +13,12 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "NolPayLinkCardComponentTest",
+        "NolPayPaymentComponentTests",
+        "NolPayPhoneMetadataServiceTests",
+        "NolPayUnlinkCardComponentTest"
+      ],
       "target" : {
         "containerPath" : "container:",
         "identifier" : "PrimerSDKTests",


### PR DESCRIPTION
# Description

Per title, these tests are currently making real API calls and real calls to the TransitSDK.

I'll ticket to rewrite them.

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)