### PR TITLE
feat: add apiVersion to PrimerSettings

### DIFF
--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -4,9 +4,9 @@ PODS:
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.1.1)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerSDK (2.33.0):
-    - PrimerSDK/Core (= 2.33.0)
-  - PrimerSDK/Core (2.33.0)
+  - PrimerSDK (2.33.1):
+    - PrimerSDK/Core (= 2.33.1)
+  - PrimerSDK/Core (2.33.1)
   - PrimerStripeSDK (1.0.0)
 
 DEPENDENCIES:
@@ -37,7 +37,7 @@ SPEC CHECKSUMS:
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 564105170cc7b467bf95c31851813ea41c468f8b
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerSDK: a64ea688718f9dcf99735fff3ffdb7c97ae1036e
+  PrimerSDK: 181f7b12d3d436916bfea9a2c58d49a694aa8186
   PrimerStripeSDK: c37d4e7c1b5256d67d4890c4cc4b38ddc9427489
 
 PODFILE CHECKSUM: fa17ead44d40b0b09abc2f30a5cc3d8aefe389e1

--- a/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
+++ b/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
@@ -177,7 +177,7 @@
                                 <rect key="frame" x="0.0" y="163" width="414" height="561"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="Yce-hH-uhX">
-                                        <rect key="frame" x="20" y="20" width="374" height="4052"/>
+                                        <rect key="frame" x="20" y="20" width="374" height="4127"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="oCT-9e-d89" userLabel="Environment Stack View">
                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="318.5"/>
@@ -346,7 +346,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="f7f-4e-ZPN" userLabel="SDK Settings Stack View">
-                                                <rect key="frame" x="0.0" y="823" width="374" height="973.5"/>
+                                                <rect key="frame" x="0.0" y="823" width="374" height="1048.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SDK Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HZ9-hO-miI">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="33.5"/>
@@ -354,29 +354,51 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="JMx-kT-CNz" userLabel="Checkout Flow Stack View">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="JMx-kT-CNz" userLabel="Api Version Stack View">
                                                         <rect key="frame" x="0.0" y="53.5" width="374" height="55"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Checkout flow" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YnN-Gz-z4B">
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="API Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YnN-Gz-z4B">
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="17"/>
                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Mp3-M5-t9x">
+                                                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Mp3-M5-t9x" userLabel="API Version Segmented Control">
+                                                                <rect key="frame" x="0.0" y="24" width="374" height="32"/>
+                                                                <segments>
+                                                                    <segment title="2.3"/>
+                                                                    <segment title="2.4"/>
+                                                                    <segment title="latest"/>
+                                                                </segments>
+                                                                <connections>
+                                                                    <action selector="apiVersionSegmentedControlValueChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="SZ1-R3-k11"/>
+                                                                </connections>
+                                                            </segmentedControl>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="ei5-BV-JXB" userLabel="Checkout Flow Stack View">
+                                                        <rect key="frame" x="0.0" y="128.5" width="374" height="55"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Checkout flow" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H7u-Po-f89">
+                                                                <rect key="frame" x="0.0" y="0.0" width="374" height="17"/>
+                                                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="APl-oD-OXG">
                                                                 <rect key="frame" x="0.0" y="24" width="374" height="32"/>
                                                                 <segments>
                                                                     <segment title="Auto"/>
                                                                     <segment title="Manual"/>
                                                                 </segments>
                                                                 <connections>
-                                                                    <action selector="checkoutFlowSegmentedControlValueChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="ECs-ow-yJH"/>
+                                                                    <action selector="checkoutFlowSegmentedControlValueChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="OHV-9m-Wsa"/>
                                                                 </connections>
                                                             </segmentedControl>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nWM-Ez-WUl" userLabel="Vaulting Flow Stack View">
-                                                        <rect key="frame" x="0.0" y="128.5" width="374" height="48"/>
+                                                        <rect key="frame" x="0.0" y="203.5" width="374" height="48"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Vaulting flow" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n93-PX-jxr">
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="17"/>
@@ -395,7 +417,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="gHa-UJ-OZI" userLabel="Merchant Name Stack View">
-                                                        <rect key="frame" x="0.0" y="196.5" width="374" height="58"/>
+                                                        <rect key="frame" x="0.0" y="271.5" width="374" height="58"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Merchant name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DQF-57-AQg">
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="17"/>
@@ -411,7 +433,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="e5H-u1-UYv" userLabel="Theming Stack View">
-                                                        <rect key="frame" x="0.0" y="274.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="349.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Apply theming" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NrM-QC-Yfb" userLabel="Apply theming">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -425,7 +447,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="w1G-D9-qps" userLabel="Disable Success Screen Stack View">
-                                                        <rect key="frame" x="0.0" y="325.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="400.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Vault payments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U0L-jF-Mgs">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -439,10 +461,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="w1G-D9-qpn" userLabel="Disable Success Screen Stack View">
-                                                        <rect key="frame" x="0.0" y="376.5" width="374" height="50"/>
+                                                        <rect key="frame" x="0.0" y="451.5" width="374" height="50"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="w1G-D9-qpd" userLabel="Disable Success Screen Stack View">
-                                                        <rect key="frame" x="0.0" y="446.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="521.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disable success screen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1kI-6E-8gK" userLabel="Disable Success Screen Apply theming">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -456,7 +478,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="4lC-2k-qct" userLabel="Disable Success Screen Stack View">
-                                                        <rect key="frame" x="0.0" y="497.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="572.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disable init screen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wt0-U1-U8V" userLabel="Disable Success Screen Apply theming">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -471,7 +493,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="dyw-4Y-N1z" userLabel="Disable Error Screen Stack View">
-                                                        <rect key="frame" x="0.0" y="548.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="623.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disable error screen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OHe-89-28f" userLabel="Disable Error Screen Apply theming">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -485,7 +507,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="YZe-Oh-Inv" userLabel="Recapture CVV">
-                                                        <rect key="frame" x="0.0" y="599.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="674.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable CVV Recapture flow" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hxC-Ql-YpN" userLabel="Apply theming">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -499,7 +521,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="t9m-wr-w9Y" userLabel="One time payment">
-                                                        <rect key="frame" x="0.0" y="650.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="725.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Klarna EMD" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eSy-Oz-Hfs" userLabel="Apply theming">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -516,7 +538,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="6ae-Na-iSQ" userLabel="Dismiss with Gestures">
-                                                        <rect key="frame" x="0.0" y="701.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="776.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dismiss with Gestures" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NET-aR-Nxd" userLabel="Dismiss w Gestures">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -530,7 +552,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="u6D-4t-3Ra" userLabel="Dismiss with Closebutton">
-                                                        <rect key="frame" x="0.0" y="752.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="827.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dismiss with Closebutton" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7hC-rs-Gfj" userLabel="Dismiss w Closebutton">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -544,13 +566,13 @@
                                                         </subviews>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Apple Pay Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="In5-VI-PDg" userLabel="Apple Pay">
-                                                        <rect key="frame" x="0.0" y="803.5" width="374" height="17"/>
+                                                        <rect key="frame" x="0.0" y="878.5" width="374" height="17"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="KXu-LO-Zau" userLabel="Billing">
-                                                        <rect key="frame" x="0.0" y="840.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="915.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Billing Options" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sJn-QO-F0J" userLabel="ApplePay gather Billing">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -567,7 +589,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="bFz-Ec-13T" userLabel="Billing Controls">
-                                                        <rect key="frame" x="0.0" y="881.5" width="374" height="14"/>
+                                                        <rect key="frame" x="0.0" y="956.5" width="374" height="14"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="FGu-TL-mhN" userLabel="Additional Contact Fields">
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="14"/>
@@ -640,7 +662,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="EqY-FO-mDr" userLabel="Shipping">
-                                                        <rect key="frame" x="0.0" y="891.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="966.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shipping Options" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E5l-2Z-blp" userLabel="ApplePay gather Shipping">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -657,7 +679,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hmd-vB-Ft9" userLabel="Shipping Controls">
-                                                        <rect key="frame" x="0.0" y="932.5" width="374" height="34"/>
+                                                        <rect key="frame" x="0.0" y="1007.5" width="374" height="34"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="RIG-jm-T50" userLabel="Shipping Address">
                                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="0.0"/>
@@ -743,7 +765,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="GpQ-Jz-0Mz" userLabel="Check Provided Networks">
-                                                        <rect key="frame" x="0.0" y="942.5" width="374" height="31"/>
+                                                        <rect key="frame" x="0.0" y="1017.5" width="374" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Check Provided Networks" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IU9-FR-hyJ" userLabel="ApplePay check networks">
                                                                 <rect key="frame" x="0.0" y="0.0" width="318" height="31"/>
@@ -762,7 +784,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Wmb-0A-wCB" userLabel="Order Stack View">
-                                                <rect key="frame" x="0.0" y="1836.5" width="374" height="461"/>
+                                                <rect key="frame" x="0.0" y="1911.5" width="374" height="461"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Order" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rhW-8E-83f">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="33.5"/>
@@ -873,7 +895,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="cka-yb-xqD" userLabel="Customer Stack View">
-                                                <rect key="frame" x="0.0" y="2337.5" width="374" height="1565.5"/>
+                                                <rect key="frame" x="0.0" y="2412.5" width="374" height="1565.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Customer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3y1-pX-UrW">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="33.5"/>
@@ -1274,7 +1296,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="32O-OV-0ey" userLabel="Surcharge Group Stack View">
-                                                <rect key="frame" x="0.0" y="3943" width="374" height="109"/>
+                                                <rect key="frame" x="0.0" y="4018" width="374" height="109"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hmO-CL-ebG">
                                                         <rect key="frame" x="0.0" y="0.0" width="374" height="31"/>
@@ -1408,7 +1430,6 @@
                         <outlet property="billingAddressStackView" destination="bM9-q3-7b4" id="tfD-RC-unz"/>
                         <outlet property="billingAddressStateTextField" destination="9XT-5Y-iB0" id="O4F-QT-v2W"/>
                         <outlet property="billingAddressSwitch" destination="Tgl-HM-zu5" id="0zQ-d2-QoW"/>
-                        <outlet property="checkoutFlowSegmentedControl" destination="Mp3-M5-t9x" id="Csd-pD-aIy"/>
                         <outlet property="clientTokenStackView" destination="IFG-cl-uk6" id="MaN-wY-MoO"/>
                         <outlet property="clientTokenTextField" destination="xjQ-Kj-2GL" id="5mh-UG-g6v"/>
                         <outlet property="closeButtonDismissalSwitch" destination="G04-bw-KwN" id="Qna-pK-NIB"/>
@@ -1977,13 +1998,13 @@
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="placeholderTextColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29803921568627451" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29803921570000003" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Debug App/Sources/Network/Networking.swift
+++ b/Debug App/Sources/Network/Networking.swift
@@ -15,6 +15,17 @@ enum APIVersion: String {
     case v2_2 = "2.2"
     case v2_3 = "2.3"
     case v2_4 = "2.4"
+
+    static func from(primerApiVersion: PrimerAPIVersion) -> APIVersion {
+        switch primerApiVersion {
+        case .V2_3:
+            return .v2_3
+        case .V2_4:
+            return .v2_4
+        default:
+            return .v2_3
+        }
+    }
 }
 
 enum HTTPMethod: String {
@@ -273,6 +284,7 @@ class Networking {
     
     static func requestClientSession(
         requestBody: ClientSessionRequestBody, customDefinedApiKey: String? = nil,
+        apiVersion: PrimerAPIVersion,
         completion: @escaping (String?, Error?) -> Void
     ) {
         let url = environment.baseUrl.appendingPathComponent("/api/client-session")
@@ -289,7 +301,7 @@ class Networking {
         
         let networking = Networking()
         networking.request(
-            apiVersion: .v2_4,
+            apiVersion: APIVersion.from(primerApiVersion: apiVersion),
             url: url,
             method: .post,
             queryParameters: nil,

--- a/Debug App/Sources/View Controllers/MerchantDropInUIViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantDropInUIViewController.swift
@@ -55,7 +55,8 @@ class MerchantDropInUIViewController: UIViewController, PrimerDelegate {
         if let clientToken = clientToken {
             Primer.shared.showVaultManager(clientToken: clientToken)
         } else if let clientSession = clientSession {
-            Networking.requestClientSession(requestBody: clientSession) { (clientToken, err) in
+            Networking.requestClientSession(requestBody: clientSession,
+                                            apiVersion: settings.apiVersion) { (clientToken, err) in
                 if let err = err {
                     print(err)
                     let merchantErr = NSError(domain: "merchant-domain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch client token"])
@@ -77,7 +78,8 @@ class MerchantDropInUIViewController: UIViewController, PrimerDelegate {
             Primer.shared.showUniversalCheckout(clientToken: clientToken)
 
         } else if let clientSession = clientSession {
-            Networking.requestClientSession(requestBody: clientSession) { (clientToken, err) in
+            Networking.requestClientSession(requestBody: clientSession,
+                                            apiVersion: settings.apiVersion) { (clientToken, err) in
                 if let err = err {
                     print(err)
                     let merchantErr = NSError(domain: "merchant-domain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch client token"])
@@ -104,7 +106,8 @@ class MerchantDropInUIViewController: UIViewController, PrimerDelegate {
                                             intent: paymentMethodTypeSessionIntent,
                                             clientToken: clientToken)
         } else if let clientSession = clientSession {
-            Networking.requestClientSession(requestBody: clientSession) { (clientToken, err) in
+            Networking.requestClientSession(requestBody: clientSession,
+                                            apiVersion: settings.apiVersion) { (clientToken, err) in
                 if let err = err {
                     print(err)
                     let merchantErr = NSError(domain: "merchant-domain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch client token"])

--- a/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift
@@ -377,7 +377,8 @@ extension MerchantHeadlessCheckoutAvailablePaymentMethodsViewController {
             })
 
         } else if let clientSession = clientSession {
-            Networking.requestClientSession(requestBody: clientSession) { (clientToken, err) in
+            Networking.requestClientSession(requestBody: clientSession,
+                                            apiVersion: settings.apiVersion) { (clientToken, err) in
                 self.hideLoadingOverlay()
 
                 if let err = err {

--- a/Debug App/Sources/View Controllers/MerchantHeadlessVaultManagerViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantHeadlessVaultManagerViewController.swift
@@ -51,7 +51,8 @@ class MerchantHeadlessVaultManagerViewController: UIViewController, PrimerHeadle
             self.clientToken = clientToken
             self.startPrimerHeadlessUniversalCheckout(with: clientToken)
         } else if let clientSession = clientSession {
-            Networking.requestClientSession(requestBody: clientSession) { (clientToken, err) in
+            Networking.requestClientSession(requestBody: clientSession,
+                                            apiVersion: settings.apiVersion) { (clientToken, err) in
                 if let err = err {
                     self.hideLoadingOverlay()
                     let rvc = MerchantResultViewController.instantiate(checkoutData: self.checkoutData, error: err, logs: self.logs)

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -10,6 +10,7 @@ import PrimerSDK
 import UIKit
 
 var environment: Environment = .sandbox
+var apiVersion: PrimerAPIVersion = .V2_3
 var customDefinedApiKey: String?
 var performPaymentAfterVaulting: Bool = false
 var paymentSessionType: MerchantMockDataManager.SessionType = .generic
@@ -356,6 +357,19 @@ class MerchantSessionAndSettingsViewController: UIViewController {
     @IBAction func testingModeSegmentedControlValueChanged(_ sender: UISegmentedControl) {
         renderMode = RenderMode(rawValue: sender.selectedSegmentIndex)!
         render()
+    }
+
+    @IBAction func apiVersionSegmentedControlValueChanged(_ sender: UISegmentedControl) {
+        switch sender.selectedSegmentIndex {
+        case 0:
+            apiVersion = .V2_3
+        case 1:
+            apiVersion = .V2_4
+        case 2:
+            apiVersion = .latest
+        default:
+            apiVersion = .V2_3
+        }
     }
     
     @IBAction func environmentSegmentedControlValuewChanged(_ sender: UISegmentedControl) {
@@ -773,7 +787,8 @@ class MerchantSessionAndSettingsViewController: UIViewController {
                     billingOptions: billingOptions),
                 stripeOptions: stripePublishableKey == nil ? nil : PrimerStripeOptions(publishableKey: stripePublishableKey!, mandateData: mandateData)),
             uiOptions: uiOptions,
-            debugOptions: PrimerDebugOptions(is3DSSanityCheckEnabled: false)
+            debugOptions: PrimerDebugOptions(is3DSSanityCheckEnabled: false),
+            apiVersion: apiVersion
         )
         
         switch renderMode {
@@ -819,7 +834,8 @@ class MerchantSessionAndSettingsViewController: UIViewController {
                     billingOptions: billingOptions),
                 stripeOptions: stripePublishableKey == nil ? nil : PrimerStripeOptions(publishableKey: stripePublishableKey!)),
             uiOptions: nil,
-            debugOptions: PrimerDebugOptions(is3DSSanityCheckEnabled: false)
+            debugOptions: PrimerDebugOptions(is3DSSanityCheckEnabled: false),
+            apiVersion: apiVersion
         )
         
         switch renderMode {

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -9,6 +9,7 @@ internal protocol PrimerSettingsProtocol {
     var paymentMethodOptions: PrimerPaymentMethodOptions { get }
     var uiOptions: PrimerUIOptions { get }
     var debugOptions: PrimerDebugOptions { get }
+    var apiVersion: PrimerAPIVersion { get }
 }
 
 public class PrimerSettings: PrimerSettingsProtocol, Codable {
@@ -24,6 +25,7 @@ public class PrimerSettings: PrimerSettingsProtocol, Codable {
     let uiOptions: PrimerUIOptions
     let debugOptions: PrimerDebugOptions
     let clientSessionCachingEnabled: Bool
+    public let apiVersion: PrimerAPIVersion
 
     public init(
         paymentHandling: PrimerPaymentHandling = .auto,
@@ -32,7 +34,8 @@ public class PrimerSettings: PrimerSettingsProtocol, Codable {
         uiOptions: PrimerUIOptions? = nil,
         threeDsOptions: PrimerThreeDsOptions? = nil,
         debugOptions: PrimerDebugOptions? = nil,
-        clientSessionCachingEnabled: Bool = false
+        clientSessionCachingEnabled: Bool = false,
+        apiVersion: PrimerAPIVersion = .V2_3
     ) {
         self.paymentHandling = paymentHandling
         self.localeData = localeData ?? PrimerLocaleData()
@@ -40,6 +43,7 @@ public class PrimerSettings: PrimerSettingsProtocol, Codable {
         self.uiOptions = uiOptions ?? PrimerUIOptions()
         self.debugOptions = debugOptions ?? PrimerDebugOptions()
         self.clientSessionCachingEnabled = clientSessionCachingEnabled
+        self.apiVersion = apiVersion
     }
 }
 
@@ -317,7 +321,6 @@ internal protocol PrimerDebugOptionsProtocol {
 }
 
 public class PrimerDebugOptions: PrimerDebugOptionsProtocol, Codable {
-
     let is3DSSanityCheckEnabled: Bool
 
     public init(is3DSSanityCheckEnabled: Bool? = nil) {
@@ -332,10 +335,19 @@ internal protocol PrimerThreeDsOptionsProtocol {
 }
 
 public class PrimerThreeDsOptions: PrimerThreeDsOptionsProtocol, Codable {
-
     let threeDsAppRequestorUrl: String?
 
     public init(threeDsAppRequestorUrl: String? = nil) {
         self.threeDsAppRequestorUrl = threeDsAppRequestorUrl
     }
 }
+
+// MARK: - API Version
+// swiftlint:disable identifier_name
+public enum PrimerAPIVersion: String, Codable {
+    case V2_3 = "2.3"
+    case V2_4 = "2.4"
+
+    public static let latest = PrimerAPIVersion.V2_3
+}
+// swiftlint:enable identifier_name

--- a/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
@@ -10,9 +10,11 @@
 import Foundation
 
 enum PrimerAPI: Endpoint, Equatable {
+    // MARK: - Pull ApiVersion from PrimerSettings
 
-    // MARK: - Single API version variable for easier updates
-    private static let apiVersion = "2.4"
+    private static var apiVersion: String {
+        PrimerSettings.current.apiVersion.rawValue
+    }
 
     static func == (lhs: PrimerAPI, rhs: PrimerAPI) -> Bool {
         switch (lhs, rhs) {

--- a/Tests/Primer/Network/Endpoints/ListCardNetworksEndpointTests.swift
+++ b/Tests/Primer/Network/Endpoints/ListCardNetworksEndpointTests.swift
@@ -38,7 +38,7 @@ final class ListCardNetworksEndpointTests: XCTestCase {
 
         networkService.onReceiveEndpoint = { endpoint in
             XCTAssertEqual(endpoint.path, "/v1/bin-data/\(bin)/networks")
-            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.2")
+            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.3")
             XCTAssertEqual(endpoint.headers?["Primer-Client-Token"], mockClientToken.accessToken)
             expectValidEndpointReceived.fulfill()
         }
@@ -68,7 +68,7 @@ final class ListCardNetworksEndpointTests: XCTestCase {
 
         networkService.onReceiveEndpoint = { endpoint in
             XCTAssertEqual(endpoint.path, "/v1/bin-data/\(bin)/networks")
-            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.2")
+            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.3")
             XCTAssertEqual(endpoint.headers?["Primer-Client-Token"], mockClientToken.accessToken)
             expectValidEndpointReceived.fulfill()
         }

--- a/Tests/Primer/Network/Factories/NetworkRequestFactoryTests.swift
+++ b/Tests/Primer/Network/Factories/NetworkRequestFactoryTests.swift
@@ -13,7 +13,7 @@ final class NetworkRequestFactoryTests: XCTestCase {
 
     var networkRequestFactory: NetworkRequestFactory!
 
-    func defaultHeaders(apiVersion: String = "2.2",
+    func defaultHeaders(apiVersion: String = "2.3",
                         isPost: Bool = false,
                         jwt: String? = nil) -> [String: String] {
         var headers = [

--- a/Tests/Primer/UI/PrimerInputElementTests.swift
+++ b/Tests/Primer/UI/PrimerInputElementTests.swift
@@ -96,12 +96,12 @@ final class PrimerInputElementTests: XCTestCase {
     func test_validate_expiryDate() throws {
         let sut = PrimerInputElementType.expiryDate
 
-        XCTAssertTrue(sut.validate(value: "12/24", detectedValueType: nil))
-        XCTAssertTrue(sut.validate(value: "1224", detectedValueType: nil))
+        XCTAssertTrue(sut.validate(value: "12/25", detectedValueType: nil))
+        XCTAssertTrue(sut.validate(value: "1225", detectedValueType: nil))
 
         // Current logic says the string stripped of "/" should be exactly 4 digits
         // note: this seems to be at odds with CardComponents validation
-        XCTAssertFalse(sut.validate(value: "12/2024", detectedValueType: nil))
+        XCTAssertFalse(sut.validate(value: "12/2025", detectedValueType: nil))
     }
 }
 

--- a/Tests/Utilities/Mocks.swift
+++ b/Tests/Utilities/Mocks.swift
@@ -289,6 +289,7 @@ struct MockPrimerSettings: PrimerSettingsProtocol {
     var uiOptions = PrimerUIOptions()
     var threeDsOptions = PrimerThreeDsOptions()
     var debugOptions = PrimerDebugOptions()
+    var apiVersion: PrimerAPIVersion = .V2_3
 }
 
 let mockPaymentMethodConfig = PrimerAPIConfiguration(


### PR DESCRIPTION
# Description

[ACC-4831](https://primerapi.atlassian.net/browse/ACC-4831)

- Adds `apiVersion` to `PrimerSettings`
- Adds logic to default to version 2.3 for now
- Adds ability to choose apiVersion in Debug app for SDK and ClientSession creation


# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)

[ACC-4831]: https://primerapi.atlassian.net/browse/ACC-4831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ