### PR TITLE
chore: Add DeepLink Handling

### DIFF
--- a/Debug App/Info.plist
+++ b/Debug App/Info.plist
@@ -40,6 +40,16 @@
 				<string>ui-tests</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>primer</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>primer</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>

--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -67,7 +67,6 @@
 		F0C2147F6FA26527BE55549A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = FC701AFD94F96F0F1D108D1A /* LaunchScreen.xib */; };
 		F0CD61562DACEFC200582D59 /* TestSettings+PrimerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CD61552DACEFB600582D59 /* TestSettings+PrimerSettings.swift */; };
 		FD5ADBCFA70DB606339F3AF2 /* TransactionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D3D6CF0F006A06B7CEC71B /* TransactionResponse.swift */; };
-		FD66C74ECEE3AE3E49D8E39F /* Pods_Debug_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2473E883EB381CF828CE4BF7 /* Pods_Debug_App.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -125,7 +124,6 @@
 		1594BC5C96ECC3F46C811B2F /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		1D05E65C196E6715D7D8B0C6 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Main.strings; sourceTree = "<group>"; };
 		229849A3DBE0858EE90673B9 /* CreateClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateClientToken.swift; sourceTree = "<group>"; };
-		2473E883EB381CF828CE4BF7 /* Pods_Debug_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A328E38DA586FFE0ED2894B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Main.strings; sourceTree = "<group>"; };
 		2E64F057A39A91CA01CCB57F /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Main.strings; sourceTree = "<group>"; };
 		33E18D5B5190C64631309D1B /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -141,7 +139,6 @@
 		6D2261DDEE5DC5D2ED518037 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		6D665EEA8106E51925C3CF2B /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Main.strings; sourceTree = "<group>"; };
 		70D3D6CF0F006A06B7CEC71B /* TransactionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionResponse.swift; sourceTree = "<group>"; };
-		71AE48B4F3FEE849F208DE88 /* Pods-Debug App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.debug.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.debug.xcconfig"; sourceTree = "<group>"; };
 		721B75053C8E82756FB8AD0D /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		72845A3010F10A88F2EC7849 /* CheckoutTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutTheme.swift; sourceTree = "<group>"; };
 		72E691B9A6A8EBB9F6A6B266 /* MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift; sourceTree = "<group>"; };
@@ -241,7 +238,6 @@
 		F09978812D00B7620058E4B5 /* Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
 		F0CD61552DACEFB600582D59 /* TestSettings+PrimerSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TestSettings+PrimerSettings.swift"; sourceTree = "<group>"; };
 		F816A2444633C4336A7CB071 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
-		F8DB1C2F5E2F2E46EF731FE4 /* Pods-Debug App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.release.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.release.xcconfig"; sourceTree = "<group>"; };
 		F9023841AFCE8E3205CB713A /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		F96CB43EDFEE9D7117F694EB /* Pods_Debug_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB1F71737862EF5D0F4FE5AB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -657,9 +653,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Debug App/Pods-Debug App-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Debug App/Pods-Debug App-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Debug App/Sources/AppDelegate.swift
+++ b/Debug App/Sources/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                      continue userActivity: NSUserActivity,
                      restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if let url = userActivity.webpageURL {
-            let handled = AppetizeUrlHandler.handleUrl(url)
+            let handled = SDKDemoUrlHandler.handleUrl(url)
             if handled == true {
                 return handled
             }

--- a/Debug App/Sources/Utilities/AppLinkConfigProvider.swift
+++ b/Debug App/Sources/Utilities/AppLinkConfigProvider.swift
@@ -60,10 +60,10 @@ extension UserDefaults: AppLinkPayloadProviding {
     }
 }
 
-struct AppetizeUrlHandler {
+struct SDKDemoUrlHandler {
     // Handle incoming livedemostore url
     static func handleUrl(_ url: URL) -> Bool {
-        if url.absoluteString.contains("https://sdk-demo.primer.io"),
+        if url.absoluteString.contains("sdk-demo.primer.io"),
         let clientToken = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems?.first(where: { $0.name == "clientToken"}),
         let settings = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems?.first(where: { $0.name == "settings"}) {
             let DeeplinkConfigProvider = DeeplinkConfigProvider(clientToken: clientToken.value, settingsJwt: settings.value)

--- a/Debug App/Sources/Utilities/AppLinkConfigProvider.swift
+++ b/Debug App/Sources/Utilities/AppLinkConfigProvider.swift
@@ -62,6 +62,7 @@ extension UserDefaults: AppLinkPayloadProviding {
 
 struct SDKDemoUrlHandler {
     // Handle incoming livedemostore url
+    @discardableResult
     static func handleUrl(_ url: URL) -> Bool {
         if url.absoluteString.contains("sdk-demo.primer.io"),
         let clientToken = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems?.first(where: { $0.name == "clientToken"}),

--- a/Debug App/Sources/Utilities/TestHelper.swift
+++ b/Debug App/Sources/Utilities/TestHelper.swift
@@ -15,7 +15,12 @@ class TestHelper {
     // MARK: Deep linking
 
     static func handle(url: URL) {
-        guard url.host == "ui-tests" else {
+        // Handles sdk-demo test links as deepLinks
+        if url.host == "sdk-demo.primer.io" {
+            let _ = SDKDemoUrlHandler.handleUrl(url)
+            return
+        }
+        guard url.host == "ui-tests" || url.host == "sdk-demo.primer.io" else {
             return
         }
 

--- a/Debug App/Sources/Utilities/TestHelper.swift
+++ b/Debug App/Sources/Utilities/TestHelper.swift
@@ -20,7 +20,8 @@ class TestHelper {
             let _ = SDKDemoUrlHandler.handleUrl(url)
             return
         }
-        guard url.host == "ui-tests" || url.host == "sdk-demo.primer.io" else {
+        
+        guard url.host == "ui-tests" else {
             return
         }
 

--- a/Debug App/Sources/Utilities/TestHelper.swift
+++ b/Debug App/Sources/Utilities/TestHelper.swift
@@ -17,7 +17,7 @@ class TestHelper {
     static func handle(url: URL) {
         // Handles sdk-demo test links as deepLinks
         if url.host == "sdk-demo.primer.io" {
-            let _ = SDKDemoUrlHandler.handleUrl(url)
+            SDKDemoUrlHandler.handleUrl(url)
             return
         }
         


### PR DESCRIPTION
# Description

Adds DeepLinking support for existing UniversalLinks. This speeds up E2E test execution by removing the need to paste in values for ClientToken and Settings.

Sample [Link](primer://sdk-demo.primer.io/latest/iOS?clientToken= eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImNsaWVudC10b2tlbi1zaWduaW5nLWtleSJ9.eyJleHAiOjE3NDc3Mzc4NTIsImFjY2Vzc1Rva2VuIjoiZTRmMmZhNTctY2JjMS00NGViLWFiMTUtY2JiYTNiYjA4YjBlIiwiYW5hbHl0aWNzVXJsIjoiaHR0cHM6Ly9hbmFseXRpY3MuYXBpLnNhbmRib3guY29yZS5wcmltZXIuaW8vbWl4cGFuZWwiLCJhbmFseXRpY3NVcmxWMiI6Imh0dHBzOi8vYW5hbHl0aWNzLnNhbmRib3guZGF0YS5wcmltZXIuaW8vY2hlY2tvdXQvdHJhY2siLCJpbnRlbnQiOiJDSEVDS09VVCIsImNvbmZpZ3VyYXRpb25VcmwiOiJodHRwczovL2FwaS5zYW5kYm94LnByaW1lci5pby9jbGllbnQtc2RrL2NvbmZpZ3VyYXRpb24iLCJjb3JlVXJsIjoiaHR0cHM6Ly9hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJwY2lVcmwiOiJodHRwczovL3Nkay5hcGkuc2FuZGJveC5wcmltZXIuaW8iLCJlbnYiOiJTQU5EQk9YIiwicGF5bWVudEZsb3ciOiJERUZBVUxUIn0.o655T9pHnAGOXhqQFJaVd8PGQhme6LKkq4oh2y53MS4&settings= eyJwYXltZW50SGFuZGxpbmciOiJBVVRPIn0=) to test with.

When opened, the Debug App should open to the Test Settings segment with values populated