### PR TITLE
fix: Fix Discover card network image not showing

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
@@ -259,7 +259,7 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
         case .diners:
             return UIImage(named: "genericCard", in: Bundle.primerResources, compatibleWith: nil)
         case .discover:
-            return UIImage(named: "discover", in: Bundle.primerResources, compatibleWith: nil)
+            return UIImage(named: "discover-card-icon-colored", in: Bundle.primerResources, compatibleWith: nil)
         case .elo:
             return UIImage(named: "genericCard", in: Bundle.primerResources, compatibleWith: nil)
         case .hiper:


### PR DESCRIPTION
# Description

[CHKT-4054
](https://primerapi.atlassian.net/browse/ACC-4054)

Name of the icon in the code was wrong so UIImage was NIL