### PR TITLE
ci: Fix mgmt of sonar coverage files in workflows + fix master scan workflow

### DIFF
--- a/.github/actions/sonar/action.yml
+++ b/.github/actions/sonar/action.yml
@@ -32,6 +32,8 @@ runs:
     - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e  #v4.1.7
       with:
         pattern: coverage-file-*
+    - shell: bash
+      run: mv coverage-file-*/sonar-coverage-*.xml ./
     - name: Install Sonar
       shell: bash
       run: |

--- a/.github/workflows/build-test-upload.yml
+++ b/.github/workflows/build-test-upload.yml
@@ -106,10 +106,6 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e  #v4.1.7
-        with:
-          pattern: coverage-file-*
-      - run: mv coverage-file-*/sonar-coverage-*.xml ./
       - name: SonarCloud Scan
         uses: ./.github/actions/sonar
         with:

--- a/.github/workflows/test-and-code-quality.yml
+++ b/.github/workflows/test-and-code-quality.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-tests:
+  sdk-unit-tests:
     runs-on: macos-13-large
     timeout-minutes: 20
     name: "SDK - Unit Tests"
@@ -35,19 +35,52 @@ jobs:
           fastlane-password: ${{ secrets.FASTLANE_PASSWORD }}
           match-keychain-name: ${{ secrets.MATCH_KEYCHAIN_NAME }}
           match-keychain-password: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          sdk-name: sdk
+
+  optional-sdk-tests:
+    name: Optional SDK Tests
+    runs-on: macos-13-large
+    strategy:
+      max-parallel: 3
+      matrix:
+        package-swift:
+          - { name: 'nol-pay', file: 'Package.NolPay.swift' }
+          - { name: 'klarna', file: Package.Klarna.swift }
+          - { name: '3DS', file: Package.3DS.swift }
+    steps:
+      - name: Cancel previous jobs
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # v0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - name: Git - Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          ref: ${{ github.ref }}
+      - name: Run SDK tests
+        uses: ./.github/actions/sdk-tests
+        with:
+          ssh-private-key: ${{ secrets.SSH_KEY }}
+          known-hosts: ${{ secrets.KNOWN_HOSTS }}
+          match-password: ${{ secrets.MATCH_PASSWORD }}
+          match-git-private-key: ${{ secrets.FASTLANE_PASSWORD }}
+          fastlane-session: ${{ secrets.FASTLANE_SESSION }}
+          fastlane-password: ${{ secrets.FASTLANE_PASSWORD }}
+          match-keychain-name: ${{ secrets.MATCH_KEYCHAIN_NAME }}
+          match-keychain-password: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          sdk-name: ${{ matrix.package-swift.name }}
+          package-swift: ${{  matrix.package-swift.file }}
+        
 
   sonarcloud:
     needs:
-      - unit-tests
+      - sdk-unit-tests
+      - optional-sdk-tests
     runs-on: macos-13-large
     name: SonarCloud
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e  #v4.1.7
-        with:
-          name: coverage-file-sdk
       - name: SonarCloud Scan
         uses: ./.github/actions/sonar
         with:
@@ -55,4 +88,4 @@ jobs:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           sonar-host: https://sonarcloud.io./
           branch: ${{ github.head_ref }}
-          coverage-file-names: sonar-coverage-sdk.xml
+          coverage-file-names: sonar-coverage-sdk.xml,sonar-coverage-3DS.xml,sonar-coverage-nol-pay.xml,sonar-coverage-klarna.xml


### PR DESCRIPTION
# Description

* Fix duplicate downloading of artifacts in jobs using sonar action
* Fix coverage file selection for master scan job

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)