### PR TITLE
fix: Fix error reporting for apple pay display failure

### DIFF
--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.1.1)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerSDK (2.30.1):
-    - PrimerSDK/Core (= 2.30.1)
-  - PrimerSDK/Core (2.30.1)
+  - PrimerSDK (2.31.0):
+    - PrimerSDK/Core (= 2.31.0)
+  - PrimerSDK/Core (2.31.0)
   - PrimerStripeSDK (1.0.0)
 
 DEPENDENCIES:
@@ -37,7 +37,7 @@ SPEC CHECKSUMS:
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 564105170cc7b467bf95c31851813ea41c468f8b
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerSDK: e14fcc7357d743e1aeec6afdcae27ce7e21f02a5
+  PrimerSDK: 78d1a48ba9b4677f78da9750448af6c72007f4fe
   PrimerStripeSDK: c37d4e7c1b5256d67d4890c4cc4b38ddc9427489
 
 PODFILE CHECKSUM: fa17ead44d40b0b09abc2f30a5cc3d8aefe389e1

--- a/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
@@ -10,6 +10,7 @@ import PassKit
 
 protocol ApplePayPresenting {
     var isPresentable: Bool { get }
+    var errorForDisplay: Error { get }
     func present(withRequest applePayRequest: ApplePayRequest,
                  delegate: PKPaymentAuthorizationControllerDelegate) -> Promise<Void>
 }
@@ -33,13 +34,6 @@ class ApplePayPresentationManager: ApplePayPresenting, LogReporter {
     func present(withRequest applePayRequest: ApplePayRequest,
                  delegate: PKPaymentAuthorizationControllerDelegate) -> Promise<Void> {
         Promise { seal in
-            guard isPresentable else {
-                let error = errorForDisplay
-                ErrorHandler.handle(error: error)
-                seal.reject(error)
-                return
-            }
-
             let request = createRequest(for: applePayRequest)
 
             let paymentController = PKPaymentAuthorizationController(paymentRequest: request)

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -232,6 +232,9 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
                         }.catch { error in
                             seal.reject(error)
                         }
+                } else {
+                    ErrorHandler.handle(error: self.applePayPresentationManager.errorForDisplay)
+                    return
                 }
             }
         }

--- a/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
@@ -262,6 +262,10 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
 fileprivate class MockApplePayPresentationManager: ApplePayPresenting {
     var isPresentable: Bool = true
 
+    var errorForDisplay: Error = PrimerError.unableToPresentPaymentMethod(paymentMethodType: "APPLE_PAY",
+                                                                          userInfo: .errorUserInfoDictionary(),
+                                                                          diagnosticsId: UUID().uuidString)
+
     var onPresent: ((ApplePayRequest, PKPaymentAuthorizationControllerDelegate) -> Promise<Void>)?
 
     func present(withRequest applePayRequest: ApplePayRequest, delegate: PKPaymentAuthorizationControllerDelegate) -> Promise<Void> {


### PR DESCRIPTION
# Description

There are currently two checks for whether Apple Pay can be presented, one in inside `ApplePayPresentationManager` and the other outside wrapping the call to `present` on the manager.

Only the former reports a presentation error on failure to show the Apple Pay dialog. This is never reached due to the outer wrap.

This PR removes the inner check and reports the error if the remaining check fails.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)