### PR TITLE
chore: Migrate Appetize previews to new demo

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,7 +34,7 @@ build_type = ENV['BUILD_TYPE'] || "preview"
 podfile_path = "Debug App/Podfile"
 pr_number = ENV['PR_NUMBER']
 
-sdk_demo_url = "https://primer-sdk-demo-git-demo-fixes-primer-io.vercel.app/"
+sdk_demo_url = "https://sdk-demo.primer.io/api/mobile/ios/"
 
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,7 +34,8 @@ build_type = ENV['BUILD_TYPE'] || "preview"
 podfile_path = "Debug App/Podfile"
 pr_number = ENV['PR_NUMBER']
 
-sdk_demo_url = "https://sdk-demo.primer.io/api/mobile/ios/"
+sdk_demo_api_url = "https://sdk-demo.primer.io/api/mobile/ios/"
+sdk_demo_url = "https://sdk-demo.primer.io/"
 
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
@@ -218,7 +219,7 @@ platform :ios do
     # Find public key of appetize
     # If a build exists with this name, we will overwrite it
     url_end = get_appetize_version_name(build_type, pr_number)
-    uri = URI(sdk_demo_url + "#{url_end}")
+    uri = URI(sdk_demo_api_url + "#{url_end}")
     public_key = Net::HTTP.get(uri)
     puts "public_key: " + public_key
 
@@ -232,7 +233,7 @@ platform :ios do
     )
 
     update_deployment_url(lane_context[SharedValues::APPETIZE_APP_URL])
-    update_livedemostore_url(sdk_demo_url + url_end)
+    update_livedemostore_url(sdk_demo_url + url_end + "/ios")
 
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,6 +34,8 @@ build_type = ENV['BUILD_TYPE'] || "preview"
 podfile_path = "Debug App/Podfile"
 pr_number = ENV['PR_NUMBER']
 
+sdk_demo_url = "https://primer-sdk-demo-git-demo-fixes-primer-io.vercel.app/"
+
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
 #--------------------- END CONSTANTS -----------------------#
@@ -216,7 +218,7 @@ platform :ios do
     # Find public key of appetize
     # If a build exists with this name, we will overwrite it
     url_end = get_appetize_version_name(build_type, pr_number)
-    uri = URI('https://livedemostore.common.primer.io/appetize/ios/' + "#{url_end}")
+    uri = URI(sdk_demo_url + "#{url_end}")
     public_key = Net::HTTP.get(uri)
     puts "public_key: " + public_key
 
@@ -230,7 +232,7 @@ platform :ios do
     )
 
     update_deployment_url(lane_context[SharedValues::APPETIZE_APP_URL])
-    update_livedemostore_url("https://livedemostore.common.primer.io/ios/#{url_end}")
+    update_livedemostore_url(sdk_demo_url + url_end)
 
   end
 


### PR DESCRIPTION
Updates logic to migrate from LiveDemoStore to the new demo