### PR TITLE
fix: Add missing start_async methods to tokenization view models

### DIFF
--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/FormPaymentMethodTokenizationViewModel.swift
@@ -477,6 +477,26 @@ final class FormPaymentMethodTokenizationViewModel: PaymentMethodTokenizationVie
         super.start()
     }
 
+    override func start_async() {
+        checkoutEventsNotifierModule.didStartTokenization = {
+            self.enableUserInteraction(false)
+        }
+
+        checkoutEventsNotifierModule.didFinishTokenization = {
+            self.enableUserInteraction(true)
+        }
+
+        didStartPayment = {
+            self.enableUserInteraction(false)
+        }
+
+        didFinishPayment = { _ in
+            self.enableUserInteraction(true)
+        }
+
+        super.start()
+    }
+
     override func validate() throws {
         guard let decodedJWTToken = PrimerAPIConfigurationModule.decodedJWTToken else {
             let err = PrimerError.invalidClientToken(userInfo: .errorUserInfoDictionary(),
@@ -897,6 +917,14 @@ final class FormPaymentMethodTokenizationViewModel: PaymentMethodTokenizationVie
                                         userInfo: .errorUserInfoDictionary(),
                                         diagnosticsId: UUID().uuidString)
         ErrorHandler.handle(error: err)
+    }
+
+    // MARK: Private helper methods
+
+    private func enableUserInteraction(_ enable: Bool) {
+        DispatchQueue.main.async {
+            PrimerUIManager.primerRootViewController?.enableUserInteraction(enable)
+        }
     }
 }
 

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -81,6 +81,18 @@ final class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
         super.start()
     }
 
+    override func start_async() {
+        didFinishPayment = { err in
+            if let error = err {
+                self.applePayControllerCompletion?(PKPaymentAuthorizationResult(status: .failure, errors: [error]))
+            } else {
+                self.applePayControllerCompletion?(PKPaymentAuthorizationResult(status: .success, errors: nil))
+            }
+        }
+
+        super.start_async()
+    }
+
     override func performPreTokenizationSteps() -> Promise<Void> {
         let event = Analytics.Event.ui(
             action: .click,


### PR DESCRIPTION
- Add start_async implementation to FormPaymentMethodTokenizationViewModel with user interaction controls
- Add start_async implementation to ApplePayTokenizationViewModel with payment completion handling
- Ensures consistent async behavior across tokenization view models
