### PR TITLE
fix: Remove precondition on presentPaymentMethod

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/PrimerUIManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/PrimerUIManager.swift
@@ -88,11 +88,12 @@ internal class PrimerUIManager: PrimerUIManaging {
         let paymentMethodTokenizationViewModel = PrimerAPIConfiguration.paymentMethodConfigViewModels.filter({ $0.config.type == type }).first
 
         guard let paymentMethodTokenizationViewModel else {
-            let error = PrimerError.unableToPresentPaymentMethod(paymentMethodType: type,
-                                                                 userInfo: .errorUserInfoDictionary(
-                                                                    additionalInfo: ["message": "paymentMethodTokenizationViewModel was not present when calling presentPaymentMethod",]
-                                                                 ),
-                                                                 diagnosticsId: UUID().uuidString)
+            let error = PrimerError.unableToPresentPaymentMethod(
+                paymentMethodType: type,
+                userInfo: .errorUserInfoDictionary(
+                    additionalInfo: ["message": "paymentMethodTokenizationViewModel was not present when calling presentPaymentMethod"]
+                ),
+                diagnosticsId: UUID().uuidString)
             ErrorHandler.handle(error: error)
             return
         }

--- a/Sources/PrimerSDK/Classes/User Interface/PrimerUIManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/PrimerUIManager.swift
@@ -87,7 +87,15 @@ internal class PrimerUIManager: PrimerUIManaging {
     func presentPaymentMethod(type: String) {
         let paymentMethodTokenizationViewModel = PrimerAPIConfiguration.paymentMethodConfigViewModels.filter({ $0.config.type == type }).first
 
-        precondition(paymentMethodTokenizationViewModel != nil, "PrimerUIManager should have validated that the view model exists.")
+        guard let paymentMethodTokenizationViewModel else {
+            let error = PrimerError.unableToPresentPaymentMethod(paymentMethodType: type,
+                                                                 userInfo: .errorUserInfoDictionary(
+                                                                    additionalInfo: ["message": "paymentMethodTokenizationViewModel was not present when calling presentPaymentMethod",]
+                                                                 ),
+                                                                 diagnosticsId: UUID().uuidString)
+            ErrorHandler.handle(error: error)
+            return
+        }
 
         var imgView: UIImageView?
         if let squareLogo = PrimerAPIConfiguration.paymentMethodConfigViewModels.filter({ $0.config.type == type }).first?.uiModule.icon {
@@ -101,21 +109,21 @@ internal class PrimerUIManager: PrimerUIManaging {
 
         PrimerUIManager.primerRootViewController?.showLoadingScreenIfNeeded(imageView: imgView, message: nil)
 
-        paymentMethodTokenizationViewModel?.checkoutEventsNotifierModule.didStartTokenization = {
+        paymentMethodTokenizationViewModel.checkoutEventsNotifierModule.didStartTokenization = {
             PrimerUIManager.primerRootViewController?.showLoadingScreenIfNeeded(imageView: imgView, message: nil)
         }
 
-        paymentMethodTokenizationViewModel?.willPresentPaymentMethodUI = {
+        paymentMethodTokenizationViewModel.willPresentPaymentMethodUI = {
             PrimerUIManager.primerRootViewController?.showLoadingScreenIfNeeded(imageView: imgView, message: nil)
         }
 
-        paymentMethodTokenizationViewModel?.didPresentPaymentMethodUI = {}
+        paymentMethodTokenizationViewModel.didPresentPaymentMethodUI = {}
 
-        paymentMethodTokenizationViewModel?.willDismissPaymentMethodUI = {
+        paymentMethodTokenizationViewModel.willDismissPaymentMethodUI = {
             PrimerUIManager.primerRootViewController?.showLoadingScreenIfNeeded(imageView: imgView, message: nil)
         }
 
-        paymentMethodTokenizationViewModel?.start()
+        paymentMethodTokenizationViewModel.start()
     }
 
     func prepareRootViewController() -> Promise<Void> {


### PR DESCRIPTION
# Description

[ESC-202](https://primerapi.atlassian.net/browse/ESC-202)

- Replaces the precondition with a logged error and graceful failure


[ESC-202]: https://primerapi.atlassian.net/browse/ESC-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ