### PR TITLE
fix: Fix main thread crash in 3DS cleanup

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
+++ b/Sources/PrimerSDK/Classes/Core/3DS/3DSService.swift
@@ -177,7 +177,9 @@ final class ThreeDSService: ThreeDSServiceProtocol, LogReporter {
     ) async throws -> String {
         #if canImport(Primer3DS)
 
-        defer { cleanup() } // MARK: REVIEW_CHECK - Same logic as PromiseKit's ensure
+        defer {
+            Task { await cleanup() }
+        }
 
         do {
             return try await executeAuthentication(paymentMethodTokenData: paymentMethodTokenData, sdkDismissed: sdkDismissed)
@@ -218,6 +220,7 @@ final class ThreeDSService: ThreeDSServiceProtocol, LogReporter {
     }
 
     #if canImport(Primer3DS)
+    @MainActor
     private func cleanup() {
         let dismiss3DSUIEvent = Analytics.Event.ui(
             action: .dismiss,


### PR DESCRIPTION
Wrap cleanup call in Task to handle async execution properly and add @MainActor to ensure UI operations run on main thread.
