### PR TITLE
chore: Enable PrimerHeadlessUniversalCheckout.PaymentMethod creation for tests

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
@@ -8,6 +8,10 @@
 import Foundation
 import PassKit
 
+protocol PrimerPaymentMethodProviding {
+    func paymentMethod(for paymentMethodType: String) -> PrimerPaymentMethod?
+}
+
 extension PrimerHeadlessUniversalCheckout {
 
     public class PaymentMethod: NSObject {
@@ -34,9 +38,9 @@ extension PrimerHeadlessUniversalCheckout {
         public private(set) var paymentMethodManagerCategories: [PrimerPaymentMethodManagerCategory]
         public private(set) var requiredInputDataClass: PrimerRawData.Type?
 
-        init?(paymentMethodType: String) {
-            guard let paymentMethod = PrimerAPIConfiguration.paymentMethodConfigs?
-                    .first(where: { $0.type == paymentMethodType })
+
+        init?(paymentMethodType: String, paymentMethodProvider: PrimerPaymentMethodProviding = DefaultPaymentMethodProvider()) {
+            guard let paymentMethod = paymentMethodProvider.paymentMethod(for: paymentMethodType)
             else {
                 return nil
             }
@@ -62,6 +66,13 @@ extension PrimerHeadlessUniversalCheckout {
             }
 
             super.init()
+        }
+
+        private class DefaultPaymentMethodProvider: PrimerPaymentMethodProviding {
+            func paymentMethod(for paymentMethodType: String) -> PrimerPaymentMethod? {
+                PrimerAPIConfiguration.paymentMethodConfigs?
+                        .first(where: { $0.type == paymentMethodType })
+            }
         }
     }
 }

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
@@ -74,5 +74,15 @@ extension PrimerHeadlessUniversalCheckout {
                         .first(where: { $0.type == paymentMethodType })
             }
         }
+
+        #if DEBUG
+        init(type: String,
+             supportedPrimerSessionIntents: [PrimerSessionIntent] = [],
+             paymentMethodManagerCategories: [PrimerPaymentMethodManagerCategory] = [.nativeUI]) {
+            self.paymentMethodType = type
+            self.supportedPrimerSessionIntents = supportedPrimerSessionIntents
+            self.paymentMethodManagerCategories = paymentMethodManagerCategories
+        }
+        #endif
     }
 }

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
@@ -67,12 +67,14 @@ extension PrimerHeadlessUniversalCheckout {
             super.init()
         }
 
+        // swiftlint:disable nesting
         private class DefaultPaymentMethodProvider: PrimerPaymentMethodProviding {
             func paymentMethod(for paymentMethodType: String) -> PrimerPaymentMethod? {
                 PrimerAPIConfiguration.paymentMethodConfigs?
                         .first(where: { $0.type == paymentMethodType })
             }
         }
+        // swiftlint:enable nesting
 
         #if DEBUG
         init(type: String,

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Models/PrimerHeadlessUniversalCheckoutPaymentMethod.swift
@@ -38,7 +38,6 @@ extension PrimerHeadlessUniversalCheckout {
         public private(set) var paymentMethodManagerCategories: [PrimerPaymentMethodManagerCategory]
         public private(set) var requiredInputDataClass: PrimerRawData.Type?
 
-
         init?(paymentMethodType: String, paymentMethodProvider: PrimerPaymentMethodProviding = DefaultPaymentMethodProvider()) {
             guard let paymentMethod = paymentMethodProvider.paymentMethod(for: paymentMethodType)
             else {

--- a/Tests/Primer/Data Models/PrimerPaymentMethodTests.swift
+++ b/Tests/Primer/Data Models/PrimerPaymentMethodTests.swift
@@ -184,6 +184,22 @@ final class PrimerPaymentMethodTests: XCTestCase {
         }
     }
 
+    func test_initializeHeadlessPaymentMethod_withProvider() throws {
+        let primerPaymentMethod = createPaymentMethod(withImplementationType: .nativeSdk)
+        let paymentMethodProvider = TestPaymentMethodProvider(paymentMethod: primerPaymentMethod)
+        let pm = PrimerHeadlessUniversalCheckout.PaymentMethod(paymentMethodType: primerPaymentMethod.type, paymentMethodProvider: paymentMethodProvider)
+
+
+        let headlessPaymentMethod = PrimerHeadlessUniversalCheckout.PaymentMethod(paymentMethodType: "PAYMENT_CARD")
+
+        XCTAssertNotNil(pm)
+    }
+
+    func test_initializeHeadlessPaymentMethod_raw() throws {
+        let headlessPaymentMethod = PrimerHeadlessUniversalCheckout.PaymentMethod(type: "PAYMENT_CARD")
+        XCTAssertEqual(headlessPaymentMethod.paymentMethodType, "PAYMENT_CARD")
+    }
+
     // MARK: Helpers
 
     private func createPaymentMethod(withImplementationType implementationType: PrimerPaymentMethod.ImplementationType,
@@ -198,5 +214,16 @@ final class PrimerPaymentMethodTests: XCTestCase {
             options: nil,
             displayMetadata: nil
         )
+    }
+
+    private struct TestPaymentMethodProvider: PrimerPaymentMethodProviding {
+        var paymentMethod: PrimerPaymentMethod
+        func paymentMethod(for paymentMethodType: String) -> PrimerPaymentMethod? {
+            if paymentMethod.type == paymentMethodType {
+                return paymentMethod
+            } else {
+                return nil
+            }
+        }
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -273,7 +273,7 @@ platform :ios do
 
     match(
       type: options[:match_type],
-      readonly: false,
+      readonly: true,
       keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"],
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -273,7 +273,7 @@ platform :ios do
 
     match(
       type: options[:match_type],
-      readonly: true,
+      readonly: false,
       keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"],
     )


### PR DESCRIPTION
Background: a merchant developer would like to create `PrimerHeadlessUniversalCheckout.PaymentMethod`s in their test suite. Our current initializer did not allow this, as it relied on the side effect of `PrimerAPIConfiguration` providing a `PrimerPaymentMethod` to back the `PrimerHeadlessUniversalCheckout.PaymentMethod`.

Two solutions are presented here:

1. Injected the `PrimerPaymentMethodProviding` object, implemented a default in `PrimerHeadlessUniversalCheckout.PaymentMethod` to perform the current behaviour.
2. Surfaced an initializer only in DEBUG builds to allow direct creation of the `PrimerHeadlessUniversalCheckout.PaymentMethod` directly