### PR TITLE
fix: Decode errors properly for 2xx response codes

### DIFF
--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -32,7 +32,7 @@ PODS:
     - IQKeyboardToolbar/Placeholderable
   - IQKeyboardToolbar/Placeholderable (1.1.1):
     - IQKeyboardCore
-  - IQKeyboardToolbarManager (1.1.2):
+  - IQKeyboardToolbarManager (1.1.3):
     - IQKeyboardToolbar
     - IQTextInputViewNotification
   - IQTextInputViewNotification (1.0.8):
@@ -43,9 +43,9 @@ PODS:
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.1.2)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerSDK (2.35.1):
-    - PrimerSDK/Core (= 2.35.1)
-  - PrimerSDK/Core (2.35.1)
+  - PrimerSDK (2.35.2):
+    - PrimerSDK/Core (= 2.35.2)
+  - PrimerSDK/Core (2.35.2)
   - PrimerStripeSDK (1.0.1)
 
 DEPENDENCIES:
@@ -83,14 +83,14 @@ SPEC CHECKSUMS:
   IQKeyboardNotification: d7382c4466c5a5adef92c7452ebf861b36050088
   IQKeyboardReturnManager: 972be48528ce9e7508ab3ab15ac7efac803f17f5
   IQKeyboardToolbar: d4bdccfb78324aec2f3920659c77bb89acd33312
-  IQKeyboardToolbarManager: 6f4072ac620c2572d4af8c09f42a801f3e4909f7
+  IQKeyboardToolbarManager: 6c693c8478d6327a7ef2107528d29698b3514dbb
   IQTextInputViewNotification: f5e954d8881fd9808b744e49e024cc0d4bcfe572
   IQTextView: ae13b4922f22e6f027f62c557d9f4f236b19d5c7
   Primer3DS: 41159e5287ff47018b7b8415f13621d11be666a2
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: c39536a4eb070da5b43ec99a4edbede241e91d25
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerSDK: c7c5f19a752de84eebfedaaf6ea3c452d0385204
+  PrimerSDK: fe15564b83b1b9041b6f401399f0a6ea719c3dab
   PrimerStripeSDK: dce5e37d10223ee724f33d1cdeaa17235a71ddbb
 
 PODFILE CHECKSUM: 665eac28ae49fa5a7b983ebc01493e77d5e13406

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
@@ -21,17 +21,17 @@ private enum CreateResumePaymentCallType: String {
 }
 
 internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
-    
+
     let apiClient: PrimerAPIClientCreateResumePaymentProtocol
-    
+
     let paymentMethodType: String
-    
+
     init(paymentMethodType: String,
          apiClient: PrimerAPIClientCreateResumePaymentProtocol = PrimerAPIClient()) {
         self.paymentMethodType = paymentMethodType
         self.apiClient = apiClient
     }
-    
+
     func createPayment(paymentRequest: Request.Body.Payment.Create) -> Promise<Response.Body.Payment> {
         guard let clientToken = PrimerAPIConfigurationModule.decodedJWTToken else {
             let err = PrimerError.invalidClientToken(userInfo: .errorUserInfoDictionary(),
@@ -39,7 +39,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             ErrorHandler.handle(error: err)
             return Promise(error: err)
         }
-        
+
         return Promise { seal in
             self.apiClient.createPayment(clientToken: clientToken,
                                          paymentRequestBody: paymentRequest) { result in
@@ -57,9 +57,9 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             }
         }
     }
-    
+
     private func validateResponse(paymentResponse: Response.Body.Payment, callType: CreateResumePaymentCallType) throws {
-        
+
         if paymentResponse.id == nil || paymentResponse.status == .failed ||
             (callType == .resume && paymentResponse.status == .pending && paymentResponse.showSuccessCheckoutOnPendingPayment == false) {
             let err = PrimerError.paymentFailed(
@@ -73,7 +73,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             throw err
         }
     }
-    
+
     func resumePaymentWithPaymentId(_ paymentId: String, paymentResumeRequest: Request.Body.Payment.Resume) -> Promise<Response.Body.Payment> {
         guard let clientToken = PrimerAPIConfigurationModule.decodedJWTToken else {
             let err = PrimerError.invalidClientToken(userInfo: .errorUserInfoDictionary(),
@@ -81,7 +81,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             ErrorHandler.handle(error: err)
             return Promise(error: err)
         }
-        
+
         return Promise { seal in
             self.apiClient.resumePayment(clientToken: clientToken,
                                          paymentId: paymentId,
@@ -93,7 +93,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
                         description: err.localizedDescription,
                         userInfo: .errorUserInfoDictionary(),
                         diagnosticsId: UUID().uuidString)
-                    
+
                     seal.reject(error)
                 case .success(let paymentResponse):
                     do {
@@ -106,7 +106,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             }
         }
     }
-    
+
     /**
      * Completes a payment using the provided JWT token and URL.
      *

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
@@ -87,7 +87,13 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
                                          paymentId: paymentId,
                                          paymentResumeRequest: paymentResumeRequest) { result in
                 switch result {
-                case .failure(let error):
+                case .failure(let err):
+                    let error = PrimerError.failedToResumePayment(
+                        paymentMethodType: self.paymentMethodType,
+                        description: err.localizedDescription,
+                        userInfo: .errorUserInfoDictionary(),
+                        diagnosticsId: UUID().uuidString)
+                    
                     seal.reject(error)
                 case .success(let paymentResponse):
                     do {

--- a/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Payment Services/CreateResumePaymentService.swift
@@ -21,17 +21,17 @@ private enum CreateResumePaymentCallType: String {
 }
 
 internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
-
+    
     let apiClient: PrimerAPIClientCreateResumePaymentProtocol
-
+    
     let paymentMethodType: String
-
+    
     init(paymentMethodType: String,
          apiClient: PrimerAPIClientCreateResumePaymentProtocol = PrimerAPIClient()) {
         self.paymentMethodType = paymentMethodType
         self.apiClient = apiClient
     }
-
+    
     func createPayment(paymentRequest: Request.Body.Payment.Create) -> Promise<Response.Body.Payment> {
         guard let clientToken = PrimerAPIConfigurationModule.decodedJWTToken else {
             let err = PrimerError.invalidClientToken(userInfo: .errorUserInfoDictionary(),
@@ -39,7 +39,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             ErrorHandler.handle(error: err)
             return Promise(error: err)
         }
-
+        
         return Promise { seal in
             self.apiClient.createPayment(clientToken: clientToken,
                                          paymentRequestBody: paymentRequest) { result in
@@ -57,9 +57,9 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             }
         }
     }
-
+    
     private func validateResponse(paymentResponse: Response.Body.Payment, callType: CreateResumePaymentCallType) throws {
-
+        
         if paymentResponse.id == nil || paymentResponse.status == .failed ||
             (callType == .resume && paymentResponse.status == .pending && paymentResponse.showSuccessCheckoutOnPendingPayment == false) {
             let err = PrimerError.paymentFailed(
@@ -73,7 +73,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             throw err
         }
     }
-
+    
     func resumePaymentWithPaymentId(_ paymentId: String, paymentResumeRequest: Request.Body.Payment.Resume) -> Promise<Response.Body.Payment> {
         guard let clientToken = PrimerAPIConfigurationModule.decodedJWTToken else {
             let err = PrimerError.invalidClientToken(userInfo: .errorUserInfoDictionary(),
@@ -81,7 +81,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             ErrorHandler.handle(error: err)
             return Promise(error: err)
         }
-
+        
         return Promise { seal in
             self.apiClient.resumePayment(clientToken: clientToken,
                                          paymentId: paymentId,
@@ -106,7 +106,7 @@ internal class CreateResumePaymentService: CreateResumePaymentServiceProtocol {
             }
         }
     }
-
+    
     /**
      * Completes a payment using the provided JWT token and URL.
      *

--- a/Tests/Primer/Network/Factories/NetworkResponseFactoryTests.swift
+++ b/Tests/Primer/Network/Factories/NetworkResponseFactoryTests.swift
@@ -67,6 +67,40 @@ final class NetworkResponseFactoryTests: XCTestCase {
             XCTFail() // should be failed-to-decode only
         }
     }
+    
+    
+    func testResponseCreation_ErrorJSON_Success() throws {
+        let jsonNetworkResponseFactory = JSONNetworkResponseFactory()
+        let metadata = ResponseMetadataModel(responseUrl: "a_url", statusCode: 202, headers: nil)
+        let string = """
+        {
+            "error": {
+               "errorId": "error-id",
+               "description": "a description",
+               "diagnosticsId": "uuid"
+            }
+        }
+        """
+
+        do {
+            let _: TestCodable = try jsonNetworkResponseFactory.model(for: string.data(using: .utf8)!,
+                                                                          forMetadata: metadata)
+            XCTFail("Expected serverError, but decoding succeeded")
+        } catch let error as InternalError {
+            switch error {
+            case .serverError(let status, let response, _, _):
+                XCTAssertEqual(status, 202)
+                XCTAssertEqual(response?.errorId, "error-id")
+                XCTAssertEqual(response?.description, "a description")
+                XCTAssertEqual(response?.diagnosticsId, "uuid")
+            default:
+                XCTFail("Expected serverError, but got \(error)")
+            }
+        } catch {
+            XCTFail("Expected InternalError.serverError, but got \(error)")
+        }
+    }
+
 
     func testResponseCreation_errorStatus_Failure() throws {
         let jsonNetworkResponseFactory = JSONNetworkResponseFactory()


### PR DESCRIPTION
# Description

[ESC-341](https://primerapi.atlassian.net/browse/ESC-341)

For certain 2xx responses (e.g., 202), the API may return an error object instead of the expected response.  
Previously, we threw a `failed-to-decode` error in such cases.  
Now, we'll attempt to decode the error response and propagate it upstream. We'll propagate `failed-to-resume` error in case resume fails from now on with proper underlying error.

# Manual Testing

To reproduce, set `is3DSSanityCheckEnabled` to `false`.

# Screenshots


# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [x]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)

[ESC-341]: https://primerapi.atlassian.net/browse/ESC-341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ