### PR TITLE
ci: Improve unit tests pipeline

### DIFF
--- a/.github/workflows/build-test-upload.yml
+++ b/.github/workflows/build-test-upload.yml
@@ -11,10 +11,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-tests-sdk:
+  unit-tests-sdk-and-debug-app:
     runs-on: macos-latest-large
     timeout-minutes: 20
-    name: "Unit Tests - SDK"
+    name: "Unit Tests - SDK & Debug App"
     steps:
       - name: Cancel previous jobs
         uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # v0.12.1
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.ref }}
-      - name: Run SDK tests
+      - name: Run SDK and Debug App tests
         uses: ./.github/actions/sdk-tests
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
@@ -35,6 +35,7 @@ jobs:
           fastlane-password: ${{ secrets.FASTLANE_PASSWORD }}
           match-keychain-name: ${{ secrets.MATCH_KEYCHAIN_NAME }}
           match-keychain-password: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          fastlane-test-lane: test_sdk_and_debug_app
           sdk-name: sdk
 
   optional-sdk-tests:
@@ -71,35 +72,8 @@ jobs:
           sdk-name: ${{ matrix.package-swift.name }}
           package-swift: ${{  matrix.package-swift.file }}
 
-  unit-tests-debug-app:
-    runs-on: macos-latest-large
-    timeout-minutes: 20
-    name: "Unit Tests - Debug App"
-    steps:
-      - name: Cancel previous jobs
-        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # v0.12.1
-        with:
-          access_token: ${{ github.token }}
-      - name: Git - Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: ${{ github.ref }}
-      - name: Run debug app tests
-        uses: ./.github/actions/sdk-tests
-        with:
-          ssh-private-key: ${{ secrets.SSH_KEY }}
-          known-hosts: ${{ secrets.KNOWN_HOSTS }}
-          match-password: ${{ secrets.MATCH_PASSWORD }}
-          match-git-private-key: ${{ secrets.FASTLANE_PASSWORD }}
-          fastlane-session: ${{ secrets.FASTLANE_SESSION }}
-          fastlane-password: ${{ secrets.FASTLANE_PASSWORD }}
-          match-keychain-name: ${{ secrets.MATCH_KEYCHAIN_NAME }}
-          match-keychain-password: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
-          fastlane-test-lane: test_debug_app
-
-
   spm-build:
-    needs: unit-tests-debug-app
+    needs: unit-tests-sdk-and-debug-app
     runs-on: macos-latest-large
     timeout-minutes: 20
     name: "Build app with SPM Integration"
@@ -143,7 +117,7 @@ jobs:
 
   sonarcloud:
     needs:
-      - unit-tests-sdk
+      - unit-tests-sdk-and-debug-app
       - optional-sdk-tests
     name: SonarCloud
     runs-on: macos-latest
@@ -165,8 +139,7 @@ jobs:
 
   build-and-upload-to-appetize:
     needs:
-      - unit-tests-sdk
-      - unit-tests-debug-app
+      - unit-tests-sdk-and-debug-app
     runs-on: macos-latest-large
     timeout-minutes: 45
     name: "Build and upload app to Appetize"

--- a/.swiftpm/xcode/xcshareddata/xcschemes/DebugAppTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/DebugAppTests.xcscheme
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "2.2">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <AutocreatedTestPlanReference>
+            </AutocreatedTestPlanReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DebugAppTests"
+               BuildableName = "DebugAppTests"
+               BlueprintName = "DebugAppTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DebugAppTests"
+            BuildableName = "DebugAppTests"
+            BlueprintName = "DebugAppTests"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Debug App/Tests/DebugAppTestPlan.xctestplan
+++ b/Debug App/Tests/DebugAppTestPlan.xctestplan
@@ -14,9 +14,9 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:Debug App\/Primer.io Debug App.xcodeproj",
-        "identifier" : "301F25EE1514F3AF2E4A7FBD",
-        "name" : "Debug App Tests"
+        "containerPath" : "container:",
+        "identifier" : "DebugAppTests",
+        "name" : "DebugAppTests"
       }
     }
   ],

--- a/Debug App/Tests/SecretsManagerTests.swift
+++ b/Debug App/Tests/SecretsManagerTests.swift
@@ -10,11 +10,16 @@ import XCTest
 final class SecretsManagerTests: XCTestCase {
 
     func testLoadFileAndGetSecret() throws {
-        let manager = SecretsManager(bundle: Bundle(for: type(of: self)))
+        let bundle = Bundle(for: type(of: self))
+        guard let nestedBundleURL = bundle.url(forResource: "PrimerSDK_DebugAppTests", withExtension: "bundle"),
+              let resourceBundle = Bundle(url: nestedBundleURL) else {
+            return XCTFail("Could not find PrimerSDK_DebugAppTests.bundle")
+        }
+
+        let manager = SecretsManager(bundle: resourceBundle)
         XCTAssertEqual(manager.properties.count, 1)
 
         let stripePublishableKey = manager.value(forKey: .stripePublishableKey)
         XCTAssertEqual(stripePublishableKey, "pk_test_123")
     }
-
 }

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,19 @@ let package = Package(
                 .copy("Classes/Third Party/PromiseKit/LICENSE")
             ]
         ),
+        .target(
+            name: "Debug_App",
+            dependencies: [
+                .byName(name: "PrimerSDK")
+            ],
+            path: "Debug App/Sources/",
+            sources: [
+                "Utilities/SecretsManager.swift",
+                "Utilities/AppLinkConfigProvider.swift",
+                "Model/TestSettings.swift",
+                "Model/TestSettings+PrimerSettings.swift"
+            ]
+        ),
         .testTarget(
             name: "Tests",
             dependencies: [
@@ -40,6 +53,20 @@ let package = Package(
                 "3DS/",
                 "Utilities/",
                 "Primer/"
+            ]
+        ),
+        .testTarget(
+            name: "DebugAppTests",
+            dependencies: [
+                .byName(name: "PrimerSDK"),
+                .byName(name: "Debug_App")
+            ],
+            path: "Debug App/Tests",
+            resources: [
+                .process("Resources"),
+                .copy("DebugAppTestPlan.xctestplan"),
+                .copy("UnitTestsTestPlan.xctestplan"),
+                .copy("Debug App Tests-Info.plist")
             ]
         )
     ],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -158,6 +158,32 @@ platform :ios do
     )
   end
 
+  desc 'This action tests both SDK and Debug App via SPM'
+  lane :test_sdk_and_debug_app do |options|
+    common_pre_build_action
+    sim_version = options[:sim_version] || default_sim_version
+    
+    run_tests(
+      package_path: ".",
+      scheme: "PrimerSDKTests",
+      sdk: "iphonesimulator#{sim_version}",
+      destination: "OS=#{sim_version},name=iPhone 16",
+      result_bundle: true,
+      code_coverage: true,
+      output_directory: Dir.pwd + "/test_output"
+    )
+    
+    run_tests(
+      package_path: ".",
+      scheme: "DebugAppTests",
+      sdk: "iphonesimulator#{sim_version}",
+      destination: "OS=#{sim_version},name=iPhone 16",
+      result_bundle: true,
+      code_coverage: true,
+      output_directory: Dir.pwd + "/test_output"
+    )
+  end
+
   lane :build_cocoapods do |options|
     common_pre_build_action
 


### PR DESCRIPTION
# Description

Previously, the SDK unit tests ran the PrimerSDK tests in SPM and the Debug App tests via Cocoapods. The latter tests ran for less than half a second but took around eight minutes to prepare. 

This PR consolidates the two tests into one lane and migrates the Debug App tests to use SPM