### PR TITLE
fix: fallback to lineItems name if no description

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
@@ -286,7 +286,7 @@ internal class ClientSession {
 
             func toOrderItem() throws -> ApplePayOrderItem {
                 let applePayOptions = PrimerSettings.current.paymentMethodOptions.applePayOptions
-                let name = (self.description ?? applePayOptions?.merchantName)
+                let name = (self.description ?? self.name ?? applePayOptions?.merchantName)
                 return try ApplePayOrderItem(
                     name: name ?? "Item",
                     unitAmount: self.amount,


### PR DESCRIPTION
# Description

Display `lineItems` name if there is no description. It might even make more sense to have `name` as a priority and `description` as a fallback, since here we're displaying a name and not a description.

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)