### PR TITLE
refactor: Clean up UI event posting

### DIFF
--- a/PrimerSDK.xcworkspace/contents.xcworkspacedata
+++ b/PrimerSDK.xcworkspace/contents.xcworkspacedata
@@ -1000,6 +1000,9 @@
                      location = "group:AnalyticsEvent.swift">
                   </FileRef>
                   <FileRef
+                     location = "group:Analytics+UIViewController.swift">
+                  </FileRef>
+                  <FileRef
                      location = "group:AnalyticsService.swift">
                   </FileRef>
                   <FileRef

--- a/Sources/PrimerSDK/Classes/Core/Analytics/Analytics+UIViewController.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/Analytics+UIViewController.swift
@@ -1,0 +1,31 @@
+import UIKit.UIViewController
+
+typealias Action = Analytics.Event.Property.Action
+typealias Place = Analytics.Event.Property.Place
+typealias ObjectId = Analytics.Event.Property.ObjectId
+typealias ObjectType = Analytics.Event.Property.ObjectType
+typealias AnalyticsContext = Analytics.Event.Property.Context
+
+extension UIViewController {
+    func postUIEvent(
+        _ action: Action,
+        context: AnalyticsContext? = nil,
+        extra: String? = nil,
+        type: ObjectType,
+        objectClass: AnyClass? = nil,
+        in place: Place,
+        id: ObjectId? = nil
+    ) {
+        Analytics.Service.record(
+            event: .ui(
+                action: action,
+                context: context,
+                extra: extra,
+                objectType: type,
+                objectId: id,
+                objectClass: objectClass.map { "\($0.self)" } ?? "\(Self.self)",
+                place: place
+            )
+        )
+    }
+}

--- a/Sources/PrimerSDK/Classes/PCI/User Interface/Root/PrimerCardFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/PCI/User Interface/Root/PrimerCardFormViewController.swift
@@ -29,21 +29,8 @@ final class PrimerCardFormViewController: PrimerFormViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let viewEvent = Analytics.Event.ui(
-            action: .view,
-            context: Analytics.Event.Property.Context(
-                issuerId: nil,
-                paymentMethodType: self.formPaymentMethodTokenizationViewModel.config.type,
-                url: nil),
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .cardForm
-        )
-        Analytics.Service.record(event: viewEvent)
-
+        let context = AnalyticsContext(paymentMethodType: formPaymentMethodTokenizationViewModel.config.type)
+        postUIEvent(.view, context: context, type: .view, in: .cardForm)
         setupView()
     }
 

--- a/Sources/PrimerSDK/Classes/User Interface/Banks/BankSelectorViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Banks/BankSelectorViewController.swift
@@ -27,21 +27,8 @@ final class BankSelectorViewController: PrimerFormViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let viewEvent =  Analytics.Event.ui(
-            action: .view,
-            context: Analytics.Event.Property.Context(
-                issuerId: nil,
-                paymentMethodType: self.viewModel.config.type,
-                url: nil),
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .bankSelectionList
-        )
-        Analytics.Service.record(event: viewEvent)
-
+        let context = AnalyticsContext(paymentMethodType: viewModel.config.type)
+        postUIEvent(.view, context: context, type: .view, in: .bankSelectionList)
         view.backgroundColor = theme.view.backgroundColor
         view.translatesAutoresizingMaskIntoConstraints = false
         let heightValue = 120 + (CGFloat(viewModel.banks.count)*viewModel.tableView.rowHeight)

--- a/Sources/PrimerSDK/Classes/User Interface/Components/PrimerCustomResult/PrimerCustomResultViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Components/PrimerCustomResult/PrimerCustomResultViewController.swift
@@ -26,18 +26,7 @@ final class PrimerCustomResultViewController: PrimerViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let viewEvent = Analytics.Event.ui(
-            action: .view,
-            context: nil,
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .errorScreen
-        )
-        Analytics.Service.record(event: viewEvent)
-
+        postUIEvent(.view, type: .view, in: .errorScreen)
         addPaymentStatusView()
     }
 

--- a/Sources/PrimerSDK/Classes/User Interface/Components/PrimerResultViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Components/PrimerResultViewController.swift
@@ -24,18 +24,7 @@ final class PrimerResultViewController: PrimerViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let viewEvent = Analytics.Event.ui(
-            action: .view,
-            context: nil,
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .errorScreen
-        )
-        Analytics.Service.record(event: viewEvent)
-
+        postUIEvent(.view, type: .view, in: .errorScreen)
         (parent as? PrimerContainerViewController)?.navigationItem.hidesBackButton = true
 
         let successImage: UIImage? = .checkCircle

--- a/Sources/PrimerSDK/Classes/User Interface/Countries/CountrySelectorViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Countries/CountrySelectorViewController.swift
@@ -20,20 +20,8 @@ final class CountrySelectorViewController: PrimerFormViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let viewEvent = Analytics.Event.ui(
-            action: .view,
-            context: Analytics.Event.Property.Context(
-                issuerId: nil,
-                paymentMethodType: self.viewModel.config.type,
-                url: nil),
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .countrySelectionList
-        )
-        Analytics.Service.record(event: viewEvent)
+        let context = AnalyticsContext(paymentMethodType: viewModel.config.type)
+        postUIEvent(.view, context: context, type: .view, in: .countrySelectionList)
 
         view.backgroundColor = theme.view.backgroundColor
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/PrimerSDK/Classes/User Interface/Root/CVVRecapture/CVVRecaptureViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/CVVRecapture/CVVRecaptureViewController.swift
@@ -17,6 +17,9 @@ final class CVVRecaptureViewController: UIViewController {
     private var cvvField: PrimerCVVFieldView!
     private var cvvContainerView: PrimerCustomFieldView!
     private let continueButton = PrimerButton()
+    
+    private var paymentMethodType: String { viewModel.cardButtonViewModel.paymentMethodType.rawValue }
+    private var analyticsContext: AnalyticsContext { AnalyticsContext(paymentMethodType: paymentMethodType) }
 
     // Designated initializer
     init(viewModel: CVVRecaptureViewModel) {
@@ -42,37 +45,12 @@ final class CVVRecaptureViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        let didAppearEvent = Analytics.Event.ui(
-            action: .present,
-            context: Analytics.Event.Property.Context(
-                issuerId: nil,
-                paymentMethodType: viewModel.cardButtonViewModel.paymentMethodType.rawValue,
-                url: nil),
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .cvvRecapture
-        )
-        Analytics.Service.record(event: didAppearEvent)
+        postUIEvent(.present, context: analyticsContext, type: .view, in: .cvvRecapture)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-
-        let dismissEvent = Analytics.Event.ui(
-            action: .dismiss,
-            context: Analytics.Event.Property.Context(
-                issuerId: nil,
-                paymentMethodType: viewModel.cardButtonViewModel.paymentMethodType.rawValue,
-                url: nil),
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .cvvRecapture
-        )
-        Analytics.Service.record(event: dismissEvent)
+        postUIEvent(.dismiss, context: analyticsContext, type: .view, in: .cvvRecapture)
     }
 
     private func bindViewModel() {

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerFormViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerFormViewController.swift
@@ -1,13 +1,3 @@
-//
-//  PrimerFormViewController.swift
-//  PrimerSDK
-//
-//  Created by Evangelos Pittas on 27/7/21.
-//
-
-// swiftlint:disable function_body_length
-// swiftlint:disable line_length
-
 import UIKit
 
 class PrimerFormViewController: PrimerViewController {

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerLoadingViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerLoadingViewController.swift
@@ -25,18 +25,7 @@ final class PrimerLoadingViewController: PrimerViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let viewEvent = Analytics.Event.ui(
-            action: .view,
-            context: nil,
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .sdkLoading
-        )
-        Analytics.Service.record(event: viewEvent)
-
+        postUIEvent(.view, type: .view, in: .sdkLoading)
         let theme: PrimerThemeProtocol = DependencyContainer.resolve()
         view.backgroundColor = theme.view.backgroundColor
 

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerVaultManagerViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerVaultManagerViewController.swift
@@ -20,18 +20,7 @@ final class PrimerVaultManagerViewController: PrimerFormViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let viewEvent = Analytics.Event.ui(
-            action: .view,
-            context: nil,
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .vaultManager
-        )
-        Analytics.Service.record(event: viewEvent)
-
+        postUIEvent(.view, type: .view, in: .vaultManager)
         title = Strings.CardFormView.vaultNavBarTitle
 
         view.backgroundColor = theme.view.backgroundColor

--- a/Sources/PrimerSDK/Classes/User Interface/TestPaymentMethods/PrimerTestPaymentMethodViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TestPaymentMethods/PrimerTestPaymentMethodViewController.swift
@@ -25,21 +25,8 @@ final class PrimerTestPaymentMethodViewController: PrimerFormViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let viewEvent = Analytics.Event.ui(
-            action: .view,
-            context: Analytics.Event.Property.Context(
-                issuerId: nil,
-                paymentMethodType: self.viewModel.config.type,
-                url: nil),
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .bankSelectionList
-        )
-        Analytics.Service.record(event: viewEvent)
-
+        let context = AnalyticsContext(paymentMethodType: viewModel.config.type)
+        postUIEvent(.view, context: context, type: .view, in: .bankSelectionList)
         setupView()
     }
 }

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewControllers/QRCodeViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewControllers/QRCodeViewController.swift
@@ -28,20 +28,8 @@ final class QRCodeViewController: PrimerFormViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let viewEvent = Analytics.Event.ui(
-            action: .view,
-            context: Analytics.Event.Property.Context(
-                issuerId: nil,
-                paymentMethodType: self.viewModel.config.type,
-                url: nil),
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .bankSelectionList
-        )
-        Analytics.Service.record(event: viewEvent)
+        let context = AnalyticsContext(paymentMethodType: viewModel.config.type)
+        postUIEvent(.view, context: context, type: .view, in: .bankSelectionList)
 
         view.backgroundColor = theme.view.backgroundColor
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Vault/VaultPaymentMethodViewController.swift
@@ -171,17 +171,7 @@ final class VaultedPaymentInstrumentsViewController: PrimerViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.title = Strings.VaultPaymentMethodViewContent.savedPaymentMethodsTitle
-
-        let uiEvent = Analytics.Event.ui(
-            action: .view,
-            context: nil,
-            extra: nil,
-            objectType: .view,
-            objectId: nil,
-            objectClass: "\(Self.self)",
-            place: .paymentMethodsList
-        )
-        Analytics.Service.record(event: uiEvent)
+        postUIEvent(.view, type: .view, in: .paymentMethodsList)
 
         let theme: PrimerThemeProtocol = DependencyContainer.resolve()
         rightBarButton = UIButton()
@@ -215,31 +205,13 @@ final class VaultedPaymentInstrumentsViewController: PrimerViewController {
     @objc
     func editButtonTapped(_ sender: UIButton) {
         isDeleting = !isDeleting
-
-        if isDeleting {
-            let uiEvent = Analytics.Event.ui(
-                action: .click,
-                context: nil,
-                extra: nil,
-                objectType: .button,
-                objectId: .cancel,
-                objectClass: "\(UIButton.self)",
-                place: .paymentMethodsList
-            )
-            Analytics.Service.record(event: uiEvent)
-        } else {
-            let uiEvent = Analytics.Event.ui(
-                action: .click,
-                context: nil,
-                extra: nil,
-                objectType: .button,
-                objectId: .edit,
-                objectClass: "\(UIButton.self)",
-                place: .paymentMethodsList
-            )
-            Analytics.Service.record(event: uiEvent)
-        }
-
+        postUIEvent(
+            .click,
+            type: .button,
+            objectClass: UIButton.self,
+            in: .paymentMethodsList,
+            id: isDeleting ? .cancel : .edit
+        )
         let title = isDeleting ? Strings.Generic.cancel : Strings.Generic.edit
         rightBarButton.setTitle(title, for: .normal)
     }
@@ -298,38 +270,19 @@ extension VaultedPaymentInstrumentsViewController: UITableViewDataSource, UITabl
             // It will reload the payment instrument on the Universal Checkout view.
             delegate?.reload()
         } else {
-            let uiEvent = Analytics.Event.ui(
-                action: .click,
-                context: nil,
-                extra: nil,
-                objectType: .listItem,
-                objectId: .delete,
-                objectClass: "\(UIButton.self)",
-                place: .paymentMethodsList
-            )
-            Analytics.Service.record(event: uiEvent)
-
+            postUIEvent(.click, type: .listItem, objectClass: UIButton.self, in: .paymentMethodsList, id: .delete)
             let alert = AlertController(
                 title: Strings.Alert.deleteConfirmationButtonTitle,
                 message: "",
                 preferredStyle: .alert
             )
 
-            alert.addAction(UIAlertAction(
-                                title: Strings.Generic.cancel,
-                                style: .cancel,
-                                handler: { _ in
-                                    let uiEvent = Analytics.Event.ui(
-                                        action: .click,
-                                        context: nil,
-                                        extra: "alert_button",
-                                        objectType: .button,
-                                        objectId: .cancel,
-                                        objectClass: "\(UIButton.self)",
-                                        place: .paymentMethodsList
-                                    )
-                                    Analytics.Service.record(event: uiEvent)
-                                }))
+            alert.addAction(
+                UIAlertAction(
+                    title: Strings.Generic.cancel,
+                    style: .cancel,
+                    handler: { [weak self] _ in self?.postAlertButtonClickEvent(id: .cancel) }
+            ))
 
             alert.addAction(UIAlertAction(
                                 title: Strings.Generic.delete,
@@ -337,21 +290,22 @@ extension VaultedPaymentInstrumentsViewController: UITableViewDataSource, UITabl
                                 handler: { [weak self] _ in
                                     guard let id = paymentMethod.id else { return }
                                     self?.deletePaymentMethod(id)
-                                    let uiEvent = Analytics.Event.ui(
-                                        action: .click,
-                                        context: nil,
-                                        extra: "alert_button",
-                                        objectType: .button,
-                                        objectId: .done,
-                                        objectClass: "\(UIButton.self)",
-                                        place: .paymentMethodsList
-                                    )
-                                    Analytics.Service.record(event: uiEvent)
+                                    self?.postAlertButtonClickEvent(id: .done)
                                 }))
-
             alert.show()
         }
         tableView.reloadData()
+    }
+    
+    private func postAlertButtonClickEvent(id: ObjectId) {
+        postUIEvent(
+            .click,
+            extra: "alert_button",
+            type: .button,
+            objectClass: UIButton.self,
+            in: .paymentMethodsList,
+            id: id
+        )
     }
 }
 // swiftlint:enable function_body_length


### PR DESCRIPTION
# Description

Tidies up the instances of posting ui events by creating a method restricted to UIViewControllers which are the classes that should concern themselves with UI events. Not included as part of this is moving posting ui events from non-ui contexts, which would be a wise next step

# Manual Testing

Tests are unaffected

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge
