### PR TITLE
chore: Deprecate a delegate method with a typo and add a new one with a proper name

### DIFF
--- a/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift
@@ -344,6 +344,11 @@ extension MerchantHeadlessCheckoutAvailablePaymentMethodsViewController: PrimerH
         print("\n\nMERCHANT APP\n\(#function)\npaymentMethodType: \(paymentMethodType)")
         self.logs.append(#function)
     }
+
+    func primerHeadlessUniversalCheckoutUIDidDismissPaymentMethod() {
+        print("\n\nMERCHANT APP\n\(#function)\nUIDidDismissPaymentMethod")
+        self.logs.append(#function)
+    }
 }
 
 extension MerchantHeadlessCheckoutAvailablePaymentMethodsViewController {

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
@@ -96,6 +96,7 @@ internal class PrimerDelegateProxy: LogReporter {
                 Primer.shared.delegate?.primerDidDismiss?()
             } else if paymentMethodManagerCategories.contains(.nativeUI) {
                 PrimerHeadlessUniversalCheckout.current.uiDelegate?.primerHeadlessUniveraslCheckoutUIDidDismissPaymentMethod?()
+                PrimerHeadlessUniversalCheckout.current.uiDelegate?.primerHeadlessUniversalCheckoutUIDidDismissPaymentMethod?()
             }
         }
     }

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckoutProtocols.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckoutProtocols.swift
@@ -15,7 +15,9 @@ import UIKit
 public protocol PrimerHeadlessUniversalCheckoutUIDelegate {
     @objc optional func primerHeadlessUniversalCheckoutUIDidStartPreparation(for paymentMethodType: String)
     @objc optional func primerHeadlessUniversalCheckoutUIDidShowPaymentMethod(for paymentMethodType: String)
+    @available(*, deprecated, message: "use `primerHeadlessUniversalCheckoutUIDidDismissPaymentMethod` instead")
     @objc optional func primerHeadlessUniveraslCheckoutUIDidDismissPaymentMethod()
+    @objc optional func primerHeadlessUniversalCheckoutUIDidDismissPaymentMethod()
 }
 
 @objc
@@ -35,3 +37,5 @@ public protocol PrimerHeadlessUniversalCheckoutDelegate {
     @objc optional func primerHeadlessUniversalCheckoutDidUpdateClientSession(_ clientSession: PrimerClientSession)
     @objc optional func primerHeadlessUniversalCheckoutWillCreatePaymentWithData(_ data: PrimerCheckoutPaymentMethodData, decisionHandler: @escaping (PrimerPaymentCreationDecision) -> Void)
 }
+// swiftlint:enable type_name
+// swiftlint:enable line_length


### PR DESCRIPTION
To avoid a breaking change due to a typo in a method name add the method with a proper name and deprecation of the old one.