### PR TITLE
fix: Align accountNumberLast4Digits with Android

### DIFF
--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.1.1)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerSDK (2.32.1):
-    - PrimerSDK/Core (= 2.32.1)
-  - PrimerSDK/Core (2.32.1)
+  - PrimerSDK (2.33.0):
+    - PrimerSDK/Core (= 2.33.0)
+  - PrimerSDK/Core (2.33.0)
   - PrimerStripeSDK (1.0.0)
 
 DEPENDENCIES:
@@ -37,9 +37,9 @@ SPEC CHECKSUMS:
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 564105170cc7b467bf95c31851813ea41c468f8b
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerSDK: 41eb9f627fa189f3edafdb18ea2a671d4403b3e2
+  PrimerSDK: a64ea688718f9dcf99735fff3ffdb7c97ae1036e
   PrimerStripeSDK: c37d4e7c1b5256d67d4890c4cc4b38ddc9427489
 
 PODFILE CHECKSUM: fa17ead44d40b0b09abc2f30a5cc3d8aefe389e1
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/Debug App/Sources/View Controllers/MerchantHeadlessVaultManagerViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantHeadlessVaultManagerViewController.swift
@@ -345,8 +345,11 @@ class MerchantVaultedPaymentMethodCell: UITableViewCell {
                 self.paymentMethodLabel.text = "Failed to find logo for \(paymentMethod.paymentMethodType)"
             }
 
-            paymentMethodLabel.text = "Pay with \(paymentMethodAsset.paymentMethodName) "
-
+            if paymentMethod.paymentMethodType == "STRIPE_ACH" {
+                paymentMethodLabel.text = "Pay with ACH \(paymentMethod.paymentInstrumentData.bankName ?? "-") **** \(paymentMethod.paymentInstrumentData.accountNumberLast4Digits ?? "-")"
+            } else {
+                paymentMethodLabel.text = "Pay with \(paymentMethodAsset.paymentMethodName) "
+            }
         } else {
             self.paymentMethodLogoView.isHidden = true
             self.paymentMethodLabel.isHidden = false

--- a/Sources/PrimerSDK/Classes/Data Models/TokenizationResponse.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/TokenizationResponse.swift
@@ -112,7 +112,7 @@ extension Response.Body.Tokenization {
         case .stripeAch:
             return CardButtonViewModel(
                 network: self.paymentInstrumentData?.bankName ?? "Bank account",
-                cardholder: "•••• \(self.paymentInstrumentData?.accountNumberLastFourDigits ?? "")",
+                cardholder: "•••• \(self.paymentInstrumentData?.accountNumberLast4Digits ?? "")",
                 last4: "",
                 expiry: "",
                 imageName: self.icon,
@@ -154,13 +154,41 @@ extension Response.Body.Tokenization {
         public let sessionInfo: SessionInfo?
 
         public let bankName: String?
-        public let accountNumberLastFourDigits: String?
+        public let accountNumberLast4Digits: String?
 
         // swiftlint:disable:next nesting
         public struct SessionInfo: Codable {
             public let locale: String?
             public let platform: String?
             public let redirectionUrl: String?
+        }
+
+        //swiftlint:disable:next identifier_name
+        enum CodingKeys: String, CodingKey {
+            case paypalBillingAgreementId
+            case first6Digits
+            case last4Digits
+            case expirationMonth
+            case expirationYear
+            case cardholderName
+            case network
+            case isNetworkTokenized
+            case klarnaCustomerToken
+            case sessionData
+            case externalPayerInfo
+            case shippingAddress
+            case binData
+            case threeDSecureAuthentication
+            case gocardlessMandateId
+            case authorizationToken
+            case mx
+            case currencyCode
+            case productId
+            case paymentMethodConfigId
+            case paymentMethodType
+            case sessionInfo
+            case bankName
+            case accountNumberLast4Digits = "accountNumberLastFourDigits"
         }
     }
 }

--- a/Sources/PrimerSDK/Classes/Data Models/TokenizationResponse.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/TokenizationResponse.swift
@@ -163,7 +163,7 @@ extension Response.Body.Tokenization {
             public let redirectionUrl: String?
         }
 
-        //swiftlint:disable:next identifier_name
+        // swiftlint:disable:next nesting
         enum CodingKeys: String, CodingKey {
             case paypalBillingAgreementId
             case first6Digits
@@ -181,6 +181,7 @@ extension Response.Body.Tokenization {
             case threeDSecureAuthentication
             case gocardlessMandateId
             case authorizationToken
+// swiftlint:disable:next identifier_name
             case mx
             case currencyCode
             case productId

--- a/Tests/Primer/v2/HeadlessVaultManagerTests.swift
+++ b/Tests/Primer/v2/HeadlessVaultManagerTests.swift
@@ -104,7 +104,7 @@ final class HeadlessVaultManagerTests: XCTestCase {
                                                                                                                  paymentMethodType: nil,
                                                                                                                  sessionInfo: nil,
                                                                                                                  bankName: nil,
-                                                                                                                 accountNumberLastFourDigits: nil),
+                                                                                                                 accountNumberLast4Digits: nil),
                                          threeDSecureAuthentication: nil,
                                          token: "anything",
                                          tokenType: .multiUse,
@@ -305,7 +305,7 @@ final class HeadlessVaultManagerTests: XCTestCase {
                                                                                                                  paymentMethodType: nil,
                                                                                                                  sessionInfo: nil,
                                                                                                                  bankName: nil,
-                                                                                                                 accountNumberLastFourDigits: nil),
+                                                                                                                 accountNumberLast4Digits: nil),
                                          threeDSecureAuthentication: nil,
                                          token: "anything",
                                          tokenType: .multiUse,
@@ -395,7 +395,7 @@ final class HeadlessVaultManagerTests: XCTestCase {
                     paymentMethodType: nil,
                     sessionInfo: nil,
                     bankName: nil,
-                    accountNumberLastFourDigits: nil),
+                    accountNumberLast4Digits: nil),
                 analyticsId: "analytics-id")
         ]
 
@@ -474,7 +474,7 @@ final class HeadlessVaultManagerTests: XCTestCase {
                     paymentMethodType: nil,
                     sessionInfo: nil,
                     bankName: nil,
-                    accountNumberLastFourDigits: nil),
+                    accountNumberLast4Digits: nil),
                 analyticsId: "analytics-id")
         ]
 
@@ -515,7 +515,7 @@ final class HeadlessVaultManagerTests: XCTestCase {
                     paymentMethodType: nil,
                     sessionInfo: nil,
                     bankName: nil,
-                    accountNumberLastFourDigits: nil),
+                    accountNumberLast4Digits: nil),
                 analyticsId: "analytics-id")
         ]
 

--- a/Tests/Utilities/Mocks.swift
+++ b/Tests/Utilities/Mocks.swift
@@ -76,7 +76,7 @@ class Mocks {
         paymentMethodType: nil,
         sessionInfo: nil,
         bankName: nil,
-        accountNumberLastFourDigits: nil)
+        accountNumberLast4Digits: nil)
 
     static var payment = Response.Body.Payment(
         id: "mock_id",


### PR DESCRIPTION
# Description

This changes accountNumberLastFourDigits to accountNumberLast4Digits to align with Android, and adds the output to the Headless Vault Example