### PR TITLE
feat: handle Apple Pay shipping methods

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PassKit
 
 // MARK: - PRIMER SETTINGS
 
@@ -139,17 +140,21 @@ public class PrimerApplePayOptions: Codable {
     /// canMakePayments(usingNetworks:) was returning false if there were no cards in the Wallet,
     /// we introduced this flag to continue supporting the old behaviour. Default value is `true`.
     let checkProvidedNetworks: Bool
+    /// An array of shipping method objects that describe the supported shipping methods.
+    let shippingMethods: [PKShippingMethod]
 
     public init(merchantIdentifier: String,
                 merchantName: String,
                 isCaptureBillingAddressEnabled: Bool = false,
                 showApplePayForUnsupportedDevice: Bool = true,
-                checkProvidedNetworks: Bool = true) {
+                checkProvidedNetworks: Bool = true,
+                shippingMethods: [PKShippingMethod] = []) {
         self.merchantIdentifier = merchantIdentifier
         self.merchantName = merchantName
         self.isCaptureBillingAddressEnabled = isCaptureBillingAddressEnabled
         self.showApplePayForUnsupportedDevice = showApplePayForUnsupportedDevice
         self.checkProvidedNetworks = checkProvidedNetworks
+        self.shippingMethods = shippingMethods
     }
 }
 

--- a/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
@@ -74,6 +74,7 @@ class ApplePayPresentationManager: ApplePayPresenting, LogReporter {
         request.merchantCapabilities = [.capability3DS]
         request.supportedNetworks = supportedNetworks
         request.paymentSummaryItems = applePayRequest.items.compactMap({ $0.applePayItem })
+        request.shippingMethods = applePayOptions?.shippingMethods ?? []
 
         return request
     }


### PR DESCRIPTION
# Description

Being able to add some shipping methods to Apple Pay. 

Documentation:
https://developer.apple.com/documentation/passkit_apple_pay_and_wallet/pkpaymentrequest/1619226-shippingmethods

- Non-breaking as `shippingMethods` are optional

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)