### PR TITLE
chore: Update .gitignore to ignore files generated by other editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,13 @@ fastlane/report.xml
 Debug App/Pods
 Debug App/Podfile.lock
 Debug App/secrets.defaults.properties
+
+# Alternative editors
+# Neovim
+.nvim
+buildserver.json
+.avanterules
+
+# Cursor/VSCode
+launch.json
+.cursorrules


### PR DESCRIPTION
# Description

Updates .gitignore to ignore files generated by neovim, xcodebuild.nvim, avante.nvim, Cursor and VSCode editors.