### PR TITLE
refactor: Remove 'Async' suffix from test class names

### DIFF
--- a/Tests/Klarna/KlarnaTokenizationManagerTests.swift
+++ b/Tests/Klarna/KlarnaTokenizationManagerTests.swift
@@ -1,9 +1,15 @@
+//
+//  KlarnaTokenizationManagerTests.swift
+//
+//  Copyright © 2025 Primer API Ltd. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
 #if canImport(PrimerKlarnaSDK)
 import PrimerKlarnaSDK
 @testable import PrimerSDK
 import XCTest
 
-final class KlarnaTokenizationManagerAsyncTests: XCTestCase {
+final class KlarnaTokenizationManagerTests: XCTestCase {
     var sut: KlarnaTokenizationManager!
     var tokenizationService: MockTokenizationService!
     var createResumePaymentService: MockCreateResumePaymentService!
@@ -217,7 +223,7 @@ final class KlarnaTokenizationManagerAsyncTests: XCTestCase {
     }
 }
 
-extension KlarnaTokenizationManagerAsyncTests {
+extension KlarnaTokenizationManagerTests {
     private var address: Response.Body.Klarna.BillingAddress {
         .init(addressLine1: "address_line_1",
               addressLine2: "address_line_2",

--- a/Tests/Primer/Analytics/AnalyticsServiceTests.swift
+++ b/Tests/Primer/Analytics/AnalyticsServiceTests.swift
@@ -1,5 +1,5 @@
 //
-//  AnalyticsServiceAsyncTests.swift
+//  AnalyticsServiceTests.swift
 //
 //  Copyright © 2025 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
@@ -7,7 +7,7 @@
 @testable import PrimerSDK
 import XCTest
 
-final class AnalyticsServiceAsyncTests: XCTestCase {
+final class AnalyticsServiceTests: XCTestCase {
     var sut: Analytics.Service!
     var apiClient: MockPrimerAPIAnalyticsClient!
     var storage: MockAnalyticsStorage!

--- a/Tests/Primer/Banks/BanksTokenizationComponentTests.swift
+++ b/Tests/Primer/Banks/BanksTokenizationComponentTests.swift
@@ -1,5 +1,5 @@
 //
-//  BanksTokenizationComponentAsyncTests.swift
+//  BanksTokenizationComponentTests.swift
 //
 //  Copyright © 2025 Primer API Ltd. All rights reserved.
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
@@ -7,7 +7,7 @@
 @testable import PrimerSDK
 import XCTest
 
-final class BanksTokenizationComponentAsyncTests: XCTestCase {
+final class BanksTokenizationComponentTests: XCTestCase {
     // MARK: - Test Dependencies
 
     private var apiClient: MockBanksAPIClient!

--- a/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  ApplePayTokenizationViewModelAsyncTests.swift
+//  ApplePayTokenizationViewModelTests.swift
 //
 //  Copyright © 2025 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
@@ -11,7 +11,7 @@ import XCTest
 private typealias ShippingMethodOptions = Response.Body.Configuration.CheckoutModule.ShippingMethodOptions
 private typealias ShippingMethod = Response.Body.Configuration.CheckoutModule.ShippingMethodOptions.ShippingMethod
 
-final class ApplePayTokenizationViewModelAsyncTests: XCTestCase {
+final class ApplePayTokenizationViewModelTests: XCTestCase {
     // MARK: - Test Dependencies
 
     private var sut: ApplePayTokenizationViewModel!

--- a/Tests/Primer/Tokenization/View Models/BankSelectorTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/BankSelectorTokenizationViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  PayPalTokenizationViewModelAsyncTests.swift
+//  BankSelectorTokenizationViewModelTests.swift
 //
 //  Copyright © 2025 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
@@ -7,15 +7,16 @@
 @testable import PrimerSDK
 import XCTest
 
-final class PayPalTokenizationViewModelAsyncTests: XCTestCase {
+final class BankSelectorTokenizationViewModelTests: XCTestCase {
     // MARK: - Test Dependencies
 
-    var sut: PayPalTokenizationViewModel!
-    var uiManager: MockPrimerUIManager!
-    var tokenizationService: MockTokenizationService!
-    var createResumePaymentService: MockCreateResumePaymentService!
+    private var uiManager: MockPrimerUIManager!
+    private var tokenizationService: MockTokenizationService!
+    private var createResumePaymentService: MockCreateResumePaymentService!
+    private var banksApiClient: MockBanksAPIClient!
+    private var sut: BankSelectorTokenizationViewModel!
 
-    // MARK: - Test Helper Data
+    // MARK: - Helper Data
 
     private let tokenizationResponseBody = Response.Body.Tokenization(
         analyticsId: "analytics_id",
@@ -74,11 +75,15 @@ final class PayPalTokenizationViewModelAsyncTests: XCTestCase {
         uiManager.primerRootViewController = MockPrimerRootViewController()
         tokenizationService = MockTokenizationService()
         createResumePaymentService = MockCreateResumePaymentService()
+        banksApiClient = MockBanksAPIClient()
 
-        sut = PayPalTokenizationViewModel(config: Mocks.PaymentMethods.paypalPaymentMethod,
-                                          uiManager: uiManager,
-                                          tokenizationService: tokenizationService,
-                                          createResumePaymentService: createResumePaymentService)
+        sut = BankSelectorTokenizationViewModel(
+            config: Mocks.PaymentMethods.adyenIDealPaymentMethod,
+            uiManager: uiManager,
+            tokenizationService: tokenizationService,
+            createResumePaymentService: createResumePaymentService,
+            apiClient: banksApiClient
+        )
     }
 
     override func tearDownWithError() throws {
@@ -97,14 +102,22 @@ final class PayPalTokenizationViewModelAsyncTests: XCTestCase {
         let uiDelegate = MockPrimerHeadlessUniversalCheckoutUIDelegate()
         PrimerHeadlessUniversalCheckout.current.uiDelegate = uiDelegate
 
-        let expectWillCreatePaymentWithData = self.expectation(description: "Will create payment with data")
+        let banks = setupBanksAPIClient()
+
+        let expectDidShowPaymentMethod = expectation(description: "UI shows payment method")
+        uiDelegate.onUIDidShowPaymentMethod = { _ in
+            self.sut.bankSelectionCompletion?(banks.result.first!)
+            expectDidShowPaymentMethod.fulfill()
+        }
+
+        let expectWillCreatePaymentWithData = expectation(description: "Will create payment with data")
         delegate.onWillCreatePaymentWithData = { data, decision in
-            XCTAssertEqual(data.paymentMethodType.type, PrimerPaymentMethodType.payPal.rawValue)
+            XCTAssertEqual(data.paymentMethodType.type, "ADYEN_IDEAL")
             decision(.abortPaymentCreation())
             expectWillCreatePaymentWithData.fulfill()
         }
 
-        let expectDidFail = self.expectation(description: "Payment flow fails")
+        let expectDidFail = expectation(description: "Payment flow fails")
         delegate.onDidFail = { error in
             switch error {
             case PrimerError.merchantError:
@@ -118,6 +131,7 @@ final class PayPalTokenizationViewModelAsyncTests: XCTestCase {
         sut.start()
 
         wait(for: [
+            expectDidShowPaymentMethod,
             expectWillCreatePaymentWithData,
             expectDidFail
         ], timeout: 10.0, enforceOrder: true)
@@ -130,62 +144,42 @@ final class PayPalTokenizationViewModelAsyncTests: XCTestCase {
         let uiDelegate = MockPrimerHeadlessUniversalCheckoutUIDelegate()
         PrimerHeadlessUniversalCheckout.current.uiDelegate = uiDelegate
 
-        PrimerInternal.shared.intent = .checkout
-
-        let settings = PrimerSettings(paymentMethodOptions: .init(urlScheme: "urlscheme://app"))
-        DependencyContainer.register(settings as PrimerSettingsProtocol)
-
         let apiClient = MockPrimerAPIClient()
         PrimerAPIConfigurationModule.apiClient = apiClient
         apiClient.fetchConfigurationWithActionsResult = (PrimerAPIConfiguration.current, nil)
 
-        let payPalService = MockPayPalService()
-        sut.payPalService = payPalService
-        payPalService.onStartOrderSession = {
-            .init(orderId: "order_id", approvalUrl: "https://approval.url/")
-        }
-        payPalService.onFetchPayPalExternalPayerInfo = { _ in
-            .init(orderId: "order_id", externalPayerInfo: .init(externalPayerId: "external_payer_id",
-                                                                email: "john@appleseed.com",
-                                                                firstName: "John",
-                                                                lastName: "Appleseed"))
+        let banks = setupBanksAPIClient()
+
+        let expectDidShowPaymentMethod = expectation(description: "UI shows payment method")
+        uiDelegate.onUIDidShowPaymentMethod = { _ in
+            self.sut.bankSelectionCompletion?(banks.result.first!)
+            expectDidShowPaymentMethod.fulfill()
         }
 
-        let webAuthenticationService = MockWebAuthenticationService()
-        sut.webAuthenticationService = webAuthenticationService
-        webAuthenticationService.onConnect = { _, _ in
-            URL(string: "https://webauthsvc.app/")!
-        }
-
-        let expectWillCreatePaymentWithData = self.expectation(description: "Will create payment with data")
+        let expectWillCreatePaymentWithData = expectation(description: "Will create payment with data")
         delegate.onWillCreatePaymentWithData = { data, decision in
-            XCTAssertEqual(data.paymentMethodType.type, PrimerPaymentMethodType.payPal.rawValue)
+            XCTAssertEqual(data.paymentMethodType.type, "ADYEN_IDEAL")
             decision(.continuePaymentCreation())
             expectWillCreatePaymentWithData.fulfill()
         }
 
-        let expectDidShowPaymentMethod = self.expectation(description: "UI shows payment method")
-        uiDelegate.onUIDidShowPaymentMethod = { _ in
-            expectDidShowPaymentMethod.fulfill()
-        }
-
-        let expectDidTokenize = self.expectation(description: "Payment method tokenizes")
-        tokenizationService.onTokenize = { _ in
-            expectDidTokenize.fulfill()
-            return .success(self.tokenizationResponseBody)
-        }
-
-        let expectDidCreatePayment = self.expectation(description: "Payment gets created")
-        createResumePaymentService.onCreatePayment = { _ in
-            expectDidCreatePayment.fulfill()
-            return self.paymentResponseBody
-        }
-
-        let expectDidCompleteCheckout = self.expectation(description: "Checkout completes successfully")
+        let expectDidCompleteCheckoutWithData = expectation(description: "Checkout completes successfully")
         delegate.onDidCompleteCheckoutWithData = { data in
             XCTAssertEqual(data.payment?.id, "id")
             XCTAssertEqual(data.payment?.orderId, "order_id")
-            expectDidCompleteCheckout.fulfill()
+            expectDidCompleteCheckoutWithData.fulfill()
+        }
+
+        let expectDidTokenize = expectation(description: "Payment method tokenizes")
+        tokenizationService.onTokenize = { _ in
+            expectDidTokenize.fulfill()
+            return Result.success(self.tokenizationResponseBody)
+        }
+
+        let expectDidCreatePayment = expectation(description: "Payment gets created")
+        createResumePaymentService.onCreatePayment = { _ in
+            expectDidCreatePayment.fulfill()
+            return self.paymentResponseBody
         }
 
         delegate.onDidFail = { error in
@@ -195,11 +189,22 @@ final class PayPalTokenizationViewModelAsyncTests: XCTestCase {
         sut.start()
 
         wait(for: [
-            expectWillCreatePaymentWithData,
             expectDidShowPaymentMethod,
+            expectWillCreatePaymentWithData,
             expectDidTokenize,
             expectDidCreatePayment,
-            expectDidCompleteCheckout
+            expectDidCompleteCheckoutWithData
         ], timeout: 10.0, enforceOrder: true)
+    }
+
+    // MARK: - Helpers
+
+    func setupBanksAPIClient() -> BanksListSessionResponse {
+        let banks: BanksListSessionResponse = .init(
+            result: [.init(id: "id", name: "name", iconUrlStr: "icon", disabled: false)]
+        )
+        banksApiClient.result = banks
+
+        return banks
     }
 }

--- a/Tests/Primer/Tokenization/View Models/CardFormPaymentMethodTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/CardFormPaymentMethodTokenizationViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  CardFormPaymentMethodTokenizationViewModelAsyncTests.swift
+//  CardFormPaymentMethodTokenizationViewModelTests.swift
 //
 //  Copyright © 2025 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
@@ -7,7 +7,7 @@
 @testable import PrimerSDK
 import XCTest
 
-final class CardFormPaymentMethodTokenizationViewModelAsyncTests: XCTestCase, TokenizationViewModelTestCase {
+final class CardFormPaymentMethodTokenizationViewModelTests: XCTestCase, TokenizationViewModelTestCase {
     
     // MARK: - Test Dependencies
     

--- a/Tests/Primer/Tokenization/View Models/CheckoutWithVaultedPaymentMethodViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/CheckoutWithVaultedPaymentMethodViewModelTests.swift
@@ -1,7 +1,13 @@
+//
+//  CheckoutWithVaultedPaymentMethodViewModelTests.swift
+//
+//  Copyright © 2025 Primer API Ltd. All rights reserved.
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
 @testable import PrimerSDK
 import XCTest
 
-final class CheckoutWithVaultedPaymentMethodViewModelAsyncTests: XCTestCase {
+final class CheckoutWithVaultedPaymentMethodViewModelTests: XCTestCase {
     // MARK: - Test Dependencies
 
     private var sut: CheckoutWithVaultedPaymentMethodViewModel!

--- a/Tests/Primer/Tokenization/View Models/FormPaymentMethodTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/FormPaymentMethodTokenizationViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  FormPaymentMethodTokenizationViewModelAsyncTests.swift
+//  FormPaymentMethodTokenizationViewModelTests.swift
 //
 //  Copyright © 2025 Primer API Ltd. All rights reserved.
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
@@ -7,7 +7,7 @@
 @testable import PrimerSDK
 import XCTest
 
-final class FormPaymentMethodTokenizationViewModelAsyncTests: XCTestCase {
+final class FormPaymentMethodTokenizationViewModelTests: XCTestCase {
     
     // MARK: - Test Dependencies
     

--- a/Tests/Primer/Tokenization/View Models/QRCodeTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/QRCodeTokenizationViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  QRCodeTokenizationViewModelAsyncTests.swift
+//  QRCodeTokenizationViewModelTests.swift
 //
 //  Copyright © 2025 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
@@ -7,7 +7,7 @@
 @testable import PrimerSDK
 import XCTest
 
-final class QRCodeTokenizationViewModelAsyncTests: XCTestCase {
+final class QRCodeTokenizationViewModelTests: XCTestCase {
     // MARK: - Test Dependencies
 
     var sut: QRCodeTokenizationViewModel!

--- a/Tests/Primer/Tokenization/View Models/WebRedirectPaymentMethodTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/WebRedirectPaymentMethodTokenizationViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  WebRedirectPaymentMethodTokenizationViewModelAsyncTests.swift
+//  WebRedirectPaymentMethodTokenizationViewModelTests.swift
 //
 //  Copyright © 2025 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
@@ -7,7 +7,7 @@
 @testable import PrimerSDK
 import XCTest
 
-final class WebRedirectPaymentMethodTokenizationViewModelAsyncTests: XCTestCase {
+final class WebRedirectPaymentMethodTokenizationViewModelTests: XCTestCase {
     // MARK: - Test Dependencies
     
     private var sut: WebRedirectPaymentMethodTokenizationViewModel!

--- a/Tests/Stripe/StripeAchTokenizationViewModelTests.swift
+++ b/Tests/Stripe/StripeAchTokenizationViewModelTests.swift
@@ -1,5 +1,5 @@
 //
-//  StripeAchTokenizationViewModelAsyncTests.swift
+//  StripeAchTokenizationViewModelTests.swift
 //
 //  Copyright © 2025 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
@@ -7,7 +7,7 @@
 @testable import PrimerSDK
 import XCTest
 
-final class StripeAchTokenizationViewModelAsyncTests: XCTestCase {
+final class StripeAchTokenizationViewModelTests: XCTestCase {
     // MARK: - Test Dependencies
 
     private var sut: StripeAchTokenizationViewModel!


### PR DESCRIPTION
Remove leftover 'Async' naming from test files after PromiseKit migration. All test classes now use standard naming convention without async suffix.
