### PR TITLE
feat: session is active

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Primer/Primer.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/Primer.swift
@@ -109,4 +109,11 @@ public class Primer {
     public func dismiss() {
         PrimerInternal.shared.dismiss()
     }
+
+    /**
+     Checkout Session is active?
+     */
+    public func checkoutSessionIsActive() -> Bool {
+        PrimerInternal.shared.checkoutSessionId != nil
+    }
 }

--- a/Sources/PrimerSDK/Classes/Core/Primer/Primer.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/Primer.swift
@@ -114,6 +114,6 @@ public class Primer {
      Checkout Session is active?
      */
     public func checkoutSessionIsActive() -> Bool {
-        PrimerInternal.shared.checkoutSessionId != nil
+        PrimerInternal.shared.checkoutSessionIsActive()
     }
 }

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
@@ -276,4 +276,8 @@ internal class PrimerInternal: LogReporter {
             }
         }
     }
+
+    internal func checkoutSessionIsActive() -> Bool {
+        checkoutSessionId != nil
+    }
 }

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
@@ -132,6 +132,7 @@ public class PrimerHeadlessUniversalCheckout: LogReporter {
 
     public func cleanUp() {
         PrimerAPIConfigurationModule.resetSession()
+        PrimerInternal.shared.checkoutSessionId = nil
     }
 
     // MARK: - HELPERS

--- a/Tests/Primer/Utils/CheckoutSessionTests.swift
+++ b/Tests/Primer/Utils/CheckoutSessionTests.swift
@@ -1,0 +1,26 @@
+//
+//  File.swift
+//  
+//
+//  Created by Niall Quinn on 06/08/24.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+final class CheckoutSessionTests: XCTestCase {
+    func test_headless_cleanup() {
+        XCTAssertFalse(Primer.shared.checkoutSessionIsActive())
+
+        let expectation = self.expectation(description: "Wait for headless load")
+
+        PrimerHeadlessUniversalCheckout.current.start(withClientToken: "") { paymentMethods, err in
+            XCTAssertTrue(Primer.shared.checkoutSessionIsActive())
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 30)
+        PrimerHeadlessUniversalCheckout.current.cleanUp()
+        XCTAssertFalse(Primer.shared.checkoutSessionIsActive())
+    }
+}


### PR DESCRIPTION
# Description

CHKT-XXXX

- These changes expose `Primer.shared.checkoutSessionIsActive`
- This will indicate if there is an active session.
- Merchant must use the `PrimerHeadlessUniversalCheckout.cleanUp()` function to rely on this.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)