### PR TITLE
feat(Apple Pay): Added support for MPAN

### DIFF
--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -905,7 +905,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
             paymentMethodOptions: PrimerPaymentMethodOptions(
                 urlScheme: "merchant://primer.io",
                 applePayOptions: PrimerApplePayOptions(
-                    merchantIdentifier: "merchant.checkout.team",
+                    merchantIdentifier: "merchant.dx.team",
                     merchantName: merchantNameTextField.text ?? "Primer Merchant",
                     isCaptureBillingAddressEnabled: applePayCaptureBillingAddress,
                     showApplePayForUnsupportedDevice: false,

--- a/PrimerSDK.xcworkspace/contents.xcworkspacedata
+++ b/PrimerSDK.xcworkspace/contents.xcworkspacedata
@@ -432,6 +432,9 @@
                location = "group:Extensions &amp; Utilities"
                name = "Extensions &amp; Utilities">
                <FileRef
+                  location = "group:ApplePayPaymentRequest+PK.swift">
+               </FileRef>
+               <FileRef
                   location = "group:UIScreenExtension.swift">
                </FileRef>
                <FileRef
@@ -2283,6 +2286,9 @@
          <Group
             location = "group:Utils"
             name = "Utils">
+            <FileRef
+               location = "group:ApplePayPaymentRequest+PK.swift">
+            </FileRef>
             <Group
                location = "group:CurrencyFormatting"
                name = "CurrencyFormatting">

--- a/Sources/PrimerSDK/Classes/Data Models/ApplePay.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ApplePay.swift
@@ -8,11 +8,23 @@ public enum MerchantCapability {
 }
 
 struct ApplePayRequest {
+    var amount: Int?
+    var paymentDescriptor: String?
     var currency: Currency
     var merchantIdentifier: String
     var countryCode: CountryCode
     var items: [ApplePayOrderItem]
     var shippingMethods: [PKShippingMethod]?
+    var recurringPaymentRequest: ApplePayRecurringPaymentRequest?
+    var deferredPaymentRequest: ApplePayDeferredPaymentRequest?
+    var automaticReloadRequest: ApplePayAutomaticReloadRequest?
+}
+
+protocol ApplePayPaymentRequestBase: Codable {
+    var paymentDescription: String? { get }
+    var billingAgreement: String? { get }
+    var managementUrl: String { get }
+    var tokenManagementUrl: String? { get }
 }
 
 struct ApplePayPaymentResponse {
@@ -40,4 +52,59 @@ struct ApplePayTokenPaymentDataHeader: Codable {
     let ephemeralPublicKey: String
     let publicKeyHash: String
     let transactionId: String
+}
+
+struct ApplePayTrialBillingOption: ApplePayBillingBase {
+    let label: String
+    let amount: Int?
+    let recurringStartDate: Double?
+    let recurringEndDate: Double?
+    let recurringIntervalUnit: ApplePayRecurringInterval?
+    let recurringIntervalCount: Int?
+}
+
+struct ApplePayDeferredBillingOption: Codable {
+    let label: String
+    let amount: Int?
+    let deferredPaymentDate: Double
+}
+
+struct ApplePayAutomaticReloadBillingOption: Codable {
+    let label: String
+    let amount: Int?
+    let automaticReloadThresholdAmount: Int
+}
+
+struct ApplePayRecurringPaymentRequest: ApplePayPaymentRequestBase {
+    let paymentDescription: String?
+    let billingAgreement: String?
+    let managementUrl: String
+    let regularBilling: ApplePayRegularBillingOption
+    let trialBilling: ApplePayTrialBillingOption?
+    let tokenManagementUrl: String?
+}
+
+struct ApplePayDeferredPaymentRequest: ApplePayPaymentRequestBase {
+    let paymentDescription: String?
+    let billingAgreement: String?
+    let managementUrl: String
+    let deferredBilling: ApplePayDeferredBillingOption
+    let freeCancellationDate: Double?
+    let freeCancellationTimeZone: String?
+    let tokenManagementUrl: String?
+}
+
+struct ApplePayAutomaticReloadRequest: ApplePayPaymentRequestBase {
+    let paymentDescription: String?
+    let billingAgreement: String?
+    let managementUrl: String
+    let automaticReloadBilling: ApplePayAutomaticReloadBillingOption
+    let tokenManagementUrl: String?
+}
+
+struct ApplePayOptions: PaymentMethodOptions {
+    let merchantName: String?
+    let recurringPaymentRequest: ApplePayRecurringPaymentRequest?
+    let deferredPaymentRequest: ApplePayDeferredPaymentRequest?
+    let automaticReloadRequest: ApplePayAutomaticReloadRequest?
 }

--- a/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ClientSession.swift
@@ -320,26 +320,33 @@ final class ClientSession {
         let vaultOnSuccess: Bool
         let options: [[String: Any]]?
         let orderedAllowedCardNetworks: [String]?
+        let descriptor: String?
 
         // swiftlint:disable:next nesting
         enum CodingKeys: String, CodingKey {
             case vaultOnSuccess,
                  options,
-                 orderedAllowedCardNetworks
+                 orderedAllowedCardNetworks,
+                 descriptor
         }
 
-        init(vaultOnSuccess: Bool,
-             options: [[String: Any]]?,
-             orderedAllowedCardNetworks: [String]?) {
+        init(
+            vaultOnSuccess: Bool,
+            options: [[String: Any]]?,
+            orderedAllowedCardNetworks: [String]?,
+            descriptor: String?
+        ) {
             self.vaultOnSuccess = vaultOnSuccess
             self.options = options
             self.orderedAllowedCardNetworks = orderedAllowedCardNetworks
+            self.descriptor = descriptor
         }
 
         required internal init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.vaultOnSuccess = (try? container.decode(Bool.self, forKey: .vaultOnSuccess)) ?? false
             self.orderedAllowedCardNetworks = try? container.decode([String].self, forKey: .orderedAllowedCardNetworks)
+            self.descriptor = try? container.decode(String.self, forKey: .descriptor)
 
             if let tmpOptions = (try? container.decode([[String: AnyCodable]]?.self, forKey: .options)),
                let optionsData = try? JSONEncoder().encode(tmpOptions),

--- a/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfigurationOptions.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PaymentMethodConfigurationOptions.swift
@@ -1,10 +1,3 @@
-//
-//  PaymentMethodConfigurationOptions.swift
-//  PrimerSDK
-//
-//  Created by Evangelos on 28/12/21.
-//
-
 import Foundation
 
 protocol PaymentMethodOptions: Codable { }
@@ -15,8 +8,42 @@ struct PayPalOptions: PaymentMethodOptions {
     let clientId: String
 }
 
-struct ApplePayOptions: PaymentMethodOptions {
-    let merchantName: String? // Apple Pay
+enum ApplePayRecurringInterval: String, Codable {
+        case minute
+        case hour
+        case day
+        case month
+        case year
+        case unknown
+
+        var nsCalendarUnit: NSCalendar.Unit? {
+            switch self {
+            case .minute: .minute
+            case .hour: .hour
+            case .day: .day
+            case .month: .month
+            case .year: .year
+            case .unknown: nil
+            }
+        }
+}
+
+protocol ApplePayBillingBase: Codable {
+    var label: String { get }
+    var amount: Int? { get }
+    var recurringStartDate: Double? { get }
+    var recurringEndDate: Double? { get }
+    var recurringIntervalUnit: ApplePayRecurringInterval? { get }
+    var recurringIntervalCount: Int? { get }
+}
+
+struct ApplePayRegularBillingOption: ApplePayBillingBase {
+    let label: String
+    let amount: Int?
+    let recurringStartDate: Double?
+    let recurringEndDate: Double?
+    let recurringIntervalUnit: ApplePayRecurringInterval?
+    let recurringIntervalCount: Int?
 }
 
 struct CardOptions: PaymentMethodOptions {

--- a/Sources/PrimerSDK/Classes/Data Models/TokenizationResponse.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/TokenizationResponse.swift
@@ -154,6 +154,8 @@ extension Response.Body.Tokenization {
         public let bankName: String?
         public let accountNumberLast4Digits: String?
 
+        public let applePayMerchantTokenIdentifier: String?
+
         // swiftlint:disable:next nesting
         public struct SessionInfo: Codable {
             public let locale: String?
@@ -188,6 +190,7 @@ extension Response.Body.Tokenization {
             case sessionInfo
             case bankName
             case accountNumberLast4Digits = "accountNumberLastFourDigits"
+            case applePayMerchantTokenIdentifier
         }
     }
 }

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/ApplePayPaymentRequest+PK.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/ApplePayPaymentRequest+PK.swift
@@ -1,0 +1,163 @@
+import PassKit
+
+@available(iOS 15.0, *)
+extension ApplePayBillingBase {
+    func toPKRecurringPaymentSummaryItem(totalAmount: Int, currency: Currency) -> PKRecurringPaymentSummaryItem {
+        let formattedAmount = NSDecimalNumber(decimal: totalAmount.formattedCurrencyAmount(currency: currency))
+        let summaryItem = PKRecurringPaymentSummaryItem(label: label, amount: formattedAmount)
+
+        summaryItem.startDate = recurringStartDate.flatMap(Date.init(timeIntervalSince1970:))
+        summaryItem.endDate = recurringEndDate.flatMap(Date.init(timeIntervalSince1970:))
+        summaryItem.intervalCount = recurringIntervalCount ?? summaryItem.intervalCount
+        summaryItem.intervalUnit = recurringIntervalUnit?.nsCalendarUnit ?? summaryItem.intervalUnit
+
+        return summaryItem
+    }
+}
+
+@available(iOS 16.0, *)
+extension ApplePayRecurringPaymentRequest {
+    func toPKRecurringPaymentRequest(
+        orderAmount: Int?,
+        currency: Currency,
+        descriptor: String?
+    ) throws -> PKRecurringPaymentRequest {
+        guard let totalAmount = regularBilling.amount ?? orderAmount else { throw handledError(.regularBillingAmount) }
+        guard let paymentDescription = paymentDescription ?? descriptor else { throw handledError(.recurringPaymentMissingDescription) }
+        guard let managementURL = URL(string: managementUrl) else { throw handledError(.recurringPaymentInvalidManagementUrl) }
+
+        let summaryItem = regularBilling.toPKRecurringPaymentSummaryItem(totalAmount: totalAmount, currency: currency)
+
+        let request = PKRecurringPaymentRequest(
+            paymentDescription: paymentDescription,
+            regularBilling: summaryItem,
+            managementURL: managementURL
+        )
+
+        request.trialBilling = trialBilling?.toPKRecurringPaymentSummaryItem(totalAmount: trialBilling?.amount ?? 0, currency: currency)
+        tokenManagementUrl.map { request.tokenNotificationURL = URL(string: $0) }
+        request.billingAgreement = billingAgreement
+
+        return request
+    }
+}
+
+@available(iOS 16.4, *)
+extension ApplePayDeferredPaymentRequest {
+    func toPKDeferredPaymentRequest(
+        orderAmount: Int?,
+        currency: Currency,
+        descriptor: String?
+    ) throws -> PKDeferredPaymentRequest {
+        guard let totalAmount = deferredBilling.amount ?? AppState.current.amount else {  throw handledError(.deferredBillingAmount) }
+        guard let paymentDescription = paymentDescription ?? descriptor else { throw handledError(.deferredPaymentMissingDescription) }
+        guard let managementURL = URL(string: managementUrl) else { throw handledError(.deferredPaymentInvalidManagementUrl) }
+
+        let summaryItem = PKDeferredPaymentSummaryItem(
+            label: deferredBilling.label,
+            amount: NSDecimalNumber(decimal: totalAmount.formattedCurrencyAmount(currency: currency))
+        )
+        summaryItem.deferredDate = Date(timeIntervalSince1970: deferredBilling.deferredPaymentDate)
+
+        let request = PKDeferredPaymentRequest(
+            paymentDescription: paymentDescription,
+            deferredBilling: summaryItem,
+            managementURL: managementURL
+        )
+
+        request.freeCancellationDate = freeCancellationDate.flatMap(Date.init(timeIntervalSince1970:))
+        freeCancellationTimeZone.map { request.freeCancellationDateTimeZone = TimeZone(identifier: $0) }
+        tokenManagementUrl.map { request.tokenNotificationURL = URL(string: $0) }
+        request.billingAgreement = billingAgreement
+
+        return request
+    }
+}
+
+@available(iOS 16.0, *)
+extension ApplePayAutomaticReloadRequest {
+    func toPKAutomaticReloadPaymentRequest(
+        orderAmount: Int?,
+        currency: Currency,
+        descriptor: String?
+    ) throws -> PKAutomaticReloadPaymentRequest {
+        guard let totalAmount = automaticReloadBilling.amount ?? orderAmount else { throw handledError(.automaticReloadBillingAmount) }
+        guard let paymentDescription = paymentDescription ?? descriptor else { throw handledError(.automaticReloadMissingDescription) }
+        guard let managementURL = URL(string: managementUrl) else { throw handledError(.automaticReloadInvalidManagementUrl) }
+
+        let summaryItem = PKAutomaticReloadPaymentSummaryItem(
+            label: automaticReloadBilling.label,
+            amount: NSDecimalNumber(decimal: totalAmount.formattedCurrencyAmount(currency: currency))
+        )
+
+        let decimal = automaticReloadBilling.automaticReloadThresholdAmount.formattedCurrencyAmount(currency: currency)
+        summaryItem.thresholdAmount = NSDecimalNumber(decimal: decimal)
+
+        let request = PKAutomaticReloadPaymentRequest(
+            paymentDescription: paymentDescription,
+            automaticReloadBilling: summaryItem,
+            managementURL: managementURL
+        )
+
+        tokenManagementUrl.map { request.tokenNotificationURL = URL(string: $0) }
+        request.billingAgreement = billingAgreement
+
+        return request
+    }
+}
+
+extension ApplePayOptions {
+    func updatePKPaymentRequestUpdate(
+        _ paymentUpdate: PKPaymentRequestUpdate,
+        orderAmount: Int?,
+        currency: Currency,
+        descriptor: String?
+    ) throws {
+        if #available(iOS 16.0, *) {
+            paymentUpdate.recurringPaymentRequest = try recurringPaymentRequest?.toPKRecurringPaymentRequest(
+                orderAmount: orderAmount,
+                currency: currency,
+                descriptor: descriptor
+            )
+
+            paymentUpdate.automaticReloadPaymentRequest = try automaticReloadRequest?.toPKAutomaticReloadPaymentRequest(
+                orderAmount: orderAmount,
+                currency: currency,
+                descriptor: descriptor
+            )
+        }
+
+        if #available(iOS 16.4, *) {
+            paymentUpdate.deferredPaymentRequest = try deferredPaymentRequest?.toPKDeferredPaymentRequest(
+                orderAmount: orderAmount,
+                currency: currency,
+                descriptor: descriptor
+            )
+        }
+    }
+}
+
+private extension String {
+    static let regularBillingAmount = "regularBilling.amount or amount"
+    static let recurringPaymentMissingDescription = "recurringPaymentRequest.paymentDescription or paymentMethod.descriptor"
+    static let recurringPaymentInvalidManagementUrl = "recurringPaymentRequest.managementUrl"
+    static let deferredBillingAmount = "deferredBilling.amount or amount"
+    static let deferredPaymentMissingDescription = "deferredPaymentRequest.paymentDescription or paymentMethod.descriptor"
+    static let deferredPaymentInvalidManagementUrl = "deferredPaymentRequest.managementUrl"
+    static let automaticReloadBillingAmount = "automaticReloadBilling.amount or amount"
+    static let automaticReloadMissingDescription = "automaticReloadRequest.paymentDescription or paymentMethod.descriptor"
+    static let automaticReloadInvalidManagementUrl = "automaticReloadRequest.managementUrl"
+}
+
+private extension ApplePayPaymentRequestBase {
+    func handledError(_ key: String) -> PrimerError {
+        let error: PrimerError = .invalidValue(
+            key: key,
+            value: nil,
+            userInfo: .errorUserInfoDictionary(),
+            diagnosticsId: UUID().uuidString
+        )
+        ErrorHandler.handle(error: error)
+        return error
+    }
+}

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/IntExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/IntExtension.swift
@@ -1,13 +1,6 @@
-//
-//  IntExtension.swift
-//  PrimerSDK
-//
-//  Created by Carl Eriksson on 14/09/2021.
-//
-
 import Foundation
 
-internal extension Int {
+extension Int {
     func toCurrencyString(currency: Currency, locale: Locale = Locale.current) -> String {
         let currencySymbol = currency.symbol ?? currency.code
 
@@ -36,5 +29,19 @@ internal extension Int {
         } else {
             return "\(formattedValue.dropLast(currencySymbol.count).trimmingCharacters(in: .whitespaces))\(currencySymbol)"
         }
+    }
+
+    func formattedCurrencyAmount(currency: Currency) -> Decimal {
+        let numberFormatter = NumberFormatter()
+
+        numberFormatter.usesGroupingSeparator = true
+        numberFormatter.numberStyle = .currency
+        numberFormatter.locale = .current
+        numberFormatter.currencySymbol = currency.symbol ?? currency.code
+        numberFormatter.minimumFractionDigits = currency.isZeroDecimal ? 0 : 2
+        numberFormatter.maximumFractionDigits = currency.isZeroDecimal ? 0 : 2
+
+        // Convert amount to Decimal. If currency is zero decimal, no need to divide by 100
+        return currency.isZeroDecimal ? Decimal(self) : Decimal(self) / 100
     }
 }

--- a/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
@@ -34,7 +34,7 @@ final class ApplePayPresentationManager: ApplePayPresenting, LogReporter {
     func present(withRequest applePayRequest: ApplePayRequest,
                  delegate: PKPaymentAuthorizationControllerDelegate) -> Promise<Void> {
         Promise { seal in
-            let request = createRequest(for: applePayRequest)
+            let request = try createRequest(for: applePayRequest)
 
             let paymentController = PKPaymentAuthorizationController(paymentRequest: request)
             paymentController.delegate = delegate
@@ -56,7 +56,7 @@ final class ApplePayPresentationManager: ApplePayPresenting, LogReporter {
         }
     }
 
-    func createRequest(for applePayRequest: ApplePayRequest) -> PKPaymentRequest {
+    func createRequest(for applePayRequest: ApplePayRequest) throws -> PKPaymentRequest {
         let request = PKPaymentRequest()
         let applePayOptions = PrimerSettings.current.paymentMethodOptions.applePayOptions
 
@@ -74,6 +74,30 @@ final class ApplePayPresentationManager: ApplePayPresenting, LogReporter {
 
         if let shippingMethods = applePayRequest.shippingMethods {
             request.shippingMethods = shippingMethods
+        }
+
+        if #available(iOS 16.0, *) {
+            request.automaticReloadPaymentRequest = try applePayRequest.automaticReloadRequest?.toPKAutomaticReloadPaymentRequest(
+                orderAmount: applePayRequest.amount,
+                currency: applePayRequest.currency,
+                descriptor: applePayRequest.paymentDescriptor
+            )
+        }
+
+        if #available(iOS 16.4, *) {
+            request.deferredPaymentRequest = try applePayRequest.deferredPaymentRequest?.toPKDeferredPaymentRequest(
+                orderAmount: applePayRequest.amount,
+                currency: applePayRequest.currency,
+                descriptor: applePayRequest.paymentDescriptor
+            )
+        }
+
+        if #available(iOS 16.0, *) {
+            request.recurringPaymentRequest = try applePayRequest.recurringPaymentRequest?.toPKRecurringPaymentRequest(
+                orderAmount: applePayRequest.amount,
+                currency: applePayRequest.currency,
+                descriptor: applePayRequest.paymentDescriptor
+            )
         }
 
         return request

--- a/Tests/Klarna/KlarnaTestsMocks.swift
+++ b/Tests/Klarna/KlarnaTestsMocks.swift
@@ -90,7 +90,9 @@ class KlarnaTestsMocks {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil),
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil
+            ),
             order: ClientSession.Order(
                 id: "mock-client-session-order-id-1",
                 merchantAmount: nil,
@@ -101,7 +103,8 @@ class KlarnaTestsMocks {
                 fees: nil,
                 lineItems: hasItems ? [getLineItem(hasAmount: hasLineItemAmout)] : nil),
             customer: nil,
-            testId: nil)
+            testId: nil
+        )
     }
 
     static func getMockPrimerApiConfiguration(clientSession: ClientSession.APIResponse) -> Response.Body.Configuration {

--- a/Tests/Primer/ApplePay/ApplePayPresentationManagerTests.swift
+++ b/Tests/Primer/ApplePay/ApplePayPresentationManagerTests.swift
@@ -32,7 +32,7 @@ final class ApplePayPresentationManagerTests: XCTestCase {
                                                           taxAmount: nil)
                                               ],
                                               shippingMethods: [.init(label: "Shipping", amount: 100)])
-        let request = sut.createRequest(for: applePayRequest)
+        let request = try sut.createRequest(for: applePayRequest)
 
         XCTAssertEqual(request.countryCode, "GB")
         XCTAssertEqual(request.currencyCode, "GBP")
@@ -156,7 +156,7 @@ final class ApplePayPresentationManagerTests: XCTestCase {
                                                                                                   options: nil,
                                                                                                   orderedAllowedCardNetworks: [
                                                                                                     "CARTES_BANCAIRES"
-                                                                                                  ]),
+                                                                                                  ], descriptor: nil),
                                                                              order: nil,
                                                                              customer: nil,
                                                                              testId: nil)

--- a/Tests/Primer/Extensions/ApplePay.swift
+++ b/Tests/Primer/Extensions/ApplePay.swift
@@ -1,0 +1,128 @@
+#if DEBUG
+import XCTest
+import PassKit
+@testable import PrimerSDK
+
+@available(iOS 16.4, *)
+extension ApplePayAutomaticReloadRequest {
+    init(description: String?, amount: Int?, managementUrl: String = "https://example.com") {
+        self.init(
+            paymentDescription: description,
+            billingAgreement: nil,
+            managementUrl: managementUrl,
+            automaticReloadBilling: ApplePayAutomaticReloadBillingOption(
+                label: "Reload Item",
+                amount: amount,
+                automaticReloadThresholdAmount: 0
+            ),
+            tokenManagementUrl: nil
+        )
+    }
+    
+    func toPK() throws -> PKAutomaticReloadPaymentRequest {
+        try toPKAutomaticReloadPaymentRequest(
+            orderAmount: nil,
+            currency: Currency(code: "USD", decimalDigits: 2),
+            descriptor: nil
+        )
+    }
+}
+
+@available(iOS 16.4, *)
+extension ApplePayDeferredPaymentRequest {
+    init(description: String?, amount: Int?) {
+        self.init(
+            paymentDescription: description,
+            billingAgreement: nil,
+            managementUrl: "https://example.com",
+            deferredBilling: ApplePayDeferredBillingOption(
+                label: "Deferred Item",
+                amount: amount,
+                deferredPaymentDate: Date().timeIntervalSince1970
+            ),
+            freeCancellationDate: nil,
+            freeCancellationTimeZone: nil,
+            tokenManagementUrl: nil
+        )
+    }
+    
+    func toPK() throws -> PKDeferredPaymentRequest {
+        try toPKDeferredPaymentRequest(
+            orderAmount: nil,
+            currency: Currency(code: "USD", decimalDigits: 2),
+            descriptor: nil
+        )
+    }
+}
+
+@available(iOS 16.4, *)
+extension ApplePayRecurringPaymentRequest {
+    init(
+        description: String?,
+        amount: Int?,
+        managementUrl: String = "https://example.com"
+    ) {
+        self.init(
+            paymentDescription: description,
+            billingAgreement: "Agreement123",
+            managementUrl: managementUrl,
+            regularBilling: ApplePayRegularBillingOption(label: "Test Billing", amount: amount),
+            trialBilling: nil,
+            tokenManagementUrl: nil
+        )
+    }
+    
+    func toPK() throws -> PKRecurringPaymentRequest {
+        try toPKRecurringPaymentRequest(
+            orderAmount: nil,
+            currency: Currency(code: "USD", decimalDigits: 2),
+            descriptor: nil
+        )
+    }
+}
+
+extension ApplePayRegularBillingOption {
+    init(label: String, amount: Int?) {
+        self.init(
+            label: label,
+            amount: amount,
+            recurringStartDate: Date().timeIntervalSince1970,
+            recurringEndDate: nil,
+            recurringIntervalUnit: .month,
+            recurringIntervalCount: 1
+        )
+    }
+}
+
+@available(iOS 16.4, *)
+extension ApplePayTrialBillingOption {
+    init() {
+        self.init(
+            label: "Trial Plan",
+            amount: 0,
+            recurringStartDate: Date().timeIntervalSince1970,
+            recurringEndDate: Date().timeIntervalSince1970,
+            recurringIntervalUnit: .month,
+            recurringIntervalCount: 1
+        )
+    }
+    
+    func toPK() throws -> PKRecurringPaymentSummaryItem {
+        toPKRecurringPaymentSummaryItem(
+            totalAmount: 0,
+            currency: Currency(code: "USD", decimalDigits: 2)
+        )
+    }
+}
+
+extension ApplePayOptions {
+    init(merchantName: String?) {
+        self.init(
+            merchantName: merchantName,
+            recurringPaymentRequest: nil,
+            deferredPaymentRequest: nil,
+            automaticReloadRequest: nil
+        )
+    }
+}
+#endif

--- a/Tests/Primer/Ideal/IdealPaymentMethodTests.swift
+++ b/Tests/Primer/Ideal/IdealPaymentMethodTests.swift
@@ -25,10 +25,13 @@ final class IdealPaymentMethodTests: XCTestCase {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil),
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil
+            ),
             order: nil,
             customer: nil,
-            testId: nil)
+            testId: nil
+        )
         guard let mockPrimerApiConfiguration = createMockApiConfiguration(clientSession: clientSession, mockPaymentMethods: [Mocks.PaymentMethods.idealFormWithRedirectPaymentMethod]) else {
             XCTFail("Unable to start mock tokenization")
             return

--- a/Tests/Primer/Ideal/PrimerHeadlessFormWithRedirectManagerTests.swift
+++ b/Tests/Primer/Ideal/PrimerHeadlessFormWithRedirectManagerTests.swift
@@ -28,10 +28,13 @@ final class PrimerHeadlessFormWithRedirectManagerTests: XCTestCase {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil),
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil
+            ),
             order: nil,
             customer: nil,
-            testId: nil)
+            testId: nil
+        )
         let idealFormWithRedirectPaymentMethod = Mocks.PaymentMethods.idealFormWithRedirectPaymentMethod
         idealFormWithRedirectPaymentMethod.baseLogoImage = PrimerTheme.BaseImage(colored: UIImage(), light: nil, dark: nil)
 

--- a/Tests/Primer/Modules/HeadlessUniversalCheckoutTests.swift
+++ b/Tests/Primer/Modules/HeadlessUniversalCheckoutTests.swift
@@ -387,7 +387,8 @@ extension HeadlessUniversalCheckoutTests {
                 orderedAllowedCardNetworks: [
                     CardNetwork.visa.rawValue,
                     CardNetwork.masterCard.rawValue
-                ]
+                ],
+                descriptor: nil
             ),
             order: nil,
             customer: nil,

--- a/Tests/Primer/Modules/XCTestCase+Tokenization.swift
+++ b/Tests/Primer/Modules/XCTestCase+Tokenization.swift
@@ -34,10 +34,13 @@ extension XCTestCase {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil),
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil
+            ),
             order: nil,
             customer: nil,
-            testId: nil)
+            testId: nil
+        )
         let mockPrimerApiConfiguration = Mocks.createMockAPIConfiguration(
             clientSession: clientSession,
             paymentMethods: mockPaymentMethods)

--- a/Tests/Primer/Utils/ApplePayPaymentRequest+PK.swift
+++ b/Tests/Primer/Utils/ApplePayPaymentRequest+PK.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import PrimerSDK
+
+@available(iOS 16.4, *)
+final class ApplePayPaymentRequest: XCTestCase {
+    
+    func testToPKRecurringPaymentSummaryItem_validInput() throws {
+        let billing = ApplePayRegularBillingOption(label: "Test Subscription", amount: nil)
+        let summaryItem = billing.toPKRecurringPaymentSummaryItem(totalAmount: 123, currency: Currency(code: "USD", decimalDigits: 2))
+        XCTAssertEqual(summaryItem.label, billing.label)
+        XCTAssertEqual(summaryItem.amount, NSDecimalNumber(decimal: 123.formattedCurrencyAmount(currency: Currency(code: "USD", decimalDigits: 2))))
+        XCTAssertEqual(summaryItem.intervalCount, billing.recurringIntervalCount)
+        XCTAssertEqual(summaryItem.intervalUnit, NSCalendar.Unit.month)
+    }
+    
+    func testToPKRecurringPaymentRequest_missingAmount_throwsError() throws {
+        let request = ApplePayRecurringPaymentRequest(description: "Test recurring payment", amount: nil)
+        assert(.regularBillingAmount, against: request.toPK)
+    }
+    
+    func testToPKRecurringPaymentRequest_missingDescriptor_throwsError() throws {
+        let request = ApplePayRecurringPaymentRequest(description: nil, amount: 123)
+        assert(.recurringPaymentMissingDescription, against: request.toPK)
+    }
+    
+    func testToPKDeferredPaymentRequest_validInput() throws {
+        let request = ApplePayDeferredPaymentRequest(description: "Request", amount: 123)
+        XCTAssertNoThrow(request.toPK)
+    }
+    
+    func testToPKDeferredPaymentRequest_missingAmount_throwsError() throws {
+        let request = ApplePayDeferredPaymentRequest(description: nil, amount: nil)
+        assert(.deferredBillingAmount, against: request.toPK)
+    }
+    
+    func testToPKDeferredPaymentRequest() throws {
+        let request = ApplePayDeferredPaymentRequest(description: nil, amount: 123)
+        assert(.deferredPaymentMissingDescription, against: request.toPK)
+    }
+    
+    func testToPKAutomaticReloadPaymentRequest_validInput() throws {
+        let request = ApplePayAutomaticReloadRequest(description: "Deferred payment", amount: 123)
+        XCTAssertNoThrow(request.toPK)
+    }
+    
+    func testToPKAutomaticReloadPaymentRequest_missingAmount_throwsError() throws {
+        let request = ApplePayAutomaticReloadRequest(description: "Reload Payment", amount: nil)
+        assert(.automaticReloadBillingAmount, against: request.toPK)
+    }
+    
+    func testToPKAutomaticReloadPaymentRequest_missingDescription_throwsError() throws {
+        let request = ApplePayAutomaticReloadRequest(description: nil, amount: 123)
+        assert(.automaticReloadMissingDescription, against: request.toPK)
+    }
+    
+    func testToPKAutomaticReloadPaymentRequest_invalidManagmentUrl_throwsError() throws {
+        let request = ApplePayAutomaticReloadRequest(description: "test", amount: 123, managementUrl: "")
+        assert(.automaticReloadInvalidManagementUrl, against: request.toPK)
+    }
+    
+    func testTrialBillingWithZeroAmount() throws {
+        XCTAssertNoThrow(ApplePayTrialBillingOption().toPK)
+    }
+    
+    func testTokenManagementUrlEdgeCases() throws {
+        let validRequest = ApplePayRecurringPaymentRequest(description: "Valid Token Management", amount: 5000)
+        XCTAssertNoThrow(try validRequest.toPK())
+
+        let invalidRequest = ApplePayRecurringPaymentRequest(description: "Valid Token Management", amount: 5000, managementUrl: "")
+        XCTAssertThrowsError(try invalidRequest.toPK())
+    }
+    
+    private func assert<T>(_ expectedErrorKey: String, against method: @escaping () throws -> T) {
+        let expectedError = getInvalidValueError(key: expectedErrorKey)
+        let failureMessage = "Invalid value 'nil' for key '\(expectedErrorKey)'"
+        XCTAssertThrowsError(try method()) { error in
+            if let err = error as? PrimerError {
+                XCTAssertEqual(err.plainDescription, expectedError.plainDescription, failureMessage)
+            }
+        }
+    }
+    
+    private func getInvalidValueError(
+        key: String,
+        value: Any? = nil
+    ) -> PrimerError {
+        PrimerError.invalidValue(
+            key: key,
+            value: value,
+            userInfo: .errorUserInfoDictionary(),
+            diagnosticsId: UUID().uuidString
+        )
+    }
+}
+
+private extension String {
+    static let regularBillingAmount = "regularBilling.amount or amount"
+    static let recurringPaymentMissingDescription = "recurringPaymentRequest.paymentDescription or paymentMethod.descriptor"
+    static let deferredBillingAmount = "deferredBilling.amount or amount"
+    static let deferredPaymentMissingDescription = "deferredPaymentRequest.paymentDescription or paymentMethod.descriptor"
+    static let automaticReloadBillingAmount = "automaticReloadBilling.amount or amount"
+    static let automaticReloadMissingDescription = "automaticReloadRequest.paymentDescription or paymentMethod.descriptor"
+    static let automaticReloadInvalidManagementUrl = "automaticReloadRequest.managementUrl"
+}

--- a/Tests/Primer/v2/HeadlessUniversalCheckoutAPIConfigurationTests.swift
+++ b/Tests/Primer/v2/HeadlessUniversalCheckoutAPIConfigurationTests.swift
@@ -19,7 +19,8 @@ class HeadlessUniversalCheckoutAPIConfigurationTests: XCTestCase {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil
             ),
             order: ClientSession.Order(
                 id: "mock-client-session-order-id-1",
@@ -111,7 +112,8 @@ class HeadlessUniversalCheckoutAPIConfigurationTests: XCTestCase {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil
             ),
             order: ClientSession.Order(
                 id: "mock-client-session-order-id-1",

--- a/Tests/Primer/v2/HeadlessVaultManagerTests.swift
+++ b/Tests/Primer/v2/HeadlessVaultManagerTests.swift
@@ -1,11 +1,3 @@
-//
-//  HeadlessVaultManagerTests.swift
-//  Debug App Tests
-//
-//  Created by Boris on 21.6.23..
-//  Copyright © 2023 Primer API Ltd. All rights reserved.
-//
-
 import XCTest
 @testable import PrimerSDK
 
@@ -19,7 +11,8 @@ final class HeadlessVaultManagerTests: XCTestCase {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil
             ),
             order: ClientSession.Order(
                 id: "mock-client-session-order-id-1",
@@ -74,42 +67,49 @@ final class HeadlessVaultManagerTests: XCTestCase {
             keys: nil,
             checkoutModules: nil)
 
-        let vaultedPaymentMethods = Response.Body.VaultedPaymentMethods(data: [
-            PrimerPaymentMethodTokenData(analyticsId: "test",
-                                         id: "test",
-                                         isVaulted: true,
-                                         isAlreadyVaulted: true,
-                                         paymentInstrumentType: .payPalBillingAgreement,
-                                         paymentMethodType: "PAYPAL",
-                                         paymentInstrumentData: Response.Body.Tokenization.PaymentInstrumentData(paypalBillingAgreementId: "",
-                                                                                                                 first6Digits: nil,
-                                                                                                                 last4Digits: nil,
-                                                                                                                 expirationMonth: nil,
-                                                                                                                 expirationYear: nil,
-                                                                                                                 cardholderName: nil,
-                                                                                                                 network: nil,
-                                                                                                                 isNetworkTokenized: nil,
-                                                                                                                 klarnaCustomerToken: nil,
-                                                                                                                 sessionData: nil,
-                                                                                                                 externalPayerInfo: nil,
-                                                                                                                 shippingAddress: nil,
-                                                                                                                 binData: nil,
-                                                                                                                 threeDSecureAuthentication: nil,
-                                                                                                                 gocardlessMandateId: nil,
-                                                                                                                 authorizationToken: nil,
-                                                                                                                 mx: nil,
-                                                                                                                 currencyCode: nil,
-                                                                                                                 productId: nil,
-                                                                                                                 paymentMethodConfigId: nil,
-                                                                                                                 paymentMethodType: nil,
-                                                                                                                 sessionInfo: nil,
-                                                                                                                 bankName: nil,
-                                                                                                                 accountNumberLast4Digits: nil),
-                                         threeDSecureAuthentication: nil,
-                                         token: "anything",
-                                         tokenType: .multiUse,
-                                         vaultData: nil)
-        ])
+        let vaultedPaymentMethods = Response.Body.VaultedPaymentMethods(
+            data: [
+                PrimerPaymentMethodTokenData(
+                    analyticsId: "test",
+                    id: "test",
+                    isVaulted: true,
+                    isAlreadyVaulted: true,
+                    paymentInstrumentType: .payPalBillingAgreement,
+                    paymentMethodType: "PAYPAL",
+                    paymentInstrumentData: Response.Body.Tokenization.PaymentInstrumentData(
+                        paypalBillingAgreementId: "",
+                        first6Digits: nil,
+                        last4Digits: nil,
+                        expirationMonth: nil,
+                        expirationYear: nil,
+                        cardholderName: nil,
+                        network: nil,
+                        isNetworkTokenized: nil,
+                        klarnaCustomerToken: nil,
+                        sessionData: nil,
+                        externalPayerInfo: nil,
+                        shippingAddress: nil,
+                        binData: nil,
+                        threeDSecureAuthentication: nil,
+                        gocardlessMandateId: nil,
+                        authorizationToken: nil,
+                        mx: nil,
+                        currencyCode: nil,
+                        productId: nil,
+                        paymentMethodConfigId: nil,
+                        paymentMethodType: nil,
+                        sessionInfo: nil,
+                        bankName: nil,
+                        accountNumberLast4Digits: nil,
+                        applePayMerchantTokenIdentifier: nil
+                    ),
+                    threeDSecureAuthentication: nil,
+                    token: "anything",
+                    tokenType: .multiUse,
+                    vaultData: nil
+                )
+            ]
+        )
         var availableVaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
 
         let mockApiClient = MockPrimerAPIClient()
@@ -153,7 +153,8 @@ final class HeadlessVaultManagerTests: XCTestCase {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil
             ),
             order: ClientSession.Order(
                 id: "mock-client-session-order-id-1",
@@ -220,7 +221,8 @@ final class HeadlessVaultManagerTests: XCTestCase {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil
             ),
             order: ClientSession.Order(
                 id: "mock-client-session-order-id-1",
@@ -275,42 +277,49 @@ final class HeadlessVaultManagerTests: XCTestCase {
             keys: nil,
             checkoutModules: nil)
 
-        let vaultedPaymentMethods = Response.Body.VaultedPaymentMethods(data: [
-            PrimerPaymentMethodTokenData(analyticsId: "test",
-                                         id: "test",
-                                         isVaulted: true,
-                                         isAlreadyVaulted: true,
-                                         paymentInstrumentType: .payPalBillingAgreement,
-                                         paymentMethodType: "PAYPAL",
-                                         paymentInstrumentData: Response.Body.Tokenization.PaymentInstrumentData(paypalBillingAgreementId: "",
-                                                                                                                 first6Digits: nil,
-                                                                                                                 last4Digits: nil,
-                                                                                                                 expirationMonth: nil,
-                                                                                                                 expirationYear: nil,
-                                                                                                                 cardholderName: nil,
-                                                                                                                 network: nil,
-                                                                                                                 isNetworkTokenized: nil,
-                                                                                                                 klarnaCustomerToken: nil,
-                                                                                                                 sessionData: nil,
-                                                                                                                 externalPayerInfo: nil,
-                                                                                                                 shippingAddress: nil,
-                                                                                                                 binData: nil,
-                                                                                                                 threeDSecureAuthentication: nil,
-                                                                                                                 gocardlessMandateId: nil,
-                                                                                                                 authorizationToken: nil,
-                                                                                                                 mx: nil,
-                                                                                                                 currencyCode: nil,
-                                                                                                                 productId: nil,
-                                                                                                                 paymentMethodConfigId: nil,
-                                                                                                                 paymentMethodType: nil,
-                                                                                                                 sessionInfo: nil,
-                                                                                                                 bankName: nil,
-                                                                                                                 accountNumberLast4Digits: nil),
-                                         threeDSecureAuthentication: nil,
-                                         token: "anything",
-                                         tokenType: .multiUse,
-                                         vaultData: nil)
-        ])
+        let vaultedPaymentMethods = Response.Body.VaultedPaymentMethods(
+            data: [
+                PrimerPaymentMethodTokenData(
+                    analyticsId: "test",
+                    id: "test",
+                    isVaulted: true,
+                    isAlreadyVaulted: true,
+                    paymentInstrumentType: .payPalBillingAgreement,
+                    paymentMethodType: "PAYPAL",
+                    paymentInstrumentData: Response.Body.Tokenization.PaymentInstrumentData(
+                        paypalBillingAgreementId: "",
+                        first6Digits: nil,
+                        last4Digits: nil,
+                        expirationMonth: nil,
+                        expirationYear: nil,
+                        cardholderName: nil,
+                        network: nil,
+                        isNetworkTokenized: nil,
+                        klarnaCustomerToken: nil,
+                        sessionData: nil,
+                        externalPayerInfo: nil,
+                        shippingAddress: nil,
+                        binData: nil,
+                        threeDSecureAuthentication: nil,
+                        gocardlessMandateId: nil,
+                        authorizationToken: nil,
+                        mx: nil,
+                        currencyCode: nil,
+                        productId: nil,
+                        paymentMethodConfigId: nil,
+                        paymentMethodType: nil,
+                        sessionInfo: nil,
+                        bankName: nil,
+                        accountNumberLast4Digits: nil,
+                        applePayMerchantTokenIdentifier: nil
+                    ),
+                    threeDSecureAuthentication: nil,
+                    token: "anything",
+                    tokenType: .multiUse,
+                    vaultData: nil
+                )
+            ]
+        )
         var mockApiClient = MockPrimerAPIClient()
         mockApiClient.fetchVaultedPaymentMethodsResult = (vaultedPaymentMethods, nil)
         mockApiClient.fetchConfigurationResult = (mockPrimerApiConfiguration, nil)
@@ -395,7 +404,8 @@ final class HeadlessVaultManagerTests: XCTestCase {
                     paymentMethodType: nil,
                     sessionInfo: nil,
                     bankName: nil,
-                    accountNumberLast4Digits: nil),
+                    accountNumberLast4Digits: nil,
+                    applePayMerchantTokenIdentifier: nil),
                 analyticsId: "analytics-id")
         ]
 
@@ -474,7 +484,8 @@ final class HeadlessVaultManagerTests: XCTestCase {
                     paymentMethodType: nil,
                     sessionInfo: nil,
                     bankName: nil,
-                    accountNumberLast4Digits: nil),
+                    accountNumberLast4Digits: nil,
+                    applePayMerchantTokenIdentifier: nil),
                 analyticsId: "analytics-id")
         ]
 
@@ -515,7 +526,8 @@ final class HeadlessVaultManagerTests: XCTestCase {
                     paymentMethodType: nil,
                     sessionInfo: nil,
                     bankName: nil,
-                    accountNumberLast4Digits: nil),
+                    accountNumberLast4Digits: nil,
+                    applePayMerchantTokenIdentifier: nil),
                 analyticsId: "analytics-id")
         ]
 

--- a/Tests/Primer/v2/RawDataManagerValidationTests.swift
+++ b/Tests/Primer/v2/RawDataManagerValidationTests.swift
@@ -46,7 +46,8 @@ class RawDataManagerValidationTests: XCTestCase {
                     CardNetwork.amex.rawValue
                     //                    ,
                     //                    CardNetwork.unknown.rawValue
-                ]
+                ],
+                descriptor: nil
             ),
             order: ClientSession.Order(
                 id: "mock-client-session-order-id-1",

--- a/Tests/Stripe/ACHMocks.swift
+++ b/Tests/Stripe/ACHMocks.swift
@@ -36,7 +36,8 @@ final class ACHMocks {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil),
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil),
             order: ClientSession.Order(
                 id: "mock-client-session-order-stripe-ach_id",
                 merchantAmount: 1050,
@@ -72,7 +73,8 @@ final class ACHMocks {
             paymentMethod: ClientSession.PaymentMethod(
                 vaultOnSuccess: false,
                 options: nil,
-                orderedAllowedCardNetworks: nil),
+                orderedAllowedCardNetworks: nil,
+                descriptor: nil),
             order: ClientSession.Order(
                 id: "mock-client-session-order-stripe-ach_id",
                 merchantAmount: emptyMerchantAmmount ? nil: 1000,

--- a/Tests/Utilities/Mocks.swift
+++ b/Tests/Utilities/Mocks.swift
@@ -76,7 +76,9 @@ class Mocks {
         paymentMethodType: nil,
         sessionInfo: nil,
         bankName: nil,
-        accountNumberLast4Digits: nil)
+        accountNumberLast4Digits: nil,
+        applePayMerchantTokenIdentifier: nil
+    )
 
     static var payment = Response.Body.Payment(
         id: "mock_id",

--- a/Tests/Utilities/Mocks/Services/MockAPIClient.swift
+++ b/Tests/Utilities/Mocks/Services/MockAPIClient.swift
@@ -1155,7 +1155,8 @@ extension MockPrimerAPIClient {
                 paymentMethod: ClientSession.PaymentMethod(
                     vaultOnSuccess: false,
                     options: nil,
-                    orderedAllowedCardNetworks: nil
+                    orderedAllowedCardNetworks: nil,
+                    descriptor: nil
                 ),
                 order: ClientSession.Order(
                     id: "mock-client-session-order-id-1",

--- a/Tests/Utilities/Test Utilities/SDKSessionHelper.swift
+++ b/Tests/Utilities/Test Utilities/SDKSessionHelper.swift
@@ -26,7 +26,8 @@ final class SDKSessionHelper {
         let session = ClientSession.APIResponse(clientSessionId: "client_session_id",
                                                 paymentMethod: .init(vaultOnSuccess: false,
                                                                      options: paymentMethodOptions,
-                                                                     orderedAllowedCardNetworks: nil),
+                                                                     orderedAllowedCardNetworks: nil,
+                                                                     descriptor: nil),
                                                 order: order,
                                                 customer: customer,
                                                 testId: showTestId ? "test_id" : nil)
@@ -90,9 +91,12 @@ final class SDKSessionHelper {
     static func updateAllowedCardNetworks(cardNetworks: [CardNetwork]) {
         PrimerAPIConfigurationModule.apiConfiguration?.clientSession = .init(
             clientSessionId: "",
-            paymentMethod: .init(vaultOnSuccess: false,
-                                 options: nil,
-                                 orderedAllowedCardNetworks: cardNetworks.map { $0.rawValue }),
+            paymentMethod: .init(
+                vaultOnSuccess: false,
+                options: nil,
+                orderedAllowedCardNetworks: cardNetworks.map(\.rawValue),
+                descriptor: nil
+            ),
             order: nil,
             customer: nil,
             testId: nil


### PR DESCRIPTION
# Description

Added support for Apple Pay MPAN. In order for Apple to return new token, we must pass exactly one additional payment request:

- deferred payment request
- automatic reload payment request
- recurring payment request


# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)