### PR TITLE
chore: Surcharge off by default in the Debug app

### DIFF
--- a/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
+++ b/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
@@ -1325,7 +1325,7 @@
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9eb-B5-B2t">
+                                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="9eb-B5-B2t">
                                                                 <rect key="frame" x="325" y="0.0" width="51" height="31"/>
                                                                 <connections>
                                                                     <action selector="surchargeSwitchValueChanged:" destination="jAd-Lg-hf8" eventType="valueChanged" id="6qN-nZ-u1E"/>

--- a/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantSessionAndSettingsViewController.swift
@@ -679,7 +679,7 @@ class MerchantSessionAndSettingsViewController: UIViewController {
             networkOptionGroup.VISA = ClientSessionRequestBody.PaymentMethod.NetworkOption(surcharge: surcharge)
             networkOptionGroup.JCB = ClientSessionRequestBody.PaymentMethod.NetworkOption(surcharge: surcharge)
             networkOptionGroup.MASTERCARD = ClientSessionRequestBody.PaymentMethod.NetworkOption(surcharge: surcharge)
-            let paymentCardOptions = ClientSessionRequestBody.PaymentMethod.PaymentMethodOption(surcharge: nil,
+            let paymentCardOptions = ClientSessionRequestBody.PaymentMethod.PaymentMethodOption(surcharge: surcharge,
                                                                                                 instalmentDuration: nil,
                                                                                                 extraMerchantData: nil,
                                                                                                 captureVaultedCardCvv: nil,


### PR DESCRIPTION
UI tests seem to be failing on 3DS because surcharge was on by default; let's try