### PR TITLE
fix: Expose VaultedPaymentMethod initialiser

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/AssetsManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/AssetsManager.swift
@@ -18,18 +18,6 @@ extension PrimerHeadlessUniversalCheckout {
             return UIImage(named: "\(cardNetwork.rawValue)-logo-colored", in: Bundle.primerResources, compatibleWith: nil)
         }
 
-        public static func getCardNetworkAsset(tokenData: Response.Body.Tokenization.PaymentInstrumentData) -> PrimerCardNetworkAsset? {
-            if let network = tokenData.network {
-                return Self.getCardNetworkAsset(cardNetworkString: network)
-            } else if let binNetwork = tokenData.binData?.network {
-                return Self.getCardNetworkAsset(cardNetworkString: binNetwork)
-            } else if let firstSix = tokenData.first6Digits {
-                return Self.getCardNetworkAsset(for: CardNetwork(cardNumber: firstSix))
-            } else {
-                return Self.getCardNetworkAsset(for: .unknown)
-            }
-        }
-
         public static func getCardNetworkAsset(cardNetworkString: String?) -> PrimerCardNetworkAsset? {
             guard let cardNetworkString else { return nil }
             return Self.getCardNetworkAsset(for: CardNetwork(cardNetworkStr: cardNetworkString))

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/AssetsManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/AssetsManager.swift
@@ -18,6 +18,23 @@ extension PrimerHeadlessUniversalCheckout {
             return UIImage(named: "\(cardNetwork.rawValue)-logo-colored", in: Bundle.primerResources, compatibleWith: nil)
         }
 
+        public static func getCardNetworkAsset(tokenData: Response.Body.Tokenization.PaymentInstrumentData) -> PrimerCardNetworkAsset? {
+            if let network = tokenData.network {
+                return Self.getCardNetworkAsset(cardNetworkString: network)
+            } else if let binNetwork = tokenData.binData?.network {
+                return Self.getCardNetworkAsset(cardNetworkString: binNetwork)
+            } else if let firstSix = tokenData.first6Digits {
+                return Self.getCardNetworkAsset(for: CardNetwork(cardNumber: firstSix))
+            } else {
+                return Self.getCardNetworkAsset(for: .unknown)
+            }
+        }
+
+        public static func getCardNetworkAsset(cardNetworkString: String?) -> PrimerCardNetworkAsset? {
+            guard let cardNetworkString else { return nil }
+            return Self.getCardNetworkAsset(for: CardNetwork(cardNetworkStr: cardNetworkString))
+        }
+
         public static func getCardNetworkAsset(for cardNetwork: CardNetwork) -> PrimerCardNetworkAsset? {
 
             let assetName = "\(cardNetwork.assetName.lowercased())-card-icon-colored"

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/VaultManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/VaultManager.swift
@@ -953,7 +953,7 @@ extension PrimerHeadlessUniversalCheckout {
         public let paymentInstrumentData: Response.Body.Tokenization.PaymentInstrumentData
         public let analyticsId: String
 
-        init(
+        public init(
             id: String,
             paymentMethodType: String,
             paymentInstrumentType: PaymentInstrumentType,

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/VaultManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/VaultManager.swift
@@ -510,11 +510,11 @@ extension PrimerHeadlessUniversalCheckout {
                 if decodedJWTToken.intent?.contains("STRIPE_ACH") == true {
                     if let sdkCompleteUrlString = decodedJWTToken.sdkCompleteUrl,
                        let sdkCompleteUrl = URL(string: sdkCompleteUrlString) {
-                        
+
                         DispatchQueue.main.async {
                             PrimerUIManager.primerRootViewController?.enableUserInteraction(true)
                         }
-                        
+
                         firstly {
                             sendAdditionalInfoEvent()
                         }
@@ -530,7 +530,7 @@ extension PrimerHeadlessUniversalCheckout {
                         .catch { err in
                             seal.reject(err)
                         }
-                        
+
                     } else {
                         let err = PrimerError.invalidClientToken(userInfo: .errorUserInfoDictionary(),
                                                                  diagnosticsId: UUID().uuidString)
@@ -813,7 +813,7 @@ extension PrimerHeadlessUniversalCheckout {
                 }
             }
         }
-        
+
         /**
          * Completes a payment using the provided JWT token and URL.
          *
@@ -832,7 +832,7 @@ extension PrimerHeadlessUniversalCheckout {
                 let apiClient: PrimerAPIClientAchProtocol = PrimerAPIConfigurationModule.apiClient ?? PrimerAPIClient()
                 let timeZone = TimeZone(abbreviation: "UTC")
                 let timeStamp = Date().toString(timeZone: timeZone)
-                
+
                 let body = Request.Body.Payment.Complete(mandateSignatureTimestamp: timeStamp)
                 apiClient.completePayment(clientToken: clientToken, url: completeUrl, paymentRequest: body) { result in
                     switch result {
@@ -844,7 +844,7 @@ extension PrimerHeadlessUniversalCheckout {
                 }
             }
         }
-        
+
         /**
          * Sends additional information via delegate `PrimerHeadlessUniversalCheckoutDelegate` if implemented in the headless checkout context.
          *
@@ -862,10 +862,10 @@ extension PrimerHeadlessUniversalCheckout {
                     seal.fulfill()
                     return
                 }
-                
+
                 let delegate = PrimerHeadlessUniversalCheckout.current.delegate
                 let isAdditionalInfoImplemented = delegate?.primerHeadlessUniversalCheckoutDidReceiveAdditionalInfo != nil
-                
+
                 guard isAdditionalInfoImplemented else {
                     let logMessage =
                         """
@@ -874,23 +874,23 @@ extension PrimerHeadlessUniversalCheckout {
     """
                     logger.warn(message: logMessage)
 
-                    let message = "Couldn't continue as due to unimplemented delegate method `primerHeadlessUniversalCheckoutDidReceiveAdditionalInfo`"
+                    let message = "Couldn't continue due to unimplemented delegate method `primerHeadlessUniversalCheckoutDidReceiveAdditionalInfo`"
                     let error = PrimerError.unableToPresentPaymentMethod(paymentMethodType: self.paymentMethodType,
                                                                          userInfo: .errorUserInfoDictionary(additionalInfo: [
                                                                             "message": message
                                                                          ]),
                                                                          diagnosticsId: UUID().uuidString)
-                    
+
                     seal.reject(error)
                     return
                 }
-                
+
                 let additionalInfo = ACHMandateAdditionalInfo()
                 PrimerDelegateProxy.primerDidReceiveAdditionalInfo(additionalInfo)
                 seal.fulfill()
             }
         }
-        
+
         /**
          * Waits for a response from the ACHMandateDelegate method.
          * The response is returned in stripeMandateCompletion handler.
@@ -914,7 +914,7 @@ extension PrimerHeadlessUniversalCheckout.VaultManager: ACHMandateDelegate {
     public func acceptMandate() {
         achMandateCompletion?(.success(()))
     }
-    
+
     public func declineMandate() {
         let error = ACHHelpers.getCancelledError(paymentMethodType: paymentMethodType)
         achMandateCompletion?(.failure(error))

--- a/Tests/Primer/Assets/AssetsManagerTests.swift
+++ b/Tests/Primer/Assets/AssetsManagerTests.swift
@@ -22,6 +22,7 @@ final class AssetsManagerTests: XCTestCase {
     }
 
     func testCardAssets() throws {
+
         XCTAssertNotNil(AssetsManager.getCardNetworkAsset(for: .cartesBancaires)?.cardImage)
         XCTAssertNotNil(AssetsManager.getCardNetworkAsset(for: .discover)?.cardImage)
         XCTAssertNotNil(AssetsManager.getCardNetworkAsset(for: .masterCard)?.cardImage)
@@ -33,6 +34,140 @@ final class AssetsManagerTests: XCTestCase {
         XCTAssertNotNil(AssetsManager.getCardNetworkAsset(for: .maestro)?.cardImage)
         XCTAssertNotNil(AssetsManager.getCardNetworkAsset(for: .mir)?.cardImage)
         XCTAssertNotNil(AssetsManager.getCardNetworkAsset(for: .unknown)?.cardImage)
+
     }
 
+    func testGetNetworkAssetForTokenData() throws {
+        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .visaNetworkToken)?.cardNetwork, .visa)
+        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .visaNetworkToken)?.cardImage)
+
+        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .mcNetworkToken)?.cardNetwork, .masterCard)
+        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .mcNetworkToken)?.cardImage)
+
+        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .cbNetworkToken)?.cardNetwork, .cartesBancaires)
+        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .cbNetworkToken)?.cardImage)
+
+        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .visaBinNetworkToken)?.cardNetwork, .visa)
+        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .visaBinNetworkToken)?.cardImage)
+
+        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .visafirstSixToken)?.cardNetwork, .visa)
+        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .visafirstSixToken)?.cardImage)
+    }
+}
+
+private extension Response.Body.Tokenization.PaymentInstrumentData {
+    static let visaNetworkToken = Self.init(paypalBillingAgreementId: nil,
+                                            first6Digits: nil,
+                                            last4Digits: nil,
+                                            expirationMonth: nil,
+                                            expirationYear: nil,
+                                            cardholderName: nil,
+                                            network: "VISA",
+                                            isNetworkTokenized: nil,
+                                            klarnaCustomerToken: nil,
+                                            sessionData: nil,
+                                            externalPayerInfo: nil,
+                                            shippingAddress: nil,
+                                            binData: nil,
+                                            threeDSecureAuthentication: nil,
+                                            gocardlessMandateId: nil,
+                                            authorizationToken: nil,
+                                            mx: nil,
+                                            currencyCode: nil,
+                                            productId: nil,
+                                            paymentMethodConfigId: nil,
+                                            paymentMethodType: "PAYMENT_CARD",
+                                            sessionInfo: nil)
+
+    static let mcNetworkToken = Self.init(paypalBillingAgreementId: nil,
+                                          first6Digits: nil,
+                                          last4Digits: nil,
+                                          expirationMonth: nil,
+                                          expirationYear: nil,
+                                          cardholderName: nil,
+                                          network: "MASTERCARD",
+                                          isNetworkTokenized: nil,
+                                          klarnaCustomerToken: nil,
+                                          sessionData: nil,
+                                          externalPayerInfo: nil,
+                                          shippingAddress: nil,
+                                          binData: nil,
+                                          threeDSecureAuthentication: nil,
+                                          gocardlessMandateId: nil,
+                                          authorizationToken: nil,
+                                          mx: nil,
+                                          currencyCode: nil,
+                                          productId: nil,
+                                          paymentMethodConfigId: nil,
+                                          paymentMethodType: "PAYMENT_CARD",
+                                          sessionInfo: nil)
+
+    static let cbNetworkToken = Self.init(paypalBillingAgreementId: nil,
+                                          first6Digits: nil,
+                                          last4Digits: nil,
+                                          expirationMonth: nil,
+                                          expirationYear: nil,
+                                          cardholderName: nil,
+                                          network: "CARTES_BANCAIRES",
+                                          isNetworkTokenized: nil,
+                                          klarnaCustomerToken: nil,
+                                          sessionData: nil,
+                                          externalPayerInfo: nil,
+                                          shippingAddress: nil,
+                                          binData: nil,
+                                          threeDSecureAuthentication: nil,
+                                          gocardlessMandateId: nil,
+                                          authorizationToken: nil,
+                                          mx: nil,
+                                          currencyCode: nil,
+                                          productId: nil,
+                                          paymentMethodConfigId: nil,
+                                          paymentMethodType: "PAYMENT_CARD",
+                                          sessionInfo: nil)
+
+    static let visaBinNetworkToken = Self.init(paypalBillingAgreementId: nil,
+                                               first6Digits: nil,
+                                               last4Digits: nil,
+                                               expirationMonth: nil,
+                                               expirationYear: nil,
+                                               cardholderName: nil,
+                                               network: nil,
+                                               isNetworkTokenized: nil,
+                                               klarnaCustomerToken: nil,
+                                               sessionData: nil,
+                                               externalPayerInfo: nil,
+                                               shippingAddress: nil,
+                                               binData: BinData(network: "VISA"),
+                                               threeDSecureAuthentication: nil,
+                                               gocardlessMandateId: nil,
+                                               authorizationToken: nil,
+                                               mx: nil,
+                                               currencyCode: nil,
+                                               productId: nil,
+                                               paymentMethodConfigId: nil,
+                                               paymentMethodType: "PAYMENT_CARD",
+                                               sessionInfo: nil)
+
+    static let visafirstSixToken = Self.init(paypalBillingAgreementId: nil,
+                                               first6Digits: "401288",
+                                               last4Digits: nil,
+                                               expirationMonth: nil,
+                                               expirationYear: nil,
+                                               cardholderName: nil,
+                                               network: nil,
+                                               isNetworkTokenized: nil,
+                                               klarnaCustomerToken: nil,
+                                               sessionData: nil,
+                                               externalPayerInfo: nil,
+                                               shippingAddress: nil,
+                                               binData: nil,
+                                               threeDSecureAuthentication: nil,
+                                               gocardlessMandateId: nil,
+                                               authorizationToken: nil,
+                                               mx: nil,
+                                               currencyCode: nil,
+                                               productId: nil,
+                                               paymentMethodConfigId: nil,
+                                               paymentMethodType: "PAYMENT_CARD",
+                                               sessionInfo: nil)
 }

--- a/Tests/Primer/Assets/AssetsManagerTests.swift
+++ b/Tests/Primer/Assets/AssetsManagerTests.swift
@@ -37,137 +37,14 @@ final class AssetsManagerTests: XCTestCase {
 
     }
 
-    func testGetNetworkAssetForTokenData() throws {
-        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .visaNetworkToken)?.cardNetwork, .visa)
-        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .visaNetworkToken)?.cardImage)
+    func testGetNetworkAssetForString() throws {
+        XCTAssertEqual(AssetsManager.getCardNetworkAsset(cardNetworkString: "VISA")?.cardNetwork, .visa)
+        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(cardNetworkString: "VISA")?.cardImage)
 
-        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .mcNetworkToken)?.cardNetwork, .masterCard)
-        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .mcNetworkToken)?.cardImage)
+        XCTAssertEqual(AssetsManager.getCardNetworkAsset(cardNetworkString: "MASTERCARD")?.cardNetwork, .masterCard)
+        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(cardNetworkString: "MASTERCARD")?.cardImage)
 
-        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .cbNetworkToken)?.cardNetwork, .cartesBancaires)
-        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .cbNetworkToken)?.cardImage)
-
-        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .visaBinNetworkToken)?.cardNetwork, .visa)
-        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .visaBinNetworkToken)?.cardImage)
-
-        XCTAssertEqual(AssetsManager.getCardNetworkAsset(tokenData: .visafirstSixToken)?.cardNetwork, .visa)
-        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(tokenData: .visafirstSixToken)?.cardImage)
+        XCTAssertEqual(AssetsManager.getCardNetworkAsset(cardNetworkString: "CARTES_BANCAIRES")?.cardNetwork, .cartesBancaires)
+        XCTAssertNotNil(AssetsManager.getCardNetworkAsset(cardNetworkString: "CARTES_BANCAIRES")?.cardImage)
     }
-}
-
-private extension Response.Body.Tokenization.PaymentInstrumentData {
-    static let visaNetworkToken = Self.init(paypalBillingAgreementId: nil,
-                                            first6Digits: nil,
-                                            last4Digits: nil,
-                                            expirationMonth: nil,
-                                            expirationYear: nil,
-                                            cardholderName: nil,
-                                            network: "VISA",
-                                            isNetworkTokenized: nil,
-                                            klarnaCustomerToken: nil,
-                                            sessionData: nil,
-                                            externalPayerInfo: nil,
-                                            shippingAddress: nil,
-                                            binData: nil,
-                                            threeDSecureAuthentication: nil,
-                                            gocardlessMandateId: nil,
-                                            authorizationToken: nil,
-                                            mx: nil,
-                                            currencyCode: nil,
-                                            productId: nil,
-                                            paymentMethodConfigId: nil,
-                                            paymentMethodType: "PAYMENT_CARD",
-                                            sessionInfo: nil)
-
-    static let mcNetworkToken = Self.init(paypalBillingAgreementId: nil,
-                                          first6Digits: nil,
-                                          last4Digits: nil,
-                                          expirationMonth: nil,
-                                          expirationYear: nil,
-                                          cardholderName: nil,
-                                          network: "MASTERCARD",
-                                          isNetworkTokenized: nil,
-                                          klarnaCustomerToken: nil,
-                                          sessionData: nil,
-                                          externalPayerInfo: nil,
-                                          shippingAddress: nil,
-                                          binData: nil,
-                                          threeDSecureAuthentication: nil,
-                                          gocardlessMandateId: nil,
-                                          authorizationToken: nil,
-                                          mx: nil,
-                                          currencyCode: nil,
-                                          productId: nil,
-                                          paymentMethodConfigId: nil,
-                                          paymentMethodType: "PAYMENT_CARD",
-                                          sessionInfo: nil)
-
-    static let cbNetworkToken = Self.init(paypalBillingAgreementId: nil,
-                                          first6Digits: nil,
-                                          last4Digits: nil,
-                                          expirationMonth: nil,
-                                          expirationYear: nil,
-                                          cardholderName: nil,
-                                          network: "CARTES_BANCAIRES",
-                                          isNetworkTokenized: nil,
-                                          klarnaCustomerToken: nil,
-                                          sessionData: nil,
-                                          externalPayerInfo: nil,
-                                          shippingAddress: nil,
-                                          binData: nil,
-                                          threeDSecureAuthentication: nil,
-                                          gocardlessMandateId: nil,
-                                          authorizationToken: nil,
-                                          mx: nil,
-                                          currencyCode: nil,
-                                          productId: nil,
-                                          paymentMethodConfigId: nil,
-                                          paymentMethodType: "PAYMENT_CARD",
-                                          sessionInfo: nil)
-
-    static let visaBinNetworkToken = Self.init(paypalBillingAgreementId: nil,
-                                               first6Digits: nil,
-                                               last4Digits: nil,
-                                               expirationMonth: nil,
-                                               expirationYear: nil,
-                                               cardholderName: nil,
-                                               network: nil,
-                                               isNetworkTokenized: nil,
-                                               klarnaCustomerToken: nil,
-                                               sessionData: nil,
-                                               externalPayerInfo: nil,
-                                               shippingAddress: nil,
-                                               binData: BinData(network: "VISA"),
-                                               threeDSecureAuthentication: nil,
-                                               gocardlessMandateId: nil,
-                                               authorizationToken: nil,
-                                               mx: nil,
-                                               currencyCode: nil,
-                                               productId: nil,
-                                               paymentMethodConfigId: nil,
-                                               paymentMethodType: "PAYMENT_CARD",
-                                               sessionInfo: nil)
-
-    static let visafirstSixToken = Self.init(paypalBillingAgreementId: nil,
-                                               first6Digits: "401288",
-                                               last4Digits: nil,
-                                               expirationMonth: nil,
-                                               expirationYear: nil,
-                                               cardholderName: nil,
-                                               network: nil,
-                                               isNetworkTokenized: nil,
-                                               klarnaCustomerToken: nil,
-                                               sessionData: nil,
-                                               externalPayerInfo: nil,
-                                               shippingAddress: nil,
-                                               binData: nil,
-                                               threeDSecureAuthentication: nil,
-                                               gocardlessMandateId: nil,
-                                               authorizationToken: nil,
-                                               mx: nil,
-                                               currencyCode: nil,
-                                               productId: nil,
-                                               paymentMethodConfigId: nil,
-                                               paymentMethodType: "PAYMENT_CARD",
-                                               sessionInfo: nil)
 }


### PR DESCRIPTION
# Description

CHKT-XXXX

- Makes initialiser for VaultedPaymentMethod public.
- Adds convenience initialiser for CardNetworkAsset from network string

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)