### PR TITLE
chore: Introduce Primer3DS as a direct dependency to PrimerSDK

### DIFF
--- a/Package.vanilla.swift
+++ b/Package.vanilla.swift
@@ -14,15 +14,9 @@ let package = Package(
             targets: ["PrimerSDK"]
         )
     ],
-    dependencies: [
-        .package(url: "https://github.com/primer-io/primer-sdk-3ds-ios", from: "2.3.1")
-    ],
     targets: [
         .target(
             name: "PrimerSDK",
-            dependencies: [
-                .product(name: "Primer3DS", package: "primer-sdk-3ds-ios")
-            ],
             path: "Sources/PrimerSDK",
             resources: [
                 .process("Resources"),
@@ -32,12 +26,11 @@ let package = Package(
         .testTarget(
             name: "Tests",
             dependencies: [
-                .product(name: "Primer3DS", package: "primer-sdk-3ds-ios"),
                 .byName(name: "PrimerSDK")
             ],
             path: "Tests/",
             sources: [
-                "3DS/",
+                "Primer/",
                 "Utilities/"
             ]
         )


### PR DESCRIPTION
Short term workaround - do not merge.