### PR TITLE
fix: Add duration tracking for network requests

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
@@ -383,6 +383,7 @@ struct NetworkCallEventProperties: AnalyticsEventProperties {
     var errorBody: String?
     var responseCode: Int?
     var params: [String: AnyCodable]?
+    var duration: TimeInterval?
 
     private enum CodingKeys: String, CodingKey {
         case callType
@@ -392,6 +393,7 @@ struct NetworkCallEventProperties: AnalyticsEventProperties {
         case errorBody
         case responseCode
         case params
+        case duration
     }
 
     fileprivate init(
@@ -400,7 +402,8 @@ struct NetworkCallEventProperties: AnalyticsEventProperties {
         url: String,
         method: HTTPMethod,
         errorBody: String?,
-        responseCode: Int?
+        responseCode: Int?,
+        duration: TimeInterval? = nil
     ) {
         self.callType = callType
         self.id = id
@@ -408,6 +411,7 @@ struct NetworkCallEventProperties: AnalyticsEventProperties {
         self.method = method
         self.errorBody = errorBody
         self.responseCode = responseCode
+        self.duration = duration
 
         let sdkProperties = SDKProperties()
         if let sdkPropertiesDict = try? sdkProperties.asDictionary(),
@@ -430,6 +434,7 @@ struct NetworkCallEventProperties: AnalyticsEventProperties {
         self.errorBody = try container.decodeIfPresent(String.self, forKey: .errorBody)
         self.responseCode = try container.decodeIfPresent(Int.self, forKey: .responseCode)
         self.params = try container.decodeIfPresent([String: AnyCodable].self, forKey: .params)
+        self.duration = try container.decodeIfPresent(TimeInterval.self, forKey: .duration)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -441,6 +446,7 @@ struct NetworkCallEventProperties: AnalyticsEventProperties {
         try container.encodeIfPresent(errorBody, forKey: .errorBody)
         try container.encodeIfPresent(responseCode, forKey: .responseCode)
         try container.encodeIfPresent(params, forKey: .params)
+        try container.encodeIfPresent(duration, forKey: .duration)
     }
 }
 
@@ -779,7 +785,8 @@ extension Analytics.Event {
                             url: String,
                             method: HTTPMethod,
                             errorBody: String?,
-                            responseCode: Int?) -> Self {
+                            responseCode: Int?,
+                            duration: TimeInterval? = nil) -> Self {
         return .init(
             eventType: .networkCall,
             properties: NetworkCallEventProperties(
@@ -788,7 +795,8 @@ extension Analytics.Event {
                 url: url,
                 method: method,
                 errorBody: errorBody,
-                responseCode: responseCode
+                responseCode: responseCode,
+                duration: duration
             )
         )
     }

--- a/Sources/PrimerSDK/Classes/PCI/Services/DefaultNetworkService.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/DefaultNetworkService.swift
@@ -69,7 +69,11 @@ class DefaultNetworkService: NetworkService, LogReporter {
                                                              endpoint: endpoint,
                                                              request: request))
 
+            let startTime = DispatchTime.now()
+
             return try requestDispatcher.dispatch(request: request) { [reportingService] result in
+                let endTime = DispatchTime.now()
+                let timeElapsed = Double(endTime.uptimeNanoseconds - startTime.uptimeNanoseconds) / 1_000_000 // Convert to milliseconds
 
                 let response: DispatcherResponse
                 switch result {
@@ -82,7 +86,8 @@ class DefaultNetworkService: NetworkService, LogReporter {
 
                 reportingService.report(eventType: .requestEnd(identifier: identifier,
                                                                endpoint: endpoint,
-                                                               response: response.metadata))
+                                                               response: response.metadata,
+                                                               duration: timeElapsed))
 
                 if let error = response.error {
                     completion(.failure(InternalError.underlyingErrors(errors: [error],

--- a/Sources/PrimerSDK/Classes/PCI/Services/Network/NetworkReportingService.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/Network/NetworkReportingService.swift
@@ -9,13 +9,13 @@ import Foundation
 
 enum NetworkEventType {
     case requestStart(identifier: String, endpoint: Endpoint, request: URLRequest)
-    case requestEnd(identifier: String, endpoint: Endpoint, response: ResponseMetadata)
+    case requestEnd(identifier: String, endpoint: Endpoint, response: ResponseMetadata, duration: TimeInterval)
     case networkConnectivity(endpoint: Endpoint)
 
     var endpoint: Endpoint {
         switch self {
         case .requestStart(_, let endpoint, _),
-             .requestEnd(_, let endpoint, _),
+             .requestEnd(_, let endpoint, _, _),
              .networkConnectivity(let endpoint):
             return endpoint
         }
@@ -52,15 +52,17 @@ class DefaultNetworkReportingService: NetworkReportingService {
                 url: request.url?.absoluteString ?? "Unknown",
                 method: endpoint.method,
                 errorBody: nil,
-                responseCode: nil)
-        case .requestEnd(let id, let endpoint, let response):
+                responseCode: nil,
+                duration: nil)
+        case .requestEnd(let id, let endpoint, let response, let duration):
             event = Analytics.Event.networkCall(
                 callType: .requestEnd,
                 id: id,
                 url: response.responseUrl ?? "Unknown",
                 method: endpoint.method,
                 errorBody: nil,
-                responseCode: response.statusCode
+                responseCode: response.statusCode,
+                duration: duration
             )
         case .networkConnectivity:
             event = Analytics.Event.networkConnectivity()

--- a/Tests/Primer/Network/Services/NetworkingReportingServiceTests.swift
+++ b/Tests/Primer/Network/Services/NetworkingReportingServiceTests.swift
@@ -67,7 +67,8 @@ final class NetworkingReportingServiceTests: XCTestCase {
 
         networkReportingService.report(eventType: .requestEnd(identifier: "id",
                                                               endpoint: endpoint,
-                                                              response: responseMetadata))
+                                                              response: responseMetadata,
+                                                              duration: 1000))
 
         XCTAssertEqual(analyticsService.events.count, 1)
 


### PR DESCRIPTION
# Description

[ACC-3668](https://primerapi.atlassian.net/browse/ACC-3668)

Adds duration tracking to `NETWORK_CALL_EVENT` `REQUEST_END` events.
Events can be inspected [here](https://primer-monitoring.kb.eu-west-1.aws.found.io:9243/s/checkout/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-30m,to:now))&_a=(columns:!(SDK.sdkType,SDK.properties.duration),filters:!(),index:'5a2c0d71-d670-455b-bb55-9442e9c76eb3',interval:auto,query:(language:kuery,query:'SDK.properties.duration:%20*%20AND%20SDK.sdkType%20:%20%22IOS_NATIVE%22%20'),sort:!(!('@timestamp',desc))))

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)

[ACC-3668]: https://primerapi.atlassian.net/browse/ACC-3668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ