### PR TITLE
chore: Route UI Tests to Lambdatest

### DIFF
--- a/.github/actions/ui-tests/action.yml
+++ b/.github/actions/ui-tests/action.yml
@@ -1,8 +1,8 @@
-name: 'Build and upload to Appetize'
-description: 'Build and upload to Appetize'
+name: 'Test via Lambdatest'
+description: 'Test via Lambdatest'
 inputs:
   appium-tests-branch:
-    description: The branch to run from mobile-appium-tests 
+    description: The branch to run from mobile-appium-tests
     required: true
     default: develop
   test-type:
@@ -11,11 +11,11 @@ inputs:
   gitlab-appium-pull-key:
     description: The key used to fetch the appium repo
     required: true
-  browserstack-user-name:
-    description: The browserstack username
+  lambdatest-user-name:
+    description: The lambdatest username
     required: true
-  browserstack-access-key:
-    description: The browserstack access key
+  lambdatest-access-key:
+    description: The lambdatest access key
     required: true
   slack-mobile-sdk-channel:
     description: The channel to report results to
@@ -32,7 +32,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Clone and launch Browserstack tests via Appium 🧪
+    - name: Clone and launch Lambdatest tests via Appium 🧪
       shell: bash
       run: |
           git clone -b ${{ inputs.appium-tests-branch || 'develop' }} https://project_41483872_bot:$GITLAB_TEMP_PATH@gitlab.com/primer-io/acceptance/mobile/mobile-appium-tests.git ./tests
@@ -40,10 +40,10 @@ runs:
       env:
         GITLAB_TEMP_PATH: ${{ inputs.gitlab-appium-pull-key }} # secrets.GITLAB_APPIUM_PULL_KEY
 
-    - name: Retrieve Browserstack ID
+    - name: Retrieve Lambdatest ID
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  #v4.1.8
       with:
-        name: browserstack_id
+        name: lambdatest_id
         path: /var/tmp
 
     - name: Setup node
@@ -55,7 +55,7 @@ runs:
       working-directory: ./tests
       shell: bash
       run: npm install
-    
+ 
     - name: npm install - slack message builder
       working-directory: ./tests
       shell: bash
@@ -65,13 +65,13 @@ runs:
       working-directory: ./tests
       shell: bash
       env:
-        BROWSERSTACK_USERNAME: ${{ inputs.browserstack-user-name }} # secrets.BROWSERSTACK_USERNAME
-        BROWSERSTACK_ACCESS_KEY: ${{ inputs.browserstack-access-key }} # secrets.BROWSERSTACK_ACCESS_KEY
+        LAMBDATEST_USERNAME: ${{ inputs.lambdatest-user-name }} # secrets.LAMBDATEST_USERNAME
+        LAMBDATEST_ACCESS_KEY: ${{ inputs.lambdatest-access-key }} # secrets.LAMBDATEST_ACCESS_KEY
       run: |
-        export BROWSERSTACK_APP_ID=$(cat /var/tmp/browserstack_id.txt)
+        export LAMBDATEST_APP_ID=$(cat /var/tmp/lambdatest_id.txt)
         export UI_TESTS_SECRETS_API_KEY="${{ inputs.ui-tests-secrets-api-key }}"
-        testType=${{ inputs.test-type }} npx wdio config/wdio.ios.bs.conf.js
-        
+        testType=${{ inputs.test-type }} npx wdio config/wdio.ios.lt.conf.js
+ 
     - name: Create Slack Report
       working-directory: ./tests
       shell: bash
@@ -96,8 +96,8 @@ runs:
       run: |
         node report-script/slack-failed-report-script.js createSlackFailedSummaryReport ${{ steps.slack.outputs.thread_ts }}
       env:
-        BROWSERSTACK_USERNAME: ${{ inputs.browserstack-user-name }} # secrets.BROWSERSTACK_USERNAME
-        BROWSERSTACK_ACCESS_KEY: ${{ inputs.browserstack-access-key }} # secrets.BROWSERSTACK_ACCESS_KEY
+        LAMBDATEST_USERNAME: ${{ inputs.lambdatest-user-name }} # secrets.LAMBDATEST_USERNAME
+        LAMBDATEST_ACCESS_KEY: ${{ inputs.lambdatest-access-key }} # secrets.LAMBDATEST_ACCESS_KEY
 
     - name: Post detailed summary to Slack channel thread
       if: ${{ failure() }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -155,7 +155,7 @@ jobs:
           sparse-checkout: .github
       - name: Run UI Tests via LambdaTest [${{ inputs.testType }}] 🧪
         id: ui-tests-test-via-lambdatest
-        uses: ./.github/actions/ui-tests-lambdatest
+        uses: ./.github/actions/ui-tests
         with:
           appium-tests-branch: ${{ inputs.appiumTestsBranch }}
           test-type: ${{ inputs.testType }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -179,7 +179,7 @@ jobs:
           sparse-checkout: .github
       - name: Run UI Tests via LambdaTest [${{ inputs.testType }}] 🧪
         id: ui-tests-test-via-lambdatest
-        uses: ./.github/actions/ui-tests-lambdatest
+        uses: ./.github/actions/ui-tests
         with:
           appium-tests-branch: ${{ inputs.appiumTestsBranch }}
           test-type: ${{ inputs.testType }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -165,6 +165,7 @@ jobs:
           slack-mobile-sdk-channel: ${{ secrets.SLACK_MOBILE_SDK_CHANNEL }}
           slack-reporter-bot-token: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
           ui-tests-secrets-api-key: ${{ secrets.UI_TESTS_SECRETS_API_KEY }}
+          test-app-artifact-url: ${{ needs.build-and-upload-to-firebase-and-lambdatest.outputs.artifact-url }}
 
   test-via-lambdatest-manual:
     runs-on: ubuntu-latest
@@ -189,3 +190,4 @@ jobs:
           slack-mobile-sdk-channel: ${{ secrets.SLACK_MOBILE_SDK_CHANNEL }}
           slack-reporter-bot-token: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
           ui-tests-secrets-api-key: ${{ secrets.UI_TESTS_SECRETS_API_KEY }}
+          test-app-artifact-url: ${{ needs.build-and-upload-to-firebase-and-lambdatest.outputs.artifact-url }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -128,6 +128,13 @@ jobs:
           retention-days: 1
           path: /var/tmp/browserstack_id.txt
           if-no-files-found: error
+      - name: Save LambdaTest ID
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
+        id: save_lambdatest_id_step
+        with:
+          name: lambdatest_id
+          retention-days: 1
+          path: /var/tmp/lambdatest_id.txt
       - name: Save App Artifact
         id: save_app_artifact_step
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -119,6 +119,8 @@ jobs:
           APPETIZE_API_TOKEN: ${{ secrets.APPETIZE_API_TOKEN }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
+          LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
           SOURCE_BRANCH: ${{ github.ref }}
       - name: Save Browserstack ID
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           echo "STRIPE_PUBLISHABLE_KEY=${{ secrets.STRIPE_PUBLISHABLE_KEY }}" > Debug\ App/secrets.defaults.properties
 
-      - name: Distribute internally on Firebase and upload to Browserstack 🚀
+      - name: Distribute internally on Firebase and upload to LambdaTest 🚀
         run: |
           bundle exec fastlane qa_release
         env:
@@ -138,7 +138,7 @@ jobs:
 
   test-via-lambdatest:
     runs-on: ubuntu-latest
-    needs: build-and-upload-to-firebase-and-browserstack
+    needs: build-and-upload-to-firebase-and-lambdatest
     name: "LambdaTest test"
     if: ${{ inputs.testType == '' }}
     strategy:
@@ -168,7 +168,7 @@ jobs:
 
   test-via-lambdatest-manual:
     runs-on: ubuntu-latest
-    needs: build-and-upload-to-firebase-and-browserstack
+    needs: build-and-upload-to-firebase-and-lambdatest
     name: "LambdaTest test (manual)"
     if: ${{ inputs.testType != '' }}
     steps:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -54,10 +54,10 @@ jobs:
           slack-reporter-token: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
           github-run-id: ${{ github.run_id }}
           stripe-publishable-key: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
-  build-and-upload-to-firebase-and-browserstack:
+  build-and-upload-to-firebase-and-lambdatest:
     runs-on: macos-latest
     timeout-minutes: 20
-    name: "Distribute app to Firebase and Browserstack"
+    name: "Distribute app to Firebase and LambdaTest"
     outputs:
       artifact-url: ${{ steps.save_app_artifact_step.outputs.artifact-url }}
     steps:
@@ -117,19 +117,9 @@ jobs:
           MATCH_KEYCHAIN_NAME: ${{ secrets.MATCH_KEYCHAIN_NAME }}
           MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
           APPETIZE_API_TOKEN: ${{ secrets.APPETIZE_API_TOKEN }}
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           LAMBDATEST_USERNAME: ${{ secrets.LAMBDATEST_USERNAME }}
           LAMBDATEST_ACCESS_KEY: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
           SOURCE_BRANCH: ${{ github.ref }}
-      - name: Save Browserstack ID
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
-        id: save_browserstack_id_step
-        with:
-          name: browserstack_id
-          retention-days: 1
-          path: /var/tmp/browserstack_id.txt
-          if-no-files-found: error
       - name: Save LambdaTest ID
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         id: save_lambdatest_id_step
@@ -145,41 +135,41 @@ jobs:
           retention-days: 1
           path: '/Users/runner/work/primer-sdk-ios/primer-sdk-ios/Debug App.ipa'
           if-no-files-found: error
-  test-via-browserstack:
-      runs-on: ubuntu-latest
-      needs: build-and-upload-to-firebase-and-browserstack
-      name: "Browserstack test"
-      if: ${{ inputs.testType == '' }}
-      strategy:
-            max-parallel: 1
-            matrix:
-              test-type:
-                - "MOCKED"
-                - "E2E"
-      steps:
-        - name: Git - Checkout
-          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-          with:
-            ref: ${{ github.ref }}
-            sparse-checkout: .github
-        - name: Run UI Tests via Browserstack 🧪
-          id: ui-tests-test-via-browserstack
-          uses: ./.github/actions/ui-tests
-          with:
-            appium-tests-branch: ${{ inputs.appiumTestsBranch }}
-            test-type: ${{ matrix.test-type }}
-            gitlab-appium-pull-key: ${{ secrets.GITLAB_APPIUM_PULL_KEY }}
-            browserstack-user-name: ${{ secrets.BROWSERSTACK_USERNAME }}
-            browserstack-access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-            slack-mobile-sdk-channel: ${{ secrets.SLACK_MOBILE_SDK_CHANNEL }}
-            slack-reporter-bot-token: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
-            ui-tests-secrets-api-key: ${{ secrets.UI_TESTS_SECRETS_API_KEY }}
-            test-app-artifact-url: ${{ needs.build-and-upload-to-firebase-and-browserstack.outputs.artifact-url }}
-  
-  test-via-browserstack-manual:
+
+  test-via-lambdatest:
     runs-on: ubuntu-latest
     needs: build-and-upload-to-firebase-and-browserstack
-    name: "Browserstack test (manual)"
+    name: "LambdaTest test"
+    if: ${{ inputs.testType == '' }}
+    strategy:
+      max-parallel: 1
+      matrix:
+        test-type:
+          - "MOCKED"
+          - "E2E"
+    steps:
+      - name: Git - Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.ref }}
+          sparse-checkout: .github
+      - name: Run UI Tests via LambdaTest [${{ inputs.testType }}] 🧪
+        id: ui-tests-test-via-lambdatest
+        uses: ./.github/actions/ui-tests-lambdatest
+        with:
+          appium-tests-branch: ${{ inputs.appiumTestsBranch }}
+          test-type: ${{ inputs.testType }}
+          gitlab-appium-pull-key: ${{ secrets.GITLAB_APPIUM_PULL_KEY }}
+          lambdatest-user-name: ${{ secrets.LAMBDATEST_USERNAME }}
+          lambdatest-access-key: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
+          slack-mobile-sdk-channel: ${{ secrets.SLACK_MOBILE_SDK_CHANNEL }}
+          slack-reporter-bot-token: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
+          ui-tests-secrets-api-key: ${{ secrets.UI_TESTS_SECRETS_API_KEY }}
+
+  test-via-lambdatest-manual:
+    runs-on: ubuntu-latest
+    needs: build-and-upload-to-firebase-and-browserstack
+    name: "LambdaTest test (manual)"
     if: ${{ inputs.testType != '' }}
     steps:
       - name: Git - Checkout
@@ -187,15 +177,15 @@ jobs:
         with:
           ref: ${{ github.ref }}
           sparse-checkout: .github
-      - name: Run UI Tests via Browserstack [${{ inputs.testType }}] 🧪
-        id: ui-tests-test-via-browserstack
-        uses: ./.github/actions/ui-tests
+      - name: Run UI Tests via LambdaTest [${{ inputs.testType }}] 🧪
+        id: ui-tests-test-via-lambdatest
+        uses: ./.github/actions/ui-tests-lambdatest
         with:
           appium-tests-branch: ${{ inputs.appiumTestsBranch }}
           test-type: ${{ inputs.testType }}
           gitlab-appium-pull-key: ${{ secrets.GITLAB_APPIUM_PULL_KEY }}
-          browserstack-user-name: ${{ secrets.BROWSERSTACK_USERNAME }}
-          browserstack-access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          lambdatest-user-name: ${{ secrets.LAMBDATEST_USERNAME }}
+          lambdatest-access-key: ${{ secrets.LAMBDATEST_ACCESS_KEY }}
           slack-mobile-sdk-channel: ${{ secrets.SLACK_MOBILE_SDK_CHANNEL }}
           slack-reporter-bot-token: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
           ui-tests-secrets-api-key: ${{ secrets.UI_TESTS_SECRETS_API_KEY }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,8 +159,6 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-browserstack (0.3.2)
-      rest-client (~> 2.0, >= 2.0.2)
     fastlane-plugin-firebase_app_distribution (0.9.1)
       google-apis-firebaseappdistribution_v1 (~> 0.3.0)
       google-apis-firebaseappdistribution_v1alpha (~> 0.2.0)
@@ -302,7 +300,6 @@ DEPENDENCIES
   activesupport (~> 7.0, <= 7.0.8)
   cocoapods (~> 1.15.0)
   fastlane
-  fastlane-plugin-browserstack
   fastlane-plugin-firebase_app_distribution
   fastlane-plugin-lambdatest
   fastlane-plugin-versioning

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,8 @@ GEM
     fastlane-plugin-firebase_app_distribution (0.9.1)
       google-apis-firebaseappdistribution_v1 (~> 0.3.0)
       google-apis-firebaseappdistribution_v1alpha (~> 0.2.0)
+    fastlane-plugin-lambdatest (0.1.5)
+      rest-client (~> 2.0, >= 2.0.2)
     fastlane-plugin-versioning (0.5.2)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
@@ -302,6 +304,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-browserstack
   fastlane-plugin-firebase_app_distribution
+  fastlane-plugin-lambdatest
   fastlane-plugin-versioning
 
 BUNDLED WITH

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -106,6 +106,11 @@ platform :ios do
       file_path: ENV["IPA_OUTPUT_PATH"]
     )
 
+    # Upload to LambdaTest
+    upload_to_lambdatest_and_save_id(
+      file_path: ENV["IPA_OUTPUT_PATH"]
+    )
+
     # Upload to Firebase
     firebase_app_distribution(
       service_credentials_file: "firebase_credentials.json",
@@ -265,6 +270,20 @@ platform :ios do
 
   end
 
+  desc 'This action uploads the .ipa to LambdaTest and save its ID into a file'
+  private_lane :upload_to_lambdatest_and_save_id do |options|
+
+    upload_to_lambdatest(
+      lt_username: ENV["LAMBDATEST_USERNAME"],
+      lt_access_key: ENV["LAMBDATEST_ACCESS_KEY"],
+      file_path: options[:file_path],
+      custom_id: source_branch_trimmed
+    )
+
+    save_lambdatest_id(lambdatest_id: ENV['APP_URL'])
+
+  end
+
   desc 'This action creates a temporary keychain and installs certificates and provisioning profiles'
   private_lane :setup_signing do |options|
 
@@ -335,6 +354,18 @@ platform :ios do
     File.open(browserstack_id_file, 'w') { |file| file.write(options[:browserstack_id]) }
 
   end
+
+  desc 'Store the LambdaTest ID into a file'
+  private_lane :save_lambdatest_id do |options|
+
+    lambdatest_id_to_save = options[:lambdatest_id]
+    lambdatest_id_file = "/var/tmp/lambdatest_id.txt" 
+
+    UI.message("Saving #{lambdatest_id_to_save} into #{lambdatest_id_file}")
+
+    File.open(lambdatest_id_file, 'w') { |file| file.write(options[:lambdatest_id]) }
+
+  end 
 
   ################## END PRIVATE LANES ######################
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -277,7 +277,8 @@ platform :ios do
       lt_username: ENV["LAMBDATEST_USERNAME"],
       lt_access_key: ENV["LAMBDATEST_ACCESS_KEY"],
       file_path: options[:file_path],
-      custom_id: source_branch_trimmed
+      custom_id: source_branch_trimmed,
+      visibility: "org"
     )
 
     save_lambdatest_id(lambdatest_id: ENV['APP_URL'])

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -91,7 +91,7 @@ platform :ios do
       podfile: podfile_path
     )
 
-    # Build for browserstack
+    # Build for lambdatest
     build_app(
       scheme: app_scheme,
       workspace: app_workspace,
@@ -99,11 +99,6 @@ platform :ios do
       include_bitcode: false,
       export_method: "development",
       xcargs: "-allowProvisioningUpdates"
-    )
-
-    # Upload to Browserstack
-    upload_to_browserstack_and_save_id(
-      file_path: ENV["IPA_OUTPUT_PATH"]
     )
 
     # Upload to LambdaTest
@@ -257,19 +252,6 @@ platform :ios do
 
   end
 
-  desc 'This action uploads the .ipa to Browserstack and save its ID into a file'
-  private_lane :upload_to_browserstack_and_save_id do |options|
-
-    upload_to_browserstack_app_automate(
-      browserstack_username: ENV["BROWSERSTACK_USERNAME"],
-      browserstack_access_key: ENV["BROWSERSTACK_ACCESS_KEY"],
-      file_path: options[:file_path]
-    )
-
-    save_browserstack_id(browserstack_id: ENV['BROWSERSTACK_APP_ID'])
-
-  end
-
   desc 'This action uploads the .ipa to LambdaTest and save its ID into a file'
   private_lane :upload_to_lambdatest_and_save_id do |options|
 
@@ -344,18 +326,6 @@ platform :ios do
     sh("echo LIVEDEMOSTORE_URL=#{url} >> $GITHUB_ENV")
   end
 
-  desc 'Store the Browserstack ID into a file'
-  private_lane :save_browserstack_id do |options|
-
-    browserstack_id_to_save = options[:browserstack_id]
-    browserstack_id_file = "/var/tmp/browserstack_id.txt"
-
-    UI.message("Saving #{browserstack_id_to_save} into #{browserstack_id_file}")
-
-    File.open(browserstack_id_file, 'w') { |file| file.write(options[:browserstack_id]) }
-
-  end
-
   desc 'Store the LambdaTest ID into a file'
   private_lane :save_lambdatest_id do |options|
 
@@ -366,7 +336,7 @@ platform :ios do
 
     File.open(lambdatest_id_file, 'w') { |file| file.write(options[:lambdatest_id]) }
 
-  end 
+  end
 
   ################## END PRIVATE LANES ######################
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -278,7 +278,7 @@ platform :ios do
       lt_access_key: ENV["LAMBDATEST_ACCESS_KEY"],
       file_path: options[:file_path],
       custom_id: source_branch_trimmed,
-      visibility: "org"
+      visibility: "team"
     )
 
     save_lambdatest_id(lambdatest_id: ENV['APP_URL'])

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -3,6 +3,5 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-firebase_app_distribution'
-gem 'fastlane-plugin-browserstack'
 gem 'fastlane-plugin-versioning'
 gem 'fastlane-plugin-lambdatest'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -5,3 +5,4 @@
 gem 'fastlane-plugin-firebase_app_distribution'
 gem 'fastlane-plugin-browserstack'
 gem 'fastlane-plugin-versioning'
+gem 'fastlane-plugin-lambdatest'


### PR DESCRIPTION
[ACC-5606](https://primerapi.atlassian.net/browse/ACC-5606)

# Description

- Upload the built app to LambdaTest
- Run UI Tests via LambdaTest

Example manual run: https://appautomation.lambdatest.com/test?build=10588189&testID=RMAA-IOS-2485053-1751984802421556566QJQ

Improvements which I would like to do, not to be tackled here:
- Break up the `ui-tests` job to separate manual and automatic runs. (See Android).

[ACC-5606]: https://primerapi.atlassian.net/browse/ACC-5606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ