### PR TITLE
fix: Reduce console noise for nil remoteUrl in ImageManager

### DIFF
--- a/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
+++ b/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
@@ -208,6 +208,18 @@ final class ImageManager: LogReporter {
 
     func getImage(file: ImageFile) -> Promise<ImageFile> {
         return Promise { seal in
+            // Check if image already exists (cached or bundled)
+            if file.image != nil {
+                seal.fulfill(file)
+                return
+            }
+
+            // Check if remoteUrl is nil (no download possible)
+            guard file.remoteUrl != nil else {
+                seal.fulfill(file)
+                return
+            }
+
             let downloader = Downloader()
 
             let timingEventId = UUID().uuidString
@@ -262,6 +274,16 @@ final class ImageManager: LogReporter {
     }
 
     func getImage(file: ImageFile) async throws -> ImageFile {
+        // Check if image already exists (cached or bundled)
+        if file.image != nil {
+            return file
+        }
+
+        // Check if remoteUrl is nil (no download possible)
+        guard file.remoteUrl != nil else {
+            return file
+        }
+
         let download = Downloader()
         let timingEventId = UUID().uuidString
         let timingEventStart = Analytics.Event.allImagesLoading(

--- a/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
+++ b/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
@@ -112,8 +112,7 @@ final class ImageManager: LogReporter {
     func getImages(for imageFiles: [ImageFile]) -> Promise<[ImageFile]> {
         return Promise { seal in
             guard !imageFiles.isEmpty else {
-                seal.fulfill([])
-                return
+                return seal.fulfill([])
             }
 
             let timingEventId = UUID().uuidString
@@ -209,15 +208,13 @@ final class ImageManager: LogReporter {
     func getImage(file: ImageFile) -> Promise<ImageFile> {
         return Promise { seal in
             // Check if image already exists (cached or bundled)
-            if file.image != nil {
-                seal.fulfill(file)
-                return
+            guard file.image == nil else {
+                return seal.fulfill(file)
             }
 
             // Check if remoteUrl is nil (no download possible)
             guard file.remoteUrl != nil else {
-                seal.fulfill(file)
-                return
+                return seal.fulfill(file)
             }
 
             let downloader = Downloader()
@@ -275,7 +272,7 @@ final class ImageManager: LogReporter {
 
     func getImage(file: ImageFile) async throws -> ImageFile {
         // Check if image already exists (cached or bundled)
-        if file.image != nil {
+        guard file.image == nil else {
             return file
         }
 

--- a/Tests/Primer/Modules/ImageFileTests.swift
+++ b/Tests/Primer/Modules/ImageFileTests.swift
@@ -1,0 +1,193 @@
+//
+//  ImageFileTests.swift
+//  PrimerSDKTests
+//
+//  Created by Boris on 15/7/25.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+final class ImageFileTests: XCTestCase {
+    
+    // MARK: - getPaymentMethodType Tests
+    
+    func testGetPaymentMethodType_ValidPaymentMethod() {
+        // Test exact match
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "APPLE_PAY"), "APPLE_PAY")
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "PAYMENT_CARD"), "PAYMENT_CARD")
+        
+        // Test with logo suffix
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "APPLE_PAY-logo"), "APPLE_PAY")
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "PAYMENT_CARD-logo"), "PAYMENT_CARD")
+        
+        // Test with icon suffix
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "APPLE_PAY-icon"), "APPLE_PAY")
+        
+        // Test with colored suffix
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "APPLE_PAY-colored"), "APPLE_PAY")
+        
+        // Test with dark/light suffix
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "APPLE_PAY-dark"), "APPLE_PAY")
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "APPLE_PAY-light"), "APPLE_PAY")
+        
+        // Test with multiple suffixes
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "APPLE_PAY-logo-dark"), "APPLE_PAY")
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "PAYMENT_CARD-icon-light"), "PAYMENT_CARD")
+        
+        // Test case insensitive
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "apple_pay"), "APPLE_PAY")
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "Apple_Pay"), "APPLE_PAY")
+        
+        // Test with dashes converted to underscores
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "apple-pay"), "APPLE_PAY")
+        XCTAssertEqual(ImageFile.getPaymentMethodType(fromFileName: "payment-card"), "PAYMENT_CARD")
+    }
+    
+    func testGetPaymentMethodType_InvalidPaymentMethod() {
+        XCTAssertNil(ImageFile.getPaymentMethodType(fromFileName: "INVALID_METHOD"))
+        XCTAssertNil(ImageFile.getPaymentMethodType(fromFileName: "random-file"))
+        XCTAssertNil(ImageFile.getPaymentMethodType(fromFileName: ""))
+    }
+    
+    // MARK: - getBundledImageFileName Tests
+    
+    func testGetBundledImageFileName_ValidPaymentMethod() {
+        // Test logo assets
+        XCTAssertEqual(
+            ImageFile.getBundledImageFileName(
+                forPaymentMethodType: "APPLE_PAY",
+                themeMode: .dark,
+                assetType: .logo
+            ),
+            "apple-pay-logo-dark"
+        )
+        
+        XCTAssertEqual(
+            ImageFile.getBundledImageFileName(
+                forPaymentMethodType: "APPLE_PAY",
+                themeMode: .light,
+                assetType: .logo
+            ),
+            "apple-pay-logo-light"
+        )
+        
+        // Test icon assets
+        XCTAssertEqual(
+            ImageFile.getBundledImageFileName(
+                forPaymentMethodType: "APPLE_PAY",
+                themeMode: .dark,
+                assetType: .icon
+            ),
+            "apple-pay-icon-dark"
+        )
+        
+        // Test payment card
+        XCTAssertEqual(
+            ImageFile.getBundledImageFileName(
+                forPaymentMethodType: "PAYMENT_CARD",
+                themeMode: .colored,
+                assetType: .logo
+            ),
+            "payment-card-logo-colored"
+        )
+    }
+    
+    func testGetBundledImageFileName_InvalidPaymentMethod() {
+        XCTAssertNil(
+            ImageFile.getBundledImageFileName(
+                forPaymentMethodType: "INVALID_METHOD",
+                themeMode: .dark,
+                assetType: .logo
+            )
+        )
+    }
+    
+    func testGetBundledImageFileName_XfersPayNow() {
+        // Special case for XFERS_PAYNOW
+        if let fileName = ImageFile.getBundledImageFileName(
+            forPaymentMethodType: "XFERS_PAYNOW",
+            themeMode: .dark,
+            assetType: .logo
+        ) {
+            XCTAssertTrue(fileName.contains("xfers"))
+        }
+    }
+    
+    // MARK: - Image Property Tests
+    
+    func testCachedImage() {
+        // Test without data
+        let imageFile1 = ImageFile(
+            fileName: "test-image-no-data",
+            fileExtension: "png",
+            remoteUrl: URL(string: "https://example.com/image.png")
+        )
+        XCTAssertNil(imageFile1.cachedImage)
+        
+        // Test with base64 data
+        if let testImage = UIImage(systemName: "star"),
+           let imageData = testImage.pngData() {
+            let imageFile2 = ImageFile(
+                fileName: "test-image-with-data",
+                fileExtension: "png",
+                remoteUrl: URL(string: "https://example.com/image.png"),
+                base64Data: imageData
+            )
+            // Note: cachedImage reads from file system, so this might still be nil
+            // unless the file was successfully written
+            _ = imageFile2.cachedImage
+        }
+    }
+    
+    func testBundledImage() {
+        // Test dark theme
+        let darkImageFile = ImageFile(
+            fileName: "apple-pay-logo-dark",
+            fileExtension: "png",
+            remoteUrl: nil
+        )
+        // This might be nil if the bundled resource doesn't exist in test target
+        _ = darkImageFile.bundledImage
+        
+        // Test light theme
+        let lightImageFile = ImageFile(
+            fileName: "apple-pay-logo-light",
+            fileExtension: "png",
+            remoteUrl: nil
+        )
+        _ = lightImageFile.bundledImage
+        
+        // Test colored theme
+        let coloredImageFile = ImageFile(
+            fileName: "payment-card-logo-colored",
+            fileExtension: "png",
+            remoteUrl: nil
+        )
+        _ = coloredImageFile.bundledImage
+    }
+    
+    func testImageProperty() {
+        // Test without cached image
+        let imageFile1 = ImageFile(
+            fileName: "test-image",
+            fileExtension: "png",
+            remoteUrl: URL(string: "https://example.com/image.png")
+        )
+        // Should return bundled image if no cached image
+        _ = imageFile1.image
+        
+        // Test with cached image via base64Data
+        if let testImage = UIImage(systemName: "star"),
+           let imageData = testImage.pngData() {
+            let imageFile2 = ImageFile(
+                fileName: "test-image-cached",
+                fileExtension: "png",
+                remoteUrl: URL(string: "https://example.com/image.png"),
+                base64Data: imageData
+            )
+            // The image property returns cachedImage ?? bundledImage
+            _ = imageFile2.image
+        }
+    }
+}

--- a/Tests/Primer/Modules/ImageManagerTests.swift
+++ b/Tests/Primer/Modules/ImageManagerTests.swift
@@ -292,14 +292,14 @@ final class ImageManagerTests: XCTestCase {
 
 // MARK: - Mock Classes
 
-class MockDownloader {
+final private class MockDownloader {
     var shouldSucceed = true
     var mockFile: File?
     var mockError: Error = NSError(domain: "test", code: 0, userInfo: nil)
     
     func download(file: File) -> Promise<File> {
         return Promise { seal in
-            if shouldSucceed, let mockFile = mockFile {
+            if shouldSucceed, let mockFile {
                 seal.fulfill(mockFile)
             } else {
                 seal.reject(mockError)
@@ -308,7 +308,7 @@ class MockDownloader {
     }
     
     func download(file: File) async throws -> File {
-        if shouldSucceed, let mockFile = mockFile {
+        if shouldSucceed, let mockFile {
             return mockFile
         } else {
             throw mockError

--- a/Tests/Primer/Modules/ImageManagerTests.swift
+++ b/Tests/Primer/Modules/ImageManagerTests.swift
@@ -1,0 +1,317 @@
+//
+//  ImageManagerTests.swift
+//  PrimerSDKTests
+//
+//  Created by Boris on 15/7/25.
+//
+
+import XCTest
+@testable import PrimerSDK
+
+final class ImageManagerTests: XCTestCase {
+    
+    var sut: ImageManager!
+    var mockDownloader: MockDownloader!
+    
+    override func setUp() {
+        super.setUp()
+        sut = ImageManager()
+        mockDownloader = MockDownloader()
+    }
+    
+    override func tearDown() {
+        sut = nil
+        mockDownloader = nil
+        super.tearDown()
+    }
+    
+    // MARK: - getImages Tests (Promise version)
+    
+    func testGetImages_EmptyArray_ReturnsEmptyArray() {
+        let expectation = self.expectation(description: "getImages completes")
+        
+        firstly {
+            sut.getImages(for: [])
+        }
+        .done { imageFiles in
+            XCTAssertEqual(imageFiles.count, 0)
+            expectation.fulfill()
+        }
+        .catch { error in
+            XCTFail("Should not fail with error: \(error)")
+        }
+        
+        waitForExpectations(timeout: 1.0)
+    }
+    
+    func testGetImages_ValidImageFiles_ReturnsImages() {
+        let expectation = self.expectation(description: "getImages completes")
+        
+        // Create test image files with pre-loaded data
+        var imageFiles: [ImageFile] = []
+        
+        if let testImage = UIImage(systemName: "star"),
+           let imageData = testImage.pngData() {
+            
+            // Write test images to documents directory first
+            if let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+                let testFileName1 = "test-image-1.png"
+                let testFileName2 = "test-image-2.png"
+                let testFileURL1 = documentsURL.appendingPathComponent(testFileName1)
+                let testFileURL2 = documentsURL.appendingPathComponent(testFileName2)
+                
+                do {
+                    try imageData.write(to: testFileURL1)
+                    try imageData.write(to: testFileURL2)
+                    
+                    // Create image files that will read from local files
+                    let imageFile1 = ImageFile(
+                        fileName: "test-image-1",
+                        fileExtension: "png",
+                        remoteUrl: nil
+                    )
+                    
+                    let imageFile2 = ImageFile(
+                        fileName: "test-image-2",
+                        fileExtension: "png",
+                        remoteUrl: nil
+                    )
+                    
+                    imageFiles = [imageFile1, imageFile2]
+                } catch {
+                    XCTFail("Failed to create test files: \(error)")
+                }
+            }
+        }
+        
+        firstly {
+            sut.getImages(for: imageFiles)
+        }
+        .done { returnedFiles in
+            // Clean up test files
+            if let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+                try? FileManager.default.removeItem(at: documentsURL.appendingPathComponent("test-image-1.png"))
+                try? FileManager.default.removeItem(at: documentsURL.appendingPathComponent("test-image-2.png"))
+            }
+            expectation.fulfill()
+        }
+        .catch { error in
+            // Clean up test files
+            if let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+                try? FileManager.default.removeItem(at: documentsURL.appendingPathComponent("test-image-1.png"))
+                try? FileManager.default.removeItem(at: documentsURL.appendingPathComponent("test-image-2.png"))
+            }
+            // It's OK if this fails in test environment
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 2.0)
+    }
+    
+    // MARK: - getImages Tests (Async version)
+    
+    func testGetImagesAsync_EmptyArray_ReturnsEmptyArray() async throws {
+        let imageFiles = try await sut.getImages(for: [])
+        XCTAssertEqual(imageFiles.count, 0)
+    }
+    
+    func testGetImagesAsync_ValidImageFiles() async throws {
+        // Create test image files
+        let imageFile1 = ImageFile(
+            fileName: "test-image-1",
+            fileExtension: "png",
+            remoteUrl: URL(string: "https://example.com/image1.png")
+        )
+        
+        let imageFile2 = ImageFile(
+            fileName: "test-image-2",
+            fileExtension: "png",
+            remoteUrl: URL(string: "https://example.com/image2.png")
+        )
+        
+        // Note: In real implementation, this would need proper mocking
+        // of the Downloader class
+        let imageFiles = [imageFile1, imageFile2]
+        
+        do {
+            _ = try await sut.getImages(for: imageFiles)
+            // In a real test, we'd verify the returned files
+        } catch {
+            // Expected to fail without proper mocking
+        }
+    }
+    
+    // MARK: - getImage Tests (Promise version)
+    
+    func testGetImage_WithCachedImage_ReturnsImageFile() {
+        let expectation = self.expectation(description: "getImage completes")
+        
+        var imageFile = ImageFile(
+            fileName: "test-image",
+            fileExtension: "png",
+            remoteUrl: URL(string: "https://example.com/image.png")
+        )
+        
+        // Create with base64 data to simulate cached image
+        if let testImage = UIImage(systemName: "star"),
+           let imageData = testImage.pngData() {
+            // Re-create the file with base64Data
+            let imageFileWithData = ImageFile(
+                fileName: imageFile.fileName,
+                fileExtension: imageFile.fileExtension,
+                remoteUrl: imageFile.remoteUrl,
+                base64Data: imageData
+            )
+            imageFile = imageFileWithData
+        }
+        
+        firstly {
+            sut.getImage(file: imageFile)
+        }
+        .done { returnedFile in
+            XCTAssertNotNil(returnedFile.cachedImage)
+            expectation.fulfill()
+        }
+        .catch { error in
+            // May fail due to downloader not being mocked
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 2.0)
+    }
+    
+    func testGetImage_WithBundledImage_ReturnsBundledImage() {
+        let expectation = self.expectation(description: "getImage completes")
+        
+        let imageFile = ImageFile(
+            fileName: "apple-pay-logo-dark",
+            fileExtension: "png",
+            remoteUrl: URL(string: "https://example.com/image.png")
+        )
+        
+        firstly {
+            sut.getImage(file: imageFile)
+        }
+        .done { returnedFile in
+            // Should return the file even if download fails
+            // because it has a bundled image
+            expectation.fulfill()
+        }
+        .catch { error in
+            // If bundled image exists, it should not fail
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 2.0)
+    }
+    
+    // MARK: - getImage Tests (Async version)
+    
+    func testGetImageAsync_WithCachedImage() async throws {
+        var imageFile = ImageFile(
+            fileName: "test-image",
+            fileExtension: "png",
+            remoteUrl: URL(string: "https://example.com/image.png")
+        )
+        
+        // Create with base64 data to simulate cached image
+        if let testImage = UIImage(systemName: "star"),
+           let imageData = testImage.pngData() {
+            imageFile = ImageFile(
+                fileName: imageFile.fileName,
+                fileExtension: imageFile.fileExtension,
+                remoteUrl: imageFile.remoteUrl,
+                base64Data: imageData
+            )
+        }
+        
+        do {
+            _ = try await sut.getImage(file: imageFile)
+        } catch {
+            // Expected to fail without proper mocking
+        }
+    }
+    
+    // MARK: - clean Tests
+    
+    func testClean_RemovesPNGFiles() {
+        // Create a test PNG file in documents directory
+        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            XCTFail("Could not get documents directory")
+            return
+        }
+        
+        let testFileName = "test-image-\(UUID().uuidString).png"
+        let testFileURL = documentsURL.appendingPathComponent(testFileName)
+        
+        // Create test file
+        let testData = Data("test".utf8)
+        do {
+            try testData.write(to: testFileURL)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: testFileURL.path))
+            
+            // Clean
+            ImageManager.clean()
+            
+            // Verify file is removed
+            XCTAssertFalse(FileManager.default.fileExists(atPath: testFileURL.path))
+        } catch {
+            XCTFail("Failed to create test file: \(error)")
+        }
+    }
+    
+    func testClean_DoesNotRemoveNonPNGFiles() {
+        // Create a test non-PNG file in documents directory
+        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            XCTFail("Could not get documents directory")
+            return
+        }
+        
+        let testFileName = "test-file-\(UUID().uuidString).txt"
+        let testFileURL = documentsURL.appendingPathComponent(testFileName)
+        
+        // Create test file
+        let testData = Data("test".utf8)
+        do {
+            try testData.write(to: testFileURL)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: testFileURL.path))
+            
+            // Clean
+            ImageManager.clean()
+            
+            // Verify file is NOT removed
+            XCTAssertTrue(FileManager.default.fileExists(atPath: testFileURL.path))
+            
+            // Clean up
+            try FileManager.default.removeItem(at: testFileURL)
+        } catch {
+            XCTFail("Failed to create/remove test file: \(error)")
+        }
+    }
+}
+
+// MARK: - Mock Classes
+
+class MockDownloader {
+    var shouldSucceed = true
+    var mockFile: File?
+    var mockError: Error = NSError(domain: "test", code: 0, userInfo: nil)
+    
+    func download(file: File) -> Promise<File> {
+        return Promise { seal in
+            if shouldSucceed, let mockFile = mockFile {
+                seal.fulfill(mockFile)
+            } else {
+                seal.reject(mockError)
+            }
+        }
+    }
+    
+    func download(file: File) async throws -> File {
+        if shouldSucceed, let mockFile = mockFile {
+            return mockFile
+        } else {
+            throw mockError
+        }
+    }
+}

--- a/Tests/Primer/Modules/ImageManagerTests.swift
+++ b/Tests/Primer/Modules/ImageManagerTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class ImageManagerTests: XCTestCase {
     
     var sut: ImageManager!
-    var mockDownloader: MockDownloader!
+    private var mockDownloader: MockDownloader!
     
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
  ## Summary
  Fixes console noise error `[invalid-value] Invalid value nil for key remoteUrl` reported by GlassesUSA in ESC-481.

  ## Problem
  When payment methods don't have remote icon URLs, ImageManager attempts to download files with nil `remoteUrl`, causing unnecessary error logging.

  ## Solution
  - Add early checks in `getImage()` methods to skip download when:
    - Image already exists (cached or bundled)
    - remoteUrl is nil
  - Uses idiomatic Swift `guard` statements for consistency

  ## Impact
  - Eliminates console noise for valid use cases
  - No functional changes - bundled and base64 images continue to work as before
  - Cleaner logs for merchants

  Fixes: ESC-481