### PR TITLE
fix: Add some checkoutData in the case of error

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
@@ -150,7 +150,7 @@ extension PaymentMethodTokenizationViewModel {
                                                                  userInfo: .errorUserInfoDictionary(),
                                                                  diagnosticsId: UUID().uuidString)
                     }
-
+                    self.setCheckoutDataFromError(primerErr)
                     return PrimerDelegateProxy.raisePrimerDidFailWithError(primerErr, data: self.paymentCheckoutData)
                 }
                 .done { merchantErrorMessage in
@@ -515,6 +515,18 @@ Make sure you call the decision handler otherwise the SDK will hang.
     func nullifyEventCallbacks() {
         self.didStartPayment = nil
         self.didFinishPayment = nil
+    }
+
+    func setCheckoutDataFromError(_ error: PrimerError) {
+        switch error {
+        case .paymentFailed(_, let paymentId, _, _, _):
+            self.paymentCheckoutData = PrimerCheckoutData(
+                payment: PrimerCheckoutDataPayment(id: paymentId,
+                                                   orderId: nil,
+                                                   paymentFailureReason: PrimerPaymentErrorCode.failed))
+        default:
+            return
+        }
     }
 }
 

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
@@ -518,14 +518,22 @@ Make sure you call the decision handler otherwise the SDK will hang.
     }
 
     func setCheckoutDataFromError(_ error: PrimerError) {
-        switch error {
+        if let checkoutData = error.checkoutData {
+            self.paymentCheckoutData = checkoutData
+        }
+    }
+}
+
+extension PrimerError {
+    var checkoutData: PrimerCheckoutData? {
+        switch self {
         case .paymentFailed(_, let paymentId, _, _, _):
-            self.paymentCheckoutData = PrimerCheckoutData(
+            return PrimerCheckoutData(
                 payment: PrimerCheckoutDataPayment(id: paymentId,
                                                    orderId: nil,
                                                    paymentFailureReason: PrimerPaymentErrorCode.failed))
         default:
-            return
+            return nil
         }
     }
 }

--- a/Tests/Primer/Extensions/ErrorExtensionTests.swift
+++ b/Tests/Primer/Extensions/ErrorExtensionTests.swift
@@ -177,15 +177,4 @@ final class ErrorExtensionTests: XCTestCase {
         XCTAssertFalse(differentDomainError.isNetworkError, "Expected error from a different domain to not be identified as a network error")
     }
 
-    func test_checkoutData() {
-        let error = PrimerError.paymentFailed(paymentMethodType: "PMT", paymentId: "123", status: "FAILED", userInfo: nil, diagnosticsId: "id")
-        let checkoutData = error.checkoutData
-
-        XCTAssertEqual(checkoutData?.payment?.id, "123")
-        XCTAssertEqual(checkoutData?.payment?.paymentFailureReason, PrimerPaymentErrorCode.failed)
-
-        let error2 = PrimerError.cancelled(paymentMethodType: "PMT", userInfo: nil, diagnosticsId: "id")
-        XCTAssertNil(error2.checkoutData)
-    }
-
 }

--- a/Tests/Primer/Extensions/ErrorExtensionTests.swift
+++ b/Tests/Primer/Extensions/ErrorExtensionTests.swift
@@ -177,5 +177,15 @@ final class ErrorExtensionTests: XCTestCase {
         XCTAssertFalse(differentDomainError.isNetworkError, "Expected error from a different domain to not be identified as a network error")
     }
 
+    func test_checkoutData() {
+        let error = PrimerError.paymentFailed(paymentMethodType: "PMT", paymentId: "123", status: "FAILED", userInfo: nil, diagnosticsId: "id")
+        let checkoutData = error.checkoutData
+
+        XCTAssertEqual(checkoutData?.payment?.id, "123")
+        XCTAssertEqual(checkoutData?.payment?.paymentFailureReason, PrimerPaymentErrorCode.failed)
+
+        let error2 = PrimerError.cancelled(paymentMethodType: "PMT", userInfo: nil, diagnosticsId: "id")
+        XCTAssertNil(error2.checkoutData)
+    }
 
 }

--- a/Tests/Primer/Tokenization/View Models/CardFormPaymentMethodTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/CardFormPaymentMethodTokenizationViewModelTests.swift
@@ -174,6 +174,27 @@ final class CardFormPaymentMethodTokenizationViewModelTests: XCTestCase, Tokeniz
         }
     }
 
+    func test_checkoutDataFromError() throws {
+
+        let sut = PaymentMethodTokenizationViewModel(config: PrimerPaymentMethod(id: "id",
+                                                                                 implementationType: .nativeSdk,
+                                                                                 type: "PMT",
+                                                                                 name: "",
+                                                                                 processorConfigId: nil,
+                                                                                 surcharge: nil,
+                                                                                 options: nil,
+                                                                                 displayMetadata: nil))
+
+        let error = PrimerError.paymentFailed(paymentMethodType: "PMT", paymentId: "123", status: "FAILED", userInfo: nil, diagnosticsId: "id")
+        sut.setCheckoutDataFromError(error)
+
+        XCTAssertEqual(sut.paymentCheckoutData?.payment?.id, "123")
+        XCTAssertEqual(sut.paymentCheckoutData?.payment?.paymentFailureReason, PrimerPaymentErrorCode.failed)
+
+        let error2 = PrimerError.cancelled(paymentMethodType: "PMT", userInfo: nil, diagnosticsId: "id")
+        XCTAssertNil(error2.checkoutData)
+    }
+
     // MARK: Helpers
 
     private var checkoutModule: PrimerAPIConfiguration.CheckoutModule {


### PR DESCRIPTION
# Description

[DPS-615](https://primerapi.atlassian.net/browse/DPS-615)

- Adds `PrimerCheckoutData` with a `paymentId` to the callback in the case of error.

This unblocks the merchant, but we will create a ticket to build a more robust solution which returns the actual response, and aligns with Android.

# Manual Testing

In the Debug App, perform a PayPal payment (on Headless) - it should fail and allow you to inspect the callback.

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)

[DPS-615]: https://primerapi.atlassian.net/browse/DPS-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ