### PR TITLE
ci: Dont use fail-fast in UI Tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -142,6 +142,7 @@ jobs:
     name: "LambdaTest test"
     if: ${{ inputs.testType == '' }}
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         test-type:


### PR DESCRIPTION
Our E2E tests were not fully running - a failure in the MOCKED tests would cause the E2E tests to be skipped.