### PR TITLE
feat: display order shippingMethod if there is no checkoutModules

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -378,8 +378,16 @@ class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
             )
             pkShippingMethod.detail = shippingMethod.methodDescription
             pkShippingMethod.identifier = shippingMethod.methodId
+            
+            let selectedShippingMethod = try? ApplePayOrderItem(
+                name: shippingMethodName,
+                unitAmount: shippingMethod.amount,
+                quantity: 1,
+                discountAmount: nil,
+                taxAmount: nil
+            )
 
-            return .init(shippingMethods: [pkShippingMethod], selectedShippingMethodOrderItem: nil)
+            return .init(shippingMethods: [pkShippingMethod], selectedShippingMethodOrderItem: selectedShippingMethod)
         }
 
         // Convert to PKShippingMethods


### PR DESCRIPTION
# Description

This change makes it possible to display a shipping method that is available in the `clientSession.order.shipping` if `checkoutModules` is nil.

This is useful in cases where only one delivery method is available and therefore no change of shipping method is possible by the user. It's also useful to display the `shippingMethod` very easily just from the `clientSession`.

A great use case for this, is a payment without the need of the shippingAddress (so it's no EC). In that case, the `shippingMethod` price should not change it's already calculated and there is no need to have `checkoutModules` in that case.

I would have liked to update the example, but it doesn't seem to work with `shippingMethod`.

This should be non-breaking as `checkoutModules` always has priority and this change is like a fallback. 

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)