### PR TITLE
chore: Skip critical path tests job on release PRs

### DIFF
--- a/.github/workflows/build-test-upload.yml
+++ b/.github/workflows/build-test-upload.yml
@@ -174,7 +174,6 @@ jobs:
     needs:
       - unit-tests-sdk
       - unit-tests-debug-app
-      - critical-ui-tests
     runs-on: macos-13-large
     timeout-minutes: 45
     name: "Build and upload app to Appetize"


### PR DESCRIPTION
# Description

I noticed on the 2.27.0 release that we were running critical path tests and the full nightly suite simulataneously. This is duplicated effort and has the potential to cause BrowserStack collisions leading to long waits before tests and unintentional failures.

This PR does the following:
1. Ensures that the critical path tests only run on non-release branches
2. Removes the appetize job dependency on critical path tests

(re: (2), this means that the appetize job runs in parallel which seems sensible given that we might want an appetize build for a WIP feature branch regardless of whether tests pass) 

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)