### PR TITLE
refactor(UIColor): add 'primer' prefix to gray color

### DIFF
--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/UIColorExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/UIColorExtension.swift
@@ -11,11 +11,11 @@ public extension UIColor {
 
     // MARK: - Gray
 
-    static let gray100  = #colorLiteral(red: 0.9606924653, green: 0.9608384967, blue: 0.9606702924, alpha: 1)
-    static let gray200  = #colorLiteral(red: 0.9214878678, green: 0.9216204286, blue: 0.9214589, alpha: 1)
-    static let gray300  = #colorLiteral(red: 0.8548267484, green: 0.8549502492, blue: 0.8547996879, alpha: 1)
-    static let gray400  = #colorLiteral(red: 0.705819428, green: 0.7059227824, blue: 0.7057968378, alpha: 1)
-    static let gray500  = #colorLiteral(red: 0.5607333183, green: 0.5608169436, blue: 0.5607150793, alpha: 1)
-    static let gray600  = #colorLiteral(red: 0.4117260277, green: 0.4117894769, blue: 0.4117121696, alpha: 1)
-    static let gray700  = #colorLiteral(red: 0.2666399777, green: 0.2666836977, blue: 0.2666304708, alpha: 1)
+    static let primerGray100  = #colorLiteral(red: 0.9606924653, green: 0.9608384967, blue: 0.9606702924, alpha: 1)
+    static let primerGray200  = #colorLiteral(red: 0.9214878678, green: 0.9216204286, blue: 0.9214589, alpha: 1)
+    static let primerGray300  = #colorLiteral(red: 0.8548267484, green: 0.8549502492, blue: 0.8547996879, alpha: 1)
+    static let primerGray400  = #colorLiteral(red: 0.705819428, green: 0.7059227824, blue: 0.7057968378, alpha: 1)
+    static let primerGray500  = #colorLiteral(red: 0.5607333183, green: 0.5608169436, blue: 0.5607150793, alpha: 1)
+    static let primerGray600  = #colorLiteral(red: 0.4117260277, green: 0.4117894769, blue: 0.4117121696, alpha: 1)
+    static let primerGray700  = #colorLiteral(red: 0.2666399777, green: 0.2666836977, blue: 0.2666304708, alpha: 1)
 }

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel+FormViews.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel+FormViews.swift
@@ -70,7 +70,7 @@ extension FormPaymentMethodTokenizationViewModel {
                                     in: Bundle.primerResources,
                                     compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
         let calendarImageView = UIImageView(image: calendarImage)
-        calendarImageView.tintColor = .gray600
+        calendarImageView.tintColor = .primerGray600
         calendarImageView.clipsToBounds = true
         calendarImageView.contentMode = .scaleAspectFit
         dueAtContainerStackView.addArrangedSubview(calendarImageView)
@@ -80,7 +80,7 @@ extension FormPaymentMethodTokenizationViewModel {
             let dueDateAttributedString = NSMutableAttributedString()
             let prefix = NSAttributedString(
                 string: Strings.AccountInfoPaymentView.dueAt,
-                attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray600])
+                attributes: [NSAttributedString.Key.foregroundColor: UIColor.primerGray600])
             let formatter = DateFormatter().withExpirationDisplayDateFormat()
             let dueAtDate = NSAttributedString(
                 string: formatter.string(from: expDate),
@@ -100,7 +100,7 @@ extension FormPaymentMethodTokenizationViewModel {
         let accountNumberInfoContainerStackView = PrimerStackView()
         accountNumberInfoContainerStackView.axis = .vertical
         accountNumberInfoContainerStackView.spacing = 12.0
-        accountNumberInfoContainerStackView.addBackground(color: .gray100)
+        accountNumberInfoContainerStackView.addBackground(color: .primerGray100)
         accountNumberInfoContainerStackView.layoutMargins = UIEdgeInsets(top: spacing,
                                                                          left: spacing,
                                                                          bottom: spacing,
@@ -125,7 +125,7 @@ extension FormPaymentMethodTokenizationViewModel {
                                                             bottom: spacing,
                                                             right: spacing)
         accountNumberStackView.layer.cornerRadius = PrimerDimensions.cornerRadius / 2
-        accountNumberStackView.layer.borderColor = UIColor.gray200.cgColor
+        accountNumberStackView.layer.borderColor = UIColor.primerGray200.cgColor
         accountNumberStackView.layer.borderWidth = 2.0
         accountNumberStackView.isLayoutMarginsRelativeArrangement = true
         accountNumberStackView.layer.cornerRadius = 8.0
@@ -185,7 +185,7 @@ extension FormPaymentMethodTokenizationViewModel {
         for stepsText in stepsTexts {
 
             let confirmationStepLabel = UILabel()
-            confirmationStepLabel.textColor = .gray600
+            confirmationStepLabel.textColor = .primerGray600
             confirmationStepLabel.font = UIFont.systemFont(ofSize: PrimerDimensions.Font.label)
             confirmationStepLabel.numberOfLines = 0
             confirmationStepLabel.text = stepsText
@@ -211,7 +211,7 @@ extension FormPaymentMethodTokenizationViewModel {
         completeYourPaymentLabel.textColor = theme.text.title.color
 
         let descriptionLabel = UILabel()
-        descriptionLabel.textColor = .gray600
+        descriptionLabel.textColor = .primerGray600
         descriptionLabel.font = UIFont.systemFont(ofSize: PrimerDimensions.Font.body)
         descriptionLabel.numberOfLines = 0
         descriptionLabel.text = Strings.VoucherInfoPaymentView.descriptionLabel
@@ -226,7 +226,7 @@ extension FormPaymentMethodTokenizationViewModel {
                                     in: Bundle.primerResources,
                                     compatibleWith: nil)?.withRenderingMode(.alwaysTemplate)
         let calendarImageView = UIImageView(image: calendarImage)
-        calendarImageView.tintColor = .gray600
+        calendarImageView.tintColor = .primerGray600
         calendarImageView.clipsToBounds = true
         calendarImageView.contentMode = .scaleAspectFit
         expiresAtContainerStackView.addArrangedSubview(calendarImageView)
@@ -236,7 +236,7 @@ extension FormPaymentMethodTokenizationViewModel {
             let expiresAtAttributedString = NSMutableAttributedString()
             let prefix = NSAttributedString(
                 string: Strings.VoucherInfoPaymentView.expiresAt,
-                attributes: [NSAttributedString.Key.foregroundColor: UIColor.gray600])
+                attributes: [NSAttributedString.Key.foregroundColor: UIColor.primerGray600])
             let formatter = DateFormatter()
             formatter.dateStyle = .medium
             formatter.timeStyle = .short
@@ -259,7 +259,7 @@ extension FormPaymentMethodTokenizationViewModel {
         voucherInfoContainerStackView.spacing = 12.0
         voucherInfoContainerStackView.layoutMargins = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
         voucherInfoContainerStackView.layer.cornerRadius = PrimerDimensions.cornerRadius / 2
-        voucherInfoContainerStackView.layer.borderColor = UIColor.gray200.cgColor
+        voucherInfoContainerStackView.layer.borderColor = UIColor.primerGray200.cgColor
         voucherInfoContainerStackView.layer.borderWidth = 2.0
         voucherInfoContainerStackView.isLayoutMarginsRelativeArrangement = true
         voucherInfoContainerStackView.layer.cornerRadius = 8.0
@@ -274,7 +274,7 @@ extension FormPaymentMethodTokenizationViewModel {
             let voucherValueLabel = UILabel()
             voucherValueLabel.text = voucherValue.description
             voucherValueLabel.font = UIFont.systemFont(ofSize: PrimerDimensions.Font.label)
-            voucherValueLabel.textColor = .gray600
+            voucherValueLabel.textColor = .primerGray600
             voucherValueStackView.addArrangedSubview(voucherValueLabel)
 
             let voucherValueText = UILabel()
@@ -290,7 +290,7 @@ extension FormPaymentMethodTokenizationViewModel {
             if let lastValue = VoucherValue.currentVoucherValues.last, voucherValue != lastValue {
                 // Separator view
                 let separatorView = PrimerView()
-                separatorView.backgroundColor = .gray200
+                separatorView.backgroundColor = .primerGray200
                 separatorView.translatesAutoresizingMaskIntoConstraints = false
                 separatorView.heightAnchor.constraint(equalToConstant: 1).isActive = true
                 voucherInfoContainerStackView.addArrangedSubview(separatorView)


### PR DESCRIPTION
# Description

[ACC-5495](https://primerapi.atlassian.net/browse/ACC-5495)

Added 'primer' prefix to gray color constants in UIColor extension and updated all corresponding usages.

# Before Merging

- [x]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

[ACC-5495]: https://primerapi.atlassian.net/browse/ACC-5495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ