### PR TITLE
fix: Remove +1 year card expiry validation logic

### DIFF
--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/DateExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/DateExtension.swift
@@ -47,9 +47,7 @@ internal extension Date {
     }
 
     var isValidExpiryDate: Bool {
-        let oneYearLaterEndOfMonthDate = self.oneYearLater.endOfMonth
-        let now = Date()
-        return now < oneYearLaterEndOfMonthDate
+        return Date() < endOfMonth
     }
 
     var yearComponentAsString: String {

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
@@ -66,7 +66,7 @@ internal extension String {
         }
 
         guard let date = _self.toDate(withFormat: "MMyy") else { return false }
-        let isValid = date.endOfMonth > Date()
+        let isValid = date.isValidExpiryDate
 
         if !isValid {
             let event = Analytics.Event.message(

--- a/Tests/Primer/Extensions/DateExtensionTests.swift
+++ b/Tests/Primer/Extensions/DateExtensionTests.swift
@@ -23,7 +23,8 @@ final class DateExtensionTests: XCTestCase {
     func testExpiryDateIsValid() {
         XCTAssertTrue(Date().isValidExpiryDate)
         XCTAssertTrue(Date().oneYearLater.isValidExpiryDate)
-        XCTAssertTrue((Date() - (60 * 60 * 24 * 360)).isValidExpiryDate)
+        XCTAssertFalse((Date() - (60 * 60 * 24 * 180)).isValidExpiryDate)
+        XCTAssertFalse((Date() - (60 * 60 * 24 * 360)).isValidExpiryDate)
         XCTAssertFalse((Date() - (60 * 60 * 24 * 400)).isValidExpiryDate)
     }
 

--- a/Tests/Primer/Extensions/StringExtensionTests.swift
+++ b/Tests/Primer/Extensions/StringExtensionTests.swift
@@ -232,7 +232,7 @@ final class StringExtensionTests: XCTestCase {
         XCTAssertThrowsError(try "01/2022".validateExpiryDateString())
         XCTAssertThrowsError(try "08/2022".validateExpiryDateString())
         XCTAssertThrowsError(try "2022/2023".validateExpiryDateString())
-        XCTAssertNoThrow(try almostOneYearAgoDateString().validateExpiryDateString())
+        XCTAssertThrowsError(try almostOneYearAgoDateString().validateExpiryDateString())
         XCTAssertNoThrow(try "01/2028".validateExpiryDateString())
         XCTAssertNoThrow(try "02/2028".validateExpiryDateString())
         XCTAssertNoThrow(try "12/2028".validateExpiryDateString())


### PR DESCRIPTION
# Description

We previously allowed this as some cards technically allow using expired cards where expiry < 1 year in the past.

Now we are aligning across platforms and removing this logic.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)