### PR TITLE
chore: Remove 3ds package from Debug App

### DIFF
--- a/Debug App/Primer.io Debug App SPM.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App SPM.xcodeproj/project.pbxproj
@@ -55,7 +55,6 @@
 		F00C66142ACC67FA00187028 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B18D7E7738BF86467B0F1465 /* Images.xcassets */; };
 		F00C66152ACC67FA00187028 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = FC701AFD94F96F0F1D108D1A /* LaunchScreen.xib */; };
 		F00C66162ACC67FA00187028 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE259612A00F85709107B872 /* Main.storyboard */; };
-		F01193FF2B28FD1700D0ABD9 /* Primer3DS in Frameworks */ = {isa = PBXBuildFile; productRef = F01193FE2B28FD1700D0ABD9 /* Primer3DS */; };
 		F04510E32ACD98E100A0A48C /* PrimerSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F04510E22ACD98E100A0A48C /* PrimerSDK */; };
 		F04510E62ACD990A00A0A48C /* PrimerKlarnaSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F04510E52ACD990A00A0A48C /* PrimerKlarnaSDK */; };
 		F08F63E02BA0BE83006EF9A9 /* SessionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F08F63DF2BA0BE83006EF9A9 /* SessionConfiguration.swift */; };
@@ -172,7 +171,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F01193FF2B28FD1700D0ABD9 /* Primer3DS in Frameworks */,
 				F04510E32ACD98E100A0A48C /* PrimerSDK in Frameworks */,
 				F04510E62ACD990A00A0A48C /* PrimerKlarnaSDK in Frameworks */,
 				0498E1CF2BFB509F00EEF9EE /* PrimerNolPaySDK in Frameworks */,
@@ -420,7 +418,6 @@
 			packageProductDependencies = (
 				F04510E22ACD98E100A0A48C /* PrimerSDK */,
 				F04510E52ACD990A00A0A48C /* PrimerKlarnaSDK */,
-				F01193FE2B28FD1700D0ABD9 /* Primer3DS */,
 				0498E1CE2BFB509F00EEF9EE /* PrimerNolPaySDK */,
 				87BD7B7F2C2350B900BE70E8 /* PrimerStripeSDK */,
 			);
@@ -462,7 +459,6 @@
 			mainGroup = 1C9799A622D0CCDBBF94925B;
 			packageReferences = (
 				F04510E42ACD990A00A0A48C /* XCRemoteSwiftPackageReference "primer-klarna-sdk-ios" */,
-				F01193FD2B28FD1700D0ABD9 /* XCRemoteSwiftPackageReference "primer-sdk-3ds-ios" */,
 				0498E1CD2BFB509F00EEF9EE /* XCRemoteSwiftPackageReference "primer-nol-pay-sdk-ios" */,
 				87BD7B7E2C2350B900BE70E8 /* XCRemoteSwiftPackageReference "primer-stripe-sdk-ios" */,
 			);
@@ -813,14 +809,6 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		F01193FD2B28FD1700D0ABD9 /* XCRemoteSwiftPackageReference "primer-sdk-3ds-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/primer-io/primer-sdk-3ds-ios";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
-			};
-		};
 		F04510E42ACD990A00A0A48C /* XCRemoteSwiftPackageReference "primer-klarna-sdk-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/primer-io/primer-klarna-sdk-ios";
@@ -841,11 +829,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 87BD7B7E2C2350B900BE70E8 /* XCRemoteSwiftPackageReference "primer-stripe-sdk-ios" */;
 			productName = PrimerStripeSDK;
-		};
-		F01193FE2B28FD1700D0ABD9 /* Primer3DS */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F01193FD2B28FD1700D0ABD9 /* XCRemoteSwiftPackageReference "primer-sdk-3ds-ios" */;
-			productName = Primer3DS;
 		};
 		F04510E22ACD98E100A0A48C /* PrimerSDK */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
# Description

This was the source of the packages constantly resolving. Now 3DS is in the main SDK, adding it also to the Debug App caused a circular dependency