### PR TITLE
chore: Add Klarna Dependency to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,42 +6,44 @@ let package = Package(
     name: "PrimerSDK",
     defaultLocalization: "en",
     platforms: [
-        .iOS("13.1")
+        .iOS("13.1"),
     ],
     products: [
         .library(
             name: "PrimerSDK",
             targets: ["PrimerSDK"]
-        )
+        ),
     ],
     dependencies: [
-        .package(url: "https://github.com/primer-io/primer-sdk-3ds-ios", from: "2.4.1")
+        .package(url: "https://github.com/primer-io/primer-sdk-3ds-ios", from: "2.4.1"),
+        .package(url: "https://github.com/primer-io/primer-klarna-sdk-ios", from: "1.1.2"),
     ],
     targets: [
         .target(
             name: "PrimerSDK",
             dependencies: [
-                .product(name: "Primer3DS", package: "primer-sdk-3ds-ios")
+                .product(name: "Primer3DS", package: "primer-sdk-3ds-ios"),
+                .product(name: "PrimerKlarnaSDK", package: "primer-klarna-sdk-ios"),
             ],
             path: "Sources/PrimerSDK",
             resources: [
                 .process("Resources"),
-                .copy("Classes/Third Party/PromiseKit/LICENSE")
+                .copy("Classes/Third Party/PromiseKit/LICENSE"),
             ]
         ),
         .testTarget(
             name: "Tests",
             dependencies: [
                 .product(name: "Primer3DS", package: "primer-sdk-3ds-ios"),
-                .byName(name: "PrimerSDK")
+                .byName(name: "PrimerSDK"),
             ],
             path: "Tests/",
             sources: [
                 "3DS/",
                 "Utilities/",
-                "Primer/"
+                "Primer/",
             ]
-        )
+        ),
     ],
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
# Description

**DO NOT MERGE - PR for visibility**

We need to add the Klarna dependency as a merchant requires for iminent go-live. Currently SPM optional dependencies are incompatible with the runtime checks we perform to determine inclusion.

The need to do this is temporary, please see this ticket: [ACC-4586](https://primerapi.atlassian.net/browse/ACC-4586) for a path to overcoming this need. 

I expect to implement the fixes in the coming weeks.