### PR TITLE
fix: Adds orderId to the PrimerCheckoutData in error case

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
@@ -62,6 +62,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             let err = PrimerError.paymentFailed(
                 paymentMethodType: self.paymentMethodType,
                 paymentId: paymentResponse.id ?? "unknown",
+                orderId: paymentResponse.orderId ?? nil,
                 status: paymentResponse.status.rawValue,
                 userInfo: .errorUserInfoDictionary(),
                 diagnosticsId: UUID().uuidString)

--- a/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
@@ -57,6 +57,7 @@ public enum PrimerError: PrimerErrorProtocol {
     case merchantError(message: String, userInfo: [String: String]?, diagnosticsId: String)
     case paymentFailed(paymentMethodType: String?,
                        paymentId: String,
+                       orderId: String?,
                        status: String,
                        userInfo: [String: String]?,
                        diagnosticsId: String)
@@ -191,7 +192,7 @@ public enum PrimerError: PrimerErrorProtocol {
             return diagnosticsId
         case .merchantError(_, _, let diagnosticsId):
             return diagnosticsId
-        case .paymentFailed(_, _, _, _, let diagnosticsId):
+        case .paymentFailed(_, _, _, _, _, let diagnosticsId):
             return diagnosticsId
         case .applePayTimedOut(_, let diagnosticsId):
             return diagnosticsId
@@ -252,7 +253,7 @@ public enum PrimerError: PrimerErrorProtocol {
             return "Payment method \(paymentMethodType) is not supported on \(category) manager"
         case .merchantError(let message, _, _):
             return message
-        case .paymentFailed(_, let paymentId, let status, _, _):
+        case .paymentFailed(_, let paymentId, _, let status, _, _):
             return "The payment with id \(paymentId) was created or resumed but ended up in a \(status) status."
         case .applePayTimedOut:
             return "Apple Pay timed out"
@@ -301,7 +302,7 @@ public enum PrimerError: PrimerErrorProtocol {
              .underlyingErrors(_, let userInfo, _),
              .missingSDK(_, _, let userInfo, _),
              .merchantError(_, let userInfo, _),
-             .paymentFailed(_, _, _, let userInfo, _),
+             .paymentFailed(_, _, _, _, let userInfo, _),
              .applePayTimedOut(let userInfo, _),
              .failedToCreatePayment(_, _, let userInfo, _),
              .failedToResumePayment(_, _, let userInfo, _),
@@ -428,7 +429,7 @@ and other parameters are set correctly for the current environment.
              .unableToPresentPaymentMethod(let paymentMethodType, _, _),
              .unsupportedPaymentMethod(let paymentMethodType, _, _),
              .missingSDK(let paymentMethodType, _, _, _),
-             .paymentFailed(let paymentMethodType?, _, _, _, _),
+             .paymentFailed(let paymentMethodType?, _, _, _, _, _),
              .failedToCreatePayment(let paymentMethodType, _, _, _),
              .failedToResumePayment(let paymentMethodType, _, _, _):
             return paymentMethodType

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
@@ -527,10 +527,10 @@ Make sure you call the decision handler otherwise the SDK will hang.
 extension PrimerError {
     var checkoutData: PrimerCheckoutData? {
         switch self {
-        case .paymentFailed(_, let paymentId, _, _, _):
+        case .paymentFailed(_, let paymentId, let orderId, _, _, _):
             return PrimerCheckoutData(
                 payment: PrimerCheckoutDataPayment(id: paymentId,
-                                                   orderId: nil,
+                                                   orderId: orderId,
                                                    paymentFailureReason: PrimerPaymentErrorCode.failed))
         default:
             return nil

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
@@ -150,7 +150,7 @@ extension PaymentMethodTokenizationViewModel {
                                                                  userInfo: .errorUserInfoDictionary(),
                                                                  diagnosticsId: UUID().uuidString)
                     }
-
+                    self.setCheckoutDataFromError(primerErr)
                     return PrimerDelegateProxy.raisePrimerDidFailWithError(primerErr, data: self.paymentCheckoutData)
                 }
                 .done { merchantErrorMessage in
@@ -515,6 +515,18 @@ Make sure you call the decision handler otherwise the SDK will hang.
     func nullifyEventCallbacks() {
         self.didStartPayment = nil
         self.didFinishPayment = nil
+    }
+
+    func setCheckoutDataFromError(_ error: PrimerError) {
+        switch error {
+        case .paymentFailed(_, let paymentId, _, _, _):
+            self.paymentCheckoutData = PrimerCheckoutData(
+                payment: PrimerCheckoutDataPayment(id: paymentId,
+                                                   orderId: nil,
+                                                   paymentFailureReason: PrimerPaymentErrorCode.failed))
+        default:
+            return
+        }
     }
 }
 

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
@@ -518,14 +518,22 @@ Make sure you call the decision handler otherwise the SDK will hang.
     }
 
     func setCheckoutDataFromError(_ error: PrimerError) {
-        switch error {
+        if let checkoutData = error.checkoutData {
+            self.paymentCheckoutData = checkoutData
+        }
+    }
+}
+
+extension PrimerError {
+    var checkoutData: PrimerCheckoutData? {
+        switch self {
         case .paymentFailed(_, let paymentId, _, _, _):
-            self.paymentCheckoutData = PrimerCheckoutData(
+            return PrimerCheckoutData(
                 payment: PrimerCheckoutDataPayment(id: paymentId,
                                                    orderId: nil,
                                                    paymentFailureReason: PrimerPaymentErrorCode.failed))
         default:
-            return
+            return nil
         }
     }
 }

--- a/Tests/Primer/Extensions/ErrorExtensionTests.swift
+++ b/Tests/Primer/Extensions/ErrorExtensionTests.swift
@@ -177,15 +177,4 @@ final class ErrorExtensionTests: XCTestCase {
         XCTAssertFalse(differentDomainError.isNetworkError, "Expected error from a different domain to not be identified as a network error")
     }
 
-    func test_checkoutData() {
-        let error = PrimerError.paymentFailed(paymentMethodType: "PMT", paymentId: "123", status: "FAILED", userInfo: nil, diagnosticsId: "id")
-        let checkoutData = error.checkoutData
-
-        XCTAssertEqual(checkoutData?.payment?.id, "123")
-        XCTAssertEqual(checkoutData?.payment?.paymentFailureReason, PrimerPaymentErrorCode.failed)
-
-        let error2 = PrimerError.cancelled(paymentMethodType: "PMT", userInfo: nil, diagnosticsId: "id")
-        XCTAssertNil(error2.checkoutData)
-    }
-
 }

--- a/Tests/Primer/Extensions/ErrorExtensionTests.swift
+++ b/Tests/Primer/Extensions/ErrorExtensionTests.swift
@@ -177,5 +177,15 @@ final class ErrorExtensionTests: XCTestCase {
         XCTAssertFalse(differentDomainError.isNetworkError, "Expected error from a different domain to not be identified as a network error")
     }
 
+    func test_checkoutData() {
+        let error = PrimerError.paymentFailed(paymentMethodType: "PMT", paymentId: "123", status: "FAILED", userInfo: nil, diagnosticsId: "id")
+        let checkoutData = error.checkoutData
+
+        XCTAssertEqual(checkoutData?.payment?.id, "123")
+        XCTAssertEqual(checkoutData?.payment?.paymentFailureReason, PrimerPaymentErrorCode.failed)
+
+        let error2 = PrimerError.cancelled(paymentMethodType: "PMT", userInfo: nil, diagnosticsId: "id")
+        XCTAssertNil(error2.checkoutData)
+    }
 
 }

--- a/Tests/Primer/Tokenization/View Models/CardFormPaymentMethodTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/CardFormPaymentMethodTokenizationViewModelTests.swift
@@ -185,10 +185,16 @@ final class CardFormPaymentMethodTokenizationViewModelTests: XCTestCase, Tokeniz
                                                                                  options: nil,
                                                                                  displayMetadata: nil))
 
-        let error = PrimerError.paymentFailed(paymentMethodType: "PMT", paymentId: "123", status: "FAILED", userInfo: nil, diagnosticsId: "id")
+        let error = PrimerError.paymentFailed(paymentMethodType: "PMT",
+                                              paymentId: "123",
+                                              orderId: "OrderId",
+                                              status: "FAILED",
+                                              userInfo: nil,
+                                              diagnosticsId: "id")
         sut.setCheckoutDataFromError(error)
 
         XCTAssertEqual(sut.paymentCheckoutData?.payment?.id, "123")
+        XCTAssertEqual(sut.paymentCheckoutData?.payment?.orderId, "OrderId")
         XCTAssertEqual(sut.paymentCheckoutData?.payment?.paymentFailureReason, PrimerPaymentErrorCode.failed)
 
         let error2 = PrimerError.cancelled(paymentMethodType: "PMT", userInfo: nil, diagnosticsId: "id")

--- a/Tests/Primer/Tokenization/View Models/CardFormPaymentMethodTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/CardFormPaymentMethodTokenizationViewModelTests.swift
@@ -174,6 +174,27 @@ final class CardFormPaymentMethodTokenizationViewModelTests: XCTestCase, Tokeniz
         }
     }
 
+    func test_checkoutDataFromError() throws {
+
+        let sut = PaymentMethodTokenizationViewModel(config: PrimerPaymentMethod(id: "id",
+                                                                                 implementationType: .nativeSdk,
+                                                                                 type: "PMT",
+                                                                                 name: "",
+                                                                                 processorConfigId: nil,
+                                                                                 surcharge: nil,
+                                                                                 options: nil,
+                                                                                 displayMetadata: nil))
+
+        let error = PrimerError.paymentFailed(paymentMethodType: "PMT", paymentId: "123", status: "FAILED", userInfo: nil, diagnosticsId: "id")
+        sut.setCheckoutDataFromError(error)
+
+        XCTAssertEqual(sut.paymentCheckoutData?.payment?.id, "123")
+        XCTAssertEqual(sut.paymentCheckoutData?.payment?.paymentFailureReason, PrimerPaymentErrorCode.failed)
+
+        let error2 = PrimerError.cancelled(paymentMethodType: "PMT", userInfo: nil, diagnosticsId: "id")
+        XCTAssertNil(error2.checkoutData)
+    }
+
     // MARK: Helpers
 
     private var checkoutModule: PrimerAPIConfiguration.CheckoutModule {


### PR DESCRIPTION
Small enhancement to also add the `orderId` to the error context