### PR TITLE
fix: Respect showSuccessCheckoutOnPendingPayment on resume validation

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Cache/Cache.swift
+++ b/Sources/PrimerSDK/Classes/Core/Cache/Cache.swift
@@ -1,0 +1,50 @@
+//
+//  Cache.swift
+//  PrimerSDK
+//
+//  Created by Niall Quinn on 31/07/24.
+//
+
+import Foundation
+
+class Cache<Key: Hashable, Value> {
+    private let cache = NSCache<WrappedKey, Entry>()
+
+    func insert(_ value: Value, forKey key: Key) {
+        cache.setObject(Entry(value: value), forKey: WrappedKey(key))
+    }
+
+    func value(forKey key: Key) -> Value? {
+        guard let entry = cache.object(forKey: WrappedKey(key)) else {
+            return nil
+        }
+        return entry.value
+    }
+
+    func removeValue(forKey key: Key) {
+        cache.removeObject(forKey: WrappedKey(key))
+    }
+}
+
+private extension Cache {
+    final class WrappedKey: NSObject {
+        let key: Key
+        init(_ key: Key) { self.key = key }
+
+        override var hash: Int { return key.hashValue }
+
+        override func isEqual(_ object: Any?) -> Bool {
+            guard let value = object as? WrappedKey else {
+                return false
+            }
+            return value.key == key
+        }
+    }
+}
+
+private extension Cache {
+    final class Entry {
+        let value: Value
+        init(value: Value) { self.value = value }
+    }
+}

--- a/Sources/PrimerSDK/Classes/Core/Cache/ConfigurationCache/ConfigurationCache.swift
+++ b/Sources/PrimerSDK/Classes/Core/Cache/ConfigurationCache/ConfigurationCache.swift
@@ -1,0 +1,8 @@
+//
+//  ConfigurationCache.swift
+//  PrimerSDK
+//
+//  Created by Niall Quinn on 31/07/24.
+//
+
+import Foundation

--- a/Sources/PrimerSDK/Classes/Core/Cache/ConfigurationCache/ConfigurationCache.swift
+++ b/Sources/PrimerSDK/Classes/Core/Cache/ConfigurationCache/ConfigurationCache.swift
@@ -6,3 +6,68 @@
 //
 
 import Foundation
+
+protocol ConfigurationCaching {
+    func clearCache()
+    func setData(_ data: ConfigurationCachedData, forKey key: String)
+    func data(forKey key: String) -> ConfigurationCachedData?
+}
+
+class ConfigurationCache: ConfigurationCaching {
+    static let shared = ConfigurationCache()
+    private var cache = Cache<String, ConfigurationCachedData>()
+
+    func clearCache() {
+        cache = Cache<String, ConfigurationCachedData>()
+    }
+
+    func data(forKey key: String) -> ConfigurationCachedData? {
+        if let cachedData = cache.value(forKey: key) {
+            if validateCachedConfig(key: key, cachedData: cachedData) == false {
+                cache.removeValue(forKey: key)
+                return nil
+            }
+            return cachedData
+        }
+        return nil
+    }
+
+    func setData(_ data: ConfigurationCachedData, forKey key: String) {
+        // Cache includes at most one cached configuration
+        clearCache()
+        cache.insert(data, forKey: key)
+    }
+
+    private func validateCachedConfig(key: String, cachedData: ConfigurationCachedData) -> Bool {
+        let timestamp = cachedData.timestamp
+        let now = Date().timeIntervalSince1970
+        let timeInterval = now - timestamp
+
+        if timeInterval > cachedData.ttl {
+            return false
+        }
+
+        return true
+    }
+}
+
+class ConfigurationCachedData {
+    let config: PrimerAPIConfiguration
+    let timestamp: TimeInterval
+    let ttl: TimeInterval
+
+    init(config: PrimerAPIConfiguration, ttl: TimeInterval) {
+        self.config = config
+        self.timestamp = Date().timeIntervalSince1970
+        self.ttl = ttl
+    }
+
+    init(config: PrimerAPIConfiguration, headers: [String: String]? = nil) {
+        //Extract ttl from headers
+        self.config = config
+        self.timestamp = Date().timeIntervalSince1970
+        self.ttl = Self.FallbackCacheExpiration
+    }
+
+    static let FallbackCacheExpiration: TimeInterval = 60 * 60 * 1000
+}

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
@@ -45,7 +45,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
                     seal.reject(error)
                 case .success(let paymentResponse):
                     do {
-                        try self.validateResponse(paymentResponse: paymentResponse, callType: "create")
+                        try self.validateResponse(paymentResponse: paymentResponse, callType: .create)
                         seal.fulfill(paymentResponse)
                     } catch {
                         seal.reject(error)
@@ -70,8 +70,10 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
         }
     }
 
-    private func validateResponse(paymentResponse: Response.Body.Payment, callType: String) throws {
-        if paymentResponse.id == nil || paymentResponse.status == .failed {
+    private func validateResponse(paymentResponse: Response.Body.Payment, callType: PaymentCallType) throws {
+
+        if paymentResponse.id == nil || paymentResponse.status == .failed ||
+            (callType == .resume && paymentResponse.status == .pending && paymentResponse.showSuccessCheckoutOnPendingPayment == false) {
             let err = PrimerError.paymentFailed(
                 paymentMethodType: self.paymentMethodType,
                 paymentId: paymentResponse.id ?? "unknown",
@@ -101,7 +103,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
                     seal.reject(error)
                 case .success(let paymentResponse):
                     do {
-                        try self.validateResponse(paymentResponse: paymentResponse, callType: "resume")
+                        try self.validateResponse(paymentResponse: paymentResponse, callType: .resume)
                         seal.fulfill(paymentResponse)
                     } catch {
                         seal.reject(error)
@@ -109,5 +111,9 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
                 }
             }
         }
+    }
+
+    enum PaymentCallType: String {
+        case create, resume
     }
 }

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/Klarna/Components/KlarnaTokenizationComponent.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Composable/Klarna/Components/KlarnaTokenizationComponent.swift
@@ -183,7 +183,7 @@ private extension KlarnaTokenizationComponent {
     private func requestPrimerConfiguration(decodedJWTToken: DecodedJWTToken, request: ClientSessionUpdateRequest) -> Promise<Void> {
         return Promise { seal in
             apiClient.requestPrimerConfigurationWithActions(clientToken: decodedJWTToken,
-                                                            request: request) { [weak self] result in
+                                                            request: request) { [weak self] result, _ in
                 guard let self = self else { return }
                 switch result {
                 case .success(let configuration):

--- a/Sources/PrimerSDK/Classes/Data Models/API/PaymentAPIModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/API/PaymentAPIModel.swift
@@ -118,10 +118,11 @@ extension Response.Body {
         public let requiredAction: Response.Body.Payment.RequiredAction?
         public let status: Status
         public let paymentFailureReason: PrimerPaymentErrorCode.RawValue?
+        public let showSuccessCheckoutOnPendingPayment: Bool? = false
 
         // swiftlint:disable:next nesting
         public enum CodingKeys: String, CodingKey {
-            case id, paymentId, amount, currencyCode, customer, customerId, order, orderId, requiredAction, status, paymentFailureReason
+            case id, paymentId, amount, currencyCode, customer, customerId, order, orderId, requiredAction, status, paymentFailureReason, showSuccessCheckoutOnPendingPayment
             case dateStr = "date"
         }
 

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerConfiguration.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerConfiguration.swift
@@ -11,6 +11,7 @@ import Foundation
 import PassKit
 
 typealias PrimerAPIConfiguration = Response.Body.Configuration
+typealias PrimerAPIConfigurationResponse = (config: Response.Body.Configuration, ttl: TimeInterval)
 
 extension Request.URLParameters {
 

--- a/Sources/PrimerSDK/Classes/Services/Network/NetworkService.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/NetworkService.swift
@@ -8,8 +8,12 @@
 import Foundation
 
 typealias ResponseCompletion<T> = (Result<T, Error>) -> Void
+typealias ResponseCompletionWithHeaders<T> = (Result<T, Error>, [String: String]?) -> Void
 
 internal protocol NetworkService {
     @discardableResult
     func request<T: Decodable>(_ endpoint: Endpoint, completion: @escaping ResponseCompletion<T>) -> PrimerCancellable?
+    
+    @discardableResult
+    func request<T: Decodable>(_ endpoint: Endpoint, completion: @escaping ResponseCompletionWithHeaders<T>) -> PrimerCancellable?
 }

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
@@ -76,9 +76,17 @@ internal class PrimerAPIClient: PrimerAPIClientProtocol {
 
     func fetchConfiguration(clientToken: DecodedJWTToken,
                             requestParameters: Request.URLParameters.Configuration?,
-                            completion: @escaping APICompletion<PrimerAPIConfiguration>) {
+                            completion: @escaping ConfigurationCompletion) {
         let endpoint = PrimerAPI.fetchConfiguration(clientToken: clientToken, requestParameters: requestParameters)
-        execute(endpoint, completion: completion)
+        networkService.request(endpoint) { (result: Result<PrimerAPIConfiguration, Error>, headers) in
+            switch result {
+            case .success(let result):
+                completion(.success(result), headers)
+            case .failure(let error):
+                ErrorHandler.shared.handle(error: error)
+                completion(.failure(error), nil)
+            }
+        }
     }
 
     func createPayPalOrderSession(clientToken: DecodedJWTToken,
@@ -157,10 +165,18 @@ internal class PrimerAPIClient: PrimerAPIClientProtocol {
 
     func requestPrimerConfigurationWithActions(clientToken: DecodedJWTToken,
                                                request: ClientSessionUpdateRequest,
-                                               completion: @escaping APICompletion<PrimerAPIConfiguration>) {
+                                               completion: @escaping ConfigurationCompletion) {
 
         let endpoint = PrimerAPI.requestPrimerConfigurationWithActions(clientToken: clientToken, request: request)
-        execute(endpoint, completion: completion)
+        networkService.request(endpoint) { (result: Result<PrimerAPIConfiguration, Error>, headers) in
+            switch result {
+            case .success(let result):
+                completion(.success(result), headers)
+            case .failure(let error):
+                ErrorHandler.shared.handle(error: error)
+                completion(.failure(error), nil)
+            }
+        }
     }
 
     func sendAnalyticsEvents(clientToken: DecodedJWTToken?,

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClientProtocol.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClientProtocol.swift
@@ -9,6 +9,7 @@ import Foundation
 
 typealias APIResult<T> = Result<T, Error>
 typealias APICompletion<T> = (APIResult<T>) -> Void
+typealias ConfigurationCompletion = (Result<PrimerAPIConfiguration, Error>, [String: String]?) -> Void
 
 protocol PrimerAPIClientProtocol:
     PrimerAPIClientAnalyticsProtocol,
@@ -23,7 +24,7 @@ protocol PrimerAPIClientProtocol:
     func fetchConfiguration(
         clientToken: DecodedJWTToken,
         requestParameters: Request.URLParameters.Configuration?,
-        completion: @escaping APICompletion<Response.Body.Configuration>)
+        completion: @escaping ConfigurationCompletion)
 
     func validateClientToken(
         request: Request.Body.ClientTokenValidation,
@@ -31,7 +32,7 @@ protocol PrimerAPIClientProtocol:
 
     func requestPrimerConfigurationWithActions(clientToken: DecodedJWTToken,
                                                request: ClientSessionUpdateRequest,
-                                               completion: @escaping APICompletion<PrimerAPIConfiguration>)
+                                               completion: @escaping ConfigurationCompletion)
 
     // MARK: Klarna
 

--- a/Tests/Primer/Services/CreateResumeServiceTests.swift
+++ b/Tests/Primer/Services/CreateResumeServiceTests.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Niall Quinn on 31/07/24.
+//
+
+import Foundation


### PR DESCRIPTION
# Description
This PR respects the `showSuccessCheckoutOnPendingPayment` flag when validating `Payment` response on the `/resume` call.

- If the `Payment` response is in state `PENDING` and `showSuccessCheckoutOnPendingPayment` is `false`, we will throw the payment failed error, as we would if the state was `FAILED`
- If the `Payment` response is in state `PENDING` and `showSuccessCheckoutOnPendingPayment` is `true`, we will continue on the success path


# Manual Testing

Test with Fintechture as outlined [here](https://www.notion.so/primerio/Fintecture-Smart-Transfer-260f22a95b2643a8ad3ae9dc77a80bb1?pvs=4)

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)