### PR TITLE
chore: Align PrimerApiVersion with Android

### DIFF
--- a/Debug App/Sources/Network/Networking.swift
+++ b/Debug App/Sources/Network/Networking.swift
@@ -16,7 +16,7 @@ enum APIVersion: String {
     case v2_3 = "2.3"
     case v2_4 = "2.4"
 
-    static func from(primerApiVersion: PrimerAPIVersion) -> APIVersion {
+    static func from(primerApiVersion: PrimerApiVersion) -> APIVersion {
         switch primerApiVersion {
         case .V2_3:
             return .v2_3
@@ -284,7 +284,7 @@ class Networking {
     
     static func requestClientSession(
         requestBody: ClientSessionRequestBody, customDefinedApiKey: String? = nil,
-        apiVersion: PrimerAPIVersion,
+        apiVersion: PrimerApiVersion,
         completion: @escaping (String?, Error?) -> Void
     ) {
         let url = environment.baseUrl.appendingPathComponent("/api/client-session")

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -10,7 +10,7 @@ import PrimerSDK
 import UIKit
 
 var environment: Environment = .sandbox
-var apiVersion: PrimerAPIVersion = .V2_3
+var apiVersion: PrimerApiVersion = .V2_3
 var customDefinedApiKey: String?
 var performPaymentAfterVaulting: Bool = false
 var paymentSessionType: MerchantMockDataManager.SessionType = .generic

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -9,7 +9,7 @@ internal protocol PrimerSettingsProtocol {
     var paymentMethodOptions: PrimerPaymentMethodOptions { get }
     var uiOptions: PrimerUIOptions { get }
     var debugOptions: PrimerDebugOptions { get }
-    var apiVersion: PrimerAPIVersion { get }
+    var apiVersion: PrimerApiVersion { get }
 }
 
 public class PrimerSettings: PrimerSettingsProtocol, Codable {
@@ -25,7 +25,7 @@ public class PrimerSettings: PrimerSettingsProtocol, Codable {
     let uiOptions: PrimerUIOptions
     let debugOptions: PrimerDebugOptions
     let clientSessionCachingEnabled: Bool
-    public let apiVersion: PrimerAPIVersion
+    public let apiVersion: PrimerApiVersion
 
     public init(
         paymentHandling: PrimerPaymentHandling = .auto,
@@ -35,7 +35,7 @@ public class PrimerSettings: PrimerSettingsProtocol, Codable {
         threeDsOptions: PrimerThreeDsOptions? = nil,
         debugOptions: PrimerDebugOptions? = nil,
         clientSessionCachingEnabled: Bool = false,
-        apiVersion: PrimerAPIVersion = .V2_3
+        apiVersion: PrimerApiVersion = .V2_3
     ) {
         self.paymentHandling = paymentHandling
         self.localeData = localeData ?? PrimerLocaleData()
@@ -344,10 +344,10 @@ public class PrimerThreeDsOptions: PrimerThreeDsOptionsProtocol, Codable {
 
 // MARK: - API Version
 // swiftlint:disable identifier_name
-public enum PrimerAPIVersion: String, Codable {
+public enum PrimerApiVersion: String, Codable {
     case V2_3 = "2.3"
     case V2_4 = "2.4"
 
-    public static let latest = PrimerAPIVersion.V2_3
+    public static let latest = PrimerApiVersion.V2_3
 }
 // swiftlint:enable identifier_name

--- a/Tests/Utilities/Mocks.swift
+++ b/Tests/Utilities/Mocks.swift
@@ -289,7 +289,7 @@ struct MockPrimerSettings: PrimerSettingsProtocol {
     var uiOptions = PrimerUIOptions()
     var threeDsOptions = PrimerThreeDsOptions()
     var debugOptions = PrimerDebugOptions()
-    var apiVersion: PrimerAPIVersion = .V2_3
+    var apiVersion: PrimerApiVersion = .V2_3
 }
 
 let mockPaymentMethodConfig = PrimerAPIConfiguration(


### PR DESCRIPTION
We are misaligned with Android here, changes `PrimerAPIVersion` -> `PrimerApiVersion`