### PR TITLE
fix: Make success asset visible In dark mode

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/Components/PrimerResultViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Components/PrimerResultViewController.swift
@@ -41,16 +41,16 @@ internal class PrimerResultViewController: PrimerViewController {
 
         (parent as? PrimerContainerViewController)?.navigationItem.hidesBackButton = true
 
-        let successImage = UIImage(named: "check-circle", in: Bundle.primerResources, compatibleWith: nil)
+        let successImage = UIImage(named: "check-circle", in: Bundle.primerResources, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
         successImage?.accessibilityIdentifier = "check-circle"
 
-        let failureImage = UIImage(named: "x-circle", in: Bundle.primerResources, compatibleWith: nil)
+        let failureImage = UIImage(named: "x-circle", in: Bundle.primerResources, compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
         failureImage?.accessibilityIdentifier = "x-circle"
 
         let img = (screenType == .success) ? successImage : failureImage
         let imgView = UIImageView(image: img)
         imgView.contentMode = .scaleAspectFit
-        imgView.tintColor = .black
+        imgView.tintColor = .label
         imgView.translatesAutoresizingMaskIntoConstraints = false
         imgView.heightAnchor.constraint(equalToConstant: 20.0).isActive = true
         imgView.widthAnchor.constraint(equalToConstant: 20.0).isActive = true


### PR DESCRIPTION
[ACC-4058](https://primerapi.atlassian.net/browse/ACC-4058)

[ACC-4058]: https://primerapi.atlassian.net/browse/ACC-4058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ