### PR TITLE
fix: apply uiDelegate when set in PrimerHeadlessUniversalCheckout.current.start

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
@@ -64,6 +64,10 @@ public class PrimerHeadlessUniversalCheckout: LogReporter {
             PrimerHeadlessUniversalCheckout.current.delegate = delegate
         }
 
+        if uiDelegate != nil {
+            PrimerHeadlessUniversalCheckout.current.uiDelegate = uiDelegate
+        }
+
         if PrimerHeadlessUniversalCheckout.current.delegate == nil {
             let message = """
                 PrimerHeadlessUniversalCheckout delegate has not been set, \

--- a/Tests/Primer/Utils/CheckoutSessionTests.swift
+++ b/Tests/Primer/Utils/CheckoutSessionTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import PrimerSDK
 
 final class CheckoutSessionTests: XCTestCase {
-    func test_headless_cleanup() {
+    func test_headless_cleanup() throws {
         XCTAssertFalse(Primer.shared.checkoutSessionIsActive())
 
         let expectation = self.expectation(description: "Wait for headless load")
@@ -23,4 +23,26 @@ final class CheckoutSessionTests: XCTestCase {
         PrimerHeadlessUniversalCheckout.current.cleanUp()
         XCTAssertFalse(Primer.shared.checkoutSessionIsActive())
     }
+
+    func test_headless_delegates() throws {
+        let mockDelegate = MockDelegate()
+        let expectation = self.expectation(description: "Wait for headless load")
+        PrimerHeadlessUniversalCheckout.current.start(withClientToken: "", delegate: mockDelegate, uiDelegate: mockDelegate) { paymentMethods, err in
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 30)
+        guard let mockDelegate = PrimerHeadlessUniversalCheckout.current.delegate as? MockDelegate, let mockUIDelegate = PrimerHeadlessUniversalCheckout.current.uiDelegate as? MockDelegate else {
+            XCTFail("Delegates not set")
+            return
+        }
+        
+        XCTAssertEqual(mockDelegate.id, "mock-id")
+        XCTAssertEqual(mockUIDelegate.id, "mock-id")
+    }
+}
+
+private class MockDelegate: PrimerHeadlessUniversalCheckoutDelegate, PrimerHeadlessUniversalCheckoutUIDelegate {
+    let id = "mock-id"
+    func primerHeadlessUniversalCheckoutDidCompleteCheckoutWithData(_ data: PrimerSDK.PrimerCheckoutData) {}
 }


### PR DESCRIPTION
# Description

[ACC-3935](https://primerapi.atlassian.net/browse/ACC-3935)

the uiDelegate property when starting the headless is ignored in the function. Setting it afterward directly works 


# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)

[ACC-3935]: https://primerapi.atlassian.net/browse/ACC-3935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ