### PR TITLE
feat(Klarna): auto continue when single payment option

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/Klarna Categories Sheet/PrimerKlarnaCategoriesViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Klarna Categories Sheet/PrimerKlarnaCategoriesViewController.swift
@@ -175,16 +175,20 @@ extension PrimerKlarnaCategoriesViewController: PrimerHeadlessErrorableDelegate,
                     guard let self = self else { return }
 
                     // If only one payment category is available, skip the selection and continue with the only option
-                    if let onlyPaymentCategory = paymentCategories.first, paymentCategories.count == 1 {
-                        let klarnaCollectableData = KlarnaCollectableData.paymentCategory(onlyPaymentCategory, clientToken: clientToken)
-                        self.klarnaComponent.updateCollectedData(collectableData: klarnaCollectableData)
+                    if paymentCategories.count == 1, let onlyPaymentCategory = paymentCategories.first {
+                        klarnaComponent.updateCollectedData(
+                            collectableData: .paymentCategory(
+                                onlyPaymentCategory,
+                                clientToken: clientToken
+                            )
+                        )
                         showLoader()
                         return
                     }
 
-                    self.hideLoader()
+                    hideLoader()
                     self.clientToken = clientToken
-                    self.klarnaCategoriesVM.updatePaymentCategories(paymentCategories)
+                    klarnaCategoriesVM.updatePaymentCategories(paymentCategories)
                 }
 
             case .paymentSessionFinalizationRequired:
@@ -200,7 +204,7 @@ extension PrimerKlarnaCategoriesViewController: PrimerHeadlessErrorableDelegate,
                 }
 
                 // If only one payment category is available, automatically authorize the session
-                if self.klarnaComponent.availableCategories.count == 1 {
+                if klarnaComponent.availableCategories.count == 1 {
                     showLoader()
                     authorizeSession()
                 }


### PR DESCRIPTION
# Description

[ESC-487](https://primerapi.atlassian.net/browse/ESC-487)

This PR adds functionality to automatically continue the Klarna payment flow when only a single payment option is provided by the SDK. This streamlines the user experience by removing unnecessary interaction when no choice is required.

# Manual Testing

Mock the paymentSession to return only 1 payment category on `PrimerHeadlessKlarnaComponent+SessionCreation.swift` Line 52

```
// self.createSessionStep(paymentSession)
if let firstCategory = paymentSession.categories.first {
    let newPaymentSession: Response.Body.Klarna.PaymentSession = .init(
        clientToken: paymentSession.clientToken,
        sessionId: paymentSession.clientToken,
        categories: [firstCategory],
        hppSessionId: paymentSession.hppSessionId,
        hppRedirectUrl: paymentSession.hppRedirectUrl
    )
    self.createSessionStep(newPaymentSession)
} else {
    self.createSessionStep(paymentSession)
}
```

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)

[ESC-487]: https://primerapi.atlassian.net/browse/ESC-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ