### PR TITLE
refactor: Log caller info in handled usage

### DIFF
--- a/Sources/PrimerSDK/Classes/Error Handler/ErrorHandler.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/ErrorHandler.swift
@@ -9,14 +9,24 @@ import Foundation
 final class ErrorHandler: LogReporter {
 
     // Call this function to log any error to Analytics
-    static func handle(error: Error) {
-        ErrorHandler.shared.handle(error: error)
+    static func handle(
+        error: Error,
+        file: String = #file,
+        line: Int = #line,
+        function: String = #function
+    ) {
+        ErrorHandler.shared.handle(error: error, file: file, line: line, function: function)
     }
 
     static var shared = ErrorHandler()
 
-    func handle(error: Error) {
-        self.logger.error(message: error.localizedDescription)
+    func handle(
+        error: Error,
+        file: String = #file,
+        line: Int = #line,
+        function: String = #function
+    ) {
+        self.logger.error(message: error.localizedDescription, file: file, line: line, function: function)
 
         // Check if error should be filtered from server reporting
         if shouldFilterError(error) {

--- a/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/PrimerError.swift
@@ -23,17 +23,32 @@ protocol PrimerErrorProtocol: CustomNSError, LocalizedError {
     var analyticsContext: [String: Any] { get }
 }
 
-func handled<E: Error>(error: E) -> E {
-    ErrorHandler.handle(error: error)
+func handled<E: Error>(
+    error: E,
+    file: String = #file,
+    line: Int = #line,
+    function: String = #function
+) -> E {
+    ErrorHandler.handle(error: error, file: file, line: line, function: function)
     return error
 }
 
-func handled(primerError: PrimerError) -> PrimerError {
-    handled(error: primerError)
+func handled(
+    primerError: PrimerError,
+    file: String = #file,
+    line: Int = #line,
+    function: String = #function
+) -> PrimerError {
+    handled(error: primerError, file: file, line: line, function: function)
 }
 
-func handled(primerValidationError: PrimerValidationError) -> PrimerValidationError {
-    handled(error: primerValidationError)
+func handled(
+    primerValidationError: PrimerValidationError,
+    file: String = #file,
+    line: Int = #line,
+    function: String = #function
+) -> PrimerValidationError {
+    handled(error: primerValidationError, file: file, line: line, function: function)
 }
 
 public enum PrimerError: PrimerErrorProtocol {


### PR DESCRIPTION
# Description

This will now print out the caller name, function, line etc at the error handling level (as opposed to the past userInfo level)

<img width="783" height="46" alt="Screenshot 2025-08-04 at 14 54 20" src="https://github.com/user-attachments/assets/e84e948d-a75f-40a1-8b2f-ae0d40390f7f" />