### PR TITLE
fix: Ensure Cancel button dismisses checkout sheet

### DIFF
--- a/Debug App/Sources/View Controllers/CheckoutComponents/CheckoutComponentsExamplesView.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/CheckoutComponentsExamplesView.swift
@@ -15,8 +15,6 @@ struct CheckoutComponentsExamplesView: View {
     let apiVersion: PrimerApiVersion
     let clientSession: ClientSessionRequestBody?
     
-    @SwiftUI.Environment(\.dismiss) private var dismiss
-    
     init(settings: PrimerSettings, apiVersion: PrimerApiVersion, clientSession: ClientSessionRequestBody? = nil) {
         self.settings = settings
         self.apiVersion = apiVersion
@@ -34,19 +32,17 @@ struct CheckoutComponentsExamplesView: View {
         let _ = print("🔍 [CheckoutComponentsExamplesView] body called")
         let _ = print("🔍 [CheckoutComponentsExamplesView] Categories: \(ExampleCategory.allCases.map { $0.rawValue })")
         
-        NavigationView {
-            List {
-                ForEach(ExampleCategory.allCases, id: \.self) { category in
-                    NavigationLink(
-                        destination: CategoryExamplesView(
-                            category: category,
-                            settings: settings,
-                            apiVersion: apiVersion,
-                            clientSession: clientSession
-                        )
-                    ) {
-                        CategoryRow(category: category)
-                    }
+        List {
+            ForEach(ExampleCategory.allCases, id: \.self) { category in
+                NavigationLink(
+                    destination: CategoryExamplesView(
+                        category: category,
+                        settings: settings,
+                        apiVersion: apiVersion,
+                        clientSession: clientSession
+                    )
+                ) {
+                    CategoryRow(category: category)
                 }
             }
         }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Constants/CheckoutComponentsStrings.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Constants/CheckoutComponentsStrings.swift
@@ -42,6 +42,13 @@ internal struct CheckoutComponentsStrings {
         comment: "Cancel button text"
     )
 
+    static let backButton = NSLocalizedString(
+        "checkout-components-back-button",
+        bundle: Bundle.primerResources,
+        value: "Back",
+        comment: "Back button text"
+    )
+
     // MARK: - Payment Method Selection
 
     static let choosePaymentMethod = NSLocalizedString(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/CheckoutRoute.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/CheckoutRoute.swift
@@ -40,23 +40,6 @@ public enum PresentationContext {
             return true
         }
     }
-
-    /// How cancel should behave based on context
-    var cancelBehavior: CancelBehavior {
-        switch self {
-        case .direct:
-            return .dismiss
-        case .fromPaymentSelection:
-            return .navigateToPaymentSelection
-        }
-    }
-}
-
-// MARK: - Cancel Behavior
-@available(iOS 15.0, *)
-enum CancelBehavior {
-    case dismiss                      // Dismiss entirely
-    case navigateToPaymentSelection  // Navigate back to payment method selection
 }
 
 // MARK: - Navigation Behavior

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
@@ -16,7 +16,6 @@ internal struct CheckoutScopeObserver: View, LogReporter {
     private let customContent: ((PrimerCheckoutScope) -> AnyView)?
     private let scopeCustomization: ((PrimerCheckoutScope) -> Void)?
     private let onCompletion: (() -> Void)?
-    @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
 
     // Design tokens state

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
@@ -448,18 +448,8 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     }
 
     public func onCancel() {
-        // Cancel triggered
-        // Current context logged
-        // Cancel behavior setting logged
-
-        switch presentationContext.cancelBehavior {
-        case .dismiss:
-            // Action: Dismissing entire checkout flow
-            checkoutScope?.checkoutNavigator.dismiss()
-        case .navigateToPaymentSelection:
-            // Action: Navigating back to payment selection
-            checkoutScope?.checkoutNavigator.navigateToPaymentSelection()
-        }
+        // Cancel button tapped - dismiss entire checkout flow
+        checkoutScope?.onDismiss()
     }
 
     public func navigateToCountrySelection() {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -476,15 +476,18 @@ internal final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject
     public func onDismiss() {
         // Checkout dismissed
 
-        // Update both state and navigation state to dismissed
-        updateState(.dismissed)
-        updateNavigationState(.dismissed)
+        // Ensure state updates happen on main thread for SwiftUI observation
+        Task { @MainActor in
+            // Update both state and navigation state to dismissed
+            updateState(.dismissed)
+            updateNavigationState(.dismissed)
 
-        // Clean up any resources
-        _paymentMethodSelection = nil
-        currentPaymentMethodScope = nil
-        paymentMethodScopeCache.removeAll()
-        // Payment method screens now handled by PaymentMethodProtocol
+            // Clean up any resources
+            _paymentMethodSelection = nil
+            currentPaymentMethodScope = nil
+            paymentMethodScopeCache.removeAll()
+            // Payment method screens now handled by PaymentMethodProtocol
+        }
 
         // Navigate to dismiss the checkout
         navigator.dismiss()

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
@@ -37,7 +37,7 @@ internal struct CardFormScreen: View, LogReporter {
                     HStack(spacing: 4) {
                         Image(systemName: "chevron.left")
                             .font(.body.weight(.medium))
-                        Text("Back")
+                        Text(CheckoutComponentsStrings.backButton)
                     }
                     .foregroundColor(tokens?.primerColorTextPrimary ?? .primary)
                 })


### PR DESCRIPTION
Simplified cancel behavior to always dismiss the entire checkout flow instead of navigating back to payment selection.
Wrapped state updates in onDismiss() with @MainActor to ensure SwiftUI observation triggers correctly.

[ACC-5793](https://primerapi.atlassian.net/browse/ACC-5793)

[ACC-5793]: https://primerapi.atlassian.net/browse/ACC-5793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ