### PR TITLE
feat: Add domain foundation + test data factory

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/Framework/Container.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/Framework/Container.swift
@@ -311,8 +311,7 @@ actor Container: ContainerProtocol, LogReporter {
           domain: "DIContainer", code: -1,
           userInfo: [
             NSLocalizedDescriptionKey: "Synchronous resolution timed out"
-          ]
-        )
+          ])
       )
     }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/Framework/DIContainter+SwiftUI.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/Framework/DIContainter+SwiftUI.swift
@@ -63,8 +63,7 @@ extension DIContainer {
         return StateObject(wrappedValue: resolved)
       } catch {
         logger.debug(
-          message: "Failed to resolve \(String(describing: type)) from environment DI container"
-        )
+          message: "Failed to resolve \(String(describing: type)) from environment DI container")
         return StateObject(wrappedValue: fallback())
       }
     } else {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Data/Mappers/PaymentMethodMapper.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Data/Mappers/PaymentMethodMapper.swift
@@ -1,0 +1,69 @@
+//
+//  PaymentMethodMapper.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+@available(iOS 15.0, *)
+protocol PaymentMethodMapper {
+  func mapToPublic(_ internalMethod: InternalPaymentMethod) -> CheckoutPaymentMethod
+  func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod]
+}
+
+@available(iOS 15.0, *)
+final class PaymentMethodMapperImpl: PaymentMethodMapper {
+
+  private let configurationService: ConfigurationService
+
+  init(configurationService: ConfigurationService) {
+    self.configurationService = configurationService
+  }
+
+  func mapToPublic(_ internalMethod: InternalPaymentMethod) -> CheckoutPaymentMethod {
+    let formattedSurcharge = formatSurcharge(
+      internalMethod.surcharge, hasUnknownSurcharge: internalMethod.hasUnknownSurcharge
+    )
+
+    return CheckoutPaymentMethod(
+      id: internalMethod.id,
+      type: internalMethod.type,
+      name: internalMethod.name,
+      icon: internalMethod.icon,
+      metadata: internalMethod.metadata,
+      surcharge: internalMethod.surcharge,
+      hasUnknownSurcharge: internalMethod.hasUnknownSurcharge,
+      formattedSurcharge: formattedSurcharge,
+      backgroundColor: internalMethod.backgroundColor,
+      buttonText: internalMethod.buttonText,
+      textColor: internalMethod.textColor,
+      borderColor: internalMethod.borderColor,
+      borderWidth: internalMethod.borderWidth,
+      cornerRadius: internalMethod.cornerRadius
+    )
+  }
+
+  func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod] {
+    internalMethods.map { mapToPublic($0) }
+  }
+
+  private func formatSurcharge(_ surcharge: Int?, hasUnknownSurcharge: Bool) -> String? {
+
+    // Priority: unknown surcharge > actual surcharge > no fee
+    if hasUnknownSurcharge {
+      return CheckoutComponentsStrings.additionalFeeMayApply
+    }
+
+    guard let surcharge,
+      surcharge > 0,
+      let currency = configurationService.currency
+    else {
+      return CheckoutComponentsStrings.noAdditionalFee
+    }
+
+    // Use existing currency formatting extension to match Drop-in/Headless behavior
+    let formatted = surcharge.toCurrencyString(currency: currency)
+    return "+\(formatted)"  // "+" prefix for surcharges
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Helpers/ApplePayRequestBuilder.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Helpers/ApplePayRequestBuilder.swift
@@ -1,0 +1,149 @@
+//
+//  ApplePayRequestBuilder.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PassKit
+
+@available(iOS 15.0, *)
+struct ApplePayRequestBuilder {
+
+  static func build() throws -> ApplePayRequest {
+    guard
+      let countryCode = PrimerAPIConfigurationModule.apiConfiguration?.clientSession?.order?
+        .countryCode
+    else {
+      throw PrimerError.invalidClientSessionValue(name: "order.countryCode")
+    }
+
+    guard
+      let merchantIdentifier = PrimerSettings.current.paymentMethodOptions.applePayOptions?
+        .merchantIdentifier
+    else {
+      throw PrimerError.invalidMerchantIdentifier()
+    }
+
+    guard let currency = AppState.current.currency else {
+      throw PrimerError.invalidValue(key: "currency")
+    }
+
+    guard let clientSession = PrimerAPIConfigurationModule.apiConfiguration?.clientSession else {
+      throw PrimerError.invalidValue(key: "clientSession")
+    }
+
+    let shippingMethods = getShippingMethods()
+
+    return ApplePayRequest(
+      currency: currency,
+      merchantIdentifier: merchantIdentifier,
+      countryCode: countryCode,
+      items: try createOrderItems(from: clientSession),
+      shippingMethods: shippingMethods.methods
+    )
+  }
+
+  private static func createOrderItems(from clientSession: ClientSession.APIResponse) throws
+    -> [ApplePayOrderItem] {
+    var orderItems: [ApplePayOrderItem] = []
+
+    let merchantName =
+      getApplePayOptions()?.merchantName
+      ?? PrimerSettings.current.paymentMethodOptions.applePayOptions?.merchantName
+      ?? ""
+
+    if let merchantAmount = clientSession.order?.merchantAmount {
+      orderItems.append(try ApplePayOrderItem(
+        name: merchantName,
+        unitAmount: merchantAmount,
+        quantity: 1,
+        discountAmount: nil,
+        taxAmount: nil
+      ))
+
+    } else if let lineItems = clientSession.order?.lineItems, !lineItems.isEmpty {
+      for lineItem in lineItems {
+        orderItems.append(try lineItem.toOrderItem())
+      }
+
+      if let fees = clientSession.order?.fees {
+        for fee in fees {
+          switch fee.type {
+          case .surcharge:
+            orderItems.append(try ApplePayOrderItem(
+              name: Strings.ApplePay.surcharge,
+              unitAmount: fee.amount,
+              quantity: 1,
+              discountAmount: nil,
+              taxAmount: nil
+            ))
+          }
+        }
+      }
+
+      if let selectedShippingItem = getShippingMethods().selectedItem {
+        orderItems.append(selectedShippingItem)
+      }
+
+      orderItems.append(try ApplePayOrderItem(
+        name: merchantName,
+        unitAmount: clientSession.order?.totalOrderAmount,
+        quantity: 1,
+        discountAmount: nil,
+        taxAmount: nil
+      ))
+
+    } else {
+      throw PrimerError.invalidValue(
+        key: "clientSession.order.lineItems or clientSession.order.merchantAmount"
+      )
+    }
+
+    return orderItems
+  }
+
+  private struct ShippingMethodsInfo {
+    let methods: [PKShippingMethod]?
+    let selectedItem: ApplePayOrderItem?
+  }
+
+  private static func getShippingMethods() -> ShippingMethodsInfo {
+    guard
+      let options = PrimerAPIConfigurationModule
+        .apiConfiguration?
+        .checkoutModules?
+        .first(where: { $0.type == "SHIPPING" })?
+        .options as? Response.Body.Configuration.CheckoutModule.ShippingMethodOptions
+    else {
+      return ShippingMethodsInfo(methods: nil, selectedItem: nil)
+    }
+
+    let factor: NSDecimalNumber = AppState.current.currency?.isZeroDecimal == true ? 1 : 100
+
+    let pkShippingMethods = options.shippingMethods.map { method -> PKShippingMethod in
+      let amount = NSDecimalNumber(value: method.amount).dividing(by: factor)
+      let pkMethod = PKShippingMethod(label: method.name, amount: amount)
+      pkMethod.detail = method.description
+      pkMethod.identifier = method.id
+      return pkMethod
+    }
+
+    let selectedItem = options.shippingMethods
+      .first { $0.id == options.selectedShippingMethod }
+      .flatMap { try? ApplePayOrderItem(
+        name: "Shipping",
+        unitAmount: $0.amount,
+        quantity: 1,
+        discountAmount: nil,
+        taxAmount: nil
+      ) }
+
+    return ShippingMethodsInfo(methods: pkShippingMethods, selectedItem: selectedItem)
+  }
+
+  private static func getApplePayOptions() -> ApplePayOptions? {
+    PrimerAPIConfiguration.current?.paymentMethods?
+      .first(where: { $0.internalPaymentMethodType == .applePay })?
+      .options as? ApplePayOptions
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/CardNetworkDetectionInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/CardNetworkDetectionInteractor.swift
@@ -1,0 +1,40 @@
+//
+//  CardNetworkDetectionInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+protocol CardNetworkDetectionInteractor {
+  var networkDetectionStream: AsyncStream<[CardNetwork]> { get }
+  var binDataStream: AsyncStream<PrimerBinData> { get }
+  func detectNetworks(for cardNumber: String) async
+  func selectNetwork(_ network: CardNetwork) async
+}
+
+@available(iOS 15.0, *)
+final class CardNetworkDetectionInteractorImpl: CardNetworkDetectionInteractor, LogReporter {
+
+  private let repository: HeadlessRepository
+
+  var networkDetectionStream: AsyncStream<[CardNetwork]> {
+    repository.getNetworkDetectionStream()
+  }
+
+  var binDataStream: AsyncStream<PrimerBinData> {
+    repository.getBinDataStream()
+  }
+
+  init(repository: HeadlessRepository) {
+    self.repository = repository
+  }
+
+  func detectNetworks(for cardNumber: String) async {
+    await repository.updateCardNumberInRawDataManager(cardNumber)
+  }
+
+  func selectNetwork(_ network: CardNetwork) async {
+    await repository.selectCardNetwork(network)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/GetPaymentMethodsInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/GetPaymentMethodsInteractor.swift
@@ -1,0 +1,35 @@
+//
+//  GetPaymentMethodsInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+protocol GetPaymentMethodsInteractor {
+  func execute() async throws -> [InternalPaymentMethod]
+}
+
+final class GetPaymentMethodsInteractorImpl: GetPaymentMethodsInteractor, LogReporter {
+
+  private let repository: HeadlessRepository
+
+  init(repository: HeadlessRepository) {
+    self.repository = repository
+  }
+
+  func execute() async throws -> [InternalPaymentMethod] {
+    let startTime = CFAbsoluteTimeGetCurrent()
+    do {
+      let paymentMethods = try await repository.getPaymentMethods()
+      let duration = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
+      logger.info(
+        message: "[PERF] Retrieved \(paymentMethods.count) payment methods in \(String(format: "%.0f", duration))ms"
+      )
+      return paymentMethods
+    } catch {
+      logger.error(message: "Failed to fetch payment methods: \(error)", error: error)
+      throw error
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessAchPaymentInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessAchPaymentInteractor.swift
@@ -1,0 +1,133 @@
+//
+//  ProcessAchPaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+@available(iOS 15.0, *)
+protocol ProcessAchPaymentInteractor {
+  func loadUserDetails() async throws -> AchUserDetailsResult
+  func patchUserDetails(firstName: String, lastName: String, emailAddress: String) async throws
+  func validate() async throws
+  func startPaymentAndGetStripeData() async throws -> AchStripeData
+  func createBankCollector(
+    firstName: String,
+    lastName: String,
+    emailAddress: String,
+    clientSecret: String,
+    delegate: AchBankCollectorDelegate
+  ) async throws -> UIViewController
+  func getMandateData() async throws -> AchMandateResult
+  func tokenize() async throws -> PrimerPaymentMethodTokenData
+  func createPayment(tokenData: PrimerPaymentMethodTokenData) async throws -> PaymentResult
+  func completePayment(stripeData: AchStripeData) async throws -> PaymentResult
+}
+
+@available(iOS 15.0, *)
+final class ProcessAchPaymentInteractorImpl: ProcessAchPaymentInteractor, LogReporter {
+
+  private let repository: AchRepository
+
+  init(repository: AchRepository) {
+    self.repository = repository
+  }
+
+  func loadUserDetails() async throws -> AchUserDetailsResult {
+    do {
+      return try await repository.loadUserDetails()
+    } catch {
+      logger.error(message: "ACH user details loading failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func patchUserDetails(firstName: String, lastName: String, emailAddress: String) async throws {
+    do {
+      try await repository.patchUserDetails(
+        firstName: firstName,
+        lastName: lastName,
+        emailAddress: emailAddress
+      )
+    } catch {
+      logger.error(message: "ACH user details patch failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func validate() async throws {
+    do {
+      try await repository.validate()
+    } catch {
+      logger.error(message: "ACH validation failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func startPaymentAndGetStripeData() async throws -> AchStripeData {
+    do {
+      return try await repository.startPaymentAndGetStripeData()
+    } catch {
+      logger.error(message: "ACH Stripe data retrieval failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func createBankCollector(
+    firstName: String,
+    lastName: String,
+    emailAddress: String,
+    clientSecret: String,
+    delegate: AchBankCollectorDelegate
+  ) async throws -> UIViewController {
+    do {
+      return try await repository.createBankCollector(
+        firstName: firstName,
+        lastName: lastName,
+        emailAddress: emailAddress,
+        clientSecret: clientSecret,
+        delegate: delegate
+      )
+    } catch {
+      logger.error(message: "ACH bank collector creation failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func getMandateData() async throws -> AchMandateResult {
+    do {
+      return try await repository.getMandateData()
+    } catch {
+      logger.error(message: "ACH mandate data retrieval failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func tokenize() async throws -> PrimerPaymentMethodTokenData {
+    do {
+      return try await repository.tokenize()
+    } catch {
+      logger.error(message: "ACH tokenization failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func createPayment(tokenData: PrimerPaymentMethodTokenData) async throws -> PaymentResult {
+    do {
+      return try await repository.createPayment(tokenData: tokenData)
+    } catch {
+      logger.error(message: "ACH payment creation failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func completePayment(stripeData: AchStripeData) async throws -> PaymentResult {
+    do {
+      return try await repository.completePayment(stripeData: stripeData)
+    } catch {
+      logger.error(message: "ACH payment completion failed: \(error)", error: error)
+      throw error
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessApplePayPaymentInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessApplePayPaymentInteractor.swift
@@ -1,0 +1,143 @@
+//
+//  ProcessApplePayPaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+import PassKit
+
+@available(iOS 15.0, *)
+protocol ProcessApplePayPaymentInteractor {
+  func execute(payment: PKPayment) async throws -> PaymentResult
+}
+
+@available(iOS 15.0, *)
+final class ProcessApplePayPaymentInteractorImpl: ProcessApplePayPaymentInteractor, LogReporter {
+
+  private let tokenizationService: TokenizationServiceProtocol
+  private let createPaymentService: CreateResumePaymentServiceProtocol
+
+  init(
+    tokenizationService: TokenizationServiceProtocol,
+    createPaymentService: CreateResumePaymentServiceProtocol
+  ) {
+    self.tokenizationService = tokenizationService
+    self.createPaymentService = createPaymentService
+  }
+
+  func execute(payment: PKPayment) async throws -> PaymentResult {
+    do {
+      let (configId, merchantIdentifier) = try getApplePayConfiguration()
+
+      let paymentInstrument = try buildPaymentInstrument(
+        from: payment,
+        configId: configId,
+        merchantIdentifier: merchantIdentifier
+      )
+
+      let tokenData = try await tokenizationService.tokenize(
+        requestBody: Request.Body.Tokenization(paymentInstrument: paymentInstrument)
+      )
+
+      guard let token = tokenData.token else {
+        throw PrimerError.invalidValue(key: "paymentMethodTokenData.token")
+      }
+
+      let paymentRequest = Request.Body.Payment.Create(token: token)
+      let paymentResponse = try await createPaymentService.createPayment(
+        paymentRequest: paymentRequest
+      )
+
+      return PaymentResult(
+        paymentId: paymentResponse.id ?? "",
+        status: PaymentStatus(from: paymentResponse.status),
+        amount: paymentResponse.amount,
+        currencyCode: paymentResponse.currencyCode,
+        paymentMethodType: PrimerPaymentMethodType.applePay.rawValue
+      )
+
+    } catch {
+      logger.error(
+        message: "Apple Pay payment processing failed: \(error)",
+        error: error
+      )
+      throw error
+    }
+  }
+
+  private func getApplePayConfiguration() throws -> (configId: String, merchantIdentifier: String) {
+    guard
+      let applePayConfig = PrimerAPIConfiguration.current?.paymentMethods?
+        .first(where: { $0.internalPaymentMethodType == .applePay })
+    else {
+      throw PrimerError.unsupportedPaymentMethod(
+        paymentMethodType: PrimerPaymentMethodType.applePay.rawValue
+      )
+    }
+
+    guard let configId = applePayConfig.id else {
+      throw PrimerError.invalidValue(key: "applePayConfig.id")
+    }
+
+    guard
+      let merchantIdentifier = PrimerSettings.current.paymentMethodOptions.applePayOptions?
+        .merchantIdentifier
+    else {
+      throw PrimerError.invalidMerchantIdentifier()
+    }
+
+    return (configId, merchantIdentifier)
+  }
+
+  private func buildPaymentInstrument(
+    from payment: PKPayment,
+    configId: String,
+    merchantIdentifier: String
+  ) throws -> ApplePayPaymentInstrument {
+    var isMockedBE = false
+    #if DEBUG
+      if PrimerAPIConfiguration.current?.clientSession?.testId != nil {
+        isMockedBE = true
+      }
+      if payment.token.paymentData.isEmpty {
+        isMockedBE = true
+      }
+    #endif
+
+    let tokenPaymentData: ApplePayPaymentResponseTokenPaymentData = if isMockedBE {
+      ApplePayPaymentResponseTokenPaymentData(
+        data: "apple-pay-payment-response-mock-data",
+        signature: "apple-pay-mock-signature",
+        version: "apple-pay-mock-version",
+        header: ApplePayTokenPaymentDataHeader(
+          ephemeralPublicKey: "apple-pay-mock-ephemeral-key",
+          publicKeyHash: "apple-pay-mock-public-key-hash",
+          transactionId: "apple-pay-mock-transaction-id"
+        )
+      )
+    } else {
+      try JSONDecoder().decode(
+        ApplePayPaymentResponseTokenPaymentData.self,
+        from: payment.token.paymentData
+      )
+    }
+
+    return ApplePayPaymentInstrument(
+      paymentMethodConfigId: configId,
+      sourceConfig: ApplePayPaymentInstrument.SourceConfig(
+        source: "IN_APP",
+        merchantId: merchantIdentifier
+      ),
+      token: ApplePayPaymentInstrument.PaymentResponseToken(
+        paymentMethod: ApplePayPaymentResponsePaymentMethod(
+          displayName: payment.token.paymentMethod.displayName,
+          network: payment.token.paymentMethod.network?.rawValue,
+          type: payment.token.paymentMethod.type.primerValue
+        ),
+        transactionIdentifier: payment.token.transactionIdentifier,
+        paymentData: tokenPaymentData
+      )
+    )
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessCardPaymentInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessCardPaymentInteractor.swift
@@ -1,0 +1,52 @@
+//
+//  ProcessCardPaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+struct CardPaymentData {
+  let cardNumber: String
+  let cvv: String
+  let expiryMonth: String
+  let expiryYear: String
+  let cardholderName: String
+  let selectedNetwork: CardNetwork?
+}
+
+protocol ProcessCardPaymentInteractor {
+  func execute(cardData: CardPaymentData) async throws -> PaymentResult
+}
+
+final class ProcessCardPaymentInteractorImpl: ProcessCardPaymentInteractor, LogReporter {
+
+  private let repository: HeadlessRepository
+
+  init(repository: HeadlessRepository) {
+    self.repository = repository
+  }
+
+  func execute(cardData: CardPaymentData) async throws -> PaymentResult {
+    do {
+      let startTime = CFAbsoluteTimeGetCurrent()
+      let result = try await repository.processCardPayment(
+        cardNumber: cardData.cardNumber,
+        cvv: cardData.cvv,
+        expiryMonth: cardData.expiryMonth,
+        expiryYear: cardData.expiryYear,
+        cardholderName: cardData.cardholderName,
+        selectedNetwork: cardData.selectedNetwork
+      )
+
+      let duration = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
+      logger.info(
+        message: "[PERF] Card payment processed in \(String(format: "%.0f", duration))ms: \(result.paymentId)"
+      )
+      return result
+    } catch {
+      logger.error(message: "Card payment processing failed: \(error)", error: error)
+      throw error
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessFormRedirectPaymentInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessFormRedirectPaymentInteractor.swift
@@ -1,0 +1,118 @@
+//
+//  ProcessFormRedirectPaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+protocol ProcessFormRedirectPaymentInteractor {
+
+  /// - Parameter onPollingStarted: Invoked when polling begins, signaling the user needs to complete payment in an external app
+  func execute(
+    paymentMethodType: String,
+    sessionInfo: any OffSessionPaymentSessionInfo,
+    onPollingStarted: (() -> Void)?
+  ) async throws -> PaymentResult
+
+  func cancelPolling(paymentMethodType: String)
+}
+
+@available(iOS 15.0, *)
+final class ProcessFormRedirectPaymentInteractorImpl: ProcessFormRedirectPaymentInteractor, LogReporter {
+
+  private let formRedirectRepository: FormRedirectRepository
+
+  init(formRedirectRepository: FormRedirectRepository) {
+    self.formRedirectRepository = formRedirectRepository
+  }
+
+  func execute(
+    paymentMethodType: String,
+    sessionInfo: any OffSessionPaymentSessionInfo,
+    onPollingStarted: (() -> Void)? = nil
+  ) async throws -> PaymentResult {
+    logger.debug(message: "Executing form redirect payment for \(paymentMethodType)")
+
+    let tokenizationResponse = try await formRedirectRepository.tokenize(
+      paymentMethodType: paymentMethodType,
+      sessionInfo: sessionInfo
+    )
+
+    guard let token = tokenizationResponse.tokenData.token else {
+      let error = PrimerError.invalidValue(key: "token", reason: "Missing token from tokenization")
+      ErrorHandler.handle(error: error)
+      throw error
+    }
+
+    logger.debug(message: "Tokenization completed for \(paymentMethodType)")
+
+    var paymentResponse = try await formRedirectRepository.createPayment(
+      token: token,
+      paymentMethodType: paymentMethodType
+    )
+
+    logger.debug(message: "Payment created with status: \(paymentResponse.status.rawValue)")
+
+    switch paymentResponse.status {
+    case .failed:
+      let error = PrimerError.paymentFailed(
+        paymentMethodType: paymentMethodType,
+        paymentId: paymentResponse.paymentId,
+        orderId: nil,
+        status: paymentResponse.status.rawValue
+      )
+      ErrorHandler.handle(error: error)
+      throw error
+
+    case .pending:
+      if let statusUrl = paymentResponse.statusUrl {
+        onPollingStarted?()
+
+        logger.debug(message: "Polling for payment completion at \(statusUrl.absoluteString)")
+        let resumeToken = try await formRedirectRepository.pollForCompletion(statusUrl: statusUrl)
+        logger.debug(message: "Polling completed for \(paymentMethodType)")
+
+        paymentResponse = try await formRedirectRepository.resumePayment(
+          paymentId: paymentResponse.paymentId,
+          resumeToken: resumeToken,
+          paymentMethodType: paymentMethodType
+        )
+
+        logger.debug(message: "Payment resumed with status: \(paymentResponse.status.rawValue)")
+
+        if paymentResponse.status == .failed {
+          let error = PrimerError.paymentFailed(
+            paymentMethodType: paymentMethodType,
+            paymentId: paymentResponse.paymentId,
+            orderId: nil,
+            status: paymentResponse.status.rawValue
+          )
+          ErrorHandler.handle(error: error)
+          throw error
+        }
+      } else {
+        let error = PrimerError.invalidValue(key: "statusUrl", reason: "Missing status URL for pending payment - cannot start polling")
+        ErrorHandler.handle(error: error)
+        throw error
+      }
+
+    case .success:
+      break
+    }
+
+    return PaymentResult(
+      paymentId: paymentResponse.paymentId,
+      status: .success,
+      token: token,
+      amount: nil,
+      paymentMethodType: paymentMethodType
+    )
+  }
+
+  func cancelPolling(paymentMethodType: String) {
+    let error = PrimerError.cancelled(paymentMethodType: paymentMethodType)
+    formRedirectRepository.cancelPolling(error: error)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessKlarnaPaymentInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessKlarnaPaymentInteractor.swift
@@ -1,0 +1,73 @@
+//
+//  ProcessKlarnaPaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+@available(iOS 15.0, *)
+protocol ProcessKlarnaPaymentInteractor {
+  func createSession() async throws -> KlarnaSessionResult
+  func configureForCategory(clientToken: String, categoryId: String) async throws -> UIView?
+  func authorize() async throws -> KlarnaAuthorizationResult
+  func finalize() async throws -> KlarnaAuthorizationResult
+  func tokenize(authToken: String) async throws -> PaymentResult
+}
+
+@available(iOS 15.0, *)
+final class ProcessKlarnaPaymentInteractorImpl: ProcessKlarnaPaymentInteractor, LogReporter {
+
+  private let repository: KlarnaRepository
+
+  init(repository: KlarnaRepository) {
+    self.repository = repository
+  }
+
+  func createSession() async throws -> KlarnaSessionResult {
+    do {
+      return try await repository.createSession()
+    } catch {
+      logger.error(message: "Klarna session creation failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func configureForCategory(clientToken: String, categoryId: String) async throws -> UIView? {
+    do {
+      return try await repository.configureForCategory(
+        clientToken: clientToken, categoryId: categoryId
+      )
+    } catch {
+      logger.error(message: "Klarna category configuration failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func authorize() async throws -> KlarnaAuthorizationResult {
+    do {
+      return try await repository.authorize()
+    } catch {
+      logger.error(message: "Klarna authorization failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func finalize() async throws -> KlarnaAuthorizationResult {
+    do {
+      return try await repository.finalize()
+    } catch {
+      logger.error(message: "Klarna finalization failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func tokenize(authToken: String) async throws -> PaymentResult {
+    do {
+      return try await repository.tokenize(authToken: authToken)
+    } catch {
+      logger.error(message: "Klarna tokenization failed: \(error)", error: error)
+      throw error
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessPayPalPaymentInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessPayPalPaymentInteractor.swift
@@ -1,0 +1,119 @@
+//
+//  ProcessPayPalPaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+protocol ProcessPayPalPaymentInteractor {
+  func execute() async throws -> PaymentResult
+}
+
+@available(iOS 15.0, *)
+final class ProcessPayPalPaymentInteractorImpl: ProcessPayPalPaymentInteractor, LogReporter {
+
+  private let repository: PayPalRepository
+
+  init(repository: PayPalRepository) {
+    self.repository = repository
+  }
+
+  func execute() async throws -> PaymentResult {
+    let intent = PrimerInternal.shared.intent
+
+    logger.debug(message: "Starting PayPal payment flow with intent: \(String(describing: intent))")
+
+    switch intent {
+    case .vault:
+      return try await executeVaultFlow()
+    case .checkout, .none:
+      return try await executeCheckoutFlow()
+    }
+  }
+
+  private func executeCheckoutFlow() async throws -> PaymentResult {
+    logger.debug(message: "Executing PayPal checkout (order) flow")
+
+    do {
+      // 1. Start order session
+      let (orderId, approvalUrl) = try await repository.startOrderSession()
+      logger.debug(message: "PayPal order session started with orderId: \(orderId)")
+
+      guard let url = URL(string: approvalUrl) else {
+        throw PrimerError.invalidValue(
+          key: "approvalUrl",
+          value: approvalUrl,
+          reason: "Invalid PayPal approval URL"
+        )
+      }
+
+      // 2. Open web authentication
+      _ = try await repository.openWebAuthentication(url: url)
+      logger.debug(message: "PayPal web authentication completed")
+
+      // 3. Fetch payer info
+      let payerInfo = try await repository.fetchPayerInfo(orderId: orderId)
+      logger.debug(message: "PayPal payer info fetched")
+
+      // 4. Tokenize and process payment
+      let result = try await repository.tokenize(
+        paymentInstrument: .order(orderId: orderId, payerInfo: payerInfo)
+      )
+      logger.debug(message: "PayPal checkout payment completed successfully")
+
+      return result
+
+    } catch {
+      logger.error(
+        message: "PayPal checkout flow failed: \(error)",
+        error: error
+      )
+      throw error
+    }
+  }
+
+  private func executeVaultFlow() async throws -> PaymentResult {
+    logger.debug(message: "Executing PayPal vault (billing agreement) flow")
+
+    do {
+      // 1. Start billing agreement session
+      let approvalUrl = try await repository.startBillingAgreementSession()
+      logger.debug(message: "PayPal billing agreement session started")
+
+      guard let url = URL(string: approvalUrl) else {
+        throw PrimerError.invalidValue(
+          key: "approvalUrl",
+          value: approvalUrl,
+          reason: "Invalid PayPal approval URL"
+        )
+      }
+
+      // 2. Open web authentication
+      _ = try await repository.openWebAuthentication(url: url)
+      logger.debug(message: "PayPal web authentication completed")
+
+      // 3. Confirm billing agreement
+      let billingAgreementResult = try await repository.confirmBillingAgreement()
+      logger.debug(
+        message: "PayPal billing agreement confirmed: \(billingAgreementResult.billingAgreementId)"
+      )
+
+      // 4. Tokenize and process payment
+      let result = try await repository.tokenize(
+        paymentInstrument: .billingAgreement(result: billingAgreementResult)
+      )
+      logger.debug(message: "PayPal vault payment completed successfully")
+
+      return result
+
+    } catch {
+      logger.error(
+        message: "PayPal vault flow failed: \(error)",
+        error: error
+      )
+      throw error
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessQRCodePaymentInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessQRCodePaymentInteractor.swift
@@ -1,0 +1,53 @@
+//
+//  ProcessQRCodePaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+protocol ProcessQRCodePaymentInteractor {
+  func startPayment() async throws -> QRCodePaymentData
+  func pollAndComplete(statusUrl: URL, paymentId: String) async throws -> PaymentResult
+  func cancelPolling()
+}
+
+@available(iOS 15.0, *)
+final class ProcessQRCodePaymentInteractorImpl: ProcessQRCodePaymentInteractor, LogReporter {
+
+  private let repository: QRCodeRepository
+  private let paymentMethodType: String
+
+  init(repository: QRCodeRepository, paymentMethodType: String) {
+    self.repository = repository
+    self.paymentMethodType = paymentMethodType
+  }
+
+  func startPayment() async throws -> QRCodePaymentData {
+    do {
+      return try await repository.startPayment(paymentMethodType: paymentMethodType)
+    } catch {
+      logger.error(message: "QR code start payment failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func pollAndComplete(statusUrl: URL, paymentId: String) async throws -> PaymentResult {
+    do {
+      let resumeToken = try await repository.pollForCompletion(statusUrl: statusUrl)
+      return try await repository.resumePayment(
+        paymentId: paymentId,
+        resumeToken: resumeToken,
+        paymentMethodType: paymentMethodType
+      )
+    } catch {
+      logger.error(message: "QR code poll/complete failed: \(error)", error: error)
+      throw error
+    }
+  }
+
+  func cancelPolling() {
+    repository.cancelPolling(paymentMethodType: paymentMethodType)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessWebRedirectPaymentInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ProcessWebRedirectPaymentInteractor.swift
@@ -1,0 +1,110 @@
+//
+//  ProcessWebRedirectPaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+import UIKit
+
+@available(iOS 15.0, *)
+protocol ProcessWebRedirectPaymentInteractor {
+  func execute(paymentMethodType: String) async throws -> PaymentResult
+}
+
+@available(iOS 15.0, *)
+final class ProcessWebRedirectPaymentInteractorImpl: ProcessWebRedirectPaymentInteractor, LogReporter {
+
+  // See: https://developer.vippsmobilepay.com/docs/knowledge-base/user-flow/#deep-link-flow
+  // If changing these values, they must also be updated in `Info.plist` `LSApplicationQueriesSchemes` of the host app.
+  #if DEBUG
+  private static let adyenVippsDeeplinkUrl = "vippsmt://"
+  #else
+  private static let adyenVippsDeeplinkUrl = "vipps://"
+  #endif
+
+  private let repository: WebRedirectRepository
+  private let clientSessionActionsFactory: () -> ClientSessionActionsProtocol
+  private let deeplinkAbilityProvider: DeeplinkAbilityProviding
+
+  init(
+    repository: WebRedirectRepository,
+    clientSessionActionsFactory: @escaping () -> ClientSessionActionsProtocol = { ClientSessionActionsModule() },
+    deeplinkAbilityProvider: DeeplinkAbilityProviding = UIApplication.shared
+  ) {
+    self.repository = repository
+    self.clientSessionActionsFactory = clientSessionActionsFactory
+    self.deeplinkAbilityProvider = deeplinkAbilityProvider
+  }
+
+  func execute(paymentMethodType: String) async throws -> PaymentResult {
+    do {
+      logger.debug(message: "[WebRedirect] Starting payment for: \(paymentMethodType)")
+
+      let clientSessionActions = clientSessionActionsFactory()
+      try await clientSessionActions.selectPaymentMethodIfNeeded(paymentMethodType, cardNetwork: nil)
+
+      try await handlePrimerWillCreatePaymentEvent(paymentMethodType: paymentMethodType)
+
+      let sessionInfo = createSessionInfo(for: paymentMethodType)
+
+      let (redirectUrl, statusUrl) = try await repository.tokenize(
+        paymentMethodType: paymentMethodType,
+        sessionInfo: sessionInfo
+      )
+
+      _ = try await repository.openWebAuthentication(
+        paymentMethodType: paymentMethodType,
+        url: redirectUrl
+      )
+
+      let resumeToken = try await repository.pollForCompletion(statusUrl: statusUrl)
+
+      let result = try await repository.resumePayment(
+        paymentMethodType: paymentMethodType,
+        resumeToken: resumeToken
+      )
+
+      logger.debug(message: "[WebRedirect] Payment completed: \(result.status)")
+      return result
+    } catch {
+      throw handled(error: error)
+    }
+  }
+
+  private func createSessionInfo(for paymentMethodType: String) -> WebRedirectSessionInfo {
+    let localeCode = PrimerSettings.current.localeData.localeCode
+
+    if paymentMethodType == PrimerPaymentMethodType.adyenVipps.rawValue {
+      let vippsAppInstalled = isVippsAppInstalled()
+      if !vippsAppInstalled {
+        return WebRedirectSessionInfo(locale: localeCode, platform: "WEB")
+      }
+    }
+
+    return WebRedirectSessionInfo(locale: localeCode)
+  }
+
+  private func isVippsAppInstalled() -> Bool {
+    guard let url = URL(string: Self.adyenVippsDeeplinkUrl) else {
+      return false
+    }
+    return deeplinkAbilityProvider.canOpenURL(url)
+  }
+
+  private func handlePrimerWillCreatePaymentEvent(paymentMethodType: String) async throws {
+    guard PrimerInternal.shared.intent != .vault else { return }
+
+    let checkoutPaymentMethodType = PrimerCheckoutPaymentMethodType(type: paymentMethodType)
+    let checkoutPaymentMethodData = PrimerCheckoutPaymentMethodData(type: checkoutPaymentMethodType)
+
+    let decision = await PrimerDelegateProxy.primerWillCreatePaymentWithData(checkoutPaymentMethodData)
+
+    switch decision.type {
+    case let .abort(errorMessage):
+      throw PrimerError.merchantError(message: errorMessage ?? "")
+    case .continue:
+      return
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/SubmitVaultedPaymentInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/SubmitVaultedPaymentInteractor.swift
@@ -1,0 +1,49 @@
+//
+//  SubmitVaultedPaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+protocol SubmitVaultedPaymentInteractor {
+  func execute(
+    vaultedPaymentMethodId: String,
+    paymentMethodType: String,
+    additionalData: PrimerVaultedPaymentMethodAdditionalData?
+  ) async throws -> PaymentResult
+}
+
+@available(iOS 15.0, *)
+final class SubmitVaultedPaymentInteractorImpl: SubmitVaultedPaymentInteractor, LogReporter {
+
+  private let repository: HeadlessRepository
+
+  init(repository: HeadlessRepository) {
+    self.repository = repository
+  }
+
+  func execute(
+    vaultedPaymentMethodId: String,
+    paymentMethodType: String,
+    additionalData: PrimerVaultedPaymentMethodAdditionalData?
+  ) async throws -> PaymentResult {
+    do {
+      let startTime = CFAbsoluteTimeGetCurrent()
+      let result = try await repository.processVaultedPayment(
+        vaultedPaymentMethodId: vaultedPaymentMethodId,
+        paymentMethodType: paymentMethodType,
+        additionalData: additionalData
+      )
+      let duration = (CFAbsoluteTimeGetCurrent() - startTime) * 1000
+      logger.info(
+        message: "[PERF] Vaulted payment processed in \(String(format: "%.0f", duration))ms: \(result.paymentId)"
+      )
+      return result
+    } catch {
+      logger.error(message: "[Vault] Vaulted payment processing failed: \(error)", error: error)
+      throw error
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ValidateInputInteractor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/ValidateInputInteractor.swift
@@ -1,0 +1,41 @@
+//
+//  ValidateInputInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+protocol ValidateInputInteractor {
+  func validate(value: String, type: PrimerInputElementType) async -> ValidationResult
+  func validateMultiple(fields: [PrimerInputElementType: String]) async -> [PrimerInputElementType:
+    ValidationResult]
+}
+
+final class ValidateInputInteractorImpl: ValidateInputInteractor, LogReporter {
+
+  private let validationService: ValidationService
+
+  init(validationService: ValidationService) {
+    self.validationService = validationService
+  }
+
+  func validate(value: String, type: PrimerInputElementType) async -> ValidationResult {
+    let result = validationService.validateField(type: type, value: value)
+    if !result.isValid {
+      logger.debug(
+        message: "Validation failed for \(type.stringValue): \(result.errorMessage ?? "Unknown error")"
+      )
+    }
+    return result
+  }
+
+  func validateMultiple(fields: [PrimerInputElementType: String]) async -> [PrimerInputElementType:
+    ValidationResult] {
+    var results: [PrimerInputElementType: ValidationResult] = [:]
+    for (type, value) in fields {
+      results[type] = await validate(value: value, type: type)
+    }
+    return results
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Models/InternalPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Models/InternalPaymentMethod.swift
@@ -1,0 +1,75 @@
+//
+//  InternalPaymentMethod.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+struct InternalPaymentMethod: Equatable {
+  let id: String
+  let type: String
+  let name: String
+  let icon: UIImage?
+  let configId: String?
+  let isEnabled: Bool
+  let supportedCurrencies: [String]?
+  let requiredInputElements: [PrimerInputElementType]
+  let metadata: [String: Any]?
+  let surcharge: Int?
+  let hasUnknownSurcharge: Bool
+  let networkSurcharges: [String: Int]?
+  let backgroundColor: UIColor?
+  let buttonText: String?
+  let textColor: UIColor?
+  let borderColor: UIColor?
+  let borderWidth: CGFloat?
+  let cornerRadius: CGFloat?
+
+  init(
+    id: String,
+    type: String,
+    name: String,
+    icon: UIImage? = nil,
+    configId: String? = nil,
+    isEnabled: Bool = true,
+    supportedCurrencies: [String]? = nil,
+    requiredInputElements: [PrimerInputElementType] = [],
+    metadata: [String: Any]? = nil,
+    surcharge: Int? = nil,
+    hasUnknownSurcharge: Bool = false,
+    networkSurcharges: [String: Int]? = nil,
+    backgroundColor: UIColor? = nil,
+    buttonText: String? = nil,
+    textColor: UIColor? = nil,
+    borderColor: UIColor? = nil,
+    borderWidth: CGFloat? = nil,
+    cornerRadius: CGFloat? = nil
+  ) {
+    self.id = id
+    self.type = type
+    self.name = name
+    self.icon = icon
+    self.configId = configId
+    self.isEnabled = isEnabled
+    self.supportedCurrencies = supportedCurrencies
+    self.requiredInputElements = requiredInputElements
+    self.metadata = metadata
+    self.surcharge = surcharge
+    self.hasUnknownSurcharge = hasUnknownSurcharge
+    self.networkSurcharges = networkSurcharges
+    self.backgroundColor = backgroundColor
+    self.buttonText = buttonText
+    self.textColor = textColor
+    self.borderColor = borderColor
+    self.borderWidth = borderWidth
+    self.cornerRadius = cornerRadius
+  }
+
+  static func == (lhs: InternalPaymentMethod, rhs: InternalPaymentMethod) -> Bool {
+    lhs.id == rhs.id && lhs.type == rhs.type && lhs.name == rhs.name
+      && lhs.isEnabled == rhs.isEnabled && lhs.surcharge == rhs.surcharge
+      && lhs.hasUnknownSurcharge == rhs.hasUnknownSurcharge
+      && lhs.backgroundColor == rhs.backgroundColor
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Models/PaymentResult.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Models/PaymentResult.swift
@@ -40,6 +40,7 @@ public struct PaymentResult {
   }
 }
 
+/// When switching on this enum, always include a `default` case to handle future additions.
 public enum PaymentStatus {
   case pending
   case processing

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Models/PaymentResult.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Models/PaymentResult.swift
@@ -1,0 +1,60 @@
+//
+//  PaymentResult.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+public struct PaymentResult {
+  public let paymentId: String
+  public let status: PaymentStatus
+  public let token: String?
+  public let redirectUrl: String?
+  public let errorMessage: String?
+  public let metadata: [String: Any]?
+  public let amount: Int?
+  public let currencyCode: String?
+  public let paymentMethodType: String?
+
+  public init(
+    paymentId: String,
+    status: PaymentStatus,
+    token: String? = nil,
+    redirectUrl: String? = nil,
+    errorMessage: String? = nil,
+    metadata: [String: Any]? = nil,
+    amount: Int? = nil,
+    currencyCode: String? = nil,
+    paymentMethodType: String? = nil
+  ) {
+    self.paymentId = paymentId
+    self.status = status
+    self.token = token
+    self.redirectUrl = redirectUrl
+    self.errorMessage = errorMessage
+    self.metadata = metadata
+    self.amount = amount
+    self.currencyCode = currencyCode
+    self.paymentMethodType = paymentMethodType
+  }
+}
+
+public enum PaymentStatus {
+  case pending
+  case processing
+  case authorized
+  case success
+  case failed
+  case cancelled
+  case requires3DS
+  case requiresAction
+
+  init(from apiStatus: Response.Body.Payment.Status) {
+    switch apiStatus {
+    case .success: self = .success
+    case .pending: self = .pending
+    case .failed: self = .failed
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/AchRepository.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/AchRepository.swift
@@ -1,0 +1,56 @@
+//
+//  AchRepository.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+@available(iOS 15.0, *)
+struct AchUserDetailsResult {
+  let firstName: String
+  let lastName: String
+  let emailAddress: String
+}
+
+@available(iOS 15.0, *)
+struct AchMandateResult {
+  let fullMandateText: String?
+  let templateMandateText: String?
+}
+
+@available(iOS 15.0, *)
+struct AchStripeData {
+  let stripeClientSecret: String
+  let sdkCompleteUrl: URL
+  let paymentId: String
+  let decodedJWTToken: DecodedJWTToken
+}
+
+@available(iOS 15.0, *)
+@MainActor
+protocol AchRepository {
+  func loadUserDetails() async throws -> AchUserDetailsResult
+  func patchUserDetails(firstName: String, lastName: String, emailAddress: String) async throws
+  func validate() async throws
+  func startPaymentAndGetStripeData() async throws -> AchStripeData
+  func createBankCollector(
+    firstName: String,
+    lastName: String,
+    emailAddress: String,
+    clientSecret: String,
+    delegate: AchBankCollectorDelegate
+  ) async throws -> UIViewController
+  func getMandateData() async throws -> AchMandateResult
+  func tokenize() async throws -> PrimerPaymentMethodTokenData
+  func createPayment(tokenData: PrimerPaymentMethodTokenData) async throws -> PaymentResult
+  func completePayment(stripeData: AchStripeData) async throws -> PaymentResult
+}
+
+@available(iOS 15.0, *)
+@MainActor
+protocol AchBankCollectorDelegate: AnyObject {
+  func achBankCollectorDidSucceed(paymentId: String)
+  func achBankCollectorDidCancel()
+  func achBankCollectorDidFail(error: PrimerError)
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/FormRedirectRepository.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/FormRedirectRepository.swift
@@ -1,0 +1,35 @@
+//
+//  FormRedirectRepository.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+protocol FormRedirectRepository {
+    func tokenize(
+        paymentMethodType: String,
+        sessionInfo: any OffSessionPaymentSessionInfo
+    ) async throws -> FormRedirectTokenizationResponse
+
+    func createPayment(token: String, paymentMethodType: String) async throws -> FormRedirectPaymentResponse
+
+    func resumePayment(paymentId: String, resumeToken: String, paymentMethodType: String) async throws -> FormRedirectPaymentResponse
+
+    func pollForCompletion(statusUrl: URL) async throws -> String
+
+    func cancelPolling(error: PrimerError)
+}
+
+@available(iOS 15.0, *)
+struct FormRedirectTokenizationResponse {
+    let tokenData: PrimerPaymentMethodTokenData
+}
+
+@available(iOS 15.0, *)
+struct FormRedirectPaymentResponse {
+    let paymentId: String
+    let status: Response.Body.Payment.Status
+    let statusUrl: URL?
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/HeadlessRepository.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/HeadlessRepository.swift
@@ -1,0 +1,31 @@
+//
+//  HeadlessRepository.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+protocol HeadlessRepository {
+  func getPaymentMethods() async throws -> [InternalPaymentMethod]
+  func processCardPayment(
+    cardNumber: String,
+    cvv: String,
+    expiryMonth: String,
+    expiryYear: String,
+    cardholderName: String,
+    selectedNetwork: CardNetwork?
+  ) async throws -> PaymentResult
+  func getNetworkDetectionStream() -> AsyncStream<[CardNetwork]>
+  func getBinDataStream() -> AsyncStream<PrimerBinData>
+  func updateCardNumberInRawDataManager(_ cardNumber: String) async
+  func selectCardNetwork(_ cardNetwork: CardNetwork) async
+  func fetchVaultedPaymentMethods() async throws -> [PrimerHeadlessUniversalCheckout
+    .VaultedPaymentMethod]
+  func processVaultedPayment(
+    vaultedPaymentMethodId: String,
+    paymentMethodType: String,
+    additionalData: PrimerVaultedPaymentMethodAdditionalData?
+  ) async throws -> PaymentResult
+  func deleteVaultedPaymentMethod(_ id: String) async throws
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/HeadlessRepository.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/HeadlessRepository.swift
@@ -16,8 +16,8 @@ protocol HeadlessRepository {
     cardholderName: String,
     selectedNetwork: CardNetwork?
   ) async throws -> PaymentResult
-  func getNetworkDetectionStream() -> AsyncStream<[CardNetwork]>
-  func getBinDataStream() -> AsyncStream<PrimerBinData>
+  nonisolated func getNetworkDetectionStream() -> AsyncStream<[CardNetwork]>
+  nonisolated func getBinDataStream() -> AsyncStream<PrimerBinData>
   func updateCardNumberInRawDataManager(_ cardNumber: String) async
   func selectCardNetwork(_ cardNetwork: CardNetwork) async
   func fetchVaultedPaymentMethods() async throws -> [PrimerHeadlessUniversalCheckout

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/KlarnaRepository.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/KlarnaRepository.swift
@@ -1,0 +1,31 @@
+//
+//  KlarnaRepository.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+@available(iOS 15.0, *)
+struct KlarnaSessionResult {
+  let clientToken: String
+  let sessionId: String
+  let categories: [KlarnaPaymentCategory]
+  let hppSessionId: String?
+}
+
+@available(iOS 15.0, *)
+enum KlarnaAuthorizationResult: Equatable {
+  case approved(authToken: String)
+  case finalizationRequired(authToken: String)
+  case declined
+}
+
+@available(iOS 15.0, *)
+@MainActor protocol KlarnaRepository {
+  func createSession() async throws -> KlarnaSessionResult
+  func configureForCategory(clientToken: String, categoryId: String) async throws -> UIView?
+  func authorize() async throws -> KlarnaAuthorizationResult
+  func finalize() async throws -> KlarnaAuthorizationResult
+  func tokenize(authToken: String) async throws -> PaymentResult
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/PayPalRepository.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/PayPalRepository.swift
@@ -1,0 +1,50 @@
+//
+//  PayPalRepository.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+struct PayPalBillingAgreementResult: Equatable {
+  let billingAgreementId: String
+  let externalPayerInfo: PayPalPayerInfo?
+  let shippingAddress: PayPalShippingAddress?
+}
+
+@available(iOS 15.0, *)
+struct PayPalPayerInfo: Equatable {
+  let externalPayerId: String?
+  let email: String?
+  let firstName: String?
+  let lastName: String?
+}
+
+@available(iOS 15.0, *)
+struct PayPalShippingAddress: Equatable {
+  let firstName: String?
+  let lastName: String?
+  let addressLine1: String?
+  let addressLine2: String?
+  let city: String?
+  let state: String?
+  let countryCode: String?
+  let postalCode: String?
+}
+
+@available(iOS 15.0, *)
+enum PayPalPaymentInstrumentData {
+  case order(orderId: String, payerInfo: PayPalPayerInfo?)
+  case billingAgreement(result: PayPalBillingAgreementResult)
+}
+
+@available(iOS 15.0, *)
+protocol PayPalRepository {
+  func startOrderSession() async throws -> (orderId: String, approvalUrl: String)
+  func startBillingAgreementSession() async throws -> String
+  func openWebAuthentication(url: URL) async throws -> URL
+  func confirmBillingAgreement() async throws -> PayPalBillingAgreementResult
+  func fetchPayerInfo(orderId: String) async throws -> PayPalPayerInfo
+  func tokenize(paymentInstrument: PayPalPaymentInstrumentData) async throws -> PaymentResult
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/QRCodeRepository.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/QRCodeRepository.swift
@@ -1,0 +1,24 @@
+//
+//  QRCodeRepository.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+struct QRCodePaymentData {
+  let qrCodeImageData: Data
+  let statusUrl: URL
+  let paymentId: String
+}
+
+@available(iOS 15.0, *)
+protocol QRCodeRepository {
+  func startPayment(paymentMethodType: String) async throws -> QRCodePaymentData
+  func pollForCompletion(statusUrl: URL) async throws -> String
+  func resumePayment(
+    paymentId: String, resumeToken: String, paymentMethodType: String
+  ) async throws -> PaymentResult
+  func cancelPolling(paymentMethodType: String)
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/WebRedirectRepository.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Repositories/WebRedirectRepository.swift
@@ -1,0 +1,20 @@
+//
+//  WebRedirectRepository.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+protocol WebRedirectRepository {
+    func tokenize(
+        paymentMethodType: String, sessionInfo: WebRedirectSessionInfo
+    ) async throws -> (redirectUrl: URL, statusUrl: URL)
+    func openWebAuthentication(paymentMethodType: String, url: URL) async throws -> URL
+    func pollForCompletion(statusUrl: URL) async throws -> String
+    func resumePayment(
+        paymentMethodType: String, resumeToken: String
+    ) async throws -> PaymentResult
+    func cancelPolling(paymentMethodType: String)
+}

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEvent.swift
@@ -33,11 +33,9 @@ extension Analytics {
         let integrationType: String
         let minDeploymentTarget: String
 
-        fileprivate init(
-            eventType: Analytics.Event.EventType,
-            properties: AnalyticsEventProperties?,
-            analyticsUrl: String? = PrimerAPIConfigurationModule.decodedJWTToken?.analyticsUrlV2
-        ) {
+        fileprivate init(eventType: Analytics.Event.EventType,
+                         properties: AnalyticsEventProperties?,
+                         analyticsUrl: String? = PrimerAPIConfigurationModule.decodedJWTToken?.analyticsUrlV2) {
             self.analyticsUrl = analyticsUrl
             localId = String.randomString(length: 32)
 
@@ -785,13 +783,11 @@ extension Analytics.Event {
         )
     }
 
-    static func message(
-        message: String?,
-        messageType: Property.MessageType,
-        severity: Property.Severity,
-        diagnosticsId: String? = nil,
-        context: [String: Any]? = nil
-    ) -> Self {
+    static func message(message: String?,
+                        messageType: Property.MessageType,
+                        severity: Property.Severity,
+                        diagnosticsId: String? = nil,
+                        context: [String: Any]? = nil) -> Self {
         .init(
             eventType: .message,
             properties: MessageEventProperties(
@@ -804,15 +800,13 @@ extension Analytics.Event {
         )
     }
 
-    static func ui(
-        action: Property.Action,
-        context: Property.Context?,
-        extra: String?,
-        objectType: Property.ObjectType,
-        objectId: Property.ObjectId?,
-        objectClass: String?,
-        place: Property.Place
-    ) -> Self {
+    static func ui(action: Property.Action,
+                   context: Property.Context?,
+                   extra: String?,
+                   objectType: Property.ObjectType,
+                   objectId: Property.ObjectId?,
+                   objectClass: String?,
+                   place: Property.Place) -> Self {
         .init(
             eventType: .ui,
             properties: UIEventProperties(
@@ -822,20 +816,17 @@ extension Analytics.Event {
                 objectType: objectType,
                 objectId: objectId,
                 objectClass: objectClass,
-                place: place
-            )
+                place: place)
         )
     }
 
-    static func networkCall(
-        callType: Property.NetworkCallType,
-        id: String,
-        url: String,
-        method: HTTPMethod,
-        errorBody: String?,
-        responseCode: Int?,
-        duration: TimeInterval? = nil
-    ) -> Self {
+    static func networkCall(callType: Property.NetworkCallType,
+                            id: String,
+                            url: String,
+                            method: HTTPMethod,
+                            errorBody: String?,
+                            responseCode: Int?,
+                            duration: TimeInterval? = nil) -> Self {
         .init(
             eventType: .networkCall,
             properties: NetworkCallEventProperties(
@@ -864,12 +855,10 @@ extension Analytics.Event {
         )
     }
 
-    static func timer(
-        momentType: Property.TimerType,
-        id: String?,
-        duration: TimeInterval? = nil,
-        context: [String: Any]? = nil
-    ) -> Self {
+    static func timer(momentType: Property.TimerType,
+                      id: String?,
+                      duration: TimeInterval? = nil,
+                      context: [String: Any]? = nil) -> Self {
         .init(
             eventType: .timerEvent,
             properties: TimerEventProperties(
@@ -887,16 +876,12 @@ extension Analytics.Event {
         case vaultManager = "VAULT_MANAGER"
     }
 
-    static func dropInLoading(
-        duration: Int,
-        source: DropInLoadingSource
-    ) -> Self {
-        .timer(
-            momentType: .end,
-            id: "DROP_IN_LOADING",
-            duration: TimeInterval(duration),
-            context: ["source": source.rawValue]
-        )
+    static func dropInLoading(duration: Int,
+                              source: DropInLoadingSource) -> Self {
+        .timer(momentType: .end,
+               id: "DROP_IN_LOADING",
+               duration: TimeInterval(duration),
+               context: ["source": source.rawValue])
     }
 
     static func headlessLoading(duration: Int) -> Self {
@@ -908,22 +893,15 @@ extension Analytics.Event {
         case network = "NETWORK"
     }
 
-    static func configurationLoading(
-        duration: Int,
-        source: ConfigurationLoadingSource
-    ) -> Self {
-        .timer(
-            momentType: .end,
-            id: "CONFIGURATION_LOADING",
-            duration: TimeInterval(duration),
-            context: ["source": source.rawValue]
-        )
+    static func configurationLoading(duration: Int,
+                                     source: ConfigurationLoadingSource) -> Self {
+        .timer(momentType: .end, id: "CONFIGURATION_LOADING",
+               duration: TimeInterval(duration),
+               context: ["source": source.rawValue])
     }
 
-    static func allImagesLoading(
-        momentType: Property.TimerType,
-        id: String?
-    ) -> Self {
+    static func allImagesLoading(momentType: Property.TimerType,
+                                 id: String?) -> Self {
         .init(
             eventType: .paymentMethodAllImagesLoading,
             properties: TimerEventProperties(
@@ -933,10 +911,8 @@ extension Analytics.Event {
         )
     }
 
-    static func imageLoading(
-        momentType: Property.TimerType,
-        id: String?
-    ) -> Self {
+    static func imageLoading(momentType: Property.TimerType,
+                             id: String?) -> Self {
         .init(
             eventType: .paymentMethodImageLoading,
             properties: TimerEventProperties(

--- a/Sources/PrimerSDK/Classes/Core/Logging/PrimerLogger.swift
+++ b/Sources/PrimerSDK/Classes/Core/Logging/PrimerLogger.swift
@@ -52,46 +52,38 @@ public protocol PrimerLogger {
 
 extension PrimerLogger {
 
-    public func debug(
-        message: String,
-        userInfo: Encodable? = nil,
-        file: String = #file,
-        line: Int = #line,
-        function: String = #function
-    ) {
+    public func debug(message: String,
+                      userInfo: Encodable? = nil,
+                      file: String = #file,
+                      line: Int = #line,
+                      function: String = #function) {
         let metadata = PrimerLogMetadata(file: file, line: line, function: function)
         logProxy(level: .debug, message: message, userInfo: userInfo, metadata: metadata)
     }
 
-    public func info(
-        message: String,
-        userInfo: Encodable? = nil,
-        file: String = #file,
-        line: Int = #line,
-        function: String = #function
-    ) {
+    public func info(message: String,
+                     userInfo: Encodable? = nil,
+                     file: String = #file,
+                     line: Int = #line,
+                     function: String = #function) {
         let metadata = PrimerLogMetadata(file: file, line: line, function: function)
         logProxy(level: .info, message: message, userInfo: userInfo, metadata: metadata)
     }
 
-    public func warn(
-        message: String,
-        userInfo: Encodable? = nil,
-        file: String = #file,
-        line: Int = #line,
-        function: String = #function
-    ) {
+    public func warn(message: String,
+                     userInfo: Encodable? = nil,
+                     file: String = #file,
+                     line: Int = #line,
+                     function: String = #function) {
         let metadata = PrimerLogMetadata(file: file, line: line, function: function)
         logProxy(level: .warning, message: message, userInfo: userInfo, metadata: metadata)
     }
 
-    public func error(
-        message: String,
-        userInfo: Encodable? = nil,
-        file: String = #file,
-        line: Int = #line,
-        function: String = #function
-    ) {
+    public func error(message: String,
+                      userInfo: Encodable? = nil,
+                      file: String = #file,
+                      line: Int = #line,
+                      function: String = #function) {
         let metadata = PrimerLogMetadata(file: file, line: line, function: function)
         logProxy(level: .error, message: message, userInfo: userInfo, metadata: metadata)
     }
@@ -152,23 +144,18 @@ extension PrimerLogger {
         }
     }
 
-    private func logUserInfo(
-        level: LogLevel,
-        userInfo: Encodable?,
-        metadata: PrimerLogMetadata
-    ) {
+    private func logUserInfo(level: LogLevel,
+                             userInfo: Encodable?, metadata: PrimerLogMetadata) {
         guard let userInfo, let dictionary = try? userInfo.asDictionary() else {
             return
         }
         logProxy(level: level, message: dictionary.debugDescription, userInfo: nil, metadata: metadata)
     }
 
-    private func logProxy(
-        level: LogLevel,
-        message: String,
-        userInfo: Encodable?,
-        metadata: PrimerLogMetadata
-    ) {
+    private func logProxy(level: LogLevel,
+                          message: String,
+                          userInfo: Encodable?,
+                          metadata: PrimerLogMetadata) {
         // Currently we only send logs for debug builds to avoid transmission of PII / PCI data in production
         #if DEBUG
         guard level.rawValue >= logLevel.rawValue else { return }

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerDelegate.swift
@@ -60,10 +60,8 @@ final class PrimerDelegateProxy: LogReporter {
             if PrimerInternal.shared.sdkIntegrationType == .headless,
                (decisionHandler as ((PrimerHeadlessUniversalCheckoutResumeDecision) -> Void)?) != nil {
                 let delegate = PrimerHeadlessUniversalCheckout.current.delegate
-                delegate?.primerHeadlessUniversalCheckoutDidTokenizePaymentMethod?(
-                    paymentMethodTokenData,
-                    decisionHandler: decisionHandler
-                )
+                delegate?.primerHeadlessUniversalCheckoutDidTokenizePaymentMethod?(paymentMethodTokenData,
+                                                                                   decisionHandler: decisionHandler)
 
             } else if PrimerInternal.shared.sdkIntegrationType == .dropIn,
                       (decisionHandler as ((PrimerResumeDecision) -> Void)?) != nil {
@@ -95,10 +93,8 @@ final class PrimerDelegateProxy: LogReporter {
         DispatchQueue.main.async {
             if PrimerInternal.shared.sdkIntegrationType == .headless,
                (decisionHandler as ((PrimerHeadlessUniversalCheckoutResumeDecision) -> Void)?) != nil {
-                PrimerHeadlessUniversalCheckout.current.delegate?.primerHeadlessUniversalCheckoutDidResumeWith?(
-                    resumeToken,
-                    decisionHandler: decisionHandler
-                )
+                PrimerHeadlessUniversalCheckout.current.delegate?.primerHeadlessUniversalCheckoutDidResumeWith?(resumeToken,
+                                                                                                                decisionHandler: decisionHandler)
             } else if PrimerInternal.shared.sdkIntegrationType == .dropIn,
                       (decisionHandler as ((PrimerResumeDecision) -> Void)?) != nil {
                 Primer.shared.delegate?.primerDidResumeWith?(resumeToken, decisionHandler: decisionHandler)
@@ -132,10 +128,8 @@ final class PrimerDelegateProxy: LogReporter {
             if PrimerInternal.shared.sdkIntegrationType == .headless {
                 let delegate = PrimerHeadlessUniversalCheckout.current.delegate
                 if delegate?.primerHeadlessUniversalCheckoutWillCreatePaymentWithData != nil {
-                    delegate?.primerHeadlessUniversalCheckoutWillCreatePaymentWithData?(
-                        data,
-                        decisionHandler: decisionHandler
-                    )
+                    delegate?.primerHeadlessUniversalCheckoutWillCreatePaymentWithData?(data,
+                                                                                        decisionHandler: decisionHandler)
                 } else {
                     decisionHandler(.continuePaymentCreation())
                 }
@@ -296,10 +290,8 @@ final class PrimerDelegateProxy: LogReporter {
 
                 } else {
                     let delegate = PrimerHeadlessUniversalCheckout.current.delegate
-                    delegate?.primerHeadlessUniversalCheckoutDidFail!(
-                        withError: exposedError,
-                        checkoutData: data
-                    )
+                    delegate?.primerHeadlessUniversalCheckoutDidFail!(withError: exposedError,
+                                                                      checkoutData: data)
                     decisionHandler(.fail(withErrorMessage: nil))
                 }
 

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerSettings.swift
@@ -192,13 +192,11 @@ public final class PrimerApplePayOptions: Codable {
     let shippingOptions: ShippingOptions?
     let billingOptions: BillingOptions?
 
-    public init(
-        merchantIdentifier: String,
-        merchantName: String?,
-        isCaptureBillingAddressEnabled: Bool = false,
-        showApplePayForUnsupportedDevice: Bool = true,
-        checkProvidedNetworks: Bool = true
-    ) {
+    public init(merchantIdentifier: String,
+                merchantName: String?,
+                isCaptureBillingAddressEnabled: Bool = false,
+                showApplePayForUnsupportedDevice: Bool = true,
+                checkProvidedNetworks: Bool = true) {
         self.merchantIdentifier = merchantIdentifier
         self.merchantName = merchantName
         self.isCaptureBillingAddressEnabled = isCaptureBillingAddressEnabled
@@ -208,15 +206,13 @@ public final class PrimerApplePayOptions: Codable {
         billingOptions = nil
     }
 
-    public init(
-        merchantIdentifier: String,
-        merchantName: String?,
-        isCaptureBillingAddressEnabled: Bool = false,
-        showApplePayForUnsupportedDevice: Bool = true,
-        checkProvidedNetworks: Bool = true,
-        shippingOptions: ShippingOptions? = nil,
-        billingOptions: BillingOptions? = nil
-    ) {
+    public init(merchantIdentifier: String,
+                merchantName: String?,
+                isCaptureBillingAddressEnabled: Bool = false,
+                showApplePayForUnsupportedDevice: Bool = true,
+                checkProvidedNetworks: Bool = true,
+                shippingOptions: ShippingOptions? = nil,
+                billingOptions: BillingOptions? = nil) {
         self.merchantIdentifier = merchantIdentifier
         self.merchantName = merchantName
         self.isCaptureBillingAddressEnabled = isCaptureBillingAddressEnabled
@@ -230,10 +226,8 @@ public final class PrimerApplePayOptions: Codable {
         public let shippingContactFields: [RequiredContactField]?
         public let requireShippingMethod: Bool
 
-        public init(
-            shippingContactFields: [RequiredContactField]? = nil,
-            requireShippingMethod: Bool
-        ) {
+        public init(shippingContactFields: [RequiredContactField]? = nil,
+                    requireShippingMethod: Bool) {
             self.shippingContactFields = shippingContactFields
             self.requireShippingMethod = requireShippingMethod
         }

--- a/Tests/Primer/CheckoutComponents/Domain/Interactors/ProcessPayPalPaymentInteractorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Domain/Interactors/ProcessPayPalPaymentInteractorTests.swift
@@ -1,0 +1,430 @@
+//
+//  ProcessPayPalPaymentInteractorTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class ProcessPayPalPaymentInteractorTests: XCTestCase {
+
+    private var mockRepository: MockPayPalRepository!
+    private var sut: ProcessPayPalPaymentInteractorImpl!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        mockRepository = MockPayPalRepository()
+        sut = ProcessPayPalPaymentInteractorImpl(repository: mockRepository)
+    }
+
+    override func tearDown() async throws {
+        PrimerInternal.shared.intent = nil
+        mockRepository = nil
+        sut = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Mock Repository
+
+    private final class MockPayPalRepository: PayPalRepository {
+        var startOrderSessionResult: Result<(orderId: String, approvalUrl: String), Error> = .success(("order-123", "https://paypal.com/approve"))
+        var startBillingAgreementSessionResult: Result<String, Error> = .success("https://paypal.com/billing")
+        var openWebAuthenticationResult: Result<URL, Error> = .success(URL(string: "https://callback.com")!)
+        var confirmBillingAgreementResult: Result<PayPalBillingAgreementResult, Error> = .success(
+            PayPalBillingAgreementResult(
+                billingAgreementId: "ba-123",
+                externalPayerInfo: nil,
+                shippingAddress: nil
+            )
+        )
+        var fetchPayerInfoResult: Result<PayPalPayerInfo, Error> = .success(
+            PayPalPayerInfo(
+                externalPayerId: "payer-123",
+                email: "test@example.com",
+                firstName: "John",
+                lastName: "Doe"
+            )
+        )
+        var tokenizeResult: Result<PaymentResult, Error> = .success(
+            PaymentResult(paymentId: "payment-123", status: .success)
+        )
+
+        var startOrderSessionCalled = false
+        var startBillingAgreementSessionCalled = false
+        var openWebAuthenticationCalled = false
+        var openWebAuthenticationURL: URL?
+        var confirmBillingAgreementCalled = false
+        var fetchPayerInfoCalled = false
+        var fetchPayerInfoOrderId: String?
+        var tokenizeCalled = false
+        var tokenizePaymentInstrument: PayPalPaymentInstrumentData?
+
+        func startOrderSession() async throws -> (orderId: String, approvalUrl: String) {
+            startOrderSessionCalled = true
+            return try startOrderSessionResult.get()
+        }
+
+        func startBillingAgreementSession() async throws -> String {
+            startBillingAgreementSessionCalled = true
+            return try startBillingAgreementSessionResult.get()
+        }
+
+        func openWebAuthentication(url: URL) async throws -> URL {
+            openWebAuthenticationCalled = true
+            openWebAuthenticationURL = url
+            return try openWebAuthenticationResult.get()
+        }
+
+        func confirmBillingAgreement() async throws -> PayPalBillingAgreementResult {
+            confirmBillingAgreementCalled = true
+            return try confirmBillingAgreementResult.get()
+        }
+
+        func fetchPayerInfo(orderId: String) async throws -> PayPalPayerInfo {
+            fetchPayerInfoCalled = true
+            fetchPayerInfoOrderId = orderId
+            return try fetchPayerInfoResult.get()
+        }
+
+        func tokenize(paymentInstrument: PayPalPaymentInstrumentData) async throws -> PaymentResult {
+            tokenizeCalled = true
+            tokenizePaymentInstrument = paymentInstrument
+            return try tokenizeResult.get()
+        }
+    }
+
+    // MARK: - Checkout Flow Tests
+
+    func test_execute_withCheckoutIntent_executesCheckoutFlow() async throws {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertTrue(mockRepository.startOrderSessionCalled)
+        XCTAssertTrue(mockRepository.openWebAuthenticationCalled)
+        XCTAssertTrue(mockRepository.fetchPayerInfoCalled)
+        XCTAssertTrue(mockRepository.tokenizeCalled)
+        XCTAssertFalse(mockRepository.startBillingAgreementSessionCalled)
+        XCTAssertFalse(mockRepository.confirmBillingAgreementCalled)
+        XCTAssertEqual(result.paymentId, "payment-123")
+        XCTAssertEqual(result.status, .success)
+    }
+
+    func test_execute_withNilIntent_executesCheckoutFlow() async throws {
+        // Given
+        PrimerInternal.shared.intent = nil
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertTrue(mockRepository.startOrderSessionCalled)
+        XCTAssertTrue(mockRepository.openWebAuthenticationCalled)
+        XCTAssertTrue(mockRepository.fetchPayerInfoCalled)
+        XCTAssertTrue(mockRepository.tokenizeCalled)
+        XCTAssertEqual(result.paymentId, "payment-123")
+    }
+
+    func test_execute_checkoutFlow_passesCorrectOrderIdToFetchPayerInfo() async throws {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        mockRepository.startOrderSessionResult = .success(("custom-order-id", "https://paypal.com/approve"))
+
+        // When
+        _ = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(mockRepository.fetchPayerInfoOrderId, "custom-order-id")
+    }
+
+    func test_execute_checkoutFlow_passesCorrectURLToWebAuthentication() async throws {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        mockRepository.startOrderSessionResult = .success(("order-123", "https://paypal.com/custom-approve"))
+
+        // When
+        _ = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(mockRepository.openWebAuthenticationURL?.absoluteString, "https://paypal.com/custom-approve")
+    }
+
+    func test_execute_checkoutFlow_tokenizesWithOrderPaymentInstrument() async throws {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        mockRepository.startOrderSessionResult = .success(("order-456", "https://paypal.com/approve"))
+        let expectedPayerInfo = PayPalPayerInfo(
+            externalPayerId: "payer-xyz",
+            email: "user@test.com",
+            firstName: "Jane",
+            lastName: "Smith"
+        )
+        mockRepository.fetchPayerInfoResult = .success(expectedPayerInfo)
+
+        // When
+        _ = try await sut.execute()
+
+        // Then
+        guard case let .order(orderId, payerInfo) = mockRepository.tokenizePaymentInstrument else {
+            XCTFail("Expected order payment instrument")
+            return
+        }
+        XCTAssertEqual(orderId, "order-456")
+        XCTAssertEqual(payerInfo?.email, "user@test.com")
+        XCTAssertEqual(payerInfo?.firstName, "Jane")
+    }
+
+    // MARK: - Vault Flow Tests
+
+    func test_execute_withVaultIntent_executesVaultFlow() async throws {
+        // Given
+        PrimerInternal.shared.intent = .vault
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertTrue(mockRepository.startBillingAgreementSessionCalled)
+        XCTAssertTrue(mockRepository.openWebAuthenticationCalled)
+        XCTAssertTrue(mockRepository.confirmBillingAgreementCalled)
+        XCTAssertTrue(mockRepository.tokenizeCalled)
+        XCTAssertFalse(mockRepository.startOrderSessionCalled)
+        XCTAssertFalse(mockRepository.fetchPayerInfoCalled)
+        XCTAssertEqual(result.paymentId, "payment-123")
+        XCTAssertEqual(result.status, .success)
+    }
+
+    func test_execute_vaultFlow_passesCorrectURLToWebAuthentication() async throws {
+        // Given
+        PrimerInternal.shared.intent = .vault
+        mockRepository.startBillingAgreementSessionResult = .success("https://paypal.com/vault-approval")
+
+        // When
+        _ = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(mockRepository.openWebAuthenticationURL?.absoluteString, "https://paypal.com/vault-approval")
+    }
+
+    func test_execute_vaultFlow_tokenizesWithBillingAgreementPaymentInstrument() async throws {
+        // Given
+        PrimerInternal.shared.intent = .vault
+        let expectedResult = PayPalBillingAgreementResult(
+            billingAgreementId: "ba-789",
+            externalPayerInfo: PayPalPayerInfo(
+                externalPayerId: "vault-payer",
+                email: "vault@test.com",
+                firstName: "Vault",
+                lastName: "User"
+            ),
+            shippingAddress: nil
+        )
+        mockRepository.confirmBillingAgreementResult = .success(expectedResult)
+
+        // When
+        _ = try await sut.execute()
+
+        // Then
+        guard case let .billingAgreement(result) = mockRepository.tokenizePaymentInstrument else {
+            XCTFail("Expected billing agreement payment instrument")
+            return
+        }
+        XCTAssertEqual(result.billingAgreementId, "ba-789")
+        XCTAssertEqual(result.externalPayerInfo?.email, "vault@test.com")
+    }
+
+    // MARK: - Error Handling Tests
+
+    func test_execute_checkoutFlow_throwsErrorForInvalidApprovalURL() async {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        // Empty string produces nil from URL(string:)
+        mockRepository.startOrderSessionResult = .success(("order-123", ""))
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch let error as PrimerError {
+            switch error {
+            case let .invalidValue(key, _, _, _):
+                XCTAssertEqual(key, "approvalUrl")
+            default:
+                XCTFail("Expected invalidValue error, got: \(error)")
+            }
+        } catch {
+            XCTFail("Expected PrimerError, got: \(error)")
+        }
+    }
+
+    func test_execute_vaultFlow_throwsErrorForInvalidApprovalURL() async {
+        // Given
+        PrimerInternal.shared.intent = .vault
+        mockRepository.startBillingAgreementSessionResult = .success("")
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch let error as PrimerError {
+            switch error {
+            case let .invalidValue(key, _, _, _):
+                XCTAssertEqual(key, "approvalUrl")
+            default:
+                XCTFail("Expected invalidValue error, got: \(error)")
+            }
+        } catch {
+            XCTFail("Expected PrimerError, got: \(error)")
+        }
+    }
+
+    func test_execute_checkoutFlow_propagatesStartOrderSessionError() async {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        let expectedError = NSError(domain: "test", code: 100, userInfo: nil)
+        mockRepository.startOrderSessionResult = .failure(expectedError)
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual((error as NSError).code, 100)
+        }
+    }
+
+    func test_execute_checkoutFlow_propagatesWebAuthenticationError() async {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        let expectedError = NSError(domain: "test", code: 200, userInfo: nil)
+        mockRepository.openWebAuthenticationResult = .failure(expectedError)
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual((error as NSError).code, 200)
+        }
+    }
+
+    func test_execute_checkoutFlow_propagatesFetchPayerInfoError() async {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        let expectedError = NSError(domain: "test", code: 300, userInfo: nil)
+        mockRepository.fetchPayerInfoResult = .failure(expectedError)
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual((error as NSError).code, 300)
+        }
+    }
+
+    func test_execute_checkoutFlow_propagatesTokenizeError() async {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        let expectedError = NSError(domain: "test", code: 400, userInfo: nil)
+        mockRepository.tokenizeResult = .failure(expectedError)
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual((error as NSError).code, 400)
+        }
+    }
+
+    func test_execute_vaultFlow_propagatesStartBillingAgreementError() async {
+        // Given
+        PrimerInternal.shared.intent = .vault
+        let expectedError = NSError(domain: "test", code: 500, userInfo: nil)
+        mockRepository.startBillingAgreementSessionResult = .failure(expectedError)
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual((error as NSError).code, 500)
+        }
+    }
+
+    func test_execute_vaultFlow_propagatesConfirmBillingAgreementError() async {
+        // Given
+        PrimerInternal.shared.intent = .vault
+        let expectedError = NSError(domain: "test", code: 600, userInfo: nil)
+        mockRepository.confirmBillingAgreementResult = .failure(expectedError)
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual((error as NSError).code, 600)
+        }
+    }
+
+    // MARK: - Payment Status Tests
+
+    func test_execute_returnsCorrectPaymentStatus_pending() async throws {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        mockRepository.tokenizeResult = .success(PaymentResult(paymentId: "pending-payment", status: .pending))
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result.status, .pending)
+    }
+
+    func test_execute_returnsCorrectPaymentStatus_requires3DS() async throws {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        mockRepository.tokenizeResult = .success(PaymentResult(paymentId: "3ds-payment", status: .requires3DS))
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result.status, .requires3DS)
+    }
+
+    func test_execute_returnsFullPaymentResult() async throws {
+        // Given
+        PrimerInternal.shared.intent = .checkout
+        let testMetadata: [String: Any] = ["key": "value"]
+        mockRepository.tokenizeResult = .success(PaymentResult(
+            paymentId: "full-payment",
+            status: .success,
+            token: "token-abc",
+            redirectUrl: "https://redirect.com",
+            errorMessage: nil,
+            metadata: testMetadata,
+            amount: 1000,
+            currencyCode: "USD",
+            paymentMethodType: "PAYPAL"
+        ))
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result.paymentId, "full-payment")
+        XCTAssertEqual(result.status, .success)
+        XCTAssertEqual(result.token, "token-abc")
+        XCTAssertEqual(result.redirectUrl, "https://redirect.com")
+        XCTAssertEqual(result.amount, 1000)
+        XCTAssertEqual(result.currencyCode, "USD")
+        XCTAssertEqual(result.paymentMethodType, "PAYPAL")
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Domain/InternalPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/Domain/InternalPaymentMethodTests.swift
@@ -1,0 +1,135 @@
+//
+//  InternalPaymentMethodTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import UIKit
+import XCTest
+
+@available(iOS 15.0, *)
+final class InternalPaymentMethodTests: XCTestCase {
+
+    // MARK: - Default Init Tests
+
+    func test_init_withRequiredParams_hasExpectedDefaults() {
+        // When
+        let method = InternalPaymentMethod(id: "test-id", type: "PAYMENT_CARD", name: "Card")
+
+        // Then
+        XCTAssertEqual(method.id, "test-id")
+        XCTAssertEqual(method.type, "PAYMENT_CARD")
+        XCTAssertEqual(method.name, "Card")
+        XCTAssertNil(method.icon)
+        XCTAssertNil(method.configId)
+        XCTAssertTrue(method.isEnabled)
+        XCTAssertNil(method.supportedCurrencies)
+        XCTAssertTrue(method.requiredInputElements.isEmpty)
+        XCTAssertNil(method.metadata)
+        XCTAssertNil(method.surcharge)
+        XCTAssertFalse(method.hasUnknownSurcharge)
+        XCTAssertNil(method.networkSurcharges)
+        XCTAssertNil(method.backgroundColor)
+        XCTAssertNil(method.buttonText)
+        XCTAssertNil(method.textColor)
+        XCTAssertNil(method.borderColor)
+        XCTAssertNil(method.borderWidth)
+        XCTAssertNil(method.cornerRadius)
+    }
+
+    func test_init_withAllParams_setsAllProperties() {
+        // When
+        let method = InternalPaymentMethod(
+            id: "pm-1",
+            type: "PAYPAL",
+            name: "PayPal",
+            icon: UIImage(),
+            configId: "config-1",
+            isEnabled: false,
+            supportedCurrencies: ["USD", "EUR"],
+            requiredInputElements: [.cardNumber],
+            metadata: ["key": "value"],
+            surcharge: 50,
+            hasUnknownSurcharge: true,
+            networkSurcharges: ["VISA": 25],
+            backgroundColor: .blue,
+            buttonText: "Pay with PayPal",
+            textColor: .white,
+            borderColor: .gray,
+            borderWidth: 1.0,
+            cornerRadius: 8.0
+        )
+
+        // Then
+        XCTAssertEqual(method.id, "pm-1")
+        XCTAssertFalse(method.isEnabled)
+        XCTAssertEqual(method.supportedCurrencies, ["USD", "EUR"])
+        XCTAssertEqual(method.surcharge, 50)
+        XCTAssertTrue(method.hasUnknownSurcharge)
+        XCTAssertEqual(method.buttonText, "Pay with PayPal")
+        XCTAssertEqual(method.borderWidth, 1.0)
+        XCTAssertEqual(method.cornerRadius, 8.0)
+    }
+
+    // MARK: - Equality Tests
+
+    func test_equality_sameIdAndType_areEqual() {
+        let method1 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card")
+        let method2 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card")
+
+        XCTAssertEqual(method1, method2)
+    }
+
+    func test_equality_differentId_areNotEqual() {
+        let method1 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card")
+        let method2 = InternalPaymentMethod(id: "pm-2", type: "CARD", name: "Card")
+
+        XCTAssertNotEqual(method1, method2)
+    }
+
+    func test_equality_differentType_areNotEqual() {
+        let method1 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card")
+        let method2 = InternalPaymentMethod(id: "pm-1", type: "PAYPAL", name: "Card")
+
+        XCTAssertNotEqual(method1, method2)
+    }
+
+    func test_equality_differentSurcharge_areNotEqual() {
+        let method1 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card", surcharge: 50)
+        let method2 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card", surcharge: 100)
+
+        XCTAssertNotEqual(method1, method2)
+    }
+
+    func test_equality_differentUnknownSurcharge_areNotEqual() {
+        let method1 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card", hasUnknownSurcharge: false)
+        let method2 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card", hasUnknownSurcharge: true)
+
+        XCTAssertNotEqual(method1, method2)
+    }
+
+    func test_equality_differentBackgroundColor_areNotEqual() {
+        let method1 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card", backgroundColor: .red)
+        let method2 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card", backgroundColor: .blue)
+
+        XCTAssertNotEqual(method1, method2)
+    }
+
+    func test_equality_ignoresNonComparedProperties() {
+        // configId, supportedCurrencies, requiredInputElements, metadata, networkSurcharges etc.
+        // are NOT compared in the custom == implementation
+        let method1 = InternalPaymentMethod(
+            id: "pm-1", type: "CARD", name: "Card",
+            configId: "config-1",
+            supportedCurrencies: ["USD"]
+        )
+        let method2 = InternalPaymentMethod(
+            id: "pm-1", type: "CARD", name: "Card",
+            configId: "config-2",
+            supportedCurrencies: ["EUR"]
+        )
+
+        XCTAssertEqual(method1, method2)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mappers/PaymentMethodMapperTests.swift
+++ b/Tests/Primer/CheckoutComponents/Mappers/PaymentMethodMapperTests.swift
@@ -1,0 +1,189 @@
+//
+//  PaymentMethodMapperTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class PaymentMethodMapperTests: XCTestCase {
+
+    // MARK: - Test Helpers
+
+    private func createMapper(currency: Currency? = Currency(code: "USD", decimalDigits: 2)) -> PaymentMethodMapperImpl {
+        let configService = MockConfigurationService.withDefaultConfiguration()
+        configService.currency = currency
+        return PaymentMethodMapperImpl(configurationService: configService)
+    }
+
+    private func createInternalPaymentMethod(
+        id: String = "test-id",
+        type: String = "PAYMENT_CARD",
+        name: String = "Credit Card",
+        surcharge: Int? = nil,
+        hasUnknownSurcharge: Bool = false
+    ) -> InternalPaymentMethod {
+        InternalPaymentMethod(
+            id: id,
+            type: type,
+            name: name,
+            isEnabled: true,
+            surcharge: surcharge,
+            hasUnknownSurcharge: hasUnknownSurcharge
+        )
+    }
+
+    // MARK: - Surcharge Formatting Tests
+
+    func test_mapToPublic_noSurcharge_returnsNoAdditionalFee() {
+        // Given
+        let mapper = createMapper()
+        let internalMethod = createInternalPaymentMethod(surcharge: nil, hasUnknownSurcharge: false)
+
+        // When
+        let result = mapper.mapToPublic(internalMethod)
+
+        // Then
+        XCTAssertEqual(result.formattedSurcharge, CheckoutComponentsStrings.noAdditionalFee)
+    }
+
+    func test_mapToPublic_zeroSurcharge_returnsNoAdditionalFee() {
+        // Given
+        let mapper = createMapper()
+        let internalMethod = createInternalPaymentMethod(surcharge: 0, hasUnknownSurcharge: false)
+
+        // When
+        let result = mapper.mapToPublic(internalMethod)
+
+        // Then
+        XCTAssertEqual(result.formattedSurcharge, CheckoutComponentsStrings.noAdditionalFee)
+    }
+
+    func test_mapToPublic_hasUnknownSurcharge_returnsAdditionalFeeMayApply() {
+        // Given
+        let mapper = createMapper()
+        let internalMethod = createInternalPaymentMethod(surcharge: 100, hasUnknownSurcharge: true)
+
+        // When
+        let result = mapper.mapToPublic(internalMethod)
+
+        // Then
+        XCTAssertEqual(result.formattedSurcharge, CheckoutComponentsStrings.additionalFeeMayApply)
+    }
+
+    func test_mapToPublic_withSurcharge_formatsWithPlusPrefix() {
+        // Given
+        let mapper = createMapper(currency: Currency(code: "USD", decimalDigits: 2))
+        let internalMethod = createInternalPaymentMethod(surcharge: 150, hasUnknownSurcharge: false)
+
+        // When
+        let result = mapper.mapToPublic(internalMethod)
+
+        // Then
+        XCTAssertNotNil(result.formattedSurcharge)
+        XCTAssertTrue(result.formattedSurcharge?.hasPrefix("+") == true)
+    }
+
+    func test_mapToPublic_noCurrency_returnsNoAdditionalFee() {
+        // Given
+        let mapper = createMapper(currency: nil)
+        let internalMethod = createInternalPaymentMethod(surcharge: 100, hasUnknownSurcharge: false)
+
+        // When
+        let result = mapper.mapToPublic(internalMethod)
+
+        // Then
+        XCTAssertEqual(result.formattedSurcharge, CheckoutComponentsStrings.noAdditionalFee)
+    }
+
+    func test_mapToPublic_unknownSurcharge_takesPrecedenceOverActualSurcharge() {
+        // Given - Both surcharge and hasUnknownSurcharge set
+        let mapper = createMapper()
+        let internalMethod = createInternalPaymentMethod(surcharge: 500, hasUnknownSurcharge: true)
+
+        // When
+        let result = mapper.mapToPublic(internalMethod)
+
+        // Then - Unknown surcharge message takes precedence
+        XCTAssertEqual(result.formattedSurcharge, CheckoutComponentsStrings.additionalFeeMayApply)
+    }
+
+    // MARK: - Raw Surcharge Value Tests
+
+    func test_mapToPublic_preservesRawSurchargeValue() {
+        // Given
+        let mapper = createMapper()
+        let internalMethod = createInternalPaymentMethod(surcharge: 250)
+
+        // When
+        let result = mapper.mapToPublic(internalMethod)
+
+        // Then
+        XCTAssertEqual(result.surcharge, 250)
+    }
+
+    func test_mapToPublic_preservesHasUnknownSurchargeFlag() {
+        // Given
+        let mapper = createMapper()
+        let internalMethod = createInternalPaymentMethod(hasUnknownSurcharge: true)
+
+        // When
+        let result = mapper.mapToPublic(internalMethod)
+
+        // Then
+        XCTAssertTrue(result.hasUnknownSurcharge)
+    }
+
+    // MARK: - Array Mapping Tests
+
+    func test_mapToPublicArray_mapsAllElements() {
+        // Given
+        let mapper = createMapper()
+        let methods = [
+            createInternalPaymentMethod(id: "1", type: "PAYMENT_CARD"),
+            createInternalPaymentMethod(id: "2", type: "PAYPAL"),
+            createInternalPaymentMethod(id: "3", type: "APPLE_PAY")
+        ]
+
+        // When
+        let results = mapper.mapToPublic(methods)
+
+        // Then
+        XCTAssertEqual(results.count, 3)
+        XCTAssertEqual(results[0].id, "1")
+        XCTAssertEqual(results[1].id, "2")
+        XCTAssertEqual(results[2].id, "3")
+    }
+
+    func test_mapToPublicArray_emptyArray_returnsEmptyArray() {
+        // Given
+        let mapper = createMapper()
+        let methods: [InternalPaymentMethod] = []
+
+        // When
+        let results = mapper.mapToPublic(methods)
+
+        // Then
+        XCTAssertTrue(results.isEmpty)
+    }
+
+    func test_mapToPublicArray_preservesOrder() {
+        // Given
+        let mapper = createMapper()
+        let methods = [
+            createInternalPaymentMethod(name: "First"),
+            createInternalPaymentMethod(name: "Second"),
+            createInternalPaymentMethod(name: "Third")
+        ]
+
+        // When
+        let results = mapper.mapToPublic(methods)
+
+        // Then
+        XCTAssertEqual(results[0].name, "First")
+        XCTAssertEqual(results[1].name, "Second")
+        XCTAssertEqual(results[2].name, "Third")
+    }
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Address.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Address.swift
@@ -1,0 +1,127 @@
+//
+//  TestData+Address.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - Billing Address
+
+    enum BillingAddress {
+        static let completeUS: [String: String] = [
+            "firstName": "John",
+            "lastName": "Doe",
+            "addressLine1": "123 Main Street",
+            "addressLine2": "Apt 4B",
+            "city": "New York",
+            "state": "NY",
+            "postalCode": "10001",
+            "countryCode": "US"
+        ]
+
+        static let completeUK: [String: String] = [
+            "firstName": "Jane",
+            "lastName": "Smith",
+            "addressLine1": "10 Downing Street",
+            "city": "London",
+            "postalCode": "SW1A 2AA",
+            "countryCode": "GB"
+        ]
+
+        static let minimalRequired: [String: String] = [
+            "firstName": "John",
+            "lastName": "Doe",
+            "addressLine1": "123 Main Street",
+            "city": "New York",
+            "postalCode": "10001",
+            "countryCode": "US"
+        ]
+
+        static let empty: [String: String] = [:]
+
+        static let missingRequired: [String: String] = [
+            "firstName": "John"
+            // Missing lastName, addressLine1, etc.
+        ]
+    }
+
+    // MARK: - Postal Codes
+
+    enum PostalCodes {
+        // Valid postal codes
+        static let validUS = "10001"
+        static let validUSExtended = "10001-1234"
+        static let validUK = "SW1A 2AA"
+        static let validCanada = "M5V 3L9"
+        static let validGeneric3Chars = "123"
+        static let validGeneric10Chars = "1234567890"
+
+        // Invalid postal codes
+        static let empty = ""
+        static let tooShort = "12"
+        static let tooLong = "12345678901"
+        static let usWithLetters = "1000A"
+        static let invalidCanadian = "12345"
+        static let ukTooShort = "SW1"
+    }
+
+    // MARK: - Country Codes
+
+    enum CountryCodes {
+        static let us = "US"
+        static let usLowercase = "us"
+        static let ca = "CA"
+        static let gb = "GB"
+        static let gbLowercase = "gb"
+        static let usa3Letter = "USA"
+        static let empty = ""
+        static let singleCharacter = "U"
+        static let tooLong = "USAA"
+    }
+
+    // MARK: - OTP Codes
+
+    enum OTPCodes {
+        static let valid6Digit = "123456"
+        static let valid4Digit = "1234"
+        static let tooShort = "1234"
+        static let withNonNumeric = "12345a"
+        static let empty = ""
+        static let expectedLength6 = 6
+    }
+
+    // MARK: - Cities
+
+    enum Cities {
+        static let valid = "New York"
+        static let withHyphen = "Winston-Salem"
+        static let withPeriod = "St. Louis"
+        static let empty = ""
+        static let singleCharacter = "A"
+    }
+
+    // MARK: - States
+
+    enum States {
+        static let validAbbreviation = "NY"
+        static let validFullName = "New York"
+        static let empty = ""
+        static let singleCharacter = "N"
+    }
+
+    // MARK: - Addresses
+
+    enum Addresses {
+        static let valid = "123 Main Street"
+        static let valid3Chars = "ABC"
+        static let valid100Chars = String(repeating: "a", count: 100)
+        static let tooShort = "AB"
+        static let tooLong = String(repeating: "a", count: 101)
+        static let empty = ""
+    }
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Address.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Address.swift
@@ -89,7 +89,7 @@ extension TestData {
     enum OTPCodes {
         static let valid6Digit = "123456"
         static let valid4Digit = "1234"
-        static let tooShort = "1234"
+        static let tooShortFor6Digit = "1234"
         static let withNonNumeric = "12345a"
         static let empty = ""
         static let expectedLength6 = 6

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Amounts.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Amounts.swift
@@ -1,0 +1,39 @@
+//
+//  TestData+Amounts.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - Payment Amounts
+
+    enum Amounts {
+        static let standard = 1000          // $10.00
+        static let small = 100              // $1.00
+        static let large = 100000           // $1,000.00
+        static let withSurcharge = 2000     // $20.00
+        static let zero = 0
+    }
+
+    // MARK: - Formatted Amounts
+
+    enum FormattedAmounts {
+        static let tenDollars = "$10.00"
+        static let oneDollar = "$1.00"
+        static let hundredDollars = "$100.00"
+    }
+
+    // MARK: - Currencies
+
+    enum Currencies {
+        static let usd = "USD"
+        static let eur = "EUR"
+        static let gbp = "GBP"
+        static let jpy = "JPY"
+        static let defaultDecimalDigits = 2
+    }
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Cards.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Cards.swift
@@ -1,0 +1,139 @@
+//
+//  TestData+Cards.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - Card Numbers
+
+    enum CardNumbers {
+        // Valid card numbers (pass Luhn check)
+        static let validVisa = "4242424242424242"
+        static let validVisaAlternate = "4111111111111111"
+        static let validVisaDebit = "4000056655665556"
+        static let validMastercard = "5555555555554444"
+        static let validMastercardDebit = "5200828282828210"
+        static let validAmex = "378282246310005"
+        static let validDiscover = "6011111111111117"
+        static let validDiners = "3056930009020004"
+        static let validJCB = "3566002020360505"
+        static let valid19Digit = "4532015112830366999"
+
+        // Invalid card numbers
+        static let invalidLuhn = "4242424242424241"
+        static let invalidLuhnVisa = "4111111111111112"
+        static let tooShort = "424242"
+        static let tooLong = "42424242424242424242"
+        static let empty = ""
+        static let nonNumeric = "4242abcd42424242"
+        static let withSpaces = "4242 4242 4242 4242"
+        static let allZeros = "0000000000000000"
+        static let singleDigit = "4"
+        static let invalidRandom = "1234567890"
+        static let invalidExpiryFormat = "invalid"
+
+        // Declined/error cards
+        static let declined = "4000000000000002"
+
+        // Co-badged card (Visa + Mastercard)
+        static let coBadgedVisa = "4000002500001001"
+    }
+
+    // MARK: - Expiry Dates
+
+    enum ExpiryDates {
+        static var validFuture: (month: String, year: String) {
+            let calendar = Calendar.current
+            let date = calendar.date(byAdding: .year, value: 2, to: Date())!
+            let month = calendar.component(.month, from: date)
+            let year = calendar.component(.year, from: date)
+            return (String(format: "%02d", month), String(year % 100))
+        }
+
+        static var currentMonth: (month: String, year: String) {
+            let calendar = Calendar.current
+            let month = calendar.component(.month, from: Date())
+            let year = calendar.component(.year, from: Date())
+            return (String(format: "%02d", month), String(year % 100))
+        }
+
+        static var expired: (month: String, year: String) {
+            let calendar = Calendar.current
+            let date = calendar.date(byAdding: .month, value: -1, to: Date())!
+            let month = calendar.component(.month, from: date)
+            let year = calendar.component(.year, from: date)
+            return (String(format: "%02d", month), String(year % 100))
+        }
+
+        // Individual month/year values for edge case testing
+        static let december = "12"
+        static let january = "01"
+        static let singleDigitMonth = "5"
+        static let negativeMonth = "-01"
+        static let lettersMonth = "AB"
+        static let specialCharMonth = "1@"
+        static let monthWithWhitespace = " 12 "
+        static let year99 = "99"
+        static let year00 = "00"
+        static let year25 = "25"
+        static let year30 = "30"
+        static let lettersYear = "XY"
+
+        // Invalid formats
+        static let invalidMonth = ("13", "25")
+        static let zeroMonth = ("00", "25")
+        static let empty = ("", "")
+    }
+
+    // MARK: - CVV
+
+    enum CVV {
+        // Valid CVVs
+        static let valid3Digit = "123"
+        static let valid4Digit = "1234"  // For Amex
+
+        // Invalid CVVs
+        static let tooShort = "12"
+        static let tooLong = "12345"
+        static let empty = ""
+        static let nonNumeric = "12a"
+        static let withSpaces = "1 23"
+    }
+
+    // MARK: - Cardholder Names
+
+    enum CardholderNames {
+        // Valid names
+        static let valid = "John Doe"
+        static let validWithMiddle = "John Michael Doe"
+        static let validSingleName = "Madonna"
+        static let validWithAccents = "José García"
+        static let validWithHyphen = "Mary-Jane Watson"
+        static let validWithApostrophe = "O'Brien"
+
+        // Invalid names
+        static let withNumbers = "John Doe 3rd"
+        static let onlyNumbers = "12345"
+        static let empty = ""
+        static let tooShort = "J"
+        static let withLeadingTrailingSpaces = "  John Doe  "
+        static let onlySpaces = "    "
+        static let withSpecialCharacters = "John@Doe"
+    }
+
+    // MARK: - Card Networks
+
+    enum Networks {
+        static let visa = CardNetwork.visa
+        static let mastercard = CardNetwork.masterCard
+        static let amex = CardNetwork.amex
+        static let discover = CardNetwork.discover
+        static let unknown = CardNetwork.unknown
+    }
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Config.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Config.swift
@@ -1,0 +1,62 @@
+//
+//  TestData+Config.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - Analytics
+
+    enum Analytics {
+        static let checkoutSessionId = "checkout-session"
+        static let sdkVersion = "0.0.1"
+        static let tokenSessionId = "token-session-id"
+        static let tokenAccountId = "token-account-id"
+    }
+
+    // MARK: - JWT
+
+    enum JWT {
+        static let sandboxEnv = "SANDBOX"
+        static let productionEnv = "PRODUCTION"
+    }
+
+    // MARK: - Locale
+
+    enum Locale {
+        static let spanish = "es"
+        static let mexico = "MX"
+        static let spanishMexico = "es-MX"
+        static let french = "fr"
+        static let france = "FR"
+        static let frenchFrance = "fr-FR"
+        static let german = "de"
+        static let germany = "DE"
+        static let germanGermany = "de-DE"
+        static let japanese = "ja"
+        // Legacy aliases for backward compatibility
+        static let frenchLanguageCode = "fr"
+        static let franceRegionCode = "FR"
+        static let frenchFranceLocaleCode = "fr-FR"
+    }
+
+    // MARK: - Diagnostics IDs
+
+    enum DiagnosticsIds {
+        static let test = "test-diagnostics-123"
+        static let validation = "validation-diagnostics-456"
+    }
+
+    // MARK: - Error Keys
+
+    enum ErrorKeys {
+        static let test = "test-error-key"
+        static let cardNumber = "cardNumber"
+        static let expiry = "expiry"
+        static let cvv = "cvv"
+    }
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Config.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Config.swift
@@ -27,7 +27,7 @@ extension TestData {
 
     // MARK: - Locale
 
-    enum Locale {
+    enum TestLocale {
         static let spanish = "es"
         static let mexico = "MX"
         static let spanishMexico = "es-MX"

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Contact.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Contact.swift
@@ -1,0 +1,70 @@
+//
+//  TestData+Contact.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - Names
+
+    enum Names {
+        static let firstName = "John"
+        static let lastName = "Doe"
+        static let fullName = "John Doe"
+    }
+
+    // MARK: - First Names
+
+    enum FirstNames {
+        static let valid = "John"
+        static let withAccents = "François"
+        static let withUnicode = "René"
+        static let empty = ""
+        static let singleCharacter = "J"
+    }
+
+    // MARK: - Last Names
+
+    enum LastNames {
+        static let valid = "Doe"
+        static let withApostrophe = "O'Connor"
+        static let withHyphen = "Smith-Jones"
+        static let empty = ""
+        static let singleCharacter = "D"
+    }
+
+    // MARK: - Email Addresses
+
+    enum EmailAddresses {
+        // Valid emails
+        static let valid = "test@example.com"
+        static let validWithSubdomain = "user@mail.example.com"
+        static let validWithPlus = "user+tag@example.com"
+
+        // Invalid emails
+        static let missingAt = "testexample.com"
+        static let missingDomain = "test@"
+        static let missingLocal = "@example.com"
+        static let empty = ""
+        static let invalidFormat = "not an email"
+    }
+
+    // MARK: - Phone Numbers
+
+    enum PhoneNumbers {
+        // Valid phone numbers
+        static let validUS = "1234567890"
+        static let validWithCountryCode = "+14155551234"
+        static let validInternational = "+442071234567"
+
+        // Invalid phone numbers
+        static let tooShort = "123"
+        static let empty = ""
+        static let withLetters = "123ABC4567"
+    }
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+DI.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+DI.swift
@@ -1,0 +1,69 @@
+//
+//  TestData+DI.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - Dependency Injection
+
+    enum DI {
+        static let defaultValue = "default"
+        static let fallbackValue = "fallback"
+        static let resolvedValue = "resolved_value"
+        static let envResolvedValue = "env_resolved"
+        static let resolveTestValue = "resolve_test"
+        static let defaultIdentifier = "default"
+        static let fallbackIdentifier = "fallback"
+        static let fromContainerIdentifier = "from-container"
+        static let cachedPrefix = "cached-"
+        static let protocolFallbackValue = "protocol_fallback"
+        static let observableDefaultValue = "observable_default"
+        static let envFallbackValue = "env_fallback"
+        static let fallbackValueAlternate = "fallback_value"
+    }
+
+    // MARK: - DI Container
+
+    enum DIContainer {
+        enum Timing {
+            static let oneSecondNanoseconds: UInt64 = 1_000_000_000
+            static let oneMillisecondNanoseconds: UInt64 = 1_000_000
+        }
+
+        enum Duration {
+            static let oneMs: TimeInterval = 0.001
+            static let twoMs: TimeInterval = 0.002
+            static let threeMs: TimeInterval = 0.003
+            static let fiveMs: TimeInterval = 0.005
+            static let tenMs: TimeInterval = 0.010
+        }
+
+        enum Factory {
+            static let testIdPrefix = "test-"
+            static let syncIdPrefix = "sync-"
+            static let voidIdPrefix = "void-"
+            static let syncVoidIdPrefix = "sync-void-"
+            static let asyncSyncIdPrefix = "async-sync-"
+            static let defaultMultiplier = 10
+            static let largeMultiplier = 100
+            static let factoryName1 = "factory-1"
+            static let factoryName2 = "factory-2"
+            static let namedClosure = "named-closure"
+            static let closureTestId = "closure-test"
+        }
+
+        enum Values {
+            static let expectedValue = 42
+            static let multiplier3 = 3
+            static let multiplier4 = 4
+            static let multiplier5 = 5
+            static let multiplier7 = 7
+        }
+    }
+
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Errors.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Errors.swift
@@ -1,0 +1,134 @@
+//
+//  TestData+Errors.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - Errors
+
+    enum Errors {
+        // Network errors
+        static let networkError = NSError(
+            domain: "TestError",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "Network connection failed"]
+        )
+
+        static let networkTimeout = NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorTimedOut,
+            userInfo: [NSLocalizedDescriptionKey: "Request timed out"]
+        )
+
+        // Validation errors
+        static let validationError = NSError(
+            domain: "ValidationError",
+            code: 400,
+            userInfo: [NSLocalizedDescriptionKey: "Validation failed"]
+        )
+
+        static let invalidCardNumber = NSError(
+            domain: "PrimerValidationError",
+            code: 1001,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Invalid card number",
+                "field": "cardNumber"
+            ]
+        )
+
+        static let expiredCard = NSError(
+            domain: "PrimerValidationError",
+            code: 1002,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Card has expired",
+                "field": "expiryDate"
+            ]
+        )
+
+        static let invalidCVV = NSError(
+            domain: "PrimerValidationError",
+            code: 1003,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Invalid CVV",
+                "field": "cvv"
+            ]
+        )
+
+        // Payment errors
+        static let paymentDeclined = NSError(
+            domain: "PaymentError",
+            code: 402,
+            userInfo: [NSLocalizedDescriptionKey: "Payment was declined"]
+        )
+
+        static let insufficientFunds = NSError(
+            domain: "PaymentError",
+            code: 4001,
+            userInfo: [NSLocalizedDescriptionKey: "Payment declined: Insufficient funds"]
+        )
+
+        static let fraudCheck = NSError(
+            domain: "PaymentError",
+            code: 4002,
+            userInfo: [NSLocalizedDescriptionKey: "Payment declined: Fraud check failed"]
+        )
+
+        // Server errors
+        static let serverError = NSError(
+            domain: "ServerError",
+            code: 500,
+            userInfo: [NSLocalizedDescriptionKey: "Internal server error"]
+        )
+
+        // Configuration errors
+        static let invalidMerchantConfig = NSError(
+            domain: "ConfigurationError",
+            code: 5001,
+            userInfo: [NSLocalizedDescriptionKey: "Invalid merchant configuration"]
+        )
+
+        static let missingAPIKey = NSError(
+            domain: "ConfigurationError",
+            code: 5002,
+            userInfo: [NSLocalizedDescriptionKey: "Missing API key"]
+        )
+
+        // 3DS errors
+        static let threeDSInitializationFailed = NSError(
+            domain: "Primer3DSError",
+            code: 6001,
+            userInfo: [NSLocalizedDescriptionKey: "3DS initialization failed"]
+        )
+
+        static let threeDSChallengeTimeout = NSError(
+            domain: "Primer3DSError",
+            code: 6002,
+            userInfo: [NSLocalizedDescriptionKey: "3DS challenge timed out"]
+        )
+
+        static let threeDSChallengeCancelled = NSError(
+            domain: "Primer3DSError",
+            code: 6003,
+            userInfo: [NSLocalizedDescriptionKey: "3DS challenge was cancelled"]
+        )
+
+        // Auth errors
+        static let authenticationRequired = NSError(
+            domain: "AuthError",
+            code: 401,
+            userInfo: [NSLocalizedDescriptionKey: "Authentication required"]
+        )
+
+        // Generic errors
+        static let unknown = NSError(
+            domain: "UnknownError",
+            code: 9999,
+            userInfo: [NSLocalizedDescriptionKey: "An unknown error occurred"]
+        )
+    }
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+PaymentMethods.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+PaymentMethods.swift
@@ -1,0 +1,62 @@
+//
+//  TestData+PaymentMethods.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - Payment Method Types
+
+    enum PaymentMethodTypes {
+        static let card = "PAYMENT_CARD"
+        static let applePay = "APPLE_PAY"
+        static let paypal = "PAYPAL"
+        static let klarna = "KLARNA"
+    }
+
+    // MARK: - Payment Method Identifiers
+
+    enum PaymentMethodIds {
+        static let cardId = "card-pm-id"
+        static let paypalId = "paypal-pm-id"
+        static let applePayId = "apple-pay-pm-id"
+        static let googlePayId = "google-pay-pm-id"
+    }
+
+    // MARK: - Payment Method Names
+
+    enum PaymentMethodNames {
+        static let cardName = "Card"
+        static let paypalName = "PayPal"
+        static let applePayName = "Apple Pay"
+        static let googlePayName = "Google Pay"
+    }
+
+    // MARK: - Payment Method Options
+
+    enum PaymentMethodOptions {
+        static let monthlySubscription = "Monthly subscription"
+        static let testSubscription = "Test Subscription"
+        static let subscription = "Subscription"
+        static let exampleMerchantId = "merchant.com.example.app"
+        static let testMerchantId = "merchant.test"
+        static let testMerchantName = "Test Merchant"
+        static let myAppUrlScheme = "myapp://payment"
+        static let testAppUrl = "testapp://payment"
+        static let testAppUrlTrailing = "testapp://"
+        static let testAppScheme = "testapp"
+        static let myAppScheme = "myapp"
+    }
+
+    // MARK: - Payment IDs
+
+    enum PaymentIds {
+        static let success = "test-payment-123"
+        static let pending = "test-payment-456"
+        static let failed = "test-payment-789"
+    }
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Responses.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Responses.swift
@@ -1,0 +1,243 @@
+//
+//  TestData+Responses.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - API Responses
+
+    enum APIResponses {
+        static let validPaymentMethods = """
+        {
+            "paymentMethods": [
+                {
+                    "id": "PAYMENT_CARD",
+                    "type": "PAYMENT_CARD",
+                    "name": "Card",
+                    "isEnabled": true,
+                    "supportedCardNetworks": ["VISA", "MASTERCARD", "AMEX"]
+                }
+            ]
+        }
+        """
+
+        static let emptyPaymentMethods = """
+        {
+            "paymentMethods": []
+        }
+        """
+
+        static let malformedJSON = "{invalid json}"
+
+        static let merchantConfig = """
+        {
+            "merchantId": "test-merchant-123",
+            "settings": {
+                "theme": "light",
+                "enableAnalytics": true
+            }
+        }
+        """
+
+        static let errorResponse = """
+        {
+            "error": {
+                "code": "PAYMENT_DECLINED",
+                "message": "Insufficient funds"
+            }
+        }
+        """
+    }
+
+    // MARK: - Payment Results
+
+    enum PaymentResults {
+        static let success = (
+            status: "success",
+            transactionId: "test-payment-123",
+            error: nil as Error?,
+            threeDSRequired: false,
+            surchargeAmount: nil as Int?
+        )
+
+        static let threeDSRequired = (
+            status: "pending",
+            transactionId: "test-payment-456",
+            error: nil as Error?,
+            threeDSRequired: true,
+            surchargeAmount: nil as Int?
+        )
+
+        static let declined = (
+            status: "failure",
+            transactionId: nil as String?,
+            error: NSError(
+                domain: "PaymentError",
+                code: 402,
+                userInfo: [NSLocalizedDescriptionKey: "Payment declined: Insufficient funds"]
+            ) as Error,
+            threeDSRequired: false,
+            surchargeAmount: nil as Int?
+        )
+
+        static let withSurcharge = (
+            status: "success",
+            transactionId: "test-payment-789",
+            error: nil as Error?,
+            threeDSRequired: false,
+            surchargeAmount: 50 as Int?
+        )
+
+        static let cancelled = (
+            status: "cancelled",
+            transactionId: nil as String?,
+            error: NSError(
+                domain: "PaymentError",
+                code: -999,
+                userInfo: [NSLocalizedDescriptionKey: "Payment cancelled by user"]
+            ) as Error,
+            threeDSRequired: false,
+            surchargeAmount: nil as Int?
+        )
+    }
+
+    // MARK: - 3DS Flows
+
+    enum ThreeDSFlows {
+        static let challengeRequired = (
+            transactionId: "test-tx-123",
+            acsTransactionId: "test-acs-456",
+            acsReferenceNumber: "test-ref-789",
+            acsSignedContent: "signed-content-challenge",
+            challengeRequired: true,
+            outcome: "success"
+        )
+
+        static let frictionless = (
+            transactionId: "test-tx-234",
+            acsTransactionId: "test-acs-567",
+            acsReferenceNumber: "test-ref-890",
+            acsSignedContent: nil as String?,
+            challengeRequired: false,
+            outcome: "success"
+        )
+
+        static let failed = (
+            transactionId: "test-tx-345",
+            acsTransactionId: "test-acs-678",
+            acsReferenceNumber: "test-ref-901",
+            acsSignedContent: "signed-content-failed",
+            challengeRequired: true,
+            outcome: "failure"
+        )
+
+        static let cancelled = (
+            transactionId: "test-tx-456",
+            acsTransactionId: "test-acs-789",
+            acsReferenceNumber: "test-ref-012",
+            acsSignedContent: "signed-content-cancelled",
+            challengeRequired: true,
+            outcome: "cancelled"
+        )
+
+        static let timeout = (
+            transactionId: "test-tx-567",
+            acsTransactionId: "test-acs-890",
+            acsReferenceNumber: "test-ref-123",
+            acsSignedContent: "signed-content-timeout",
+            challengeRequired: true,
+            outcome: "timeout"
+        )
+    }
+
+    // MARK: - Network Responses
+
+    /// Typealias for network response tuple to avoid `as X?` clutter
+    typealias NetworkResponseResult = (data: Data?, response: HTTPURLResponse?, error: Error?)
+
+    enum NetworkResponses {
+        private static let testURL = URL(string: "https://api.primer.io/test")!
+        private static let defaultHeaders = ["Content-Type": "application/json"]
+
+        static func success200(with data: Data? = nil) -> NetworkResponseResult {
+            let json = data ?? APIResponses.validPaymentMethods.data(using: .utf8)
+            let response = HTTPURLResponse(
+                url: testURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: defaultHeaders
+            )
+            return (json, response, nil)
+        }
+
+        static let badRequest400: NetworkResponseResult = (
+            data: nil,
+            response: HTTPURLResponse(
+                url: testURL,
+                statusCode: 400,
+                httpVersion: nil,
+                headerFields: defaultHeaders
+            ),
+            error: nil
+        )
+
+        static let unauthorized401: NetworkResponseResult = (
+            data: nil,
+            response: HTTPURLResponse(
+                url: testURL,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: defaultHeaders
+            ),
+            error: nil
+        )
+
+        static let notFound404: NetworkResponseResult = (
+            data: nil,
+            response: HTTPURLResponse(
+                url: testURL,
+                statusCode: 404,
+                httpVersion: nil,
+                headerFields: defaultHeaders
+            ),
+            error: nil
+        )
+
+        static let serverError500: NetworkResponseResult = (
+            data: nil,
+            response: HTTPURLResponse(
+                url: testURL,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: defaultHeaders
+            ),
+            error: nil
+        )
+
+        static let timeout: NetworkResponseResult = (
+            data: nil,
+            response: nil,
+            error: NSError(
+                domain: NSURLErrorDomain,
+                code: NSURLErrorTimedOut,
+                userInfo: [NSLocalizedDescriptionKey: "Request timed out"]
+            )
+        )
+
+        static let noConnection: NetworkResponseResult = (
+            data: nil,
+            response: nil,
+            error: NSError(
+                domain: NSURLErrorDomain,
+                code: NSURLErrorNotConnectedToInternet,
+                userInfo: [NSLocalizedDescriptionKey: "No internet connection"]
+            )
+        )
+    }
+}

--- a/Tests/Primer/CheckoutComponents/TestSupport/TestData+Validation.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/TestData+Validation.swift
@@ -1,0 +1,103 @@
+//
+//  TestData+Validation.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+extension TestData {
+
+    // MARK: - Error Codes
+
+    enum ErrorCodes {
+        static let invalid = "invalid"
+        static let invalidCard = "invalid-card-number"
+        static let invalidCVV = "invalid-cvv"
+        static let invalidExpiry = "invalid-expiry"
+        static let required = "required"
+        static let unsupportedCardType = "unsupported-card-type"
+    }
+
+    // MARK: - Error Messages
+
+    enum ErrorMessages {
+        static let invalidCard = "Invalid card number"
+        static let invalidCardNumber = "Invalid card number"
+        static let invalidCVV = "Invalid CVV"
+        static let invalidExpiry = "Invalid expiry date"
+        static let required = "This field is required"
+        static let fieldRequired = "Field is required"
+        static let fieldInvalid = "Field is invalid"
+        static let retailOutletRequired = "Retail outlet is required"
+        static let retailOutletInvalid = "Invalid retail outlet"
+    }
+
+    // MARK: - Error Message Keys
+
+    enum ErrorMessageKeys {
+        // Required field keys
+        static let genericRequired = "form_error_required"
+        static let firstNameRequired = "checkout_components_first_name_required"
+        static let lastNameRequired = "checkout_components_last_name_required"
+        static let emailRequired = "checkout_components_email_required"
+        static let countryRequired = "checkout_components_country_required"
+        static let addressLine1Required = "checkout_components_address_line_1_required"
+        static let addressLine2Required = "checkout_components_address_line_2_required"
+        static let cityRequired = "checkout_components_city_required"
+        static let stateRequired = "checkout_components_state_required"
+        static let postalCodeRequired = "checkout_components_postal_code_required"
+        static let phoneNumberRequired = "checkout_components_phone_number_required"
+        static let retailOutletRequired = "checkout_components_retail_outlet_required"
+
+        // Invalid field keys
+        static let genericInvalid = "form_error_invalid"
+        static let cardNumberInvalid = "checkout_components_card_number_invalid"
+        static let cvvInvalid = "checkout_components_cvv_invalid"
+        static let expiryDateInvalid = "checkout_components_expiry_date_invalid"
+        static let cardholderNameInvalid = "checkout_components_cardholder_name_invalid"
+        static let firstNameInvalid = "checkout_components_first_name_invalid"
+        static let lastNameInvalid = "checkout_components_last_name_invalid"
+        static let emailInvalid = "checkout_components_email_invalid"
+        static let countryInvalid = "checkout_components_country_invalid"
+        static let addressLine1Invalid = "checkout_components_address_line_1_invalid"
+        static let addressLine2Invalid = "checkout_components_address_line_2_invalid"
+        static let cityInvalid = "checkout_components_city_invalid"
+        static let stateInvalid = "checkout_components_state_invalid"
+        static let postalCodeInvalid = "checkout_components_postal_code_invalid"
+        static let phoneNumberInvalid = "checkout_components_phone_number_invalid"
+        static let retailOutletInvalid = "checkout_components_retail_outlet_invalid"
+    }
+
+    // MARK: - Test Fixtures
+
+    enum TestFixtures {
+        static let defaultErrorId = "test-error-id"
+        static let defaultCode = "TEST_ERROR"
+        static let defaultMessage = "Test error message"
+    }
+
+    // MARK: - Field Names (for validation rule testing)
+
+    enum FieldNames {
+        static let email = "Email"
+        static let name = "Name"
+        static let address = "Address"
+        static let city = "City"
+        static let phone = "Phone"
+        static let firstName = "First Name"
+        static let password = "Password"
+        static let username = "Username"
+        static let pin = "PIN"
+        static let code = "Code"
+        static let title = "Title"
+        static let input = "Input"
+        static let field = "Field"
+        static let description = "Description"
+        static let digits = "Digits"
+        static let cardNumber = "Card Number"
+        static let custom = "Custom"
+    }
+}


### PR DESCRIPTION
## Summary
- Adds domain models: `InternalPaymentMethod`, `PaymentResult` for internal payment state management
- Adds repository protocols for all payment methods (ACH, Apple Pay, Card, Klarna, PayPal, QR Code, Web Redirect, Form Redirect)
- Adds domain interactors for payment processing, card network detection, and input validation
- Adds `PaymentMethodMapper` for converting between API and domain models
- Adds comprehensive `TestData` factory with extensions for addresses, cards, config, contacts, errors, payment methods, and validation

## Context
PR 4 of 15 in the CheckoutComponents feature split. Establishes the domain layer foundation that all subsequent PRs depend on. Depends on PR 3 (#1632).

Tracker: https://www.notion.so/32fca65dc30e81dabf66f33e2b58c3a1

## Test plan
- [ ] Verify domain model tests pass (`InternalPaymentMethodTests`, `PaymentMethodMapperTests`)
- [ ] Verify `ProcessPayPalPaymentInteractorTests` passes
- [ ] Confirm TestData factory compiles and provides valid test fixtures
- [ ] Run: `xcodebuild -workspace PrimerSDK.xcworkspace -scheme PrimerSDKTests -destination "platform=iOS Simulator,name=iPhone 16" test`