### PR TITLE
fix: Do not track image failures in analytics

### DIFF
--- a/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
+++ b/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
@@ -212,12 +212,6 @@ internal class ImageManager: LogReporter {
             }
             .catch { err in
                 if file.bundledImage != nil {
-                    let bundledImageEvent = Analytics.Event.message(
-                        message: "Failed to load image (\(file.fileName) with URL \(file.remoteUrl?.absoluteString ?? "null"), but found image locally",
-                        messageType: .paymentMethodImageLoadingFailed,
-                        severity: .info
-                    )
-                    Analytics.Service.record(events: [bundledImageEvent])
 
                     self.logger.warn(message: "FAILED TO DOWNLOAD LOGO BUT FOUND LOGO LOCALLY")
                     self.logger.warn(message: "Payment method [\(file.fileName)] logo URL: \(file.remoteUrl?.absoluteString ?? "null")")
@@ -225,12 +219,6 @@ internal class ImageManager: LogReporter {
                     seal.fulfill(file)
 
                 } else {
-                    let failedToLoadEvent = Analytics.Event.message(
-                        message: "Failed to load image (\(file.fileName) with URL \(file.remoteUrl?.absoluteString ?? "null")",
-                        messageType: .paymentMethodImageLoadingFailed,
-                        severity: .warning
-                    )
-                    Analytics.Service.record(events: [failedToLoadEvent])
 
                     self.logger.warn(message: "FAILED TO DOWNLOAD LOGO")
                     self.logger.warn(message: "Payment method [\(file.fileName)] logo URL: \(file.remoteUrl?.absoluteString ?? "null")")


### PR DESCRIPTION
# Description

These are benign errors which are accounting for 1/3 of our total logs. We need to pair this with an audit of the image loading pipeline (Ticket to come), but for now this will help stabilise our Elastic pipeline

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)