### PR TITLE
feat: Update default api version to 2.4

### DIFF
--- a/Debug App/Sources/Network/Networking.swift
+++ b/Debug App/Sources/Network/Networking.swift
@@ -23,7 +23,7 @@ enum APIVersion: String {
         case .V2_4:
             return .v2_4
         default:
-            return .v2_3
+            return .v2_4
         }
     }
 }

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -10,7 +10,7 @@ import PrimerSDK
 import UIKit
 
 var environment: Environment = .sandbox
-var apiVersion: PrimerApiVersion = .V2_3
+var apiVersion: PrimerApiVersion = .V2_4
 var customDefinedApiKey: String?
 var performPaymentAfterVaulting: Bool = false
 var paymentSessionType: MerchantMockDataManager.SessionType = .generic
@@ -368,7 +368,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
         case 2:
             apiVersion = .latest
         default:
-            apiVersion = .V2_3
+            apiVersion = .V2_4
         }
     }
 

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -35,7 +35,7 @@ public class PrimerSettings: PrimerSettingsProtocol, Codable {
         threeDsOptions: PrimerThreeDsOptions? = nil,
         debugOptions: PrimerDebugOptions? = nil,
         clientSessionCachingEnabled: Bool = false,
-        apiVersion: PrimerApiVersion = .V2_3
+        apiVersion: PrimerApiVersion = .V2_4
     ) {
         self.paymentHandling = paymentHandling
         self.localeData = localeData ?? PrimerLocaleData()
@@ -348,6 +348,6 @@ public enum PrimerApiVersion: String, Codable {
     case V2_3 = "2.3"
     case V2_4 = "2.4"
 
-    public static let latest = PrimerApiVersion.V2_3
+    public static let latest = PrimerApiVersion.V2_4
 }
 // swiftlint:enable identifier_name

--- a/Tests/Primer/Network/Endpoints/ListCardNetworksEndpointTests.swift
+++ b/Tests/Primer/Network/Endpoints/ListCardNetworksEndpointTests.swift
@@ -38,7 +38,7 @@ final class ListCardNetworksEndpointTests: XCTestCase {
 
         networkService.onReceiveEndpoint = { endpoint in
             XCTAssertEqual(endpoint.path, "/v1/bin-data/\(bin)/networks")
-            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.3")
+            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.4")
             XCTAssertEqual(endpoint.headers?["Primer-Client-Token"], mockClientToken.accessToken)
             expectValidEndpointReceived.fulfill()
         }
@@ -68,7 +68,7 @@ final class ListCardNetworksEndpointTests: XCTestCase {
 
         networkService.onReceiveEndpoint = { endpoint in
             XCTAssertEqual(endpoint.path, "/v1/bin-data/\(bin)/networks")
-            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.3")
+            XCTAssertEqual(endpoint.headers?["X-Api-Version"], "2.4")
             XCTAssertEqual(endpoint.headers?["Primer-Client-Token"], mockClientToken.accessToken)
             expectValidEndpointReceived.fulfill()
         }

--- a/Tests/Primer/Network/Factories/NetworkRequestFactoryTests.swift
+++ b/Tests/Primer/Network/Factories/NetworkRequestFactoryTests.swift
@@ -13,7 +13,7 @@ final class NetworkRequestFactoryTests: XCTestCase {
 
     var networkRequestFactory: NetworkRequestFactory!
 
-    func defaultHeaders(apiVersion: String = "2.3",
+    func defaultHeaders(apiVersion: String = "2.4",
                         isPost: Bool = false,
                         jwt: String? = nil) -> [String: String] {
         var headers = [
@@ -60,7 +60,7 @@ final class NetworkRequestFactoryTests: XCTestCase {
 
         XCTAssertEqual(request.httpMethod, "GET")
         XCTAssertEqual(request.url?.absoluteString, (Mocks.decodedJWTToken.configurationUrl ?? "") + "?withDisplayMetadata=true")
-        XCTAssertEqual(request.allHTTPHeaderFields, defaultHeaders(apiVersion: "2.3", jwt: "bla"))
+        XCTAssertEqual(request.allHTTPHeaderFields, defaultHeaders(apiVersion: "2.4", jwt: "bla"))
     }
 
     func testRequestCreation_paymentInstruments() throws {

--- a/Tests/Utilities/Mocks.swift
+++ b/Tests/Utilities/Mocks.swift
@@ -289,7 +289,7 @@ struct MockPrimerSettings: PrimerSettingsProtocol {
     var uiOptions = PrimerUIOptions()
     var threeDsOptions = PrimerThreeDsOptions()
     var debugOptions = PrimerDebugOptions()
-    var apiVersion: PrimerApiVersion = .V2_3
+    var apiVersion: PrimerApiVersion = .V2_4
 }
 
 let mockPaymentMethodConfig = PrimerAPIConfiguration(


### PR DESCRIPTION
# Description

[ACC-5212](https://primerapi.atlassian.net/browse/ACC-5212)

- Updates default API Version from 2.3 to 2.4

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)

[ACC-5212]: https://primerapi.atlassian.net/browse/ACC-5212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ