### PR TITLE
chore: Remove PrimerApplePayOptions.ShippingOptions from public interface

### DIFF
--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -562,10 +562,11 @@ class MerchantSessionAndSettingsViewController: UIViewController {
 
         let mandateData = PrimerStripeOptions.MandateData.templateMandate(merchantName: "Primer Inc.")
 
-        let shippingOptions = applePayCaptureShippingDetails ?
-        PrimerApplePayOptions.ShippingOptions(isCaptureShippingAddressEnabled: true,
-                                              additionalShippingContactFields: [.name, .emailAddress, .phoneNumber],
-                                              requireShippingMethod: true) : nil
+        // For Express Checkout Beta
+//        let shippingOptions = applePayCaptureShippingDetails ?
+//        PrimerApplePayOptions.ShippingOptions(isCaptureShippingAddressEnabled: true,
+//                                              additionalShippingContactFields: [.name, .emailAddress, .phoneNumber],
+//                                              requireShippingMethod: true) : nil
 
         let settings = PrimerSettings(
             paymentHandling: selectedPaymentHandling,
@@ -576,8 +577,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
                     merchantName: merchantNameTextField.text ?? "Primer Merchant",
                     isCaptureBillingAddressEnabled: applePayCaptureBillingAddress,
                     showApplePayForUnsupportedDevice: false,
-                    checkProvidedNetworks: applePayCheckProvidedNetworks,
-                    shippingOptions: shippingOptions),
+                    checkProvidedNetworks: applePayCheckProvidedNetworks),
                 stripeOptions: PrimerStripeOptions(publishableKey: MerchantMockDataManager.stripePublishableKey, mandateData: mandateData)),
             uiOptions: uiOptions,
             debugOptions: PrimerDebugOptions(is3DSSanityCheckEnabled: false)
@@ -601,10 +601,10 @@ class MerchantSessionAndSettingsViewController: UIViewController {
     @IBAction func primerHeadlessButtonTapped(_ sender: Any) {
         customDefinedApiKey = (apiKeyTextField.text ?? "").isEmpty ? nil : apiKeyTextField.text
 
-        let shippingOptions = applePayCaptureShippingDetails ?
-        PrimerApplePayOptions.ShippingOptions(isCaptureShippingAddressEnabled: true,
-                                              additionalShippingContactFields: [.name, .emailAddress, .phoneNumber],
-                                              requireShippingMethod: true) : nil
+//        let shippingOptions = applePayCaptureShippingDetails ?
+//        PrimerApplePayOptions.ShippingOptions(isCaptureShippingAddressEnabled: true,
+//                                              additionalShippingContactFields: [.name, .emailAddress, .phoneNumber],
+//                                              requireShippingMethod: true) : nil
 
         let settings = PrimerSettings(
             paymentHandling: selectedPaymentHandling,
@@ -615,8 +615,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
                     merchantName: merchantNameTextField.text ?? "Primer Merchant",
                     isCaptureBillingAddressEnabled: applePayCaptureBillingAddress,
                     showApplePayForUnsupportedDevice: false,
-                    checkProvidedNetworks: applePayCheckProvidedNetworks,
-                    shippingOptions: shippingOptions),
+                    checkProvidedNetworks: applePayCheckProvidedNetworks),
                 stripeOptions: PrimerStripeOptions(publishableKey: MerchantMockDataManager.stripePublishableKey)),
             uiOptions: nil,
             debugOptions: PrimerDebugOptions(is3DSSanityCheckEnabled: false)

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -152,12 +152,26 @@ public class PrimerApplePayOptions: Codable {
     let checkProvidedNetworks: Bool
     let shippingOptions: ShippingOptions?
 
+
     public init(merchantIdentifier: String,
                 merchantName: String?,
                 isCaptureBillingAddressEnabled: Bool = false,
                 showApplePayForUnsupportedDevice: Bool = true,
-                checkProvidedNetworks: Bool = true,
-                shippingOptions: ShippingOptions? = nil) {
+                checkProvidedNetworks: Bool = true) {
+        self.merchantIdentifier = merchantIdentifier
+        self.merchantName = merchantName
+        self.isCaptureBillingAddressEnabled = isCaptureBillingAddressEnabled
+        self.shippingOptions = nil
+        self.showApplePayForUnsupportedDevice = showApplePayForUnsupportedDevice
+        self.checkProvidedNetworks = checkProvidedNetworks
+    }
+    
+    private init(merchantIdentifier: String,
+                 merchantName: String?,
+                 isCaptureBillingAddressEnabled: Bool = false,
+                 showApplePayForUnsupportedDevice: Bool = true,
+                 checkProvidedNetworks: Bool = true,
+                 shippingOptions: ShippingOptions? = nil) {
         self.merchantIdentifier = merchantIdentifier
         self.merchantName = merchantName
         self.isCaptureBillingAddressEnabled = isCaptureBillingAddressEnabled
@@ -166,7 +180,7 @@ public class PrimerApplePayOptions: Codable {
         self.checkProvidedNetworks = checkProvidedNetworks
     }
 
-    public struct ShippingOptions: Codable {
+    internal struct ShippingOptions: Codable {
         let isCaptureShippingAddressEnabled: Bool
         let additionalShippingContactFields: [AdditionalShippingContactField]?
         let requireShippingMethod: Bool
@@ -180,7 +194,7 @@ public class PrimerApplePayOptions: Codable {
         }
 
 // swiftlint:disable:next nesting
-        public enum AdditionalShippingContactField: Codable {
+        internal enum AdditionalShippingContactField: Codable {
             case name, emailAddress, phoneNumber
         }
     }

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -152,7 +152,6 @@ public class PrimerApplePayOptions: Codable {
     let checkProvidedNetworks: Bool
     let shippingOptions: ShippingOptions?
 
-
     public init(merchantIdentifier: String,
                 merchantName: String?,
                 isCaptureBillingAddressEnabled: Bool = false,
@@ -165,7 +164,7 @@ public class PrimerApplePayOptions: Codable {
         self.showApplePayForUnsupportedDevice = showApplePayForUnsupportedDevice
         self.checkProvidedNetworks = checkProvidedNetworks
     }
-    
+
     private init(merchantIdentifier: String,
                  merchantName: String?,
                  isCaptureBillingAddressEnabled: Bool = false,


### PR DESCRIPTION
# Description

- Remove the `PrimerApplePayOptions.ShippingOptions` from public interface to facilitate EC beta

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)