### PR TITLE
fix: Fix crash when attempting to clean up 3DS prior to initialisation

### DIFF
--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.1.1)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerSDK (2.26.7):
-    - PrimerSDK/Core (= 2.26.7)
-  - PrimerSDK/Core (2.26.7)
+  - PrimerSDK (2.27.0):
+    - PrimerSDK/Core (= 2.27.0)
+  - PrimerSDK/Core (2.27.0)
 
 DEPENDENCIES:
   - IQKeyboardManagerSwift
@@ -34,7 +34,7 @@ SPEC CHECKSUMS:
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 564105170cc7b467bf95c31851813ea41c468f8b
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerSDK: 3d415b64abebc1a36bd5575169137ea5deed9eba
+  PrimerSDK: d602d8492ad2b6d04a8ee36274d9756d8ad79a67
 
 PODFILE CHECKSUM: fb702ce88fd7db36a91e9ed9e4fe87609ec9aff9
 

--- a/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
+++ b/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
@@ -105,7 +105,7 @@ class ThreeDSService: ThreeDSServiceProtocol, LogReporter {
 
             self.threeDSSDKWindow?.isHidden = true
             self.threeDSSDKWindow = nil
-            self.primer3DS.cleanup()
+            self.primer3DS?.cleanup()
         }
         .catch { err in
             var continueInfo: ThreeDS.ContinueInfo?


### PR DESCRIPTION
# Description

Uncovered by newly enabled UI test. Fix is to optionally check the explicitly unwrapped field before trying to call `cleanup`

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)