### PR TITLE
Fix: Remove event duplication from Klarna Drop-In

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/KlarnaTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/KlarnaTokenizationViewModel.swift
@@ -65,9 +65,6 @@ class KlarnaTokenizationViewModel: PaymentMethodTokenizationViewModel {
                 let clientSessionActionsModule: ClientSessionActionsProtocol = ClientSessionActionsModule()
                 return clientSessionActionsModule.selectPaymentMethodIfNeeded(self.config.type, cardNetwork: nil)
             }
-            .then { () -> Promise<Void> in
-                return self.handlePrimerWillCreatePaymentEvent(PrimerPaymentMethodData(type: self.config.type))
-            }
             .then { () -> Promise<Response.Body.Klarna.PaymentSession> in
                 return self.tokenizationComponent.createPaymentSession()
             }


### PR DESCRIPTION
# Description

[ACC-3460](https://primerapi.atlassian.net/browse/ACC-3460)

This PR purpose is to remove the duplication of `primerWillCreatePaymentWithData` event.
The logic from Klarna Headless is re-used in Klarna Drop-In, so the event is already called in Headless implementation.

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

Tested manually and run the UI(E2E) tests for Headless and Drop-in implementation.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)