### PR TITLE
chore: Update API timeout values

### DIFF
--- a/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
@@ -459,9 +459,41 @@ internal extension PrimerAPI {
 
     var timeout: TimeInterval? {
         switch self {
-        case .listCardNetworks:
-            return 10
-        default:
+        // 15-second endpoints
+        case .exchangePaymentMethodToken,
+             .fetchConfiguration,
+             .fetchVaultedPaymentMethods,
+             .deleteVaultedPaymentMethod,
+             .tokenizePaymentMethod,
+             .requestPrimerConfigurationWithActions,
+             .begin3DSRemoteAuth,
+             .continue3DSRemoteAuth,
+             .validateClientToken,
+             .createPayment,
+             .resumePayment,
+             .listCardNetworks,
+             .getPhoneMetadata:
+            return 15
+
+        // 60-second endpoints
+        case .createPayPalOrderSession,
+             .createPayPalBillingAgreementSession,
+             .confirmPayPalBillingAgreement,
+             .createKlarnaPaymentSession,
+             .createKlarnaCustomerToken,
+             .finalizeKlarnaPaymentSession,
+             .listAdyenBanks,
+             .listRetailOutlets,
+             .fetchPayPalExternalPayerInfo,
+             .testFinalizePolling,
+             .getNolSdkSecret,
+             .redirect,
+             .completePayment:
+            return 60
+
+        // No explicit timeout
+        case .poll,
+             .sendAnalyticsEvents:
             return nil
         }
     }


### PR DESCRIPTION
[JIRA](https://primerapi.atlassian.net/browse/ACC-4693)

New values:

Path | iOS Host | Timeout
-- | -- | --
/payment-instruments/<paymentMethodId>/exchange | pciUrl | 15
/ | configurationUrl | 15
/payment-instruments | pciUrl | 15
/payment-instruments/\\(id)/vault | pciUrl | 15
/payment-instruments | pciUrl | 15
/client-session/actions | pciUrl | 15
/3ds/<paymentMethodToken.token>/auth | pciUrl | 15
/3ds/<threeDSTokenId>/continue | pciUrl | 15
/client-token/validate | request.clientToken.decodedJWTToken?.pciUrl | 15
/payments | pciUrl | 15
/sdk/payments | NOT USED | 15
/payments/<paymentd)/resume | pciUrl | 15
/v1/bin-data/\\(bin)/networks | binDataUrl | 15
/paypal/orders/create | coreUrl | 60
/paypal/billing-agreements/create-agreement | coreUrl | 60
/paypal/billing-agreements/confirm-agreement | coreUrl | 60
/klarna/payment-sessions | coreUrl | 60
/klarna/customer-tokens | coreUrl | 60
/klarna/payment-sessions/finalize | coreUrl | 60
/adyen/checkout | coreUrl | 60
/payment-method-options/\\(paymentMethodId)/retail-outlets | coreUrl | 60
/ |   | default
/paypal/orders | coreUrl | 60
/finalize-polling | coreUrl | 60
/nol-pay/sdk-secrets | coreUrl | 60
/ | URL provided directly in payment response | 60
/phone-number-lookups/\\(request.phoneNumber) | pciUrl | 15
/ | completeURL provided directly in payment response | 60

