### PR TITLE
ci: Add secrets key to e2e tests

### DIFF
--- a/.github/actions/ui-tests/action.yml
+++ b/.github/actions/ui-tests/action.yml
@@ -23,7 +23,7 @@ inputs:
   slack-reporter-bot-token:
     description: The slack bot token for posting results to the channel
     required: true
-  e2e-secrets-api-key:
+  ui-tests-secrets-api-key:
     description: Key used to fetch secrets in E2E tests
     required: true
 
@@ -67,7 +67,7 @@ runs:
         BROWSERSTACK_ACCESS_KEY: ${{ inputs.browserstack-access-key }} # secrets.BROWSERSTACK_ACCESS_KEY
       run: |
         export BROWSERSTACK_APP_ID=$(cat /var/tmp/browserstack_id.txt)
-        export E2E_SECRET_API_KEY="${{ inputs.e2e-secrets-api-key }}"
+        export UI_TESTS_SECRETS_API_KEY="${{ inputs.ui-tests-secrets-api-key }}"
         testType=${{ inputs.test-type }} npx wdio config/wdio.ios.bs.conf.js
         
     - name: Create Slack Report

--- a/.github/actions/ui-tests/action.yml
+++ b/.github/actions/ui-tests/action.yml
@@ -23,6 +23,9 @@ inputs:
   slack-reporter-bot-token:
     description: The slack bot token for posting results to the channel
     required: true
+  e2e-secrets-api-key:
+    description: Key used to fetch secrets in E2E tests
+    required: true
 
 runs:
   using: "composite"
@@ -64,6 +67,7 @@ runs:
         BROWSERSTACK_ACCESS_KEY: ${{ inputs.browserstack-access-key }} # secrets.BROWSERSTACK_ACCESS_KEY
       run: |
         export BROWSERSTACK_APP_ID=$(cat /var/tmp/browserstack_id.txt)
+        export E2E_SECRET_API_KEY="${{ inputs.e2e-secrets-api-key }}"
         testType=${{ inputs.test-type }} npx wdio config/wdio.ios.bs.conf.js
         
     - name: Create Slack Report

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -148,6 +148,7 @@ jobs:
             browserstack-access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
             slack-mobile-sdk-channel: ${{ secrets.SLACK_MOBILE_SDK_CHANNEL }}
             slack-reporter-bot-token: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
+            e2e-secrets-api-key: ${{ secrets.UI_TESTS_SECRETS_API_KEY }}
   
   test-via-browserstack-manual:
     runs-on: ubuntu-latest

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -148,7 +148,7 @@ jobs:
             browserstack-access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
             slack-mobile-sdk-channel: ${{ secrets.SLACK_MOBILE_SDK_CHANNEL }}
             slack-reporter-bot-token: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
-            e2e-secrets-api-key: ${{ secrets.UI_TESTS_SECRETS_API_KEY }}
+            ui-tests-secrets-api-key: ${{ secrets.UI_TESTS_SECRETS_API_KEY }}
   
   test-via-browserstack-manual:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

This pulls the secrets API key into UI tests config

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)