### PR TITLE
fix: Disable explicit modules for iOS 26 compatibility

### DIFF
--- a/PrimerSDK.podspec
+++ b/PrimerSDK.podspec
@@ -37,7 +37,8 @@ Pod::Spec.new do |s|
                 "${PODS_CONFIGURATION_BUILD_DIR}/PrimerNolPaySDK",
                 "${PODS_XCFRAMEWORKS_BUILD_DIR}/PrimerKlarnaSDK",
                 "${PODS_XCFRAMEWORKS_BUILD_DIR}/PrimerStripeSDK"
-            ]
+            ],
+            "SWIFT_ENABLE_EXPLICIT_MODULES" => "NO"
         }
     end
 end


### PR DESCRIPTION


# Description

[ACC-6007](https://primerapi.atlassian.net/browse/ACC-6007)

Adds SWIFT_ENABLE_EXPLICIT_MODULES = NO to podspec to resolve build issues with iOS 26 where explicit modules cause compilation failures in CocoaPods integration.

# Manual Testing

Manually tested changes with optional SDKs on Xcode 26 / iOS 26

[ACC-6007]: https://primerapi.atlassian.net/browse/ACC-6007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ