### PR TITLE
fix: Handle non-200 2xx codes

### DIFF
--- a/Sources/PrimerSDK/Classes/PCI/Services/Network/Factories/NetworkResponseFactory.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/Network/Factories/NetworkResponseFactory.swift
@@ -44,7 +44,7 @@ class JSONNetworkResponseFactory: NetworkResponseFactory, LogReporter {
         log(data: response, metadata: metadata)
 
         switch metadata.statusCode {
-        case 200:
+        case 200...299:
             do {
                 return try decoder.decode(T.self, from: response)
             } catch {


### PR DESCRIPTION
# Description

Resume sends a 202 which is currently not being handled after client action completion. This fix accepts any 2xx code as an indication to attempt parsing the response body.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)