### PR TITLE
fix: Apple Pay EC Updates

### DIFF
--- a/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
+++ b/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
@@ -571,7 +571,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="sSz-mi-ge1">
+                                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sSz-mi-ge1">
                                                                         <rect key="frame" x="325" y="0.0" width="51" height="0.0"/>
                                                                         <connections>
                                                                             <action selector="captureShippingAddressSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="cjJ-n3-7ia"/>
@@ -588,7 +588,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="a2D-rC-q6f">
+                                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="a2D-rC-q6f">
                                                                         <rect key="frame" x="325" y="0.0" width="51" height="0.0"/>
                                                                         <connections>
                                                                             <action selector="applePayRequireShippingMethodSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="DDN-Nc-GkT"/>
@@ -614,7 +614,7 @@
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="HUN-X7-hv0">
+                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HUN-X7-hv0">
                                                                                 <rect key="frame" x="63.5" y="0.0" width="58.5" height="0.0"/>
                                                                                 <connections>
                                                                                     <action selector="applePayShippingContactNameSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="3pm-aE-PBw"/>
@@ -626,7 +626,7 @@
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="la4-9j-78G">
+                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="la4-9j-78G">
                                                                                 <rect key="frame" x="190.5" y="0.0" width="58.5" height="0.0"/>
                                                                                 <connections>
                                                                                     <action selector="applePayShippingContactEmailField:" destination="jAd-Lg-hf8" eventType="valueChanged" id="Zjl-2K-cO4"/>
@@ -638,7 +638,7 @@
                                                                                 <nil key="textColor"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
-                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="5AD-oh-3KE">
+                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5AD-oh-3KE">
                                                                                 <rect key="frame" x="317.5" y="0.0" width="58.5" height="0.0"/>
                                                                                 <connections>
                                                                                     <action selector="applePayShippingContactPhoneSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="LMd-t0-tSG"/>

--- a/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
+++ b/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YLF-5Z-Vka">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YLF-5Z-Vka">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -519,7 +519,7 @@
                                                             </switch>
                                                         </subviews>
                                                     </stackView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Apple Pay" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="In5-VI-PDg" userLabel="Apple Pay">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Apple Pay Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="In5-VI-PDg" userLabel="Apple Pay">
                                                         <rect key="frame" x="0.0" y="627.5" width="374" height="17"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                         <nil key="textColor"/>
@@ -545,7 +545,7 @@
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="EqY-FO-mDr" userLabel="Shipping">
                                                         <rect key="frame" x="0.0" y="715.5" width="374" height="31"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Capture Shipping Details" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E5l-2Z-blp" userLabel="ApplePay gather Shipping">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shipping Options" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E5l-2Z-blp" userLabel="ApplePay gather Shipping">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                                 <nil key="textColor"/>
@@ -554,9 +554,100 @@
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="l2a-lu-nlK">
                                                                 <rect key="frame" x="325" y="0.0" width="51" height="31"/>
                                                                 <connections>
-                                                                    <action selector="applePayCaptureShippingDetailsSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="jaT-YL-QsD"/>
+                                                                    <action selector="applePayCaptureShippingDetailsSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="1Qj-Eb-pKF"/>
                                                                 </connections>
                                                             </switch>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hmd-vB-Ft9" userLabel="Shipping Controls">
+                                                        <rect key="frame" x="0.0" y="756.5" width="374" height="54"/>
+                                                        <subviews>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="2t0-pt-FRR" userLabel="Shipping Address">
+                                                                <rect key="frame" x="0.0" y="0.0" width="374" height="0.0"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="captureShippingAddressEnabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ox-Ke-nNp" userLabel="ApplePay gather Shipping">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="318" height="0.0"/>
+                                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="sSz-mi-ge1">
+                                                                        <rect key="frame" x="325" y="0.0" width="51" height="0.0"/>
+                                                                        <connections>
+                                                                            <action selector="captureShippingAddressSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="cjJ-n3-7ia"/>
+                                                                        </connections>
+                                                                    </switch>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="RIG-jm-T50" userLabel="Shipping Address">
+                                                                <rect key="frame" x="0.0" y="20" width="374" height="0.0"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="requireShippingMethod" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gPP-bB-s5F" userLabel="ApplePay gather Shipping">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="318" height="0.0"/>
+                                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="a2D-rC-q6f">
+                                                                        <rect key="frame" x="325" y="0.0" width="51" height="0.0"/>
+                                                                        <connections>
+                                                                            <action selector="applePayRequireShippingMethodSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="DDN-Nc-GkT"/>
+                                                                        </connections>
+                                                                    </switch>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="HQK-0G-epO" userLabel="Additional Contact Fields">
+                                                                <rect key="frame" x="0.0" y="40" width="374" height="14"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="additionalShippingContactFields" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kbR-8Z-3G1" userLabel="ApplePay gather Shipping">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="374" height="0.0"/>
+                                                                        <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="PKd-Qj-PJj" userLabel="Additional Contact Fields">
+                                                                        <rect key="frame" x="0.0" y="14" width="374" height="0.0"/>
+                                                                        <subviews>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6gS-zC-rwV" userLabel="ApplePay gather Shipping">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="56.5" height="0.0"/>
+                                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                                                <nil key="textColor"/>
+                                                                                <nil key="highlightedColor"/>
+                                                                            </label>
+                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="HUN-X7-hv0">
+                                                                                <rect key="frame" x="63.5" y="0.0" width="58.5" height="0.0"/>
+                                                                                <connections>
+                                                                                    <action selector="applePayShippingContactNameSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="3pm-aE-PBw"/>
+                                                                                </connections>
+                                                                            </switch>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="email" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hpy-eN-FTo" userLabel="ApplePay gather Shipping">
+                                                                                <rect key="frame" x="127" y="0.0" width="56.5" height="0.0"/>
+                                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                                                <nil key="textColor"/>
+                                                                                <nil key="highlightedColor"/>
+                                                                            </label>
+                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="la4-9j-78G">
+                                                                                <rect key="frame" x="190.5" y="0.0" width="58.5" height="0.0"/>
+                                                                                <connections>
+                                                                                    <action selector="applePayShippingContactEmailField:" destination="jAd-Lg-hf8" eventType="valueChanged" id="Zjl-2K-cO4"/>
+                                                                                </connections>
+                                                                            </switch>
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="phone" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Z4-pb-CN4" userLabel="ApplePay gather Shipping">
+                                                                                <rect key="frame" x="254" y="0.0" width="56.5" height="0.0"/>
+                                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                                                <nil key="textColor"/>
+                                                                                <nil key="highlightedColor"/>
+                                                                            </label>
+                                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="5AD-oh-3KE">
+                                                                                <rect key="frame" x="317.5" y="0.0" width="58.5" height="0.0"/>
+                                                                                <connections>
+                                                                                    <action selector="applePayShippingContactPhoneSwitchChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="LMd-t0-tSG"/>
+                                                                                </connections>
+                                                                            </switch>
+                                                                        </subviews>
+                                                                    </stackView>
+                                                                </subviews>
+                                                            </stackView>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="GpQ-Jz-0Mz" userLabel="Check Provided Networks">
@@ -1200,8 +1291,14 @@
                         <outlet property="apiKeyStackView" destination="5Iy-N2-Dxd" id="hDA-fC-xDY"/>
                         <outlet property="apiKeyTextField" destination="h7R-0M-MoV" id="Rm3-rF-AlL"/>
                         <outlet property="applePayCaptureBillingAddressSwitch" destination="Ftc-Xf-i2J" id="IxV-lb-PXc"/>
-                        <outlet property="applePayCaptureShippingAddressSwitch" destination="l2a-lu-nlK" id="w2G-Rg-hyC"/>
+                        <outlet property="applePayCaptureShippingAddressEnabledSwitch" destination="sSz-mi-ge1" id="SlF-W0-T8O"/>
                         <outlet property="applePayCheckProvidedNetworksSwitch" destination="u8R-R4-Vq6" id="vNj-FI-1KA"/>
+                        <outlet property="applePayRequireShippingMethodSwitch" destination="a2D-rC-q6f" id="7E5-00-yn4"/>
+                        <outlet property="applePayShippingContactEmailSwitch" destination="la4-9j-78G" id="GGb-32-qmh"/>
+                        <outlet property="applePayShippingContactNameSwitch" destination="HUN-X7-hv0" id="VrI-oL-Jjs"/>
+                        <outlet property="applePayShippingContactPhoneSwitch" destination="5AD-oh-3KE" id="2lJ-0f-1Zm"/>
+                        <outlet property="applePayShippingControlStackView" destination="hmd-vB-Ft9" id="LCC-bs-UVf"/>
+                        <outlet property="applePayShippingDetailsSwitch" destination="l2a-lu-nlK" id="RbG-0x-lQg"/>
                         <outlet property="applePaySurchargeTextField" destination="XRQ-T7-rG4" id="dnh-ml-Uz0"/>
                         <outlet property="applyThemingSwitch" destination="Xts-VY-QHZ" id="qQC-rP-kmS"/>
                         <outlet property="billingAddressCityTextField" destination="b68-sT-v40" id="537-Vp-BCo"/>

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -161,9 +161,10 @@ class MerchantSessionAndSettingsViewController: UIViewController {
     var applePayCaptureShippingDetails = false
     var applePayCheckProvidedNetworks = false
 
-    var applePayCaptureShippingAddress = false
-    var applePayRequireShippingMethod = false
-    var applePayAdditionalContactFields: [PrimerApplePayOptions.ShippingOptions.AdditionalShippingContactField]? = nil
+    //Below are gated by applePayCaptureShippingDetails, default to on when above is true
+    var applePayCaptureShippingAddress = true
+    var applePayRequireShippingMethod = true
+    var applePayAdditionalContactFields: [PrimerApplePayOptions.ShippingOptions.AdditionalShippingContactField]? = [.name, .emailAddress, .phoneNumber]
 
     func setAccessibilityIds() {
         self.view.accessibilityIdentifier = "Background View"

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -8,6 +8,7 @@
 
 import PrimerSDK
 import UIKit
+import PassKit
 
 var environment: Environment = .sandbox
 var customDefinedApiKey: String?
@@ -73,9 +74,16 @@ class MerchantSessionAndSettingsViewController: UIViewController {
 
     // MARK: Apple Pay Inputs
     @IBOutlet weak var applePayCaptureBillingAddressSwitch: UISwitch!
-    @IBOutlet weak var applePayCaptureShippingAddressSwitch: UISwitch!
     @IBOutlet weak var applePayCheckProvidedNetworksSwitch: UISwitch!
-    
+
+    @IBOutlet weak var applePayShippingControlStackView: UIStackView!
+    @IBOutlet weak var applePayShippingDetailsSwitch: UISwitch!
+    @IBOutlet weak var applePayCaptureShippingAddressEnabledSwitch: UISwitch!
+    @IBOutlet weak var applePayRequireShippingMethodSwitch: UISwitch!
+    @IBOutlet weak var applePayShippingContactNameSwitch: UISwitch!
+    @IBOutlet weak var applePayShippingContactEmailSwitch: UISwitch!
+    @IBOutlet weak var applePayShippingContactPhoneSwitch: UISwitch!
+
     // MARK: Order Inputs
 
     @IBOutlet weak var currencyTextField: UITextField!
@@ -152,6 +160,10 @@ class MerchantSessionAndSettingsViewController: UIViewController {
     var applePayCaptureBillingAddress = false
     var applePayCaptureShippingDetails = false
     var applePayCheckProvidedNetworks = false
+
+    var applePayCaptureShippingAddress = false
+    var applePayRequireShippingMethod = false
+    var applePayAdditionalContactFields: [PrimerApplePayOptions.ShippingOptions.AdditionalShippingContactField]? = nil
 
     func setAccessibilityIds() {
         self.view.accessibilityIdentifier = "Background View"
@@ -404,7 +416,62 @@ class MerchantSessionAndSettingsViewController: UIViewController {
     }
     
     @IBAction func applePayCaptureShippingDetailsSwitchChanged(_ sender: UISwitch) {
+        applePayShippingControlStackView.isHidden = !sender.isOn
         applePayCaptureShippingDetails = sender.isOn
+    }
+
+    @IBAction func captureShippingAddressSwitchChanged(_ sender: UISwitch) {
+        applePayCaptureShippingAddress = sender.isOn
+    }
+
+    @IBAction func applePayRequireShippingMethodSwitchChanged(_ sender: UISwitch) {
+        applePayRequireShippingMethod = sender.isOn
+    }
+
+    @IBAction func applePayShippingContactNameSwitchChanged(_ sender: UISwitch) {
+        if sender.isOn {
+            var fields = applePayAdditionalContactFields ?? []
+            if !fields.contains(.name) {
+                fields.append(.name)
+            }
+            applePayAdditionalContactFields = fields
+        } else {
+            applePayAdditionalContactFields?.removeAll(where: { $0 == .name })
+            if applePayAdditionalContactFields?.isEmpty == true {
+                applePayAdditionalContactFields = nil
+            }
+        }
+    }
+    
+
+    @IBAction func applePayShippingContactEmailField(_ sender: UISwitch) {
+        if sender.isOn {
+            var fields = applePayAdditionalContactFields ?? []
+            if !fields.contains(.emailAddress) {
+                fields.append(.emailAddress)
+            }
+            applePayAdditionalContactFields = fields
+        } else {
+            applePayAdditionalContactFields?.removeAll(where: { $0 == .emailAddress })
+            if applePayAdditionalContactFields?.isEmpty == true {
+                applePayAdditionalContactFields = nil
+            }
+        }
+    }
+
+    @IBAction func applePayShippingContactPhoneSwitchChanged(_ sender: UISwitch) {
+        if sender.isOn {
+            var fields = applePayAdditionalContactFields ?? []
+            if !fields.contains(.phoneNumber) {
+                fields.append(.phoneNumber)
+            }
+            applePayAdditionalContactFields = fields
+        } else {
+            applePayAdditionalContactFields?.removeAll(where: { $0 == .phoneNumber })
+            if applePayAdditionalContactFields?.isEmpty == true {
+                applePayAdditionalContactFields = nil
+            }
+        }
     }
 
     @IBAction func applePayCheckProvidedNetworksSwitchValueChanged(_ sender: UISwitch) {
@@ -563,9 +630,9 @@ class MerchantSessionAndSettingsViewController: UIViewController {
         let mandateData = PrimerStripeOptions.MandateData.templateMandate(merchantName: "Primer Inc.")
 
         let shippingOptions = applePayCaptureShippingDetails ?
-        PrimerApplePayOptions.ShippingOptions(isCaptureShippingAddressEnabled: true,
-                                              additionalShippingContactFields: [.name, .emailAddress, .phoneNumber],
-                                              requireShippingMethod: true) : nil
+        PrimerApplePayOptions.ShippingOptions(isCaptureShippingAddressEnabled: applePayCaptureShippingAddress,
+                                              additionalShippingContactFields: applePayAdditionalContactFields,
+                                              requireShippingMethod: applePayRequireShippingMethod) : nil
 
         let settings = PrimerSettings(
             paymentHandling: selectedPaymentHandling,
@@ -602,9 +669,9 @@ class MerchantSessionAndSettingsViewController: UIViewController {
         customDefinedApiKey = (apiKeyTextField.text ?? "").isEmpty ? nil : apiKeyTextField.text
 
         let shippingOptions = applePayCaptureShippingDetails ?
-        PrimerApplePayOptions.ShippingOptions(isCaptureShippingAddressEnabled: true,
-                                              additionalShippingContactFields: [.name, .emailAddress, .phoneNumber],
-                                              requireShippingMethod: true) : nil
+        PrimerApplePayOptions.ShippingOptions(isCaptureShippingAddressEnabled: applePayCaptureShippingAddress,
+                                              additionalShippingContactFields: applePayAdditionalContactFields,
+                                              requireShippingMethod: applePayRequireShippingMethod) : nil
 
         let settings = PrimerSettings(
             paymentHandling: selectedPaymentHandling,

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -8,7 +8,6 @@
 
 import PrimerSDK
 import UIKit
-import PassKit
 
 var environment: Environment = .sandbox
 var customDefinedApiKey: String?

--- a/Sources/PrimerSDK/Classes/Data Models/API/PaymentAPIModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/API/PaymentAPIModel.swift
@@ -281,9 +281,42 @@ extension PrimerCheckoutDataPayment {
 @objc public class PrimerOrder: NSObject, Codable {
 
     public let countryCode: String?
+    public let shipping: PrimerShipping?
 
-    public init(countryCode: String?) {
+    public init(countryCode: String?, shipping: PrimerShipping?) {
         self.countryCode = countryCode
+        self.shipping = shipping
+    }
+
+    convenience init(clientSessionOrder: ClientSession.Order?) {
+        if let shippingMethod = clientSessionOrder?.shippingMethod {
+            let shippingMethod = PrimerShipping(amount: shippingMethod.amount,
+                                                methodId: shippingMethod.methodId,
+                                                methodName: shippingMethod.methodName,
+                                                methodDescription: shippingMethod.methodDescription)
+            self.init(countryCode: clientSessionOrder?.countryCode?.rawValue, shipping: shippingMethod)
+            return
+        }
+        self.init(countryCode: clientSessionOrder?.countryCode?.rawValue, shipping: nil)
+    }
+}
+
+// MARK: Client Session Shipping
+
+@objc public class PrimerShipping: NSObject, Codable {
+    public let amount: Int?
+    public let methodId: String?
+    public let methodName: String?
+    public let methodDescription: String?
+
+    public init(amount: Int?,
+                methodId: String?,
+                methodName: String?,
+                methodDescription: String?) {
+        self.amount = amount
+        self.methodId = methodId
+        self.methodName = methodName
+        self.methodDescription = methodDescription
     }
 }
 

--- a/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
@@ -213,7 +213,6 @@ internal class ClientSession {
             case currencyCode
             case fees
             case lineItems
-            case shippingAmount
             case shippingMethod = "shipping"
         }
 

--- a/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
@@ -201,7 +201,6 @@ internal class ClientSession {
         let currencyCode: Currency?
         let fees: [ClientSession.Order.Fee]?
         let lineItems: [ClientSession.Order.LineItem]?
-        let shippingAmount: Int?
         let shippingMethod: ShippingMethod?
 
         // swiftlint:disable:next nesting
@@ -227,7 +226,6 @@ internal class ClientSession {
             currencyCode: Currency?,
             fees: [ClientSession.Order.Fee]?,
             lineItems: [ClientSession.Order.LineItem]?,
-            shippingAmount: Int?,
             shippingMethod: ShippingMethod? = nil
         ) {
             self.id = id
@@ -238,7 +236,6 @@ internal class ClientSession {
             self.currencyCode = currencyCode
             self.fees = fees
             self.lineItems = lineItems
-            self.shippingAmount = shippingAmount
             self.shippingMethod = shippingMethod
         }
 
@@ -258,7 +255,6 @@ internal class ClientSession {
             }
             fees = (try? container.decode([ClientSession.Order.Fee]?.self, forKey: .fees)) ?? nil
             lineItems = (try? container.decode([ClientSession.Order.LineItem]?.self, forKey: .lineItems)) ?? nil
-            shippingAmount = (try? container.decode(Int?.self, forKey: .shippingAmount)) ?? nil
             shippingMethod = (try? container.decode(ShippingMethod?.self, forKey: .shippingMethod)) ?? nil
         }
 
@@ -271,7 +267,6 @@ internal class ClientSession {
             try? container.encode(currencyCode, forKey: .currencyCode)
             try? container.encode(fees, forKey: .fees)
             try? container.encode(lineItems, forKey: .lineItems)
-            try? container.encode(shippingAmount, forKey: .shippingAmount)
             try? container.encode(shippingMethod, forKey: .shippingMethod)
         }
 

--- a/Sources/PrimerSDK/Classes/Data Models/_PaymentAPIModel.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/_PaymentAPIModel.swift
@@ -21,7 +21,8 @@ extension PrimerClientSession {
                                          taxCode: apiConfiguration.clientSession?.customer?.taxId,
                                          taxAmount: apiConfiguration.clientSession?.order?.totalTaxAmount) }
 
-        let orderDetails = PrimerOrder(countryCode: apiConfiguration.clientSession?.order?.countryCode?.rawValue)
+        
+        let orderDetails = PrimerOrder(clientSessionOrder: apiConfiguration.clientSession?.order)
 
         let billing = apiConfiguration.clientSession?.customer?.billingAddress
         let shipping = apiConfiguration.clientSession?.customer?.shippingAddress

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -379,7 +379,7 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
             $0.id == options.selectedShippingMethod
         }) {
             shippingItem = try? ApplePayOrderItem(
-                name: "Shipping: \(selectedShippingMethod.name)",
+                name: "Shipping:",
                 unitAmount: selectedShippingMethod.amount,
                 quantity: 1,
                 discountAmount: nil,

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -379,7 +379,7 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
             $0.id == options.selectedShippingMethod
         }) {
             shippingItem = try? ApplePayOrderItem(
-                name: "Shipping:",
+                name: "Shipping",
                 unitAmount: selectedShippingMethod.amount,
                 quantity: 1,
                 discountAmount: nil,

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -144,9 +144,11 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
                 return ClientSessionActionsModule.updateBillingAddressViaClientSessionActionWithAddressIfNeeded(billingAddress)
             }
             .then { () -> Promise<Void> in
-                return ClientSessionActionsModule.updateShippingDetailsViaClientSessionActionIfNeeded(address: self.applePayPaymentResponse.shippingAddress,
-                                                                                mobileNumber: self.applePayPaymentResponse.mobileNumber,
-                                                                                emailAddress: self.applePayPaymentResponse.emailAddress)
+                return ClientSessionActionsModule.updateShippingDetailsViaClientSessionActionIfNeeded(
+                    address: self.applePayPaymentResponse.shippingAddress,
+                    mobileNumber: self.applePayPaymentResponse.mobileNumber,
+                    emailAddress: self.applePayPaymentResponse.emailAddress
+                )
             }
             .done {
                 seal.fulfill()
@@ -671,8 +673,8 @@ extension ApplePayTokenizationViewModel: PKPaymentAuthorizationControllerDelegat
                     continuation.resume(returning: PKPaymentRequestShippingContactUpdate(errors: nil,
                                                                                          paymentSummaryItems: orderItems.map { $0.applePayItem },
                                                                                          shippingMethods: shippingMethodsInfo.shippingMethods ?? []))
-                }.catch { error in
-                    continuation.resume(throwing: error)
+                }.catch { _ in
+                    continuation.resume(throwing: PKPaymentError(PKPaymentError.shippingContactInvalidError))
                 }
             }
         } catch {
@@ -718,8 +720,8 @@ extension ApplePayTokenizationViewModel: PKPaymentAuthorizationControllerDelegat
                     } catch {
                         continuation.resume(throwing: error)
                     }
-                }.catch { error in
-                    continuation.resume(throwing: error)
+                }.catch { _ in
+                    continuation.resume(throwing: PKPaymentError(PKPaymentError.shippingContactInvalidError))
                 }
             }
         } catch {

--- a/Tests/Klarna/KlarnaTestsMocks.swift
+++ b/Tests/Klarna/KlarnaTestsMocks.swift
@@ -76,8 +76,7 @@ class KlarnaTestsMocks {
                       taxAmount: nil,
                       taxCode: nil,
                       productType: nil)
-              ],
-              shippingAmount: nil)
+              ])
     }
 
     static func getClientSession(
@@ -100,8 +99,7 @@ class KlarnaTestsMocks {
                 countryCode: .de,
                 currencyCode: hasCurrency ? CurrencyLoader().getCurrency("EUR") : nil,
                 fees: nil,
-                lineItems: hasItems ? [getLineItem(hasAmount: hasLineItemAmout)] : nil,
-                shippingAmount: nil),
+                lineItems: hasItems ? [getLineItem(hasAmount: hasLineItemAmout)] : nil),
             customer: nil,
             testId: nil)
     }

--- a/Tests/Primer/Data Models/ApplePayTests.swift
+++ b/Tests/Primer/Data Models/ApplePayTests.swift
@@ -55,7 +55,6 @@ class ApplePayTests: XCTestCase {
                             taxCode: nil,
                             productType: nil)
                     ],
-                    shippingAmount: nil,
                     shippingMethod: nil),
                 customer: nil,
                 testId: nil)
@@ -104,8 +103,7 @@ class ApplePayTests: XCTestCase {
                             taxAmount: nil,
                             taxCode: nil,
                             productType: nil)
-                    ],
-                    shippingAmount: nil),
+                    ]),
                 customer: nil,
                 testId: nil)
 
@@ -161,8 +159,7 @@ class ApplePayTests: XCTestCase {
                     countryCode: .gb,
                     currencyCode: CurrencyLoader().getCurrency("GBP"),
                     fees: nil,
-                    lineItems: nil,
-                    shippingAmount: nil),
+                    lineItems: nil),
                 customer: nil,
                 testId: nil)
 
@@ -192,8 +189,7 @@ class ApplePayTests: XCTestCase {
                             type: .surcharge,
                             amount: 19)
                     ],
-                    lineItems: nil,
-                    shippingAmount: nil),
+                    lineItems: nil),
                 customer: nil,
                 testId: nil)
             
@@ -287,8 +283,7 @@ class ApplePayTests: XCTestCase {
                             taxAmount: nil,
                             taxCode: nil,
                             productType: nil)
-                    ],
-                    shippingAmount: nil),
+                    ]),
                 customer: nil,
                 testId: nil)
 

--- a/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
@@ -257,7 +257,6 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
                                   taxCode: nil,
                                   productType: nil)
                          ],
-                         shippingAmount: nil,
                          shippingMethod: nil
                          ),
             customer: nil,
@@ -327,7 +326,6 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
                                   taxCode: nil,
                                   productType: nil)
                          ],
-                         shippingAmount: nil,
                          shippingMethod: nil
                          ),
             customer: nil,
@@ -378,7 +376,6 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
                                   taxCode: nil,
                                   productType: nil)
                          ],
-                         shippingAmount: 100,
                          shippingMethod:
                             ClientSession.Order.ShippingMethod(amount: 100,
                                                                methodId: shippingMethodId,
@@ -471,7 +468,6 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
                                   taxCode: nil,
                                   productType: nil)
                          ],
-                         shippingAmount: 200,
                          shippingMethod:
                             ClientSession.Order.ShippingMethod(amount: 200,
                                                                methodId: "Shipping",
@@ -577,7 +573,6 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
                                   taxCode: nil,
                                   productType: nil)
                          ],
-                         shippingAmount: 200,
                          shippingMethod:
                             ClientSession.Order.ShippingMethod(amount: 200,
                                                                methodId: "Shipping",
@@ -636,8 +631,7 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
                       taxAmount: nil,
                       taxCode: nil,
                       productType: nil)
-              ],
-              shippingAmount: nil)
+              ])
     }
 
     var paymentResponseBody: Response.Body.Payment {

--- a/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
@@ -220,7 +220,7 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
         let methods = sut.getShippingMethodsInfo()
 
         XCTAssert(methods.shippingMethods?.count == 2)
-        XCTAssert(methods.selectedShippingMethodOrderItem?.name == "Shipping: Default")
+        XCTAssert(methods.selectedShippingMethodOrderItem?.name == "Shipping")
     }
 
 
@@ -613,7 +613,7 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
         XCTAssert(update3.paymentSummaryItems.count == 3)
         let shippingItem = update3.paymentSummaryItems[1]
         XCTAssertEqual(shippingItem.amount, 2)
-        XCTAssertEqual(shippingItem.label, "Shipping: Next Day")
+        XCTAssertEqual(shippingItem.label, "Shipping")
     }
 
     // MARK: Helpers

--- a/Tests/Primer/UI/ACHUserDetails/ACHUserDetailsViewControllerTests.swift
+++ b/Tests/Primer/UI/ACHUserDetails/ACHUserDetailsViewControllerTests.swift
@@ -324,8 +324,7 @@ final class ACHUserDetailsViewControllerTests: XCTestCase {
                       taxAmount: nil,
                       taxCode: nil,
                       productType: nil)
-              ],
-              shippingAmount: nil)
+              ])
     }
     
     var customer = ClientSession.Customer(

--- a/Tests/Primer/v2/HeadlessUniversalCheckoutAPIConfigurationTests.swift
+++ b/Tests/Primer/v2/HeadlessUniversalCheckoutAPIConfigurationTests.swift
@@ -40,8 +40,7 @@ class HeadlessUniversalCheckoutAPIConfigurationTests: XCTestCase {
                         taxAmount: nil,
                         taxCode: nil,
                         productType: nil)
-                ],
-                shippingAmount: nil),
+                ]),
             customer: nil,
             testId: nil)
 
@@ -133,8 +132,7 @@ class HeadlessUniversalCheckoutAPIConfigurationTests: XCTestCase {
                         taxAmount: nil,
                         taxCode: nil,
                         productType: nil)
-                ],
-                shippingAmount: nil),
+                ]),
             customer: ClientSession.Customer(
                 id: "mock-customer-id",
                 firstName: "mock-first-name",

--- a/Tests/Primer/v2/HeadlessVaultManagerTests.swift
+++ b/Tests/Primer/v2/HeadlessVaultManagerTests.swift
@@ -40,8 +40,7 @@ final class HeadlessVaultManagerTests: XCTestCase {
                         taxAmount: nil,
                         taxCode: nil,
                         productType: nil)
-                ],
-                shippingAmount: nil),
+                ]),
             customer: ClientSession.Customer(id: "testid"),
             testId: nil)
 
@@ -173,8 +172,7 @@ final class HeadlessVaultManagerTests: XCTestCase {
                         taxAmount: nil,
                         taxCode: nil,
                         productType: nil)
-                ],
-                shippingAmount: nil),
+                ]),
             customer: nil,
             testId: nil)
 
@@ -241,8 +239,7 @@ final class HeadlessVaultManagerTests: XCTestCase {
                         taxAmount: nil,
                         taxCode: nil,
                         productType: nil)
-                ],
-                shippingAmount: nil),
+                ]),
             customer: ClientSession.Customer(id: "testid"),
             testId: nil)
 

--- a/Tests/Primer/v2/RawDataManagerValidationTests.swift
+++ b/Tests/Primer/v2/RawDataManagerValidationTests.swift
@@ -67,8 +67,7 @@ class RawDataManagerValidationTests: XCTestCase {
                         taxAmount: nil,
                         taxCode: nil,
                         productType: nil)
-                ],
-                shippingAmount: nil),
+                ]),
             customer: nil,
             testId: nil)
 

--- a/Tests/Stripe/ACHMocks.swift
+++ b/Tests/Stripe/ACHMocks.swift
@@ -55,8 +55,7 @@ final class ACHMocks {
                     taxAmount: 50,
                     taxCode: nil,
                     productType: nil)
-            ],
-                shippingAmount: nil),
+            ]),
             customer: getClientSessionCustomer(firstName: firstName, lastName: lastName, email: email),
             testId: nil)
     }
@@ -82,8 +81,7 @@ final class ACHMocks {
                 countryCode: .us,
                 currencyCode: emptyCurrencyCode ? nil : CurrencyLoader().getCurrency("USD"),
                 fees: nil,
-                lineItems: emptyLineItems ? nil : [getLineItem(hasAmount: !emptyOrderAmount)],
-                shippingAmount: nil),
+                lineItems: emptyLineItems ? nil : [getLineItem(hasAmount: !emptyOrderAmount)]),
             customer: getClientSessionCustomer(firstName: "firstname", lastName: "lastname", email: "email"),
             testId: nil)
     }

--- a/Tests/Stripe/StripeAchTokenizationViewModelTests.swift
+++ b/Tests/Stripe/StripeAchTokenizationViewModelTests.swift
@@ -186,8 +186,7 @@ final class StripeAchTokenizationViewModelTests: XCTestCase {
                       taxAmount: nil,
                       taxCode: nil,
                       productType: nil)
-              ],
-              shippingAmount: nil)
+              ])
     }
     
     var paymentResponseBody: Response.Body.Payment {

--- a/Tests/Utilities/Mocks/Services/MockAPIClient.swift
+++ b/Tests/Utilities/Mocks/Services/MockAPIClient.swift
@@ -664,8 +664,7 @@ extension MockPrimerAPIClient {
                             taxAmount: nil,
                             taxCode: nil,
                             productType: nil)
-                    ],
-                    shippingAmount: nil),
+                    ]),
                 customer: nil,
                 testId: nil),
             paymentMethods: [


### PR DESCRIPTION
Final tweaks for Apple Pay Express Checkout:

- Remove the shipping method name from the lineItems display.
- Align errors
- Adds Shipping to PrimerOrder object

<img width="673" alt="Screenshot 2024-09-27 at 12 16 35" src="https://github.com/user-attachments/assets/5f516bf8-fab3-4efd-a479-62610ece3f10">


Updates the Debug App to allow more granular testing of Apple Pay Shipping controls
<img width="673" alt="Screenshot 2024-09-27 at 12 15 08" src="https://github.com/user-attachments/assets/34c3a834-a6d3-4d17-8712-d551c39674f6">
