### PR TITLE
feat: Add public API layer (scope protocols, state types)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Core/Data/PrimerApplePayState.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Core/Data/PrimerApplePayState.swift
@@ -1,0 +1,71 @@
+//
+//  PrimerApplePayState.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+import PassKit
+
+@available(iOS 15.0, *)
+public struct PrimerApplePayState: Equatable {
+
+  public internal(set) var isLoading: Bool
+  public internal(set) var isAvailable: Bool
+  public internal(set) var availabilityError: String?
+
+  public internal(set) var buttonStyle: PKPaymentButtonStyle
+  public internal(set) var buttonType: PKPaymentButtonType
+  public internal(set) var cornerRadius: CGFloat
+
+  public init(
+    isLoading: Bool = false,
+    isAvailable: Bool = false,
+    availabilityError: String? = nil,
+    buttonStyle: PKPaymentButtonStyle = .black,
+    buttonType: PKPaymentButtonType = .plain,
+    cornerRadius: CGFloat = 8.0
+  ) {
+    self.isLoading = isLoading
+    self.isAvailable = isAvailable
+    self.availabilityError = availabilityError
+    self.buttonStyle = buttonStyle
+    self.buttonType = buttonType
+    self.cornerRadius = cornerRadius
+  }
+
+  public static var `default`: PrimerApplePayState {
+    PrimerApplePayState()
+  }
+
+  public static func available(
+    buttonStyle: PKPaymentButtonStyle = .black,
+    buttonType: PKPaymentButtonType = .plain,
+    cornerRadius: CGFloat = 8.0
+  ) -> PrimerApplePayState {
+    PrimerApplePayState(
+      isLoading: false,
+      isAvailable: true,
+      availabilityError: nil,
+      buttonStyle: buttonStyle,
+      buttonType: buttonType,
+      cornerRadius: cornerRadius
+    )
+  }
+
+  public static func unavailable(error: String) -> PrimerApplePayState {
+    PrimerApplePayState(
+      isLoading: false,
+      isAvailable: false,
+      availabilityError: error
+    )
+  }
+
+  public static var loading: PrimerApplePayState {
+    PrimerApplePayState(
+      isLoading: true,
+      isAvailable: true,
+      availabilityError: nil
+    )
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Core/Data/PrimerCardFormState.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Core/Data/PrimerCardFormState.swift
@@ -60,8 +60,8 @@ public struct CardFormConfiguration: Equatable {
 /// ```
 @available(iOS 15.0, *)
 public struct FieldError: Equatable, Identifiable {
-  /// Unique identifier for this error instance.
-  public let id = UUID()
+  /// Deterministic identifier based on field type for stable SwiftUI diffing.
+  public var id: PrimerInputElementType { fieldType }
 
   /// The type of field that has the error.
   public let fieldType: PrimerInputElementType
@@ -125,8 +125,8 @@ public struct FormData: Equatable {
 /// ```
 @available(iOS 15.0, *)
 public struct PrimerCountry: Equatable, Identifiable {
-  /// Unique identifier for this country instance.
-  public let id = UUID()
+  /// Deterministic identifier based on country code for stable SwiftUI diffing.
+  public var id: String { code }
 
   /// ISO 3166-1 alpha-2 country code (e.g., "US", "GB", "DE").
   public let code: String
@@ -258,6 +258,22 @@ public struct PrimerCardFormState: Equatable {
     self.binData = binData
   }
 
+  // Custom Equatable comparing NSObject fields by value (PrimerCardNetwork/PrimerBinData don't override isEqual)
+  public static func == (lhs: PrimerCardFormState, rhs: PrimerCardFormState) -> Bool {
+    lhs.configuration == rhs.configuration &&
+    lhs.data == rhs.data &&
+    lhs.fieldErrors == rhs.fieldErrors &&
+    lhs.isLoading == rhs.isLoading &&
+    lhs.isValid == rhs.isValid &&
+    lhs.selectedCountry == rhs.selectedCountry &&
+    lhs.selectedNetwork?.network == rhs.selectedNetwork?.network &&
+    lhs.availableNetworks.map(\.network) == rhs.availableNetworks.map(\.network) &&
+    lhs.surchargeAmountRaw == rhs.surchargeAmountRaw &&
+    lhs.surchargeAmount == rhs.surchargeAmount &&
+    lhs.binData?.preferred?.network == rhs.binData?.preferred?.network &&
+    lhs.binData?.status == rhs.binData?.status
+  }
+
   // MARK: - Convenience Properties
 
   /// All fields that should be displayed (card + billing if enabled)
@@ -273,14 +289,14 @@ public struct PrimerCardFormState: Equatable {
     fieldErrors.first { $0.fieldType == fieldType }?.message
   }
 
-  public mutating func setError(
+  mutating func setError(
     _ message: String, for fieldType: PrimerInputElementType, errorCode: String? = nil
   ) {
     fieldErrors.removeAll { $0.fieldType == fieldType }
     fieldErrors.append(FieldError(fieldType: fieldType, message: message, errorCode: errorCode))
   }
 
-  public mutating func clearError(for fieldType: PrimerInputElementType) {
+  mutating func clearError(for fieldType: PrimerInputElementType) {
     fieldErrors.removeAll { $0.fieldType == fieldType }
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Core/Data/PrimerCardFormState.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Core/Data/PrimerCardFormState.swift
@@ -1,0 +1,286 @@
+//
+//  PrimerCardFormState.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+// MARK: - Field Configuration
+
+/// Defines which fields are required for the card form
+@available(iOS 15.0, *)
+public struct CardFormConfiguration: Equatable {
+  /// List of card-specific fields (card number, CVV, expiry, cardholder name)
+  public let cardFields: [PrimerInputElementType]
+
+  /// List of billing address fields (when billing address collection is enabled)
+  public let billingFields: [PrimerInputElementType]
+
+  public let requiresBillingAddress: Bool
+
+  public static let `default` = CardFormConfiguration(
+    cardFields: [.cardNumber, .expiryDate, .cvv, .cardholderName],
+    billingFields: [],
+    requiresBillingAddress: false
+  )
+
+  public init(
+    cardFields: [PrimerInputElementType],
+    billingFields: [PrimerInputElementType] = [],
+    requiresBillingAddress: Bool = false
+  ) {
+    self.cardFields = cardFields
+    self.billingFields = billingFields
+    self.requiresBillingAddress = requiresBillingAddress
+  }
+
+  /// All fields combined (card + billing)
+  public var allFields: [PrimerInputElementType] {
+    cardFields + billingFields
+  }
+}
+
+// MARK: - Field Error
+
+/// Represents a validation error for a specific form field.
+///
+/// `FieldError` provides detailed error information for individual fields,
+/// allowing you to display targeted error messages and programmatically
+/// handle validation failures.
+///
+/// Example usage:
+/// ```swift
+/// for error in formState.fieldErrors {
+///     print("Field \(error.fieldType.displayName): \(error.message)")
+///     if let code = error.errorCode {
+///         handleErrorCode(code)
+///     }
+/// }
+/// ```
+@available(iOS 15.0, *)
+public struct FieldError: Equatable, Identifiable {
+  /// Unique identifier for this error instance.
+  public let id = UUID()
+
+  /// The type of field that has the error.
+  public let fieldType: PrimerInputElementType
+
+  /// Human-readable error message to display to the user.
+  public let message: String
+
+  /// Machine-readable error code for programmatic handling.
+  public let errorCode: String?
+
+  public init(
+    fieldType: PrimerInputElementType,
+    message: String,
+    errorCode: String? = nil
+  ) {
+    self.fieldType = fieldType
+    self.message = message
+    self.errorCode = errorCode
+  }
+
+  public static func == (lhs: FieldError, rhs: FieldError) -> Bool {
+    lhs.fieldType == rhs.fieldType && lhs.message == rhs.message && lhs.errorCode == rhs.errorCode
+  }
+}
+
+// MARK: - Form Data
+
+/// Type-safe container for form field data
+@available(iOS 15.0, *)
+public struct FormData: Equatable {
+  private var data: [PrimerInputElementType: String] = [:]
+
+  public init() {}
+
+  public init(_ data: [PrimerInputElementType: String]) {
+    self.data = data
+  }
+
+  public subscript(fieldType: PrimerInputElementType) -> String {
+    get { data[fieldType] ?? "" }
+    set { data[fieldType] = newValue }
+  }
+
+  public var dictionary: [PrimerInputElementType: String] {
+    data
+  }
+}
+
+// MARK: - Country Information
+
+/// Represents a country for billing address and locale selection.
+///
+/// `PrimerCountry` provides country information including the ISO code,
+/// display name, flag emoji, and dial code for phone number formatting.
+///
+/// Example usage:
+/// ```swift
+/// if let country = formState.selectedCountry {
+///     print("Selected: \(country.flag ?? "") \(country.name) (\(country.code))")
+/// }
+/// ```
+@available(iOS 15.0, *)
+public struct PrimerCountry: Equatable, Identifiable {
+  /// Unique identifier for this country instance.
+  public let id = UUID()
+
+  /// ISO 3166-1 alpha-2 country code (e.g., "US", "GB", "DE").
+  public let code: String
+
+  /// Localized country name for display.
+  public let name: String
+
+  /// Flag emoji for the country (e.g., "🇺🇸").
+  public let flag: String?
+
+  /// International dialing code (e.g., "+1" for US).
+  public let dialCode: String?
+
+  public init(code: String, name: String, flag: String? = nil, dialCode: String? = nil) {
+    self.code = code
+    self.name = name
+    self.flag = flag
+    self.dialCode = dialCode
+  }
+
+  public static func == (lhs: PrimerCountry, rhs: PrimerCountry) -> Bool {
+    lhs.code == rhs.code && lhs.name == rhs.name && lhs.flag == rhs.flag
+      && lhs.dialCode == rhs.dialCode
+  }
+}
+
+// MARK: - Structured State
+
+/// The complete state of the card payment form including field values, validation, and network selection.
+///
+/// `PrimerCardFormState` provides a comprehensive view of the card form's current state,
+/// including:
+/// - Form configuration (which fields are required)
+/// - Current field values
+/// - Validation errors
+/// - Loading and validity states
+/// - Co-badged card network information
+/// - Surcharge amounts
+///
+/// Observe this state through `PrimerCardFormScope.state` to react to form changes:
+/// ```swift
+/// for await state in cardFormScope.state {
+///     // Check overall form validity
+///     submitButton.isEnabled = state.isValid
+///
+///     // Display field-specific errors
+///     for error in state.fieldErrors {
+///         showError(error.message, for: error.fieldType)
+///     }
+///
+///     // Handle co-badged cards
+///     if state.availableNetworks.count > 1 {
+///         showNetworkSelector(state.availableNetworks)
+///     }
+///
+///     // Show surcharge if applicable
+///     if let surcharge = state.surchargeAmount {
+///         showSurchargeLabel(surcharge)
+///     }
+/// }
+/// ```
+@available(iOS 15.0, *)
+public struct PrimerCardFormState: Equatable {
+
+  // MARK: - Core Configuration
+
+  /// Dynamic field configuration
+  public internal(set) var configuration: CardFormConfiguration
+
+  /// Type-safe form data map
+  public internal(set) var data: FormData
+
+  /// Field-specific validation errors
+  public internal(set) var fieldErrors: [FieldError]
+
+  // MARK: - Loading and Validation States
+
+  public internal(set) var isLoading: Bool
+
+  public internal(set) var isValid: Bool
+
+  // MARK: - Selection States
+
+  public internal(set) var selectedCountry: PrimerCountry?
+
+  /// Currently selected card network (for co-badged cards)
+  public internal(set) var selectedNetwork: PrimerCardNetwork?
+
+  /// Available card networks detected from card number
+  public internal(set) var availableNetworks: [PrimerCardNetwork]
+
+  // MARK: - Additional Information
+
+  /// Surcharge amount in smallest currency unit (e.g., cents)
+  public internal(set) var surchargeAmountRaw: Int?
+
+  /// Surcharge amount to display (formatted string)
+  public internal(set) var surchargeAmount: String?
+
+  // MARK: - BIN Data
+
+  public internal(set) var binData: PrimerBinData?
+
+  // MARK: - Initialization
+
+  public init(
+    configuration: CardFormConfiguration = .default,
+    data: FormData = FormData(),
+    fieldErrors: [FieldError] = [],
+    isLoading: Bool = false,
+    isValid: Bool = false,
+    selectedCountry: PrimerCountry? = nil,
+    selectedNetwork: PrimerCardNetwork? = nil,
+    availableNetworks: [PrimerCardNetwork] = [],
+    surchargeAmountRaw: Int? = nil,
+    surchargeAmount: String? = nil,
+    binData: PrimerBinData? = nil
+  ) {
+    self.configuration = configuration
+    self.data = data
+    self.fieldErrors = fieldErrors
+    self.isLoading = isLoading
+    self.isValid = isValid
+    self.selectedCountry = selectedCountry
+    self.selectedNetwork = selectedNetwork
+    self.availableNetworks = availableNetworks
+    self.surchargeAmountRaw = surchargeAmountRaw
+    self.surchargeAmount = surchargeAmount
+    self.binData = binData
+  }
+
+  // MARK: - Convenience Properties
+
+  /// All fields that should be displayed (card + billing if enabled)
+  public var displayFields: [PrimerInputElementType] {
+    configuration.allFields
+  }
+
+  public func hasError(for fieldType: PrimerInputElementType) -> Bool {
+    fieldErrors.contains { $0.fieldType == fieldType }
+  }
+
+  public func errorMessage(for fieldType: PrimerInputElementType) -> String? {
+    fieldErrors.first { $0.fieldType == fieldType }?.message
+  }
+
+  public mutating func setError(
+    _ message: String, for fieldType: PrimerInputElementType, errorCode: String? = nil
+  ) {
+    fieldErrors.removeAll { $0.fieldType == fieldType }
+    fieldErrors.append(FieldError(fieldType: fieldType, message: message, errorCode: errorCode))
+  }
+
+  public mutating func clearError(for fieldType: PrimerInputElementType) {
+    fieldErrors.removeAll { $0.fieldType == fieldType }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/ComponentTypeAliases.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/ComponentTypeAliases.swift
@@ -1,0 +1,49 @@
+//
+//  ComponentTypeAliases.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+// MARK: - Component Type Aliases
+
+/// Basic UI component returning any View (wrapped in AnyView at usage site internally)
+@available(iOS 15.0, *)
+public typealias Component = () -> any View
+
+/// Container component that wraps content with custom presentation
+@available(iOS 15.0, *)
+public typealias ContainerComponent = (@escaping () -> any View) -> any View
+
+/// Error display component receiving error message
+@available(iOS 15.0, *)
+public typealias ErrorComponent = (String) -> any View
+
+/// Payment method item customization receiving method data
+@available(iOS 15.0, *)
+public typealias PaymentMethodItemComponent = (CheckoutPaymentMethod) -> any View
+
+/// Country item customization receiving country data and selection callback
+@available(iOS 15.0, *)
+public typealias CountryItemComponent = (PrimerCountry, @escaping () -> Void) -> any View
+
+/// Category header component receiving category name
+@available(iOS 15.0, *)
+public typealias CategoryHeaderComponent = (String) -> any View
+
+// MARK: - Scope-Aware Screen Components
+
+/// Screen component receiving PaymentMethodSelectionScope for full customization.
+/// Enables merchants to build completely custom payment selection screens with access to
+/// payment methods list and navigation actions.
+@available(iOS 15.0, *)
+public typealias PaymentMethodSelectionScreenComponent =
+  (PrimerPaymentMethodSelectionScope) -> any View
+
+/// Screen component receiving CardFormScope for full customization.
+/// Enables merchants to build completely custom card forms with access to
+/// form state, validation, and submit actions.
+@available(iOS 15.0, *)
+public typealias CardFormScreenComponent =
+  (any PrimerCardFormScope) -> any View

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/InputFieldConfig.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/InputFieldConfig.swift
@@ -1,0 +1,62 @@
+//
+//  InputFieldConfig.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+// MARK: - Input Field Configuration
+
+/// Configuration for customizing a text input field.
+/// Supports partial customization (label, placeholder, styling) or full component replacement.
+///
+/// ## Usage Examples
+///
+/// ### Partial Customization
+/// ```swift
+/// InputFieldConfig(
+///     label: "Card Number",
+///     placeholder: "0000 0000 0000 0000",
+///     styling: PrimerFieldStyling(borderColor: .blue)
+/// )
+/// ```
+///
+/// ### Full Component Replacement
+/// ```swift
+/// InputFieldConfig(component: { MyCustomCardNumberField() })
+/// ```
+@available(iOS 15.0, *)
+public struct InputFieldConfig {
+
+  /// Custom label text. When nil, uses SDK default label.
+  public let label: String?
+
+  /// Custom placeholder text. When nil, uses SDK default placeholder.
+  public let placeholder: String?
+
+  /// Custom styling configuration. When nil, uses SDK default styling.
+  public let styling: PrimerFieldStyling?
+
+  /// Full component replacement. When provided, label/placeholder/styling are ignored
+  /// and the custom component is rendered instead.
+  public let component: Component?
+
+  /// Creates a new input field configuration.
+  /// - Parameters:
+  ///   - label: Custom label text. Default: nil (uses SDK default)
+  ///   - placeholder: Custom placeholder text. Default: nil (uses SDK default)
+  ///   - styling: Custom styling. Default: nil (uses SDK default)
+  ///   - component: Full component replacement. Default: nil (uses SDK default field)
+  public init(
+    label: String? = nil,
+    placeholder: String? = nil,
+    styling: PrimerFieldStyling? = nil,
+    component: Component? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.styling = styling
+    self.component = component
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerAchScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerAchScope.swift
@@ -1,0 +1,85 @@
+//
+//  PrimerAchScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Closure that provides a custom screen for ACH payment steps.
+@available(iOS 15.0, *)
+public typealias AchScreenComponent = (any PrimerAchScope) -> any View
+
+/// Closure that provides a custom button for ACH payment actions.
+@available(iOS 15.0, *)
+public typealias AchButtonComponent = (any PrimerAchScope) -> any View
+
+/// Scope protocol for ACH bank payment methods (Stripe ACH).
+///
+/// ACH payments follow a multi-step flow:
+/// 1. **User details collection** — first name, last name, email
+/// 2. **Bank account collection** — presented via `bankCollectorViewController`
+/// 3. **Mandate acceptance** — user reviews and accepts or declines the ACH mandate
+///
+/// Observe `state` to track the current step and react to transitions:
+/// ```swift
+/// for await achState in achScope.state {
+///     switch achState.step {
+///     case .userDetailsCollection:
+///         showUserDetailsForm()
+///     case .bankAccountCollection:
+///         presentBankCollector(achScope.bankCollectorViewController)
+///     case .mandateAcceptance:
+///         showMandate(achState.mandateText)
+///     case .processing:
+///         showLoadingIndicator()
+///     }
+/// }
+/// ```
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerAchScope: PrimerPaymentMethodScope where State == PrimerAchState {
+
+  /// Async stream of ACH payment state including current step, user details, and validation.
+  var state: AsyncStream<PrimerAchState> { get }
+
+  /// The bank collector view controller provided by Stripe SDK.
+  /// Present this when `state.step` is `.bankAccountCollection`.
+  var bankCollectorViewController: UIViewController? { get }
+
+  // MARK: - User Details Actions
+
+  /// Updates the first name field value.
+  func updateFirstName(_ value: String)
+
+  /// Updates the last name field value.
+  func updateLastName(_ value: String)
+
+  /// Updates the email address field value.
+  func updateEmailAddress(_ value: String)
+
+  /// Validates and submits user details, advancing to bank account collection.
+  func submitUserDetails()
+
+  // MARK: - Mandate Actions
+
+  /// Accepts the ACH mandate, proceeding to payment processing.
+  func acceptMandate()
+
+  /// Declines the ACH mandate, cancelling the payment flow.
+  func declineMandate()
+
+  // MARK: - Screen-Level Customization
+
+  /// Replaces the entire ACH screen (all steps) with a custom view.
+  var screen: AchScreenComponent? { get set }
+
+  /// Replaces the user details collection screen with a custom view.
+  var userDetailsScreen: AchScreenComponent? { get set }
+
+  /// Replaces the mandate acceptance screen with a custom view.
+  var mandateScreen: AchScreenComponent? { get set }
+
+  /// Replaces the submit/continue button with a custom view.
+  var submitButton: AchButtonComponent? { get set }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerAchScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerAchScope.swift
@@ -40,9 +40,6 @@ public typealias AchButtonComponent = (any PrimerAchScope) -> any View
 @MainActor
 public protocol PrimerAchScope: PrimerPaymentMethodScope where State == PrimerAchState {
 
-  /// Async stream of ACH payment state including current step, user details, and validation.
-  var state: AsyncStream<PrimerAchState> { get }
-
   /// The bank collector view controller provided by Stripe SDK.
   /// Present this when `state.step` is `.bankAccountCollection`.
   var bankCollectorViewController: UIViewController? { get }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerApplePayScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerApplePayScope.swift
@@ -1,0 +1,37 @@
+//
+//  PrimerApplePayScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PassKit
+import SwiftUI
+
+/// Protocol defining the Apple Pay scope interface for CheckoutComponents.
+/// Provides access to Apple Pay state, button customization, and payment flow control.
+/// Access availability and button configuration through the `state` async stream.
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerApplePayScope: PrimerPaymentMethodScope where State == PrimerApplePayState {
+
+  // MARK: - State
+
+  /// The current state of the Apple Pay scope as an async stream.
+  var state: AsyncStream<PrimerApplePayState> { get }
+
+  // MARK: - UI Customization
+
+  /// Custom Apple Pay screen override
+  var screen: ((_ scope: any PrimerApplePayScope) -> any View)? { get set }
+
+  /// Custom Apple Pay button override
+  var applePayButton: ((_ action: @escaping () -> Void) -> any View)? { get set }
+
+  // MARK: - ViewBuilder Components
+  // swiftlint:disable identifier_name
+  /// Returns the default Apple Pay button view
+  /// - Parameter action: The action to perform when the button is tapped
+  /// - Returns: A SwiftUI view containing the Apple Pay button
+  func PrimerApplePayButton(action: @escaping () -> Void) -> AnyView
+  // swiftlint:enable identifier_name
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerApplePayScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerApplePayScope.swift
@@ -7,6 +7,12 @@
 import PassKit
 import SwiftUI
 
+@available(iOS 15.0, *)
+public typealias ApplePayScreenComponent = (_ scope: any PrimerApplePayScope) -> any View
+
+@available(iOS 15.0, *)
+public typealias ApplePayButtonComponent = (_ action: @escaping () -> Void) -> any View
+
 /// Protocol defining the Apple Pay scope interface for CheckoutComponents.
 /// Provides access to Apple Pay state, button customization, and payment flow control.
 /// Access availability and button configuration through the `state` async stream.
@@ -16,16 +22,13 @@ public protocol PrimerApplePayScope: PrimerPaymentMethodScope where State == Pri
 
   // MARK: - State
 
-  /// The current state of the Apple Pay scope as an async stream.
-  var state: AsyncStream<PrimerApplePayState> { get }
-
   // MARK: - UI Customization
 
   /// Custom Apple Pay screen override
-  var screen: ((_ scope: any PrimerApplePayScope) -> any View)? { get set }
+  var screen: ApplePayScreenComponent? { get set }
 
   /// Custom Apple Pay button override
-  var applePayButton: ((_ action: @escaping () -> Void) -> any View)? { get set }
+  var applePayButton: ApplePayButtonComponent? { get set }
 
   // MARK: - ViewBuilder Components
   // swiftlint:disable identifier_name

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCardFormScope.swift
@@ -55,27 +55,8 @@ import SwiftUI
 public protocol PrimerCardFormScope: PrimerPaymentMethodScope
 where State == PrimerCardFormState {
 
-  /// Async stream of the current card form state including field values, validation, and networks.
-  var state: AsyncStream<PrimerCardFormState> { get }
-
   /// Card form-specific UI options from the SDK settings.
   var cardFormUIOptions: PrimerCardFormUIOptions? { get }
-
-  // MARK: - Payment Method Lifecycle
-
-  /// Initializes the card form and begins field observation.
-  func start()
-
-  /// Submits the card form for tokenization and payment processing.
-  func submit()
-
-  /// Cancels the card form and returns to the previous screen.
-  func cancel()
-
-  // MARK: - Navigation Methods
-
-  /// Called when the user taps the back button.
-  func onBack()
 
   // MARK: - Update Methods
 
@@ -178,16 +159,6 @@ where State == PrimerCardFormState {
 
   func DefaultCardFormView(styling: PrimerFieldStyling?) -> AnyView
 
-}
-
-// MARK: - Default Implementation for Payment Method Lifecycle
-
-@available(iOS 15.0, *)
-extension PrimerCardFormScope {
-
-  public func start() {
-    // Override if initialization logic needed
-  }
 }
 
 // MARK: - Structured State Default Implementations

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCardFormScope.swift
@@ -1,0 +1,262 @@
+//
+//  PrimerCardFormScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+// swiftlint:disable identifier_name
+
+import SwiftUI
+
+/// Scope interface for the card payment form, providing field management and UI customization.
+///
+/// `PrimerCardFormScope` is the primary interface for interacting with card payment forms
+/// in CheckoutComponents. It provides:
+/// - State observation for form fields, validation, and co-badged card networks
+/// - Methods to update individual field values
+/// - UI customization at field, section, and screen levels
+/// - Navigation and submission controls
+///
+/// ## State Observation
+/// Use the `state` async stream to observe form changes:
+/// ```swift
+/// for await formState in cardFormScope.state {
+///     if formState.isValid {
+///         enableSubmitButton()
+///     }
+///     if let network = formState.selectedNetwork {
+///         updateNetworkIcon(network)
+///     }
+/// }
+/// ```
+///
+/// ## Field Updates
+/// Update individual fields using the provided methods:
+/// ```swift
+/// cardFormScope.updateCardNumber("4242424242424242")
+/// cardFormScope.updateExpiryDate("12/25")
+/// cardFormScope.updateCvv("123")
+/// ```
+///
+/// ## UI Customization
+/// Customize the form at multiple levels:
+/// ```swift
+/// // Field-level customization
+/// cardFormScope.cardNumberConfig = InputFieldConfig(label: "Card Number")
+///
+/// // Section-level customization
+/// cardFormScope.cardInputSection = { AnyView(MyCustomCardSection()) }
+///
+/// // Full screen replacement
+/// cardFormScope.screen = { scope in AnyView(MyCustomCardForm(scope: scope)) }
+/// ```
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerCardFormScope: PrimerPaymentMethodScope
+where State == PrimerCardFormState {
+
+  /// Async stream of the current card form state including field values, validation, and networks.
+  var state: AsyncStream<PrimerCardFormState> { get }
+
+  /// Card form-specific UI options from the SDK settings.
+  var cardFormUIOptions: PrimerCardFormUIOptions? { get }
+
+  // MARK: - Payment Method Lifecycle
+
+  /// Initializes the card form and begins field observation.
+  func start()
+
+  /// Submits the card form for tokenization and payment processing.
+  func submit()
+
+  /// Cancels the card form and returns to the previous screen.
+  func cancel()
+
+  // MARK: - Navigation Methods
+
+  /// Called when the user taps the back button.
+  func onBack()
+
+  // MARK: - Update Methods
+
+  func updateCardNumber(_ cardNumber: String)
+  func updateCvv(_ cvv: String)
+  func updateExpiryDate(_ expiryDate: String)
+  func updateCardholderName(_ cardholderName: String)
+  func updatePostalCode(_ postalCode: String)
+  func updateCity(_ city: String)
+  func updateState(_ state: String)
+  func updateAddressLine1(_ addressLine1: String)
+  func updateAddressLine2(_ addressLine2: String)
+  func updatePhoneNumber(_ phoneNumber: String)
+  func updateFirstName(_ firstName: String)
+  func updateLastName(_ lastName: String)
+  func updateRetailOutlet(_ retailOutlet: String)
+  func updateOtpCode(_ otpCode: String)
+  func updateEmail(_ email: String)
+  func updateExpiryMonth(_ month: String)
+  func updateExpiryYear(_ year: String)
+  func updateSelectedCardNetwork(_ network: String)
+  func updateCountryCode(_ countryCode: String)
+
+  // MARK: - Nested Scope
+
+  var selectCountry: PrimerSelectCountryScope { get }
+
+  // MARK: - Screen-Level Customization
+
+  var title: String? { get set }
+  var screen: CardFormScreenComponent? { get set }
+  var cobadgedCardsView:
+    ((_ availableNetworks: [String], _ selectNetwork: @escaping (String) -> Void) -> any View)? { get set }
+  var errorScreen: ErrorComponent? { get set }
+
+  // MARK: - Submit Button Customization
+
+  var submitButtonText: String? { get set }
+  var showSubmitLoadingIndicator: Bool { get set }
+
+  // MARK: - Field-Level Customization via InputFieldConfig
+
+  var cardNumberConfig: InputFieldConfig? { get set }
+  var expiryDateConfig: InputFieldConfig? { get set }
+  var cvvConfig: InputFieldConfig? { get set }
+  var cardholderNameConfig: InputFieldConfig? { get set }
+  var postalCodeConfig: InputFieldConfig? { get set }
+  var countryConfig: InputFieldConfig? { get set }
+  var cityConfig: InputFieldConfig? { get set }
+  var stateConfig: InputFieldConfig? { get set }
+  var addressLine1Config: InputFieldConfig? { get set }
+  var addressLine2Config: InputFieldConfig? { get set }
+  var phoneNumberConfig: InputFieldConfig? { get set }
+  var firstNameConfig: InputFieldConfig? { get set }
+  var lastNameConfig: InputFieldConfig? { get set }
+  var emailConfig: InputFieldConfig? { get set }
+  var retailOutletConfig: InputFieldConfig? { get set }
+  var otpCodeConfig: InputFieldConfig? { get set }
+
+  // MARK: - Section-Level Customization
+
+  var cardInputSection: Component? { get set }
+  var billingAddressSection: Component? { get set }
+  var submitButton: Component? { get set }
+
+  // MARK: - ViewBuilder Methods for SDK Components
+
+  func PrimerCardNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerExpiryDateField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerCvvField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerCardholderNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerCountryField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerPostalCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerCityField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerStateField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerAddressLine1Field(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerAddressLine2Field(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerFirstNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerLastNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerEmailField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerPhoneNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerRetailOutletField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerOtpCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+
+  // MARK: - Validation State Communication
+
+  func updateValidationState(cardNumber: Bool, cvv: Bool, expiry: Bool, cardholderName: Bool)
+  func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool)
+
+  // MARK: - Structured State Support
+
+  func updateField(_ fieldType: PrimerInputElementType, value: String)
+  func getFieldValue(_ fieldType: PrimerInputElementType) -> String
+  func setFieldError(_ fieldType: PrimerInputElementType, message: String, errorCode: String?)
+  func clearFieldError(_ fieldType: PrimerInputElementType)
+  func getFieldError(_ fieldType: PrimerInputElementType) -> String?
+  func getFormConfiguration() -> CardFormConfiguration
+
+  // MARK: - Default Card Form View
+
+  func DefaultCardFormView(styling: PrimerFieldStyling?) -> AnyView
+
+}
+
+// MARK: - Default Implementation for Payment Method Lifecycle
+
+@available(iOS 15.0, *)
+extension PrimerCardFormScope {
+
+  public func start() {
+    // Override if initialization logic needed
+  }
+}
+
+// MARK: - Structured State Default Implementations
+
+@available(iOS 15.0, *)
+extension PrimerCardFormScope {
+
+  public func updateField(_ fieldType: PrimerInputElementType, value: String) {
+    switch fieldType {
+    case .cardNumber:
+      updateCardNumber(value)
+    case .cvv:
+      updateCvv(value)
+    case .expiryDate:
+      updateExpiryDate(value)
+    case .cardholderName:
+      updateCardholderName(value)
+    case .postalCode:
+      updatePostalCode(value)
+    case .countryCode:
+      updateCountryCode(value)
+    case .city:
+      updateCity(value)
+    case .state:
+      updateState(value)
+    case .addressLine1:
+      updateAddressLine1(value)
+    case .addressLine2:
+      updateAddressLine2(value)
+    case .phoneNumber:
+      updatePhoneNumber(value)
+    case .firstName:
+      updateFirstName(value)
+    case .lastName:
+      updateLastName(value)
+    case .email:
+      updateEmail(value)
+    case .retailer:
+      updateRetailOutlet(value)
+    case .otp:
+      updateOtpCode(value)
+    case .unknown, .all:
+      break  // Not implemented for these special cases
+    }
+  }
+
+  public func getFieldValue(_ fieldType: PrimerInputElementType) -> String {
+    ""
+  }
+
+  public func setFieldError(
+    _ fieldType: PrimerInputElementType, message: String, errorCode: String? = nil
+  ) {
+  }
+
+  public func clearFieldError(_ fieldType: PrimerInputElementType) {
+  }
+
+  public func getFieldError(_ fieldType: PrimerInputElementType) -> String? {
+    nil
+  }
+
+  public func getFormConfiguration() -> CardFormConfiguration {
+    CardFormConfiguration.default
+  }
+
+  public func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool) {
+    // No-op default; overridden in DefaultCardFormScope
+  }
+}
+
+// swiftlint:enable identifier_name

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutScope.swift
@@ -1,0 +1,171 @@
+//
+//  PrimerCheckoutScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Closure type for the `onBeforePaymentCreate` callback.
+/// Provides payment method data and a decision handler to continue or abort payment creation.
+@available(iOS 15.0, *)
+public typealias BeforePaymentCreateHandler = @Sendable (
+  _ data: PrimerCheckoutPaymentMethodData,
+  _ decisionHandler: @escaping (PrimerPaymentCreationDecision) -> Void
+) -> Void
+
+/// The main scope interface for PrimerCheckout, providing lifecycle control and customizable UI components.
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerCheckoutScope: AnyObject {
+
+  /// The current state of the checkout flow as an async stream.
+  var state: AsyncStream<PrimerCheckoutState> { get }
+
+  // MARK: - Customizable Screens
+
+  /// Default implementation provides standard checkout container.
+  var container: ContainerComponent? { get set }
+
+  /// Custom splash screen shown during SDK initialization.
+  /// Default implementation shows Primer branding.
+  var splashScreen: Component? { get set }
+
+  /// Custom loading screen shown during payment processing.
+  /// Default implementation shows a centered loading indicator with "Loading" text.
+  var loadingScreen: Component? { get set }
+
+  // Note: Success screen removed - CheckoutComponents dismisses immediately on success
+  // The delegate handles presenting the result screen via PrimerResultViewController
+
+  /// Default implementation shows error icon and message.
+  var errorScreen: ErrorComponent? { get set }
+
+  // MARK: - Nested Scopes
+
+  var paymentMethodSelection: PrimerPaymentMethodSelectionScope { get }
+
+  // MARK: - Dynamic Payment Method Scope Access
+
+  /// Gets a payment method scope using type-safe metatype (recommended approach).
+  /// This is the preferred method for static type-safe access to payment method scopes.
+  /// - Parameter scopeType: The scope type to create (e.g., PrimerCardFormScope.self)
+  /// - Returns: A configured scope instance for the payment method, or nil if not registered
+  ///
+  /// Example usage:
+  /// ```swift
+  /// let cardFormScope = checkoutScope.getPaymentMethodScope(PrimerCardFormScope.self)
+  /// ```
+  func getPaymentMethodScope<T: PrimerPaymentMethodScope>(_ scopeType: T.Type) -> T?
+
+  /// Gets a payment method scope using enum-based type specification.
+  /// This method provides discoverable access to payment method scopes via enum cases.
+  /// - Parameter methodType: The payment method type enum case
+  /// - Returns: A configured scope instance for the payment method, or nil if not registered
+  ///
+  /// Example usage:
+  /// ```swift
+  /// let cardFormScope: PrimerCardFormScope = checkoutScope.getPaymentMethodScope(for: .paymentCard)
+  /// ```
+  func getPaymentMethodScope<T: PrimerPaymentMethodScope>(for methodType: PrimerPaymentMethodType)
+    -> T?
+
+  /// Gets a payment method scope for the specified payment method string identifier.
+  /// This method provides dynamic access for runtime-determined payment methods.
+  /// - Parameter paymentMethodType: The payment method type identifier (e.g., "PAYMENT_CARD", "PAYPAL")
+  /// - Returns: A configured scope instance for the payment method, or nil if not registered
+  ///
+  /// Example usage:
+  /// ```swift
+  /// let cardFormScope: PrimerCardFormScope = checkoutScope.getPaymentMethodScope(for: "PAYMENT_CARD")
+  /// ```
+  func getPaymentMethodScope<T: PrimerPaymentMethodScope>(for paymentMethodType: String) -> T?
+
+  // MARK: - Payment Method Screen Customization
+  // Removed: setPaymentMethodScreen and getPaymentMethodScreen methods
+  // Use PaymentMethodProtocol.content() for custom UI with ViewBuilder pattern
+
+  // MARK: - Payment Callbacks
+
+  /// Called before a payment is created. Use the decision handler to provide an idempotency key
+  /// or abort payment creation. If not set, payments proceed without an idempotency key.
+  var onBeforePaymentCreate: BeforePaymentCreateHandler? { get set }
+
+  // MARK: - Payment Settings
+
+  /// Payment handling mode (auto vs manual).
+  /// - `.auto`: Payments are automatically processed after tokenization (default)
+  /// - `.manual`: Payments require explicit confirmation from your backend
+  var paymentHandling: PrimerPaymentHandling { get }
+
+  // MARK: - Navigation
+
+  /// Dismisses the checkout flow.
+  func onDismiss()
+}
+
+// MARK: - State Definition
+
+/// Represents the current state of the checkout flow.
+///
+/// `PrimerCheckoutState` provides a way to observe the checkout lifecycle and respond
+/// to state changes. Use the `state` async stream on `PrimerCheckoutScope` to receive
+/// state updates.
+///
+/// Example usage:
+/// ```swift
+/// for await state in checkoutScope.state {
+///     switch state {
+///     case .initializing:
+///         showLoadingIndicator()
+///     case .ready(let amount, let currency):
+///         showPaymentMethods(amount: amount, currency: currency)
+///     case .success(let result):
+///         showSuccessScreen(paymentId: result.paymentId)
+///     case .failure(let error):
+///         showErrorScreen(error: error)
+///     case .dismissed:
+///         handleDismissal()
+///     }
+/// }
+/// ```
+@available(iOS 15.0, *)
+public enum PrimerCheckoutState: Equatable {
+  /// Initial state while loading configuration and payment methods.
+  /// The SDK is fetching the client session and preparing available payment methods.
+  case initializing
+
+  /// Ready state with payment methods loaded and checkout available.
+  /// - Parameters:
+  ///   - totalAmount: The total payment amount in minor units (e.g., cents for USD).
+  ///   - currencyCode: The ISO 4217 currency code (e.g., "USD", "EUR", "GBP").
+  case ready(totalAmount: Int, currencyCode: String)
+
+  /// Payment completed successfully.
+  /// Contains the full payment result with payment ID, status, and other details.
+  case success(PaymentResult)
+
+  /// Checkout has been dismissed by user action or programmatically.
+  /// This is a terminal state indicating the checkout flow has ended without payment.
+  case dismissed
+
+  /// Payment or checkout failed with an error.
+  /// Contains the specific error with diagnostics information for debugging.
+  case failure(PrimerError)
+
+  public static func == (lhs: PrimerCheckoutState, rhs: PrimerCheckoutState) -> Bool {
+    switch (lhs, rhs) {
+    case (.initializing, .initializing),
+      (.dismissed, .dismissed):
+      true
+    case let (.ready(lhsAmount, lhsCurrency), .ready(rhsAmount, rhsCurrency)):
+      lhsAmount == rhsAmount && lhsCurrency == rhsCurrency
+    case let (.success(lhsResult), .success(rhsResult)):
+      lhsResult.paymentId == rhsResult.paymentId
+    case let (.failure(lhsError), .failure(rhsError)):
+      lhsError.errorId == rhsError.errorId
+    default:
+      false
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutScope.swift
@@ -9,10 +9,8 @@ import SwiftUI
 /// Closure type for the `onBeforePaymentCreate` callback.
 /// Provides payment method data and a decision handler to continue or abort payment creation.
 @available(iOS 15.0, *)
-public typealias BeforePaymentCreateHandler = @Sendable (
-  _ data: PrimerCheckoutPaymentMethodData,
-  _ decisionHandler: @escaping (PrimerPaymentCreationDecision) -> Void
-) -> Void
+public typealias BeforePaymentCreateHandler = @Sendable (_ data: PrimerCheckoutPaymentMethodData,
+                                                        _ decisionHandler: @escaping (PrimerPaymentCreationDecision) -> Void) -> Void
 
 /// The main scope interface for PrimerCheckout, providing lifecycle control and customizable UI components.
 @available(iOS 15.0, *)
@@ -34,9 +32,6 @@ public protocol PrimerCheckoutScope: AnyObject {
   /// Custom loading screen shown during payment processing.
   /// Default implementation shows a centered loading indicator with "Loading" text.
   var loadingScreen: Component? { get set }
-
-  // Note: Success screen removed - CheckoutComponents dismisses immediately on success
-  // The delegate handles presenting the result screen via PrimerResultViewController
 
   /// Default implementation shows error icon and message.
   var errorScreen: ErrorComponent? { get set }
@@ -80,10 +75,6 @@ public protocol PrimerCheckoutScope: AnyObject {
   /// let cardFormScope: PrimerCardFormScope = checkoutScope.getPaymentMethodScope(for: "PAYMENT_CARD")
   /// ```
   func getPaymentMethodScope<T: PrimerPaymentMethodScope>(for paymentMethodType: String) -> T?
-
-  // MARK: - Payment Method Screen Customization
-  // Removed: setPaymentMethodScreen and getPaymentMethodScreen methods
-  // Use PaymentMethodProtocol.content() for custom UI with ViewBuilder pattern
 
   // MARK: - Payment Callbacks
 
@@ -129,6 +120,7 @@ public protocol PrimerCheckoutScope: AnyObject {
 ///     }
 /// }
 /// ```
+/// When switching on this enum, always include a `default` case to handle future additions.
 @available(iOS 15.0, *)
 public enum PrimerCheckoutState: Equatable {
   /// Initial state while loading configuration and payment methods.

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
@@ -1,0 +1,433 @@
+//
+//  PrimerCheckoutTheme.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+// MARK: - PrimerCheckoutTheme
+
+/// Theme configuration providing optional overrides for internal design tokens.
+///
+/// Internal `DesignTokens` and `DesignTokensDark` classes (auto-generated from JSON)
+/// remain the source of truth. `PrimerCheckoutTheme` allows merchants to override specific
+/// token values without replacing the entire token system.
+///
+/// When a merchant provides an override, `DesignTokensManager` merges it with
+/// internal defaults. Nil values fall back to internal token values.
+@available(iOS 15.0, *)
+public struct PrimerCheckoutTheme {
+
+  public let colors: ColorOverrides?
+  public let radius: RadiusOverrides?
+  public let spacing: SpacingOverrides?
+  public let sizes: SizeOverrides?
+  public let typography: TypographyOverrides?
+  public let borderWidth: BorderWidthOverrides?
+
+  /// Creates a new theme configuration with optional overrides.
+  /// - Parameters:
+  ///   - colors: Color token overrides. Default: nil (uses internal defaults)
+  ///   - radius: Radius token overrides. Default: nil (uses internal defaults)
+  ///   - spacing: Spacing token overrides. Default: nil (uses internal defaults)
+  ///   - sizes: Size token overrides. Default: nil (uses internal defaults)
+  ///   - typography: Typography token overrides. Default: nil (uses internal defaults)
+  ///   - borderWidth: Border width token overrides. Default: nil (uses internal defaults)
+  public init(
+    colors: ColorOverrides? = nil,
+    radius: RadiusOverrides? = nil,
+    spacing: SpacingOverrides? = nil,
+    sizes: SizeOverrides? = nil,
+    typography: TypographyOverrides? = nil,
+    borderWidth: BorderWidthOverrides? = nil
+  ) {
+    self.colors = colors
+    self.radius = radius
+    self.spacing = spacing
+    self.sizes = sizes
+    self.typography = typography
+    self.borderWidth = borderWidth
+  }
+}
+
+// MARK: - ColorOverrides
+
+/// Optional color token overrides.
+/// Property names match internal `DesignTokens` for consistency.
+/// All properties are optional - nil values use internal defaults.
+@available(iOS 15.0, *)
+public struct ColorOverrides {
+
+  // MARK: Brand & Primary Colors
+
+  public let primerColorBrand: Color?
+
+  // MARK: Grays (matching internal DesignTokens)
+
+  public let primerColorGray000: Color?
+  public let primerColorGray100: Color?
+  public let primerColorGray200: Color?
+  public let primerColorGray300: Color?
+  public let primerColorGray400: Color?
+  public let primerColorGray500: Color?
+  public let primerColorGray600: Color?
+  public let primerColorGray700: Color?
+  public let primerColorGray900: Color?
+
+  // MARK: Semantic Colors (matching internal DesignTokens)
+
+  /// Success color (internal: primerColorGreen500)
+  public let primerColorGreen500: Color?
+  /// Error colors (internal: primerColorRed100, primerColorRed500, primerColorRed900)
+  public let primerColorRed100: Color?
+  public let primerColorRed500: Color?
+  public let primerColorRed900: Color?
+  /// Info/link colors (internal: primerColorBlue500, primerColorBlue900)
+  public let primerColorBlue500: Color?
+  public let primerColorBlue900: Color?
+
+  // MARK: Semantic UI Colors (matching internal DesignTokens)
+
+  public let primerColorBackground: Color?
+  public let primerColorTextPrimary: Color?
+  public let primerColorTextSecondary: Color?
+  public let primerColorTextPlaceholder: Color?
+  public let primerColorTextDisabled: Color?
+  public let primerColorTextNegative: Color?
+  public let primerColorTextLink: Color?
+
+  // MARK: Border Colors (matching internal DesignTokens)
+
+  public let primerColorBorderOutlinedDefault: Color?
+  public let primerColorBorderOutlinedHover: Color?
+  public let primerColorBorderOutlinedActive: Color?
+  public let primerColorBorderOutlinedFocus: Color?
+  public let primerColorBorderOutlinedDisabled: Color?
+  public let primerColorBorderOutlinedError: Color?
+  public let primerColorBorderOutlinedSelected: Color?
+  public let primerColorBorderOutlinedLoading: Color?
+
+  // MARK: Border Transparent Colors
+
+  public let primerColorBorderTransparentDefault: Color?
+  public let primerColorBorderTransparentHover: Color?
+  public let primerColorBorderTransparentActive: Color?
+  public let primerColorBorderTransparentFocus: Color?
+  public let primerColorBorderTransparentDisabled: Color?
+  public let primerColorBorderTransparentSelected: Color?
+
+  // MARK: Icon Colors
+
+  public let primerColorIconPrimary: Color?
+  public let primerColorIconDisabled: Color?
+  public let primerColorIconNegative: Color?
+  public let primerColorIconPositive: Color?
+
+  // MARK: Other
+
+  public let primerColorFocus: Color?
+  public let primerColorLoader: Color?
+
+  public init(
+    primerColorBrand: Color? = nil,
+    primerColorGray000: Color? = nil,
+    primerColorGray100: Color? = nil,
+    primerColorGray200: Color? = nil,
+    primerColorGray300: Color? = nil,
+    primerColorGray400: Color? = nil,
+    primerColorGray500: Color? = nil,
+    primerColorGray600: Color? = nil,
+    primerColorGray700: Color? = nil,
+    primerColorGray900: Color? = nil,
+    primerColorGreen500: Color? = nil,
+    primerColorRed100: Color? = nil,
+    primerColorRed500: Color? = nil,
+    primerColorRed900: Color? = nil,
+    primerColorBlue500: Color? = nil,
+    primerColorBlue900: Color? = nil,
+    primerColorBackground: Color? = nil,
+    primerColorTextPrimary: Color? = nil,
+    primerColorTextSecondary: Color? = nil,
+    primerColorTextPlaceholder: Color? = nil,
+    primerColorTextDisabled: Color? = nil,
+    primerColorTextNegative: Color? = nil,
+    primerColorTextLink: Color? = nil,
+    primerColorBorderOutlinedDefault: Color? = nil,
+    primerColorBorderOutlinedHover: Color? = nil,
+    primerColorBorderOutlinedActive: Color? = nil,
+    primerColorBorderOutlinedFocus: Color? = nil,
+    primerColorBorderOutlinedDisabled: Color? = nil,
+    primerColorBorderOutlinedError: Color? = nil,
+    primerColorBorderOutlinedSelected: Color? = nil,
+    primerColorBorderOutlinedLoading: Color? = nil,
+    primerColorBorderTransparentDefault: Color? = nil,
+    primerColorBorderTransparentHover: Color? = nil,
+    primerColorBorderTransparentActive: Color? = nil,
+    primerColorBorderTransparentFocus: Color? = nil,
+    primerColorBorderTransparentDisabled: Color? = nil,
+    primerColorBorderTransparentSelected: Color? = nil,
+    primerColorIconPrimary: Color? = nil,
+    primerColorIconDisabled: Color? = nil,
+    primerColorIconNegative: Color? = nil,
+    primerColorIconPositive: Color? = nil,
+    primerColorFocus: Color? = nil,
+    primerColorLoader: Color? = nil
+  ) {
+    self.primerColorBrand = primerColorBrand
+    self.primerColorGray000 = primerColorGray000
+    self.primerColorGray100 = primerColorGray100
+    self.primerColorGray200 = primerColorGray200
+    self.primerColorGray300 = primerColorGray300
+    self.primerColorGray400 = primerColorGray400
+    self.primerColorGray500 = primerColorGray500
+    self.primerColorGray600 = primerColorGray600
+    self.primerColorGray700 = primerColorGray700
+    self.primerColorGray900 = primerColorGray900
+    self.primerColorGreen500 = primerColorGreen500
+    self.primerColorRed100 = primerColorRed100
+    self.primerColorRed500 = primerColorRed500
+    self.primerColorRed900 = primerColorRed900
+    self.primerColorBlue500 = primerColorBlue500
+    self.primerColorBlue900 = primerColorBlue900
+    self.primerColorBackground = primerColorBackground
+    self.primerColorTextPrimary = primerColorTextPrimary
+    self.primerColorTextSecondary = primerColorTextSecondary
+    self.primerColorTextPlaceholder = primerColorTextPlaceholder
+    self.primerColorTextDisabled = primerColorTextDisabled
+    self.primerColorTextNegative = primerColorTextNegative
+    self.primerColorTextLink = primerColorTextLink
+    self.primerColorBorderOutlinedDefault = primerColorBorderOutlinedDefault
+    self.primerColorBorderOutlinedHover = primerColorBorderOutlinedHover
+    self.primerColorBorderOutlinedActive = primerColorBorderOutlinedActive
+    self.primerColorBorderOutlinedFocus = primerColorBorderOutlinedFocus
+    self.primerColorBorderOutlinedDisabled = primerColorBorderOutlinedDisabled
+    self.primerColorBorderOutlinedError = primerColorBorderOutlinedError
+    self.primerColorBorderOutlinedSelected = primerColorBorderOutlinedSelected
+    self.primerColorBorderOutlinedLoading = primerColorBorderOutlinedLoading
+    self.primerColorBorderTransparentDefault = primerColorBorderTransparentDefault
+    self.primerColorBorderTransparentHover = primerColorBorderTransparentHover
+    self.primerColorBorderTransparentActive = primerColorBorderTransparentActive
+    self.primerColorBorderTransparentFocus = primerColorBorderTransparentFocus
+    self.primerColorBorderTransparentDisabled = primerColorBorderTransparentDisabled
+    self.primerColorBorderTransparentSelected = primerColorBorderTransparentSelected
+    self.primerColorIconPrimary = primerColorIconPrimary
+    self.primerColorIconDisabled = primerColorIconDisabled
+    self.primerColorIconNegative = primerColorIconNegative
+    self.primerColorIconPositive = primerColorIconPositive
+    self.primerColorFocus = primerColorFocus
+    self.primerColorLoader = primerColorLoader
+  }
+}
+
+// MARK: - RadiusOverrides
+
+/// Optional radius token overrides.
+/// Property names match internal `DesignTokens`.
+@available(iOS 15.0, *)
+public struct RadiusOverrides {
+  /// Internal: primerRadiusXsmall (default: 2)
+  public let primerRadiusXsmall: CGFloat?
+  /// Internal: primerRadiusSmall (default: 4)
+  public let primerRadiusSmall: CGFloat?
+  /// Internal: primerRadiusMedium (default: 8)
+  public let primerRadiusMedium: CGFloat?
+  /// Internal: primerRadiusLarge (default: 12)
+  public let primerRadiusLarge: CGFloat?
+  /// Internal: primerRadiusBase (default: 4)
+  public let primerRadiusBase: CGFloat?
+
+  public init(
+    primerRadiusXsmall: CGFloat? = nil,
+    primerRadiusSmall: CGFloat? = nil,
+    primerRadiusMedium: CGFloat? = nil,
+    primerRadiusLarge: CGFloat? = nil,
+    primerRadiusBase: CGFloat? = nil
+  ) {
+    self.primerRadiusXsmall = primerRadiusXsmall
+    self.primerRadiusSmall = primerRadiusSmall
+    self.primerRadiusMedium = primerRadiusMedium
+    self.primerRadiusLarge = primerRadiusLarge
+    self.primerRadiusBase = primerRadiusBase
+  }
+}
+
+// MARK: - SpacingOverrides
+
+/// Optional spacing token overrides.
+/// Property names match internal `DesignTokens`.
+@available(iOS 15.0, *)
+public struct SpacingOverrides {
+  /// Internal: primerSpaceXxsmall (default: 2)
+  public let primerSpaceXxsmall: CGFloat?
+  /// Internal: primerSpaceXsmall (default: 4)
+  public let primerSpaceXsmall: CGFloat?
+  /// Internal: primerSpaceSmall (default: 8)
+  public let primerSpaceSmall: CGFloat?
+  /// Internal: primerSpaceMedium (default: 12)
+  public let primerSpaceMedium: CGFloat?
+  /// Internal: primerSpaceLarge (default: 16)
+  public let primerSpaceLarge: CGFloat?
+  /// Internal: primerSpaceXlarge (default: 20)
+  public let primerSpaceXlarge: CGFloat?
+  /// Internal: primerSpaceXxlarge (default: 24)
+  public let primerSpaceXxlarge: CGFloat?
+  /// Internal: primerSpaceBase (default: 4)
+  public let primerSpaceBase: CGFloat?
+
+  public init(
+    primerSpaceXxsmall: CGFloat? = nil,
+    primerSpaceXsmall: CGFloat? = nil,
+    primerSpaceSmall: CGFloat? = nil,
+    primerSpaceMedium: CGFloat? = nil,
+    primerSpaceLarge: CGFloat? = nil,
+    primerSpaceXlarge: CGFloat? = nil,
+    primerSpaceXxlarge: CGFloat? = nil,
+    primerSpaceBase: CGFloat? = nil
+  ) {
+    self.primerSpaceXxsmall = primerSpaceXxsmall
+    self.primerSpaceXsmall = primerSpaceXsmall
+    self.primerSpaceSmall = primerSpaceSmall
+    self.primerSpaceMedium = primerSpaceMedium
+    self.primerSpaceLarge = primerSpaceLarge
+    self.primerSpaceXlarge = primerSpaceXlarge
+    self.primerSpaceXxlarge = primerSpaceXxlarge
+    self.primerSpaceBase = primerSpaceBase
+  }
+}
+
+// MARK: - SizeOverrides
+
+/// Optional size token overrides.
+/// Property names match internal `DesignTokens`.
+@available(iOS 15.0, *)
+public struct SizeOverrides {
+  /// Internal: primerSizeSmall (default: 16)
+  public let primerSizeSmall: CGFloat?
+  /// Internal: primerSizeMedium (default: 20)
+  public let primerSizeMedium: CGFloat?
+  /// Internal: primerSizeLarge (default: 24)
+  public let primerSizeLarge: CGFloat?
+  /// Internal: primerSizeXlarge (default: 32)
+  public let primerSizeXlarge: CGFloat?
+  /// Internal: primerSizeXxlarge (default: 44)
+  public let primerSizeXxlarge: CGFloat?
+  /// Internal: primerSizeXxxlarge (default: 56)
+  public let primerSizeXxxlarge: CGFloat?
+  /// Internal: primerSizeBase (default: 4)
+  public let primerSizeBase: CGFloat?
+
+  public init(
+    primerSizeSmall: CGFloat? = nil,
+    primerSizeMedium: CGFloat? = nil,
+    primerSizeLarge: CGFloat? = nil,
+    primerSizeXlarge: CGFloat? = nil,
+    primerSizeXxlarge: CGFloat? = nil,
+    primerSizeXxxlarge: CGFloat? = nil,
+    primerSizeBase: CGFloat? = nil
+  ) {
+    self.primerSizeSmall = primerSizeSmall
+    self.primerSizeMedium = primerSizeMedium
+    self.primerSizeLarge = primerSizeLarge
+    self.primerSizeXlarge = primerSizeXlarge
+    self.primerSizeXxlarge = primerSizeXxlarge
+    self.primerSizeXxxlarge = primerSizeXxxlarge
+    self.primerSizeBase = primerSizeBase
+  }
+}
+
+// MARK: - TypographyOverrides
+
+/// Optional typography token overrides for customizing text styles.
+@available(iOS 15.0, *)
+public struct TypographyOverrides {
+
+  // MARK: - Typography Style
+
+  /// Individual typography style configuration.
+  public struct TypographyStyle {
+    /// Custom font family name (e.g., "Inter")
+    public let font: String?
+    /// Letter spacing in points
+    public let letterSpacing: CGFloat?
+    /// Font weight
+    public let weight: Font.Weight?
+    /// Font size in points
+    public let size: CGFloat?
+    /// Line height in points
+    public let lineHeight: CGFloat?
+
+    /// Creates a typography style with optional properties.
+    public init(
+      font: String? = nil,
+      letterSpacing: CGFloat? = nil,
+      weight: Font.Weight? = nil,
+      size: CGFloat? = nil,
+      lineHeight: CGFloat? = nil
+    ) {
+      self.font = font
+      self.letterSpacing = letterSpacing
+      self.weight = weight
+      self.size = size
+      self.lineHeight = lineHeight
+    }
+  }
+
+  // MARK: - Token Properties
+
+  /// Title extra large: Inter, -0.6 letter spacing, weight 550, size 24, line height 32
+  public let titleXlarge: TypographyStyle?
+
+  /// Title large: Inter, -0.2 letter spacing, weight 550, size 16, line height 20
+  public let titleLarge: TypographyStyle?
+
+  /// Body large: Inter, -0.2 letter spacing, weight 400, size 16, line height 20
+  public let bodyLarge: TypographyStyle?
+
+  /// Body medium: Inter, 0 letter spacing, weight 400, size 14, line height 20
+  public let bodyMedium: TypographyStyle?
+
+  /// Body small: Inter, 0 letter spacing, weight 400, size 12, line height 16
+  public let bodySmall: TypographyStyle?
+
+  /// Creates typography overrides with all optional properties.
+  public init(
+    titleXlarge: TypographyStyle? = nil,
+    titleLarge: TypographyStyle? = nil,
+    bodyLarge: TypographyStyle? = nil,
+    bodyMedium: TypographyStyle? = nil,
+    bodySmall: TypographyStyle? = nil
+  ) {
+    self.titleXlarge = titleXlarge
+    self.titleLarge = titleLarge
+    self.bodyLarge = bodyLarge
+    self.bodyMedium = bodyMedium
+    self.bodySmall = bodySmall
+  }
+}
+
+// MARK: - BorderWidthOverrides
+
+/// Optional border width token overrides.
+@available(iOS 15.0, *)
+public struct BorderWidthOverrides {
+  /// Internal: primerBorderWidthThin (default: 1)
+  public let primerBorderWidthThin: CGFloat?
+
+  /// Internal: primerBorderWidthMedium (default: 2)
+  public let primerBorderWidthMedium: CGFloat?
+
+  /// Internal: primerBorderWidthThick (default: 3)
+  public let primerBorderWidthThick: CGFloat?
+
+  /// Creates border width overrides with all optional properties.
+  public init(
+    primerBorderWidthThin: CGFloat? = nil,
+    primerBorderWidthMedium: CGFloat? = nil,
+    primerBorderWidthThick: CGFloat? = nil
+  ) {
+    self.primerBorderWidthThin = primerBorderWidthThin
+    self.primerBorderWidthMedium = primerBorderWidthMedium
+    self.primerBorderWidthThick = primerBorderWidthThick
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
@@ -17,7 +17,7 @@ import SwiftUI
 /// When a merchant provides an override, `DesignTokensManager` merges it with
 /// internal defaults. Nil values fall back to internal token values.
 @available(iOS 15.0, *)
-public struct PrimerCheckoutTheme {
+public struct PrimerCheckoutTheme: Equatable {
 
   public let colors: ColorOverrides?
   public let radius: RadiusOverrides?
@@ -57,7 +57,7 @@ public struct PrimerCheckoutTheme {
 /// Property names match internal `DesignTokens` for consistency.
 /// All properties are optional - nil values use internal defaults.
 @available(iOS 15.0, *)
-public struct ColorOverrides {
+public struct ColorOverrides: Equatable {
 
   // MARK: Brand & Primary Colors
 
@@ -225,7 +225,7 @@ public struct ColorOverrides {
 /// Optional radius token overrides.
 /// Property names match internal `DesignTokens`.
 @available(iOS 15.0, *)
-public struct RadiusOverrides {
+public struct RadiusOverrides: Equatable {
   /// Internal: primerRadiusXsmall (default: 2)
   public let primerRadiusXsmall: CGFloat?
   /// Internal: primerRadiusSmall (default: 4)
@@ -257,7 +257,7 @@ public struct RadiusOverrides {
 /// Optional spacing token overrides.
 /// Property names match internal `DesignTokens`.
 @available(iOS 15.0, *)
-public struct SpacingOverrides {
+public struct SpacingOverrides: Equatable {
   /// Internal: primerSpaceXxsmall (default: 2)
   public let primerSpaceXxsmall: CGFloat?
   /// Internal: primerSpaceXsmall (default: 4)
@@ -301,7 +301,7 @@ public struct SpacingOverrides {
 /// Optional size token overrides.
 /// Property names match internal `DesignTokens`.
 @available(iOS 15.0, *)
-public struct SizeOverrides {
+public struct SizeOverrides: Equatable {
   /// Internal: primerSizeSmall (default: 16)
   public let primerSizeSmall: CGFloat?
   /// Internal: primerSizeMedium (default: 20)
@@ -340,12 +340,12 @@ public struct SizeOverrides {
 
 /// Optional typography token overrides for customizing text styles.
 @available(iOS 15.0, *)
-public struct TypographyOverrides {
+public struct TypographyOverrides: Equatable {
 
   // MARK: - Typography Style
 
   /// Individual typography style configuration.
-  public struct TypographyStyle {
+  public struct TypographyStyle: Equatable {
     /// Custom font family name (e.g., "Inter")
     public let font: String?
     /// Letter spacing in points
@@ -410,7 +410,7 @@ public struct TypographyOverrides {
 
 /// Optional border width token overrides.
 @available(iOS 15.0, *)
-public struct BorderWidthOverrides {
+public struct BorderWidthOverrides: Equatable {
   /// Internal: primerBorderWidthThin (default: 1)
   public let primerBorderWidthThin: CGFloat?
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerEnvironment.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerEnvironment.swift
@@ -59,7 +59,7 @@ extension EnvironmentValues {
   ///     @Environment(\.primerCardFormScope) private var cardFormScope
   ///
   ///     var body: some View {
-  ///         Text("Card: \(cardFormScope?.structuredState.cardNumber.value ?? "")")
+  ///         Button("Submit", action: { cardFormScope?.submit() })
   ///     }
   /// }
   /// ```

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerEnvironment.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerEnvironment.swift
@@ -1,0 +1,104 @@
+//
+//  PrimerEnvironment.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+// MARK: - Scope Environment Keys
+
+@available(iOS 15.0, *)
+private struct PrimerCheckoutScopeKey: EnvironmentKey {
+  static let defaultValue: PrimerCheckoutScope? = nil
+}
+
+@available(iOS 15.0, *)
+private struct PrimerCardFormScopeKey: EnvironmentKey {
+  static let defaultValue: (any PrimerCardFormScope)? = nil
+}
+
+@available(iOS 15.0, *)
+private struct PrimerPaymentMethodSelectionScopeKey: EnvironmentKey {
+  static let defaultValue: PrimerPaymentMethodSelectionScope? = nil
+}
+
+@available(iOS 15.0, *)
+private struct PrimerSelectCountryScopeKey: EnvironmentKey {
+  static let defaultValue: PrimerSelectCountryScope? = nil
+}
+
+// MARK: - EnvironmentValues Extension
+
+@available(iOS 15.0, *)
+extension EnvironmentValues {
+  /// The checkout scope for accessing checkout state and actions
+  ///
+  /// Access from any custom view embedded in the checkout hierarchy:
+  /// ```swift
+  /// struct CustomPaymentView: View {
+  ///     @Environment(\.primerCheckoutScope) private var checkoutScope
+  ///
+  ///     var body: some View {
+  ///         Button("Cancel") {
+  ///             checkoutScope?.onDismiss()
+  ///         }
+  ///     }
+  /// }
+  /// ```
+  public var primerCheckoutScope: PrimerCheckoutScope? {
+    get { self[PrimerCheckoutScopeKey.self] }
+    set { self[PrimerCheckoutScopeKey.self] = newValue }
+  }
+
+  /// The card form scope for accessing card form state and actions
+  ///
+  /// Access from any custom view embedded in the card form hierarchy:
+  /// ```swift
+  /// struct CustomCardView: View {
+  ///     @Environment(\.primerCardFormScope) private var cardFormScope
+  ///
+  ///     var body: some View {
+  ///         Text("Card: \(cardFormScope?.structuredState.cardNumber.value ?? "")")
+  ///     }
+  /// }
+  /// ```
+  public var primerCardFormScope: (any PrimerCardFormScope)? {
+    get { self[PrimerCardFormScopeKey.self] }
+    set { self[PrimerCardFormScopeKey.self] = newValue }
+  }
+
+  /// The payment method selection scope for accessing selection state and actions
+  ///
+  /// Access from any custom view embedded in the payment selection hierarchy:
+  /// ```swift
+  /// struct CustomSelectionView: View {
+  ///     @Environment(\.primerPaymentMethodSelectionScope) private var selectionScope
+  ///
+  ///     var body: some View {
+  ///         // Access available payment methods
+  ///     }
+  /// }
+  /// ```
+  public var primerPaymentMethodSelectionScope: PrimerPaymentMethodSelectionScope? {
+    get { self[PrimerPaymentMethodSelectionScopeKey.self] }
+    set { self[PrimerPaymentMethodSelectionScopeKey.self] = newValue }
+  }
+
+  /// The select country scope for accessing country selection state and actions
+  ///
+  /// Access from any custom view embedded in the country selection hierarchy:
+  /// ```swift
+  /// struct CustomCountryView: View {
+  ///     @Environment(\.primerSelectCountryScope) private var countryScope
+  ///
+  ///     var body: some View {
+  ///         // Access available countries
+  ///     }
+  /// }
+  /// ```
+  public var primerSelectCountryScope: PrimerSelectCountryScope? {
+    get { self[PrimerSelectCountryScopeKey.self] }
+    set { self[PrimerSelectCountryScopeKey.self] = newValue }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerFieldStyling.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerFieldStyling.swift
@@ -1,0 +1,132 @@
+//
+//  PrimerFieldStyling.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Styling configuration for Primer input fields, enabling deep customization of field appearance
+/// including fonts, colors, borders, and layout properties.
+///
+/// All properties are optional — any `nil` value falls back to the SDK's design token defaults.
+///
+/// ```swift
+/// let styling = PrimerFieldStyling(
+///     fontName: "Helvetica Neue",
+///     fontSize: 16,
+///     textColor: .primary,
+///     backgroundColor: .gray.opacity(0.05),
+///     borderColor: .gray.opacity(0.3),
+///     focusedBorderColor: .blue,
+///     errorBorderColor: .red,
+///     cornerRadius: 8,
+///     borderWidth: 1,
+///     padding: EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16),
+///     fieldHeight: 56
+/// )
+/// ```
+@available(iOS 15.0, *)
+public struct PrimerFieldStyling {
+
+  // MARK: - Typography
+
+  /// Custom font family name for field input text (e.g., `"Helvetica Neue"`).
+  public let fontName: String?
+  /// Font size in points for field input text.
+  public let fontSize: CGFloat?
+  /// Font weight for field input text, specified as a `CGFloat` (e.g., `UIFont.Weight.bold.rawValue`).
+  public let fontWeight: CGFloat?
+  /// Custom font family name for field labels.
+  public let labelFontName: String?
+  /// Font size in points for field labels.
+  public let labelFontSize: CGFloat?
+  /// Font weight for field labels, specified as a `CGFloat`.
+  public let labelFontWeight: CGFloat?
+
+  // MARK: - Colors
+
+  /// Color for the field's input text.
+  public let textColor: Color?
+  /// Color for the field's label text.
+  public let labelColor: Color?
+  /// Background color of the field.
+  public let backgroundColor: Color?
+  /// Border color in the default (unfocused) state.
+  public let borderColor: Color?
+  /// Border color when the field is focused.
+  public let focusedBorderColor: Color?
+  /// Border color when the field has a validation error.
+  public let errorBorderColor: Color?
+  /// Color for placeholder text.
+  public let placeholderColor: Color?
+
+  // MARK: - Layout
+
+  /// Corner radius of the field's border.
+  public let cornerRadius: CGFloat?
+  /// Width of the field's border stroke.
+  public let borderWidth: CGFloat?
+  /// Inner padding of the field content.
+  public let padding: EdgeInsets?
+  /// Fixed height for the field.
+  public let fieldHeight: CGFloat?
+
+  // MARK: - Initialization
+
+  public init(
+    fontName: String? = nil,
+    fontSize: CGFloat? = nil,
+    fontWeight: CGFloat? = nil,
+    labelFontName: String? = nil,
+    labelFontSize: CGFloat? = nil,
+    labelFontWeight: CGFloat? = nil,
+    textColor: Color? = nil,
+    labelColor: Color? = nil,
+    backgroundColor: Color? = nil,
+    borderColor: Color? = nil,
+    focusedBorderColor: Color? = nil,
+    errorBorderColor: Color? = nil,
+    placeholderColor: Color? = nil,
+    cornerRadius: CGFloat? = nil,
+    borderWidth: CGFloat? = nil,
+    padding: EdgeInsets? = nil,
+    fieldHeight: CGFloat? = nil
+  ) {
+    self.fontName = fontName
+    self.fontSize = fontSize
+    self.fontWeight = fontWeight
+    self.labelFontName = labelFontName
+    self.labelFontSize = labelFontSize
+    self.labelFontWeight = labelFontWeight
+    self.textColor = textColor
+    self.labelColor = labelColor
+    self.backgroundColor = backgroundColor
+    self.borderColor = borderColor
+    self.focusedBorderColor = focusedBorderColor
+    self.errorBorderColor = errorBorderColor
+    self.placeholderColor = placeholderColor
+    self.cornerRadius = cornerRadius
+    self.borderWidth = borderWidth
+    self.padding = padding
+    self.fieldHeight = fieldHeight
+  }
+
+  // MARK: - Internal Helpers
+
+  func resolvedFont(tokens: DesignTokens?) -> Font {
+    if let fontName {
+      let uiFont = PrimerFont.uiFont(family: fontName, weight: fontWeight, size: fontSize)
+      return Font(uiFont)
+    }
+    return PrimerFont.bodyLarge(tokens: tokens)
+  }
+
+  func resolvedLabelFont(tokens: DesignTokens?) -> Font {
+    if let labelFontName {
+      let uiFont = PrimerFont.uiFont(family: labelFontName, weight: labelFontWeight, size: labelFontSize)
+      return Font(uiFont)
+    }
+    return PrimerFont.bodySmall(tokens: tokens)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerFieldStyling.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerFieldStyling.swift
@@ -35,7 +35,7 @@ public struct PrimerFieldStyling {
   public let fontName: String?
   /// Font size in points for field input text.
   public let fontSize: CGFloat?
-  /// Font weight for field input text, specified as a `CGFloat` (e.g., `UIFont.Weight.bold.rawValue`).
+  /// Font weight for field input text, specified as a CSS numeric weight `CGFloat` (100–900, e.g. 400 = regular, 700 = bold).
   public let fontWeight: CGFloat?
   /// Custom font family name for field labels.
   public let labelFontName: String?

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerFormRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerFormRedirectScope.swift
@@ -53,9 +53,6 @@ public typealias FormRedirectFormSectionComponent = (any PrimerFormRedirectScope
 @MainActor
 public protocol PrimerFormRedirectScope: PrimerPaymentMethodScope where State == PrimerFormRedirectState {
 
-  /// Async stream emitting the current form redirect state whenever it changes.
-  var state: AsyncStream<PrimerFormRedirectState> { get }
-
   /// The payment method type identifier (e.g., "ADYEN_BLIK", "ADYEN_MBWAY").
   var paymentMethodType: String { get }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerFormRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerFormRedirectScope.swift
@@ -1,0 +1,83 @@
+//
+//  PrimerFormRedirectScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+// MARK: - Type Aliases for UI Customization
+
+/// Type alias for form redirect screen customization component.
+@available(iOS 15.0, *)
+public typealias FormRedirectScreenComponent = (any PrimerFormRedirectScope) -> any View
+
+/// Type alias for form redirect button customization component.
+@available(iOS 15.0, *)
+public typealias FormRedirectButtonComponent = (any PrimerFormRedirectScope) -> any View
+
+/// Type alias for form redirect form section customization component.
+@available(iOS 15.0, *)
+public typealias FormRedirectFormSectionComponent = (any PrimerFormRedirectScope) -> any View
+
+// MARK: - Scope Protocol
+
+/// Scope protocol for form-based redirect payment methods (e.g., BLIK, MBWay).
+///
+/// Provides state observation, field management, and UI customization for payment methods
+/// that require user input (OTP code or phone number) before completing payment
+/// in an external app.
+///
+/// ## State Flow
+/// ```
+/// ready → submitting → awaitingExternalCompletion → success | failure
+/// ```
+///
+/// ## Usage
+/// ```swift
+/// if let formScope = checkoutScope.getPaymentMethodScope(
+///   PrimerFormRedirectScope.self
+/// ) {
+///   // Update a field value
+///   formScope.updateField(.otpCode, value: "123456")
+///
+///   // Observe state
+///   for await state in formScope.state {
+///     if state.isSubmitEnabled {
+///       // User can submit
+///     }
+///   }
+/// }
+/// ```
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerFormRedirectScope: PrimerPaymentMethodScope where State == PrimerFormRedirectState {
+
+  /// Async stream emitting the current form redirect state whenever it changes.
+  var state: AsyncStream<PrimerFormRedirectState> { get }
+
+  /// The payment method type identifier (e.g., "ADYEN_BLIK", "ADYEN_MBWAY").
+  var paymentMethodType: String { get }
+
+  // MARK: - Field Management
+
+  /// Updates the value of a form field.
+  /// - Parameters:
+  ///   - fieldType: The type of field to update (`.otpCode` or `.phoneNumber`).
+  ///   - value: The new value for the field.
+  func updateField(_ fieldType: PrimerFormFieldState.FieldType, value: String)
+
+  // MARK: - Screen-Level Customization
+
+  /// When set, replaces both form input and pending screens.
+  var screen: FormRedirectScreenComponent? { get set }
+
+  /// Custom form section component to replace the default form fields area.
+  var formSection: FormRedirectFormSectionComponent? { get set }
+
+  /// Custom button component to replace the submit button.
+  var submitButton: FormRedirectButtonComponent? { get set }
+
+  /// Custom text for the submit button (default: payment method specific, e.g., "Pay with BLIK").
+  var submitButtonText: String? { get set }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerKlarnaScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerKlarnaScope.swift
@@ -38,9 +38,6 @@ public typealias KlarnaButtonComponent = (any PrimerKlarnaScope) -> any View
 @MainActor
 public protocol PrimerKlarnaScope: PrimerPaymentMethodScope where State == PrimerKlarnaState {
 
-  /// Async stream of Klarna payment state including current step and available categories.
-  var state: AsyncStream<PrimerKlarnaState> { get }
-
   /// The Klarna SDK payment view. Display this when `state.step` is `.viewReady`.
   var paymentView: UIView? { get }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerKlarnaScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerKlarnaScope.swift
@@ -1,0 +1,69 @@
+//
+//  PrimerKlarnaScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Closure that provides a custom screen for Klarna payment steps.
+@available(iOS 15.0, *)
+public typealias KlarnaScreenComponent = (any PrimerKlarnaScope) -> any View
+
+/// Closure that provides a custom button for Klarna payment actions.
+@available(iOS 15.0, *)
+public typealias KlarnaButtonComponent = (any PrimerKlarnaScope) -> any View
+
+/// Scope protocol for Klarna payment methods.
+///
+/// Klarna payments follow a multi-step flow:
+/// 1. **Category selection** — user picks a Klarna payment category (Pay Now, Pay Later, etc.)
+/// 2. **Authorization** — Klarna SDK renders the payment view for user approval
+/// 3. **Finalization** — completes the payment after authorization
+///
+/// Observe `state` to track the current step:
+/// ```swift
+/// for await klarnaState in klarnaScope.state {
+///     switch klarnaState.step {
+///     case .categorySelection:
+///         showCategories(klarnaState.categories)
+///     case .viewReady:
+///         displayKlarnaPaymentView(klarnaScope.paymentView)
+///     case .awaitingFinalization:
+///         klarnaScope.finalizePayment()
+///     }
+/// }
+/// ```
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerKlarnaScope: PrimerPaymentMethodScope where State == PrimerKlarnaState {
+
+  /// Async stream of Klarna payment state including current step and available categories.
+  var state: AsyncStream<PrimerKlarnaState> { get }
+
+  /// The Klarna SDK payment view. Display this when `state.step` is `.viewReady`.
+  var paymentView: UIView? { get }
+
+  // MARK: - Payment Flow Actions
+
+  /// Selects a Klarna payment category and loads the corresponding payment view.
+  /// - Parameter categoryId: The identifier of the selected Klarna payment category.
+  func selectPaymentCategory(_ categoryId: String)
+
+  /// Authorizes the Klarna payment after the user completes the payment view.
+  func authorizePayment()
+
+  /// Finalizes the Klarna payment. Call when `state.step` is `.awaitingFinalization`.
+  func finalizePayment()
+
+  // MARK: - Screen-Level Customization
+
+  /// Replaces the entire Klarna screen with a custom view.
+  var screen: KlarnaScreenComponent? { get set }
+
+  /// Replaces the authorize button with a custom view.
+  var authorizeButton: KlarnaButtonComponent? { get set }
+
+  /// Replaces the finalize button with a custom view.
+  var finalizeButton: KlarnaButtonComponent? { get set }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPayPalScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPayPalScope.swift
@@ -1,0 +1,36 @@
+//
+//  PrimerPayPalScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Type alias for PayPal screen customization component.
+@available(iOS 15.0, *)
+public typealias PayPalScreenComponent = (any PrimerPayPalScope) -> any View
+
+/// Type alias for PayPal button customization component.
+@available(iOS 15.0, *)
+public typealias PayPalButtonComponent = (any PrimerPayPalScope) -> any View
+
+/// Scope protocol for PayPal payment method.
+/// Provides state observation and UI customization for redirect-based PayPal payments.
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerPayPalScope: PrimerPaymentMethodScope where State == PrimerPayPalState {
+
+  /// The current state of the PayPal payment flow as an async stream.
+  var state: AsyncStream<PrimerPayPalState> { get }
+
+  // MARK: - Screen-Level Customization
+
+  /// Custom screen component to replace the entire PayPal screen.
+  var screen: PayPalScreenComponent? { get set }
+
+  /// Custom button component to replace the PayPal submit button.
+  var payButton: PayPalButtonComponent? { get set }
+
+  /// Custom text for the submit button (default: "Continue with PayPal").
+  var submitButtonText: String? { get set }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPayPalScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPayPalScope.swift
@@ -20,9 +20,6 @@ public typealias PayPalButtonComponent = (any PrimerPayPalScope) -> any View
 @MainActor
 public protocol PrimerPayPalScope: PrimerPaymentMethodScope where State == PrimerPayPalState {
 
-  /// The current state of the PayPal payment flow as an async stream.
-  var state: AsyncStream<PrimerPayPalState> { get }
-
   // MARK: - Screen-Level Customization
 
   /// Custom screen component to replace the entire PayPal screen.

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodScope.swift
@@ -1,0 +1,307 @@
+//
+//  PrimerPaymentMethodScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Base protocol for all payment method scopes, providing common lifecycle and state management.
+///
+/// Every payment method scope follows a consistent lifecycle:
+/// 1. **`start()`** — Initialize the payment flow (load data, set up state).
+/// 2. **User interaction** — The user fills in details or approves the payment.
+/// 3. **`submit()`** — Validate input and trigger tokenization/payment processing.
+/// 4. **`cancel()`** — Terminate the flow at any point (called by navigation helpers).
+///
+/// Observe `state` to react to changes in the payment method's progress:
+/// ```swift
+/// for await currentState in scope.state {
+///     updateUI(for: currentState)
+/// }
+/// ```
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerPaymentMethodScope: AnyObject {
+
+  associatedtype State: Equatable
+
+  /// Async stream emitting the payment method's current state whenever it changes.
+  var state: AsyncStream<State> { get }
+
+  // MARK: - Presentation
+
+  /// How this scope was presented (determines back vs cancel button).
+  var presentationContext: PresentationContext { get }
+
+  /// Available dismissal mechanisms (close button, gestures).
+  var dismissalMechanism: [DismissalMechanism] { get }
+
+  // MARK: - Lifecycle Methods
+
+  /// Initializes the payment flow for this method.
+  ///
+  /// Call once when the scope becomes active (e.g., user selects this payment method).
+  /// Implementations typically load remote configuration, prepare the UI state,
+  /// and emit the first state update on the `state` stream.
+  func start()
+
+  /// Validates input and begins payment processing.
+  ///
+  /// Call after the user has completed all required input. Implementations validate
+  /// fields, then trigger tokenization and server-side payment creation.
+  /// The state stream reflects progress (e.g., loading indicators, success, or errors).
+  func submit()
+
+  /// Terminates the payment flow and cleans up resources.
+  ///
+  /// Safe to call at any point. After cancellation the scope should not emit further
+  /// state updates. Navigation helpers (`onBack`, `onDismiss`) call this by default.
+  func cancel()
+
+  // MARK: - Navigation Support
+
+  /// Navigates back to the previous screen. Default implementation calls `cancel()`.
+  func onBack()
+
+  /// Handles dismissal (e.g., close button tap). Default implementation calls `cancel()`.
+  func onDismiss()
+}
+
+// MARK: - Default Implementations
+
+@available(iOS 15.0, *)
+extension PrimerPaymentMethodScope {
+
+  public var presentationContext: PresentationContext { .fromPaymentSelection }
+
+  public var dismissalMechanism: [DismissalMechanism] { [] }
+
+  public func onBack() {
+    cancel()
+  }
+
+  public func onDismiss() {
+    cancel()
+  }
+}
+
+// MARK: - Payment Method Protocol
+
+/// Protocol for payment method implementations that can create their associated scopes.
+/// Enables self-registration and dynamic scope creation for different payment methods.
+@available(iOS 15.0, *)
+public protocol PaymentMethodProtocol {
+
+  associatedtype ScopeType: PrimerPaymentMethodScope
+
+  /// The payment method type identifier (e.g., "PAYMENT_CARD", "PAYPAL", "APPLE_PAY")
+  static var paymentMethodType: String { get }
+
+  /// Creates a scope instance for this payment method
+  /// - Parameters:
+  ///   - checkoutScope: The parent checkout scope for navigation and coordination
+  ///   - diContainer: The dependency injection container for resolving services
+  /// - Returns: A configured scope instance for this payment method
+  @MainActor
+  static func createScope(
+    checkoutScope: PrimerCheckoutScope,
+    diContainer: any ContainerProtocol
+  ) async throws -> ScopeType
+
+  /// Creates the view for this payment method by retrieving its scope and rendering the appropriate UI.
+  /// This method handles both custom screens (if provided) and default screens.
+  /// - Parameter checkoutScope: The parent checkout scope that manages this payment method
+  /// - Returns: The view for this payment method, or nil if the scope cannot be retrieved
+  @MainActor
+  static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView?
+
+  /// Provides custom UI for this payment method using ViewBuilder.
+  /// - Parameter content: A ViewBuilder closure that uses the payment method's scope as a parameter,
+  ///                      allowing full access to the payment method's state and behavior.
+  @MainActor
+  func content<V: View>(@ViewBuilder content: @escaping (ScopeType) -> V) -> AnyView
+
+  /// Provides the default UI implementation for this payment method.
+  @MainActor
+  func defaultContent() -> AnyView
+}
+
+// MARK: - Payment Method Registry
+
+/// Registry for managing payment method implementations and their scope creation.
+/// Provides dynamic scope creation based on payment method types.
+@available(iOS 15.0, *)
+@MainActor
+final class PaymentMethodRegistry: LogReporter {
+
+  private typealias ScopeCreator =
+    @MainActor (PrimerCheckoutScope, any ContainerProtocol) async throws -> any PrimerPaymentMethodScope
+  private typealias ViewCreator = @MainActor (any PrimerCheckoutScope) -> AnyView?
+
+  private var creators: [String: ScopeCreator] = [:]
+  private var viewBuilders: [String: ViewCreator] = [:]
+  private var typeToIdentifier: [String: String] = [:]
+
+  static let shared = PaymentMethodRegistry()
+
+  private init() {}
+
+  func register(
+    forKey key: String,
+    scopeCreator: @escaping @MainActor (PrimerCheckoutScope, any ContainerProtocol) async throws -> any PrimerPaymentMethodScope,
+    viewCreator: @escaping @MainActor (any PrimerCheckoutScope) -> AnyView?
+  ) {
+    creators[key] = scopeCreator
+    viewBuilders[key] = viewCreator
+    logger.debug(message: "✅ [PaymentMethodRegistry] Payment method \(key) registered")
+  }
+
+  /// Registers a payment method implementation
+  /// - Parameter paymentMethodType: The payment method implementation to register
+  func register<T: PaymentMethodProtocol>(_ paymentMethodType: T.Type) {
+    let typeKey = paymentMethodType.paymentMethodType
+    creators[typeKey] = { checkoutScope, diContainer in
+      try await paymentMethodType.createScope(checkoutScope: checkoutScope, diContainer: diContainer)
+    }
+
+    // Register view builder for dynamic UI creation
+    viewBuilders[typeKey] = { checkoutScope in
+      paymentMethodType.createView(checkoutScope: checkoutScope)
+    }
+
+    // Register type-to-identifier mapping for type-safe lookups
+    let scopeTypeName = String(describing: T.ScopeType.self)
+    typeToIdentifier[scopeTypeName] = typeKey
+
+    // PAYMENT METHOD OPTIONS INTEGRATION: Log when payment methods requiring special settings are registered
+    // Based on PrimerPaymentMethodOptionsProtocol: applePayOptions, klarnaOptions, stripeOptions
+    if typeKey == PrimerPaymentMethodType.applePay.rawValue {
+      logger.info(
+        message:
+          "✅ [PaymentMethodRegistry] Apple Pay registered - requires PrimerSettings.paymentMethodOptions.applePayOptions"
+      )
+    } else if [PrimerPaymentMethodType.klarna, .primerTestKlarna].map(\.rawValue).contains(typeKey) {
+      logger.info(
+        message:
+          "✅ [PaymentMethodRegistry] Klarna registered - requires PrimerSettings.paymentMethodOptions.klarnaOptions"
+      )
+    } else if typeKey.contains("STRIPE") {
+      logger.info(
+        message:
+          "✅ [PaymentMethodRegistry] Stripe (\(typeKey)) registered - requires PrimerSettings.paymentMethodOptions.stripeOptions"
+      )
+    } else {
+      logger.debug(message: "✅ [PaymentMethodRegistry] Payment method \(typeKey) registered")
+    }
+  }
+
+  /// Creates a scope for the specified payment method type (type-erased)
+  /// - Parameters:
+  ///   - paymentMethodType: The payment method type identifier
+  ///   - checkoutScope: The parent checkout scope
+  ///   - diContainer: The dependency injection container
+  /// - Returns: A configured scope instance, or nil if the payment method is not registered
+  func createScope(
+    for paymentMethodType: String,
+    checkoutScope: PrimerCheckoutScope,
+    diContainer: any ContainerProtocol
+  ) async throws -> (any PrimerPaymentMethodScope)? {
+    guard let creator = creators[paymentMethodType] else {
+      return nil
+    }
+
+    return try await creator(checkoutScope, diContainer)
+  }
+
+  /// Creates a scope for the specified payment method type (generic)
+  /// - Parameters:
+  ///   - paymentMethodType: The payment method type identifier
+  ///   - checkoutScope: The parent checkout scope
+  ///   - diContainer: The dependency injection container
+  /// - Returns: A configured scope instance, or nil if the payment method is not registered
+  func createScope<T: PrimerPaymentMethodScope>(
+    for paymentMethodType: String,
+    checkoutScope: PrimerCheckoutScope,
+    diContainer: any ContainerProtocol
+  ) async throws -> T? {
+    guard let creator = creators[paymentMethodType] else {
+      return nil
+    }
+
+    let scope = try await creator(checkoutScope, diContainer)
+    return scope as? T
+  }
+
+  /// Creates a scope for the specified scope type (type-safe with metatype)
+  /// - Parameters:
+  ///   - scopeType: The scope type to create (e.g., PrimerCardFormScope.self)
+  ///   - checkoutScope: The parent checkout scope
+  ///   - diContainer: The dependency injection container
+  /// - Returns: A configured scope instance, or nil if the scope type is not registered
+  func createScope<T: PrimerPaymentMethodScope>(
+    _ scopeType: T.Type,
+    checkoutScope: PrimerCheckoutScope,
+    diContainer: any ContainerProtocol
+  ) async throws -> T? {
+    let typeName = String(describing: scopeType)
+    guard let paymentMethodType = typeToIdentifier[typeName] else {
+      return nil
+    }
+
+    return try await createScope(
+      for: paymentMethodType, checkoutScope: checkoutScope, diContainer: diContainer
+    )
+  }
+
+  /// Creates a scope for the specified payment method enum case
+  /// - Parameters:
+  ///   - methodType: The payment method type enum case
+  ///   - checkoutScope: The parent checkout scope
+  ///   - diContainer: The dependency injection container
+  /// - Returns: A configured scope instance, or nil if the payment method is not registered
+  func createScope<T: PrimerPaymentMethodScope>(
+    for methodType: PrimerPaymentMethodType,
+    checkoutScope: PrimerCheckoutScope,
+    diContainer: any ContainerProtocol
+  ) async throws -> T? {
+    try await createScope(
+      for: methodType.rawValue, checkoutScope: checkoutScope, diContainer: diContainer
+    )
+  }
+
+  var registeredTypes: [String] {
+    Array(creators.keys)
+  }
+
+  /// Retrieves the view for a specific payment method type
+  /// - Parameters:
+  ///   - paymentMethodType: The payment method type identifier
+  ///   - checkoutScope: The parent checkout scope
+  /// - Returns: The view for this payment method, or nil if not registered
+  func getView(for paymentMethodType: String, checkoutScope: any PrimerCheckoutScope) -> AnyView? {
+    guard let viewBuilder = viewBuilders[paymentMethodType] else {
+      return nil
+    }
+    return viewBuilder(checkoutScope)
+  }
+
+  /// Internal registration method for direct creator registration.
+  /// Used by payment methods that need parameterized registration (e.g., WebRedirect APMs).
+  func registerInternal(
+    typeKey: String,
+    scopeCreator: @escaping @MainActor (PrimerCheckoutScope, any ContainerProtocol) async throws -> any PrimerPaymentMethodScope,
+    viewCreator: @escaping @MainActor (any PrimerCheckoutScope) -> AnyView?
+  ) {
+    creators[typeKey] = scopeCreator
+    viewBuilders[typeKey] = viewCreator
+  }
+
+  /// Resets the registry by clearing all registered payment methods.
+  /// This method is intended for testing purposes only.
+  func reset() {
+    creators.removeAll()
+    viewBuilders.removeAll()
+    typeToIdentifier.removeAll()
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodScope.swift
@@ -91,7 +91,7 @@ extension PrimerPaymentMethodScope {
 /// Protocol for payment method implementations that can create their associated scopes.
 /// Enables self-registration and dynamic scope creation for different payment methods.
 @available(iOS 15.0, *)
-public protocol PaymentMethodProtocol {
+protocol PaymentMethodProtocol {
 
   associatedtype ScopeType: PrimerPaymentMethodScope
 
@@ -154,7 +154,7 @@ final class PaymentMethodRegistry: LogReporter {
   ) {
     creators[key] = scopeCreator
     viewBuilders[key] = viewCreator
-    logger.debug(message: "✅ [PaymentMethodRegistry] Payment method \(key) registered")
+    logger.debug(message: "[PaymentMethodRegistry] Payment method \(key) registered")
   }
 
   /// Registers a payment method implementation
@@ -179,20 +179,20 @@ final class PaymentMethodRegistry: LogReporter {
     if typeKey == PrimerPaymentMethodType.applePay.rawValue {
       logger.info(
         message:
-          "✅ [PaymentMethodRegistry] Apple Pay registered - requires PrimerSettings.paymentMethodOptions.applePayOptions"
+          "[PaymentMethodRegistry] Apple Pay registered - requires PrimerSettings.paymentMethodOptions.applePayOptions"
       )
     } else if [PrimerPaymentMethodType.klarna, .primerTestKlarna].map(\.rawValue).contains(typeKey) {
       logger.info(
         message:
-          "✅ [PaymentMethodRegistry] Klarna registered - requires PrimerSettings.paymentMethodOptions.klarnaOptions"
+          "[PaymentMethodRegistry] Klarna registered - requires PrimerSettings.paymentMethodOptions.klarnaOptions"
       )
     } else if typeKey.contains("STRIPE") {
       logger.info(
         message:
-          "✅ [PaymentMethodRegistry] Stripe (\(typeKey)) registered - requires PrimerSettings.paymentMethodOptions.stripeOptions"
+          "[PaymentMethodRegistry] Stripe (\(typeKey)) registered - requires PrimerSettings.paymentMethodOptions.stripeOptions"
       )
     } else {
-      logger.debug(message: "✅ [PaymentMethodRegistry] Payment method \(typeKey) registered")
+      logger.debug(message: "[PaymentMethodRegistry] Payment method \(typeKey) registered")
     }
   }
 
@@ -250,8 +250,7 @@ final class PaymentMethodRegistry: LogReporter {
     }
 
     return try await createScope(
-      for: paymentMethodType, checkoutScope: checkoutScope, diContainer: diContainer
-    )
+      for: paymentMethodType, checkoutScope: checkoutScope, diContainer: diContainer)
   }
 
   /// Creates a scope for the specified payment method enum case
@@ -266,8 +265,7 @@ final class PaymentMethodRegistry: LogReporter {
     diContainer: any ContainerProtocol
   ) async throws -> T? {
     try await createScope(
-      for: methodType.rawValue, checkoutScope: checkoutScope, diContainer: diContainer
-    )
+      for: methodType.rawValue, checkoutScope: checkoutScope, diContainer: diContainer)
   }
 
   var registeredTypes: [String] {
@@ -297,11 +295,11 @@ final class PaymentMethodRegistry: LogReporter {
     viewBuilders[typeKey] = viewCreator
   }
 
-  /// Resets the registry by clearing all registered payment methods.
-  /// This method is intended for testing purposes only.
+  #if DEBUG
   func reset() {
     creators.removeAll()
     viewBuilders.removeAll()
     typeToIdentifier.removeAll()
   }
+  #endif
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodSelectionScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodSelectionScope.swift
@@ -1,0 +1,251 @@
+//
+//  PrimerPaymentMethodSelectionScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Scope interface for payment method selection screen interactions and customization.
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerPaymentMethodSelectionScope: AnyObject {
+
+  /// The current state of the payment method selection as an async stream.
+  var state: AsyncStream<PrimerPaymentMethodSelectionState> { get }
+
+  /// Controls how users can dismiss the checkout modal.
+  var dismissalMechanism: [DismissalMechanism] { get }
+
+  // MARK: - Navigation Methods
+
+  /// Called when a payment method is selected by the user.
+  /// - Parameter paymentMethod: The selected payment method.
+  func onPaymentMethodSelected(paymentMethod: CheckoutPaymentMethod)
+
+  func cancel()
+
+  // MARK: - Vault Payment Methods
+
+  /// Initiates payment with the currently selected vaulted payment method.
+  func payWithVaultedPaymentMethod() async
+
+  /// Initiates payment with the currently selected vaulted payment method and CVV.
+  /// - Parameter cvv: The CVV entered by the user
+  func payWithVaultedPaymentMethodAndCvv(_ cvv: String) async
+
+  /// Updates the CVV input value and validates it.
+  /// - Parameter cvv: The CVV value to update
+  func updateCvvInput(_ cvv: String)
+
+  /// Navigates to the screen showing all vaulted payment methods.
+  func showAllVaultedPaymentMethods()
+
+  /// Expands the payment methods section to show all available payment methods.
+  /// Called when user taps "Show other ways to pay" button.
+  func showOtherWaysToPay()
+
+  // MARK: - Customizable UI Components
+
+  /// Default implementation provides standard payment method grid/list.
+  /// The closure receives the scope for full access to payment methods and navigation actions.
+  var screen: PaymentMethodSelectionScreenComponent? { get set }
+
+  /// Default implementation shows payment method with selection state.
+  var paymentMethodItem: PaymentMethodItemComponent? { get set }
+
+  /// Category header component for grouping payment methods.
+  /// Default implementation shows category name in uppercase.
+  var categoryHeader: CategoryHeaderComponent? { get set }
+
+  /// Empty state view when no payment methods are available.
+  /// Default implementation shows icon and message.
+  var emptyStateView: Component? { get set }
+
+  // MARK: - State Definition
+
+}
+
+/// Represents the current state of available payment methods and loading status.
+@available(iOS 15.0, *)
+public struct PrimerPaymentMethodSelectionState: Equatable {
+  public internal(set) var paymentMethods: [CheckoutPaymentMethod] = []
+  public internal(set) var isLoading: Bool = false
+  public internal(set) var selectedPaymentMethod: CheckoutPaymentMethod?
+  public internal(set) var searchQuery: String = ""
+  public internal(set) var filteredPaymentMethods: [CheckoutPaymentMethod] = []
+  public internal(set) var error: String?
+  public internal(set) var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod?
+  public internal(set) var isVaultPaymentLoading: Bool = false
+
+  // MARK: - CVV Recapture State
+
+  /// Indicates whether CVV input is required for the selected vaulted card
+  public internal(set) var requiresCvvInput: Bool = false
+
+  /// The CVV value entered by the user
+  public internal(set) var cvvInput: String = ""
+
+  /// CVV validation state
+  public internal(set) var isCvvValid: Bool = false
+
+  /// CVV validation error message
+  public internal(set) var cvvError: String?
+
+  // MARK: - Payment Methods Expansion State
+
+  /// Whether the payment methods section is expanded (showing all methods).
+  /// Default is true. Set to false when user selects vaulted method or CVV input opens.
+  public internal(set) var isPaymentMethodsExpanded: Bool = true
+
+  public init(
+    paymentMethods: [CheckoutPaymentMethod] = [],
+    isLoading: Bool = false,
+    selectedPaymentMethod: CheckoutPaymentMethod? = nil,
+    searchQuery: String = "",
+    filteredPaymentMethods: [CheckoutPaymentMethod] = [],
+    error: String? = nil,
+    selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod? = nil,
+    isVaultPaymentLoading: Bool = false,
+    requiresCvvInput: Bool = false,
+    cvvInput: String = "",
+    isCvvValid: Bool = false,
+    cvvError: String? = nil,
+    isPaymentMethodsExpanded: Bool = true
+  ) {
+    self.paymentMethods = paymentMethods
+    self.isLoading = isLoading
+    self.selectedPaymentMethod = selectedPaymentMethod
+    self.searchQuery = searchQuery
+    self.filteredPaymentMethods = filteredPaymentMethods
+    self.error = error
+    self.selectedVaultedPaymentMethod = selectedVaultedPaymentMethod
+    self.isVaultPaymentLoading = isVaultPaymentLoading
+    self.requiresCvvInput = requiresCvvInput
+    self.cvvInput = cvvInput
+    self.isCvvValid = isCvvValid
+    self.cvvError = cvvError
+    self.isPaymentMethodsExpanded = isPaymentMethodsExpanded
+  }
+
+  public static func == (
+    lhs: PrimerPaymentMethodSelectionState, rhs: PrimerPaymentMethodSelectionState
+  ) -> Bool {
+    lhs.paymentMethods == rhs.paymentMethods && lhs.isLoading == rhs.isLoading
+      && lhs.selectedPaymentMethod == rhs.selectedPaymentMethod
+      && lhs.searchQuery == rhs.searchQuery
+      && lhs.filteredPaymentMethods == rhs.filteredPaymentMethods && lhs.error == rhs.error
+      && lhs.selectedVaultedPaymentMethod?.id == rhs.selectedVaultedPaymentMethod?.id
+      && lhs.isVaultPaymentLoading == rhs.isVaultPaymentLoading
+      && lhs.requiresCvvInput == rhs.requiresCvvInput && lhs.cvvInput == rhs.cvvInput
+      && lhs.isCvvValid == rhs.isCvvValid && lhs.cvvError == rhs.cvvError
+      && lhs.isPaymentMethodsExpanded == rhs.isPaymentMethodsExpanded
+  }
+}
+
+// MARK: - Payment Method Model
+
+/// Represents a payment method available for selection in the checkout flow.
+///
+/// `CheckoutPaymentMethod` contains display information and metadata for payment methods
+/// shown in the payment method selection screen. This includes the method's name, icon,
+/// any applicable surcharges, and custom styling.
+///
+/// Use this struct when customizing the payment method selection UI or when handling
+/// user selection events.
+///
+/// Example usage:
+/// ```swift
+/// for await state in selectionScope.state {
+///     for method in state.paymentMethods {
+///         print("\(method.name) - Surcharge: \(method.formattedSurcharge ?? "None")")
+///     }
+/// }
+/// ```
+@available(iOS 15.0, *)
+public struct CheckoutPaymentMethod: Equatable, Identifiable {
+  /// Unique identifier for this payment method instance.
+  public let id: String
+
+  /// The payment method type identifier (e.g., "PAYMENT_CARD", "PAYPAL", "APPLE_PAY").
+  public let type: String
+
+  /// Human-readable display name for the payment method.
+  public let name: String
+
+  /// Icon image to display for this payment method.
+  public let icon: UIImage?
+
+  /// Additional metadata associated with this payment method.
+  public let metadata: [String: Any]?
+
+  /// Surcharge amount in minor currency units (e.g., cents), if applicable.
+  public let surcharge: Int?
+
+  /// Indicates whether the surcharge amount is unknown (e.g., varies by card network).
+  public let hasUnknownSurcharge: Bool
+
+  /// Pre-formatted surcharge string for display (e.g., "+ $0.50").
+  public let formattedSurcharge: String?
+
+  /// Custom background color for the payment method button.
+  public let backgroundColor: UIColor?
+
+  /// Custom button text from display metadata (e.g., "Pay with Klarna").
+  public let buttonText: String?
+
+  /// Custom text color for the payment method button.
+  public let textColor: UIColor?
+
+  /// Custom border color for the payment method button.
+  public let borderColor: UIColor?
+
+  /// Custom border width for the payment method button.
+  public let borderWidth: CGFloat?
+
+  /// Custom corner radius for the payment method button.
+  public let cornerRadius: CGFloat?
+
+  public init(
+    id: String,
+    type: String,
+    name: String,
+    icon: UIImage? = nil,
+    metadata: [String: Any]? = nil,
+    surcharge: Int? = nil,
+    hasUnknownSurcharge: Bool = false,
+    formattedSurcharge: String? = nil,
+    backgroundColor: UIColor? = nil,
+    buttonText: String? = nil,
+    textColor: UIColor? = nil,
+    borderColor: UIColor? = nil,
+    borderWidth: CGFloat? = nil,
+    cornerRadius: CGFloat? = nil
+  ) {
+    self.id = id
+    self.type = type
+    self.name = name
+    self.icon = icon
+    self.metadata = metadata
+    self.surcharge = surcharge
+    self.hasUnknownSurcharge = hasUnknownSurcharge
+    self.formattedSurcharge = formattedSurcharge
+    self.backgroundColor = backgroundColor
+    self.buttonText = buttonText
+    self.textColor = textColor
+    self.borderColor = borderColor
+    self.borderWidth = borderWidth
+    self.cornerRadius = cornerRadius
+  }
+
+  /// Compares two payment methods by identity and payment-relevant properties only.
+  /// Intentionally excludes `metadata` (not `Equatable`), `icon`, `buttonText`,
+  /// `textColor`, `borderColor`, `borderWidth`, and `cornerRadius` — these are
+  /// display-only properties that should not trigger state change propagation.
+  public static func == (lhs: CheckoutPaymentMethod, rhs: CheckoutPaymentMethod) -> Bool {
+    lhs.id == rhs.id && lhs.type == rhs.type && lhs.name == rhs.name
+      && lhs.surcharge == rhs.surcharge && lhs.hasUnknownSurcharge == rhs.hasUnknownSurcharge
+      && lhs.formattedSurcharge == rhs.formattedSurcharge
+      && lhs.backgroundColor == rhs.backgroundColor
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerQRCodeScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerQRCodeScope.swift
@@ -1,0 +1,45 @@
+//
+//  PrimerQRCodeScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Type alias for QR code screen customization component.
+@available(iOS 15.0, *)
+public typealias QRCodeScreenComponent = (any PrimerQRCodeScope) -> any View
+
+/// Scope protocol for QR code payment methods (e.g., PromptPay, Xfers).
+///
+/// Provides state observation and UI customization for payment methods that display
+/// a QR code for the user to scan. The SDK automatically polls for completion
+/// after the QR code is displayed.
+///
+/// ## State Flow
+/// ```
+/// loading → displaying → success | failure
+/// ```
+///
+/// ## Usage
+/// ```swift
+/// if let qrScope = checkoutScope.getPaymentMethodScope(
+///   PrimerQRCodeScope.self
+/// ) {
+///   for await state in qrScope.state {
+///     if let imageData = state.qrCodeImageData {
+///       // Display QR code image
+///     }
+///   }
+/// }
+/// ```
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerQRCodeScope: PrimerPaymentMethodScope where State == PrimerQRCodeState {
+
+  /// Async stream emitting the current QR code state whenever it changes.
+  var state: AsyncStream<PrimerQRCodeState> { get }
+
+  /// Custom screen component to replace the entire QR code screen.
+  var screen: QRCodeScreenComponent? { get set }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerQRCodeScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerQRCodeScope.swift
@@ -37,9 +37,6 @@ public typealias QRCodeScreenComponent = (any PrimerQRCodeScope) -> any View
 @MainActor
 public protocol PrimerQRCodeScope: PrimerPaymentMethodScope where State == PrimerQRCodeState {
 
-  /// Async stream emitting the current QR code state whenever it changes.
-  var state: AsyncStream<PrimerQRCodeState> { get }
-
   /// Custom screen component to replace the entire QR code screen.
   var screen: QRCodeScreenComponent? { get set }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerSelectCountryScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerSelectCountryScope.swift
@@ -1,0 +1,67 @@
+//
+//  PrimerSelectCountryScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Scope interface for country selection functionality with search capabilities.
+@MainActor
+@available(iOS 15.0, *)
+public protocol PrimerSelectCountryScope: AnyObject {
+
+  /// The current state of the country selection as an async stream.
+  var state: AsyncStream<PrimerSelectCountryState> { get }
+
+  // MARK: - Navigation Methods
+
+  /// Called when a country is selected by the user.
+  /// - Parameters:
+  ///   - countryCode: The ISO country code (e.g., "US", "GB").
+  ///   - countryName: The localized country name.
+  func onCountrySelected(countryCode: String, countryName: String)
+
+  func cancel()
+
+  /// Updates the search query to filter countries.
+  /// - Parameter query: The search text entered by the user.
+  func onSearch(query: String)
+
+  // MARK: - Customizable UI Components
+
+  var screen: ((_ scope: PrimerSelectCountryScope) -> AnyView)? { get set }
+  var searchBar:
+    (
+      (_ query: String, _ onQueryChange: @escaping (String) -> Void, _ placeholder: String) ->
+        AnyView
+    )? { get set }
+
+  var countryItem: CountryItemComponent? { get set }
+
+}
+
+// MARK: - State Definition
+
+@available(iOS 15.0, *)
+public struct PrimerSelectCountryState: Equatable {
+  public internal(set) var countries: [PrimerCountry] = []
+  public internal(set) var filteredCountries: [PrimerCountry] = []
+  public internal(set) var searchQuery: String = ""
+  public internal(set) var isLoading: Bool = false
+  public internal(set) var selectedCountry: PrimerCountry?
+
+  public init(
+    countries: [PrimerCountry] = [],
+    filteredCountries: [PrimerCountry] = [],
+    searchQuery: String = "",
+    isLoading: Bool = false,
+    selectedCountry: PrimerCountry? = nil
+  ) {
+    self.countries = countries
+    self.filteredCountries = filteredCountries
+    self.searchQuery = searchQuery
+    self.isLoading = isLoading
+    self.selectedCountry = selectedCountry
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerSelectCountryScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerSelectCountryScope.swift
@@ -6,6 +6,13 @@
 
 import SwiftUI
 
+@available(iOS 15.0, *)
+public typealias SelectCountryScreenComponent = (_ scope: PrimerSelectCountryScope) -> any View
+
+@available(iOS 15.0, *)
+public typealias SearchBarComponent =
+  (_ query: String, _ onQueryChange: @escaping (String) -> Void, _ placeholder: String) -> any View
+
 /// Scope interface for country selection functionality with search capabilities.
 @MainActor
 @available(iOS 15.0, *)
@@ -30,12 +37,8 @@ public protocol PrimerSelectCountryScope: AnyObject {
 
   // MARK: - Customizable UI Components
 
-  var screen: ((_ scope: PrimerSelectCountryScope) -> AnyView)? { get set }
-  var searchBar:
-    (
-      (_ query: String, _ onQueryChange: @escaping (String) -> Void, _ placeholder: String) ->
-        AnyView
-    )? { get set }
+  var screen: SelectCountryScreenComponent? { get set }
+  var searchBar: SearchBarComponent? { get set }
 
   var countryItem: CountryItemComponent? { get set }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerWebRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerWebRedirectScope.swift
@@ -1,0 +1,64 @@
+//
+//  PrimerWebRedirectScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Type alias for web redirect screen customization component.
+@available(iOS 15.0, *)
+public typealias WebRedirectScreenComponent = (any PrimerWebRedirectScope) -> any View
+
+/// Type alias for web redirect button customization component.
+@available(iOS 15.0, *)
+public typealias WebRedirectButtonComponent = (any PrimerWebRedirectScope) -> any View
+
+/// Scope protocol for web redirect payment methods (e.g., Twint).
+///
+/// Provides state observation and UI customization for payment methods that redirect
+/// the user to an external web page to complete payment, then poll for the result.
+///
+/// ## State Flow
+/// ```
+/// idle → loading → redirecting → polling → success | failure
+/// ```
+///
+/// ## Usage
+/// ```swift
+/// if let webRedirectScope = checkoutScope.getPaymentMethodScope(
+///   PrimerWebRedirectScope.self
+/// ) {
+///   for await state in webRedirectScope.state {
+///     switch state.status {
+///     case .success:
+///       print("Payment completed")
+///     case .failure(let message):
+///       print("Payment failed: \(message)")
+///     default:
+///       break
+///     }
+///   }
+/// }
+/// ```
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerWebRedirectScope: PrimerPaymentMethodScope where State == PrimerWebRedirectState {
+
+  /// The payment method type identifier (e.g., "TWINT").
+  var paymentMethodType: String { get }
+
+  /// Async stream emitting the current web redirect state whenever it changes.
+  var state: AsyncStream<PrimerWebRedirectState> { get }
+
+  // MARK: - Screen-Level Customization
+
+  /// Custom screen component to replace the entire web redirect screen.
+  var screen: WebRedirectScreenComponent? { get set }
+
+  /// Custom button component to replace the submit button.
+  var payButton: WebRedirectButtonComponent? { get set }
+
+  /// Custom text for the submit button (default: payment method specific).
+  var submitButtonText: String? { get set }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerWebRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerWebRedirectScope.swift
@@ -48,9 +48,6 @@ public protocol PrimerWebRedirectScope: PrimerPaymentMethodScope where State == 
   /// The payment method type identifier (e.g., "TWINT").
   var paymentMethodType: String { get }
 
-  /// Async stream emitting the current web redirect state whenever it changes.
-  var state: AsyncStream<PrimerWebRedirectState> { get }
-
   // MARK: - Screen-Level Customization
 
   /// Custom screen component to replace the entire web redirect screen.

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/Providers/CardFormProvider.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/Providers/CardFormProvider.swift
@@ -1,0 +1,104 @@
+//
+//  CardFormProvider.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Provider view that wraps content with card form scope access and navigation handling.
+///
+/// Use `CardFormProvider` when embedding the card form in your own navigation hierarchy:
+/// ```swift
+/// CardFormProvider(
+///     onSuccess: { result in
+///         print("Payment succeeded: \(result.paymentId)")
+///     },
+///     onError: { error in
+///         print("Payment failed: \(error)")
+///     },
+///     onCancel: {
+///         print("User cancelled")
+///     }
+/// ) { scope in
+///     CardFormScreen(scope: scope)
+/// }
+/// ```
+///
+/// Callbacks are invoked when provided. If no callbacks are provided, navigation events
+/// are handled by the SDK's default behavior.
+@available(iOS 15.0, *)
+public struct CardFormProvider<Content: View>: View, LogReporter {
+  private let onSuccess: ((PaymentResult) -> Void)?
+  private let onError: ((String) -> Void)?
+  private let onCancel: (() -> Void)?
+  private let content: (any PrimerCardFormScope) -> Content
+
+  @Environment(\.primerCheckoutScope) private var checkoutScope
+
+  /// Creates a CardFormProvider.
+  /// - Parameters:
+  ///   - onSuccess: Called when payment succeeds with the result
+  ///   - onError: Called when payment fails with error message
+  ///   - onCancel: Called when user cancels the form
+  ///   - content: ViewBuilder that receives the card form scope
+  public init(
+    onSuccess: ((PaymentResult) -> Void)? = nil,
+    onError: ((String) -> Void)? = nil,
+    onCancel: (() -> Void)? = nil,
+    @ViewBuilder content: @escaping (any PrimerCardFormScope) -> Content
+  ) {
+    self.onSuccess = onSuccess
+    self.onError = onError
+    self.onCancel = onCancel
+    self.content = content
+  }
+
+  public var body: some View {
+    if let checkoutScope,
+      // C3: Uses concrete type because Swift generics can't accept protocol metatypes with associated types.
+      // The registry lookup uses `is T` conformance check, but the method signature requires a concrete T.
+      let cardFormScope = checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self) {
+      content(cardFormScope)
+        .environment(\.primerCardFormScope, cardFormScope)
+        .task {
+          await observeCheckoutState()
+        }
+    } else {
+      // Fallback when scope is not available
+      Text("Card form scope not available")
+        .foregroundColor(.secondary)
+    }
+  }
+
+  // MARK: - State Observation
+
+  /// Observes checkout state changes and invokes appropriate callbacks.
+  /// Uses iOS-native async/await pattern with AsyncStream.
+  private func observeCheckoutState() async {
+    guard let checkoutScope else { return }
+
+    for await state in checkoutScope.state {
+      handleStateChange(state)
+    }
+  }
+
+  /// Handles checkout state changes by invoking the appropriate callback.
+  @MainActor
+  private func handleStateChange(_ state: PrimerCheckoutState) {
+    switch state {
+    case let .success(result):
+      onSuccess?(result)
+
+    case let .failure(error):
+      onError?(error.localizedDescription)
+
+    case .dismissed:
+      onCancel?()
+
+    case .initializing, .ready:
+      // No action needed for these states
+      break
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/Providers/PaymentMethodSelectionProvider.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/Providers/PaymentMethodSelectionProvider.swift
@@ -1,0 +1,108 @@
+//
+//  PaymentMethodSelectionProvider.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Provider view that wraps content with payment method selection scope access and navigation handling.
+///
+/// Use `PaymentMethodSelectionProvider` when embedding payment selection in your own navigation hierarchy:
+/// ```swift
+/// PaymentMethodSelectionProvider(
+///     onPaymentMethodSelected: { paymentMethodType in
+///         print("Selected: \(paymentMethodType)")
+///         // Navigate to payment method screen
+///     },
+///     onCancel: {
+///         print("User cancelled")
+///     }
+/// ) { scope in
+///     PaymentMethodSelectionScreen(scope: scope)
+/// }
+/// ```
+///
+/// Callbacks are invoked when provided. If no callbacks are provided, navigation events
+/// are handled by the SDK's default behavior.
+@available(iOS 15.0, *)
+public struct PaymentMethodSelectionProvider<Content: View>: View, LogReporter {
+  private let onPaymentMethodSelected: ((String) -> Void)?
+  private let onCancel: (() -> Void)?
+  private let content: (any PrimerPaymentMethodSelectionScope) -> Content
+
+  @Environment(\.primerCheckoutScope) private var checkoutScope
+  @State private var lastSelectedPaymentMethodType: String?
+
+  /// Creates a PaymentMethodSelectionProvider.
+  /// - Parameters:
+  ///   - onPaymentMethodSelected: Called when user selects a payment method with the type identifier
+  ///   - onCancel: Called when user cancels the selection
+  ///   - content: ViewBuilder that receives the payment method selection scope
+  public init(
+    onPaymentMethodSelected: ((String) -> Void)? = nil,
+    onCancel: (() -> Void)? = nil,
+    @ViewBuilder content: @escaping (any PrimerPaymentMethodSelectionScope) -> Content
+  ) {
+    self.onPaymentMethodSelected = onPaymentMethodSelected
+    self.onCancel = onCancel
+    self.content = content
+  }
+
+  public var body: some View {
+    if let checkoutScope {
+      let selectionScope = checkoutScope.paymentMethodSelection
+      content(selectionScope)
+        .environment(\.primerPaymentMethodSelectionScope, selectionScope)
+        .task {
+          await observePaymentMethodSelection(selectionScope: selectionScope)
+        }
+        .task {
+          await observeCheckoutState()
+        }
+    } else {
+      // Fallback when scope is not available
+      Text("Payment selection scope not available")
+        .foregroundColor(.secondary)
+    }
+  }
+
+  // MARK: - State Observation
+
+  /// Observes payment method selection state changes and invokes appropriate callbacks.
+  /// Uses iOS-native async/await pattern with AsyncStream.
+  private func observePaymentMethodSelection(selectionScope: PrimerPaymentMethodSelectionScope)
+    async {
+    for await state in selectionScope.state {
+      handleSelectionStateChange(state)
+    }
+  }
+
+  /// Observes checkout state for cancel/dismiss events.
+  private func observeCheckoutState() async {
+    guard let checkoutScope else { return }
+
+    for await state in checkoutScope.state {
+      handleCheckoutStateChange(state)
+    }
+  }
+
+  /// Handles payment method selection state changes.
+  @MainActor
+  private func handleSelectionStateChange(_ state: PrimerPaymentMethodSelectionState) {
+    // Check if a NEW payment method was selected (different from last seen)
+    if let selectedMethod = state.selectedPaymentMethod,
+      selectedMethod.type != lastSelectedPaymentMethodType {
+      lastSelectedPaymentMethodType = selectedMethod.type
+      onPaymentMethodSelected?(selectedMethod.type)
+    }
+  }
+
+  /// Handles checkout state changes for cancel detection.
+  @MainActor
+  private func handleCheckoutStateChange(_ state: PrimerCheckoutState) {
+    if case .dismissed = state {
+      onCancel?()
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/Providers/SelectCountryProvider.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/Providers/SelectCountryProvider.swift
@@ -1,0 +1,87 @@
+//
+//  SelectCountryProvider.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Provider view that wraps content with country selection scope access and navigation handling.
+///
+/// Use `SelectCountryProvider` when embedding country selection in your own navigation hierarchy:
+/// ```swift
+/// SelectCountryProvider(
+///     onCountrySelected: { code, name in
+///         print("Selected: \(name) (\(code))")
+///     },
+///     onCancel: {
+///         print("User cancelled")
+///     }
+/// ) { scope in
+///     SelectCountryScreen(scope: scope)
+/// }
+/// ```
+///
+/// Callbacks are invoked when provided. If no callbacks are provided, navigation events
+/// are handled by the SDK's default behavior.
+@available(iOS 15.0, *)
+public struct SelectCountryProvider<Content: View>: View, LogReporter {
+  private let onCountrySelected: ((String, String) -> Void)?
+  private let onCancel: (() -> Void)?
+  private let content: (any PrimerSelectCountryScope) -> Content
+
+  @Environment(\.primerSelectCountryScope) private var countryScope
+  @State private var lastSelectedCountryCode: String?
+
+  /// Creates a SelectCountryProvider.
+  /// - Parameters:
+  ///   - onCountrySelected: Called when user selects a country with (code, name)
+  ///   - onCancel: Called when user cancels the selection (optional, typically handled by navigation)
+  ///   - content: ViewBuilder that receives the select country scope
+  public init(
+    onCountrySelected: ((String, String) -> Void)? = nil,
+    onCancel: (() -> Void)? = nil,
+    @ViewBuilder content: @escaping (any PrimerSelectCountryScope) -> Content
+  ) {
+    self.onCountrySelected = onCountrySelected
+    self.onCancel = onCancel
+    self.content = content
+  }
+
+  public var body: some View {
+    if let countryScope {
+      content(countryScope)
+        .environment(\.primerSelectCountryScope, countryScope)
+        .task {
+          await observeCountrySelection()
+        }
+    } else {
+      // Fallback when scope is not available
+      Text("Country selection scope not available")
+        .foregroundColor(.secondary)
+    }
+  }
+
+  // MARK: - State Observation
+
+  /// Observes country selection state changes and invokes appropriate callbacks.
+  /// Uses iOS-native async/await pattern with AsyncStream.
+  private func observeCountrySelection() async {
+    guard let countryScope else { return }
+
+    for await state in countryScope.state {
+      handleStateChange(state)
+    }
+  }
+
+  /// Handles country selection state changes by invoking the appropriate callback.
+  @MainActor
+  private func handleStateChange(_ state: PrimerSelectCountryState) {
+    // Check if a NEW country was selected (different from last seen)
+    if let selectedCountry = state.selectedCountry,
+      selectedCountry.code != lastSelectedCountryCode {
+      lastSelectedCountryCode = selectedCountry.code
+      onCountrySelected?(selectedCountry.code, selectedCountry.name)
+    }
+  }
+}

--- a/Tests/Primer/CheckoutComponents/ApplePay/PrimerApplePayStateTests.swift
+++ b/Tests/Primer/CheckoutComponents/ApplePay/PrimerApplePayStateTests.swift
@@ -1,0 +1,85 @@
+//
+//  PrimerApplePayStateTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PassKit
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class PrimerApplePayStateTests: XCTestCase {
+
+    // MARK: - Default State
+
+    func test_default_hasExpectedValues() {
+        let state = PrimerApplePayState.default
+
+        XCTAssertFalse(state.isLoading)
+        XCTAssertFalse(state.isAvailable)
+        XCTAssertNil(state.availabilityError)
+        XCTAssertEqual(state.buttonStyle, .black)
+        XCTAssertEqual(state.buttonType, .plain)
+        XCTAssertEqual(state.cornerRadius, 8.0)
+    }
+
+    // MARK: - Available Factory
+
+    func test_available_withDefaults_isAvailableNotLoading() {
+        let state = PrimerApplePayState.available()
+
+        XCTAssertTrue(state.isAvailable)
+        XCTAssertFalse(state.isLoading)
+        XCTAssertNil(state.availabilityError)
+    }
+
+    func test_available_withCustomValues_appliesAllParameters() {
+        let state = PrimerApplePayState.available(
+            buttonStyle: .white,
+            buttonType: .buy,
+            cornerRadius: 12.0
+        )
+
+        XCTAssertTrue(state.isAvailable)
+        XCTAssertEqual(state.buttonStyle, .white)
+        XCTAssertEqual(state.buttonType, .buy)
+        XCTAssertEqual(state.cornerRadius, 12.0)
+    }
+
+    // MARK: - Unavailable Factory
+
+    func test_unavailable_setsErrorAndNotAvailable() {
+        let state = PrimerApplePayState.unavailable(error: "Apple Pay is not configured")
+
+        XCTAssertFalse(state.isAvailable)
+        XCTAssertFalse(state.isLoading)
+        XCTAssertEqual(state.availabilityError, "Apple Pay is not configured")
+    }
+
+    // MARK: - Loading Factory
+
+    func test_loading_isLoadingAndAvailable() {
+        let state = PrimerApplePayState.loading
+
+        XCTAssertTrue(state.isLoading)
+        XCTAssertTrue(state.isAvailable)
+        XCTAssertNil(state.availabilityError)
+    }
+
+    // MARK: - Equality
+
+    func test_equality_sameStates_areEqual() {
+        let state1 = PrimerApplePayState.default
+        let state2 = PrimerApplePayState.default
+
+        XCTAssertEqual(state1, state2)
+    }
+
+    func test_equality_differentStates_areNotEqual() {
+        let state1 = PrimerApplePayState.default
+        let state2 = PrimerApplePayState.loading
+
+        XCTAssertNotEqual(state1, state2)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Core/PrimerCardFormStateTests.swift
+++ b/Tests/Primer/CheckoutComponents/Core/PrimerCardFormStateTests.swift
@@ -1,0 +1,253 @@
+//
+//  PrimerCardFormStateTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class PrimerCardFormStateTests: XCTestCase {
+
+    // MARK: - CardFormConfiguration Tests
+
+    func test_defaultConfiguration_hasStandardCardFields() {
+        // Given
+        let config = CardFormConfiguration.default
+
+        // Then
+        XCTAssertTrue(config.cardFields.contains(.cardNumber))
+        XCTAssertTrue(config.cardFields.contains(.expiryDate))
+        XCTAssertTrue(config.cardFields.contains(.cvv))
+        XCTAssertTrue(config.cardFields.contains(.cardholderName))
+        XCTAssertTrue(config.billingFields.isEmpty)
+        XCTAssertFalse(config.requiresBillingAddress)
+    }
+
+    func test_configuration_allFields_combinesCardAndBilling() {
+        // Given
+        let config = CardFormConfiguration(
+            cardFields: [.cardNumber, .cvv],
+            billingFields: [.firstName, .lastName],
+            requiresBillingAddress: true
+        )
+
+        // When
+        let allFields = config.allFields
+
+        // Then
+        XCTAssertEqual(allFields.count, 4)
+        XCTAssertEqual(allFields[0], .cardNumber)
+        XCTAssertEqual(allFields[1], .cvv)
+        XCTAssertEqual(allFields[2], .firstName)
+        XCTAssertEqual(allFields[3], .lastName)
+    }
+
+    func test_configuration_equality() {
+        let config1 = CardFormConfiguration(cardFields: [.cardNumber], billingFields: [.email])
+        let config2 = CardFormConfiguration(cardFields: [.cardNumber], billingFields: [.email])
+        let config3 = CardFormConfiguration(cardFields: [.cvv])
+
+        XCTAssertEqual(config1, config2)
+        XCTAssertNotEqual(config1, config3)
+    }
+
+    // MARK: - FieldError Tests
+
+    func test_fieldError_equality_sameFieldAndMessage_areEqual() {
+        let error1 = FieldError(fieldType: .cardNumber, message: "Invalid", errorCode: "E001")
+        let error2 = FieldError(fieldType: .cardNumber, message: "Invalid", errorCode: "E001")
+
+        XCTAssertEqual(error1, error2)
+    }
+
+    func test_fieldError_equality_differentField_areNotEqual() {
+        let error1 = FieldError(fieldType: .cardNumber, message: "Invalid")
+        let error2 = FieldError(fieldType: .cvv, message: "Invalid")
+
+        XCTAssertNotEqual(error1, error2)
+    }
+
+    func test_fieldError_equality_differentMessage_areNotEqual() {
+        let error1 = FieldError(fieldType: .cardNumber, message: "Invalid")
+        let error2 = FieldError(fieldType: .cardNumber, message: "Required")
+
+        XCTAssertNotEqual(error1, error2)
+    }
+
+    func test_fieldError_identifiable_hasUniqueId() {
+        let error1 = FieldError(fieldType: .cardNumber, message: "Invalid")
+        let error2 = FieldError(fieldType: .cardNumber, message: "Invalid")
+
+        XCTAssertNotEqual(error1.id, error2.id)
+    }
+
+    // MARK: - FormData Tests
+
+    func test_formData_subscript_getAndSet() {
+        // Given
+        var formData = FormData()
+
+        // When
+        formData[.cardNumber] = "4111111111111111"
+
+        // Then
+        XCTAssertEqual(formData[.cardNumber], "4111111111111111")
+    }
+
+    func test_formData_subscript_defaultsToEmptyString() {
+        let formData = FormData()
+        XCTAssertEqual(formData[.cardNumber], "")
+    }
+
+    func test_formData_initWithDictionary() {
+        // Given
+        let data: [PrimerInputElementType: String] = [
+            .cardNumber: "4111",
+            .cvv: "123",
+        ]
+
+        // When
+        let formData = FormData(data)
+
+        // Then
+        XCTAssertEqual(formData[.cardNumber], "4111")
+        XCTAssertEqual(formData[.cvv], "123")
+        XCTAssertEqual(formData.dictionary.count, 2)
+    }
+
+    func test_formData_equality() {
+        let data1 = FormData([.cardNumber: "4111"])
+        let data2 = FormData([.cardNumber: "4111"])
+        let data3 = FormData([.cardNumber: "5111"])
+
+        XCTAssertEqual(data1, data2)
+        XCTAssertNotEqual(data1, data3)
+    }
+
+    // MARK: - PrimerCountry Tests
+
+    func test_country_equality_sameData_areEqual() {
+        let country1 = PrimerCountry(code: "US", name: "United States", flag: "🇺🇸", dialCode: "+1")
+        let country2 = PrimerCountry(code: "US", name: "United States", flag: "🇺🇸", dialCode: "+1")
+
+        XCTAssertEqual(country1, country2)
+    }
+
+    func test_country_equality_differentCode_areNotEqual() {
+        let country1 = PrimerCountry(code: "US", name: "United States")
+        let country2 = PrimerCountry(code: "GB", name: "United Kingdom")
+
+        XCTAssertNotEqual(country1, country2)
+    }
+
+    func test_country_identifiable_hasUniqueId() {
+        let country1 = PrimerCountry(code: "US", name: "United States")
+        let country2 = PrimerCountry(code: "US", name: "United States")
+
+        XCTAssertNotEqual(country1.id, country2.id)
+    }
+
+    // MARK: - PrimerCardFormState Tests
+
+    func test_state_defaultInit_hasExpectedDefaults() {
+        let state = PrimerCardFormState()
+
+        XCTAssertEqual(state.configuration, .default)
+        XCTAssertTrue(state.fieldErrors.isEmpty)
+        XCTAssertFalse(state.isLoading)
+        XCTAssertFalse(state.isValid)
+        XCTAssertNil(state.selectedCountry)
+        XCTAssertNil(state.selectedNetwork)
+        XCTAssertTrue(state.availableNetworks.isEmpty)
+        XCTAssertNil(state.surchargeAmountRaw)
+        XCTAssertNil(state.surchargeAmount)
+        XCTAssertNil(state.binData)
+    }
+
+    func test_state_displayFields_matchesConfiguration() {
+        let config = CardFormConfiguration(
+            cardFields: [.cardNumber, .cvv],
+            billingFields: [.email]
+        )
+        let state = PrimerCardFormState(configuration: config)
+
+        XCTAssertEqual(state.displayFields.count, 3)
+    }
+
+    func test_state_hasError_returnsTrueForExistingError() {
+        let state = PrimerCardFormState(
+            fieldErrors: [FieldError(fieldType: .cardNumber, message: "Invalid")]
+        )
+
+        XCTAssertTrue(state.hasError(for: .cardNumber))
+        XCTAssertFalse(state.hasError(for: .cvv))
+    }
+
+    func test_state_errorMessage_returnsMessageForField() {
+        let state = PrimerCardFormState(
+            fieldErrors: [FieldError(fieldType: .cardNumber, message: "Card number is invalid")]
+        )
+
+        XCTAssertEqual(state.errorMessage(for: .cardNumber), "Card number is invalid")
+        XCTAssertNil(state.errorMessage(for: .cvv))
+    }
+
+    func test_state_setError_addsNewError() {
+        // Given
+        var state = PrimerCardFormState()
+
+        // When
+        state.setError("Required", for: .cardNumber, errorCode: "E001")
+
+        // Then
+        XCTAssertEqual(state.fieldErrors.count, 1)
+        XCTAssertEqual(state.fieldErrors.first?.fieldType, .cardNumber)
+        XCTAssertEqual(state.fieldErrors.first?.message, "Required")
+        XCTAssertEqual(state.fieldErrors.first?.errorCode, "E001")
+    }
+
+    func test_state_setError_replacesExistingErrorForSameField() {
+        // Given
+        var state = PrimerCardFormState(
+            fieldErrors: [FieldError(fieldType: .cardNumber, message: "Old error")]
+        )
+
+        // When
+        state.setError("New error", for: .cardNumber)
+
+        // Then
+        XCTAssertEqual(state.fieldErrors.count, 1)
+        XCTAssertEqual(state.errorMessage(for: .cardNumber), "New error")
+    }
+
+    func test_state_clearError_removesErrorForField() {
+        // Given
+        var state = PrimerCardFormState(
+            fieldErrors: [
+                FieldError(fieldType: .cardNumber, message: "Invalid"),
+                FieldError(fieldType: .cvv, message: "Required"),
+            ]
+        )
+
+        // When
+        state.clearError(for: .cardNumber)
+
+        // Then
+        XCTAssertEqual(state.fieldErrors.count, 1)
+        XCTAssertFalse(state.hasError(for: .cardNumber))
+        XCTAssertTrue(state.hasError(for: .cvv))
+    }
+
+    func test_state_clearError_noOpForNonExistentField() {
+        // Given
+        var state = PrimerCardFormState()
+
+        // When
+        state.clearError(for: .cardNumber)
+
+        // Then
+        XCTAssertTrue(state.fieldErrors.isEmpty)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Core/PrimerCardFormStateTests.swift
+++ b/Tests/Primer/CheckoutComponents/Core/PrimerCardFormStateTests.swift
@@ -76,11 +76,13 @@ final class PrimerCardFormStateTests: XCTestCase {
         XCTAssertNotEqual(error1, error2)
     }
 
-    func test_fieldError_identifiable_hasUniqueId() {
+    func test_fieldError_identifiable_hasDeterministicId() {
         let error1 = FieldError(fieldType: .cardNumber, message: "Invalid")
-        let error2 = FieldError(fieldType: .cardNumber, message: "Invalid")
+        let error2 = FieldError(fieldType: .cardNumber, message: "Different message")
+        let error3 = FieldError(fieldType: .expiryDate, message: "Invalid")
 
-        XCTAssertNotEqual(error1.id, error2.id)
+        XCTAssertEqual(error1.id, error2.id)
+        XCTAssertNotEqual(error1.id, error3.id)
     }
 
     // MARK: - FormData Tests
@@ -142,11 +144,13 @@ final class PrimerCardFormStateTests: XCTestCase {
         XCTAssertNotEqual(country1, country2)
     }
 
-    func test_country_identifiable_hasUniqueId() {
+    func test_country_identifiable_hasDeterministicId() {
         let country1 = PrimerCountry(code: "US", name: "United States")
-        let country2 = PrimerCountry(code: "US", name: "United States")
+        let country2 = PrimerCountry(code: "US", name: "USA")
+        let country3 = PrimerCountry(code: "GB", name: "United Kingdom")
 
-        XCTAssertNotEqual(country1.id, country2.id)
+        XCTAssertEqual(country1.id, country2.id)
+        XCTAssertNotEqual(country1.id, country3.id)
     }
 
     // MARK: - PrimerCardFormState Tests

--- a/Tests/Primer/CheckoutComponents/Mocks/MockCardNetworkDetectionInteractor.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockCardNetworkDetectionInteractor.swift
@@ -1,0 +1,33 @@
+//
+//  MockCardNetworkDetectionInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class MockCardNetworkDetectionInteractor: CardNetworkDetectionInteractor {
+
+    private(set) var detectNetworksCallCount = 0
+
+    var networkDetectionStream: AsyncStream<[CardNetwork]> {
+        AsyncStream { continuation in
+            continuation.yield([])
+            continuation.finish()
+        }
+    }
+
+    var binDataStream: AsyncStream<PrimerBinData> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func detectNetworks(for cardNumber: String) async {
+        detectNetworksCallCount += 1
+    }
+
+    func selectNetwork(_ network: CardNetwork) async {}
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockProcessCardPaymentInteractor.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockProcessCardPaymentInteractor.swift
@@ -1,0 +1,22 @@
+//
+//  MockProcessCardPaymentInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class MockProcessCardPaymentInteractor: ProcessCardPaymentInteractor {
+
+    var resultToReturn: PaymentResult = PaymentResult(paymentId: "test-payment-id", status: .success)
+    var errorToThrow: Error?
+
+    func execute(cardData: CardPaymentData) async throws -> PaymentResult {
+        if let error = errorToThrow {
+            throw error
+        }
+        return resultToReturn
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockValidateInputInteractor.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockValidateInputInteractor.swift
@@ -1,0 +1,34 @@
+//
+//  MockValidateInputInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class MockValidateInputInteractor: ValidateInputInteractor {
+
+    var validationResults: [PrimerInputElementType: ValidationResult] = [:]
+
+    func validate(value: String, type: PrimerInputElementType) async -> ValidationResult {
+        validationResults[type] ?? ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
+    }
+
+    func validateMultiple(fields: [PrimerInputElementType: String]) async -> [PrimerInputElementType: ValidationResult] {
+        var results: [PrimerInputElementType: ValidationResult] = [:]
+        for (type, _) in fields {
+            results[type] = validationResults[type] ?? ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
+        }
+        return results
+    }
+
+    func setValidResult(for type: PrimerInputElementType) {
+        validationResults[type] = ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
+    }
+
+    func setInvalidResult(for type: PrimerInputElementType, message: String, code: String = TestData.ErrorCodes.invalid) {
+        validationResults[type] = ValidationResult(isValid: false, errorCode: code, errorMessage: message)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockValidationService.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockValidationService.swift
@@ -1,0 +1,94 @@
+//
+//  MockValidationService.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class MockValidationService: ValidationService {
+
+    // MARK: - Configurable Return Values
+
+    var stubbedValidationResult = ValidationResult.valid
+    var stubbedResultsByType: [PrimerInputElementType: ValidationResult] = [:]
+
+    // MARK: - Call Tracking
+
+    private(set) var validateFieldCallCount = 0
+    private(set) var lastFieldType: PrimerInputElementType?
+    private(set) var lastFieldValue: String?
+
+    // MARK: - ValidationService Protocol
+
+    func validateCardNumber(_ number: String) -> ValidationResult {
+        validateFieldCallCount += 1
+        lastFieldType = .cardNumber
+        lastFieldValue = number
+        return stubbedResultsByType[.cardNumber] ?? stubbedValidationResult
+    }
+
+    func validateExpiry(month: String, year: String) -> ValidationResult {
+        validateFieldCallCount += 1
+        lastFieldType = .expiryDate
+        lastFieldValue = "\(month)/\(year)"
+        return stubbedResultsByType[.expiryDate] ?? stubbedValidationResult
+    }
+
+    func validateCVV(_ cvv: String, cardNetwork: CardNetwork) -> ValidationResult {
+        validateFieldCallCount += 1
+        lastFieldType = .cvv
+        lastFieldValue = cvv
+        return stubbedResultsByType[.cvv] ?? stubbedValidationResult
+    }
+
+    func validateCardholderName(_ name: String) -> ValidationResult {
+        validateFieldCallCount += 1
+        lastFieldType = .cardholderName
+        lastFieldValue = name
+        return stubbedResultsByType[.cardholderName] ?? stubbedValidationResult
+    }
+
+    func validateField(type: PrimerInputElementType, value: String?) -> ValidationResult {
+        validateFieldCallCount += 1
+        lastFieldType = type
+        lastFieldValue = value
+        return stubbedResultsByType[type] ?? stubbedValidationResult
+    }
+
+    func validate<T, R: ValidationRule>(input: T, with rule: R) -> ValidationResult where R.Input == T {
+        stubbedValidationResult
+    }
+
+    func validateFormData(_ formData: FormData, configuration: CardFormConfiguration) -> [FieldError] { [] }
+
+    func validateFields(_ fieldTypes: [PrimerInputElementType], formData: FormData) -> [FieldError] { [] }
+
+    func validateFieldWithStructuredResult(type: PrimerInputElementType, value: String?) -> FieldError? {
+        let result = validateField(type: type, value: value)
+        if result.isValid {
+            return nil
+        }
+        return FieldError(
+            fieldType: type,
+            message: result.errorMessage ?? "Validation failed",
+            errorCode: result.errorCode
+        )
+    }
+
+    // MARK: - Test Helpers
+
+    func reset() {
+        validateFieldCallCount = 0
+        lastFieldType = nil
+        lastFieldValue = nil
+        stubbedValidationResult = ValidationResult.valid
+        stubbedResultsByType = [:]
+    }
+
+    func stubResult(for type: PrimerInputElementType, result: ValidationResult) {
+        stubbedResultsByType[type] = result
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
@@ -1,0 +1,1381 @@
+//
+//  DefaultCardFormScopeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+// MARK: - DefaultCardFormScope Tests
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultCardFormScopeTests: XCTestCase {
+
+    // MARK: - Test Helpers
+
+    private func createTestContainer() async -> Container {
+        await ContainerTestHelpers.createTestContainer()
+    }
+
+    private func createCardFormScope(
+        checkoutScope: DefaultCheckoutScope,
+        processCardPaymentInteractor: ProcessCardPaymentInteractor? = nil,
+        validateInputInteractor: ValidateInputInteractor? = nil,
+        cardNetworkDetectionInteractor: CardNetworkDetectionInteractor? = nil,
+        configurationService: ConfigurationService? = nil
+    ) -> DefaultCardFormScope {
+        DefaultCardFormScope(
+            checkoutScope: checkoutScope,
+            presentationContext: .fromPaymentSelection,
+            processCardPaymentInteractor: processCardPaymentInteractor ?? MockProcessCardPaymentInteractor(),
+            validateInputInteractor: validateInputInteractor ?? MockValidateInputInteractor(),
+            cardNetworkDetectionInteractor: cardNetworkDetectionInteractor ?? MockCardNetworkDetectionInteractor(),
+            analyticsInteractor: MockAnalyticsInteractor(),
+            configurationService: configurationService ?? MockConfigurationService.withDefaultConfiguration()
+        )
+    }
+
+    // MARK: - Card Number Field Validation Tests
+
+    func test_cardNumberField_validatesCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockValidator = MockValidateInputInteractor()
+            mockValidator.setValidResult(for: .cardNumber)
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                validateInputInteractor: mockValidator
+            )
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+
+            let cardNumber = scope.getFieldValue(.cardNumber)
+            XCTAssertEqual(cardNumber, TestData.CardNumbers.validVisa)
+        }
+    }
+
+    func test_cardNumberField_invalidNumber_setsError() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockValidator = MockValidateInputInteractor()
+            mockValidator.setInvalidResult(for: .cardNumber, message: "Invalid card number")
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                validateInputInteractor: mockValidator
+            )
+
+            scope.updateCardNumber("1234567890")
+            scope.setFieldError(.cardNumber, message: "Invalid card number", errorCode: "INVALID_CARD_NUMBER")
+
+            let error = scope.getFieldError(.cardNumber)
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error, "Invalid card number")
+        }
+    }
+
+    // MARK: - CVV Field Validation Tests
+
+    func test_cvvField_validatesForCardNetwork() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockValidator = MockValidateInputInteractor()
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                validateInputInteractor: mockValidator
+            )
+
+            scope.updateCvv("123")
+            let cvv3Digit = scope.getFieldValue(.cvv)
+            XCTAssertEqual(cvv3Digit, "123")
+
+            scope.updateCvv("1234")
+            let cvv4Digit = scope.getFieldValue(.cvv)
+            XCTAssertEqual(cvv4Digit, "1234")
+        }
+    }
+
+    // MARK: - Expiry Field Validation Tests
+
+    func test_expiryField_rejectsExpiredDates() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockValidator = MockValidateInputInteractor()
+            mockValidator.setInvalidResult(for: .expiryDate, message: "Card has expired")
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                validateInputInteractor: mockValidator
+            )
+
+            scope.updateExpiryDate("01/20")
+            scope.setFieldError(.expiryDate, message: "Card has expired", errorCode: "EXPIRED_CARD")
+
+            let error = scope.getFieldError(.expiryDate)
+            XCTAssertNotNil(error)
+            XCTAssertTrue(error?.contains("expired") == true)
+        }
+    }
+
+    func test_expiryField_acceptsValidDate() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockValidator = MockValidateInputInteractor()
+            mockValidator.setValidResult(for: .expiryDate)
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                validateInputInteractor: mockValidator
+            )
+
+            scope.updateExpiryDate("12/30")
+
+            let expiryDate = scope.getFieldValue(.expiryDate)
+            XCTAssertEqual(expiryDate, "12/30")
+
+            let error = scope.getFieldError(.expiryDate)
+            XCTAssertNil(error)
+        }
+    }
+
+    // MARK: - Cardholder Name Validation Tests
+
+    func test_cardholderNameField_validatesCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockValidator = MockValidateInputInteractor()
+            mockValidator.setValidResult(for: .cardholderName)
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                validateInputInteractor: mockValidator
+            )
+
+            scope.updateCardholderName("John Doe")
+
+            let name = scope.getFieldValue(.cardholderName)
+            XCTAssertEqual(name, "John Doe")
+        }
+    }
+
+    func test_cardholderNameField_invalidName_setsError() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockValidator = MockValidateInputInteractor()
+            mockValidator.setInvalidResult(for: .cardholderName, message: "Name is required")
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                validateInputInteractor: mockValidator
+            )
+
+            scope.updateCardholderName("")
+            scope.setFieldError(.cardholderName, message: "Name is required", errorCode: "REQUIRED_FIELD")
+
+            let error = scope.getFieldError(.cardholderName)
+            XCTAssertNotNil(error)
+        }
+    }
+
+    // MARK: - State Reflects Field Validation Tests
+
+    func test_state_reflectsFieldValidation() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockValidator = MockValidateInputInteractor()
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                validateInputInteractor: mockValidator
+            )
+
+            XCTAssertTrue(scope.structuredState.fieldErrors.isEmpty)
+
+            scope.setFieldError(.cardNumber, message: "Invalid card", errorCode: "INVALID")
+            XCTAssertFalse(scope.structuredState.fieldErrors.isEmpty)
+
+            scope.clearFieldError(.cardNumber)
+            XCTAssertTrue(scope.structuredState.fieldErrors.isEmpty)
+        }
+    }
+
+    // MARK: - Submit Tests
+
+    func test_submit_withValidData_triggersPayment() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockPaymentInteractor = MockProcessCardPaymentInteractor()
+            let mockValidator = MockValidateInputInteractor()
+
+            mockValidator.setValidResult(for: .cardNumber)
+            mockValidator.setValidResult(for: .cvv)
+            mockValidator.setValidResult(for: .expiryDate)
+            mockValidator.setValidResult(for: .cardholderName)
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                processCardPaymentInteractor: mockPaymentInteractor,
+                validateInputInteractor: mockValidator
+            )
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            scope.updateValidationState(
+                cardNumber: true,
+                cvv: true,
+                expiry: true,
+                cardholderName: true
+            )
+
+            XCTAssertEqual(scope.getFieldValue(.cardNumber), TestData.CardNumbers.validVisa)
+            XCTAssertEqual(scope.getFieldValue(.cvv), "123")
+            XCTAssertEqual(scope.getFieldValue(.expiryDate), "12/30")
+            XCTAssertEqual(scope.getFieldValue(.cardholderName), "John Doe")
+        }
+    }
+
+    func test_onSubmit_callsSubmit() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            await scope.submit()
+
+            XCTAssertTrue(true, "submit should execute without crashing")
+        }
+    }
+
+    // MARK: - Co-Badged Card Detection Tests
+
+    func test_coBadgedCardDetection_exposesNetworkOptions() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockNetworkDetector = MockCardNetworkDetectionInteractor()
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                cardNetworkDetectionInteractor: mockNetworkDetector
+            )
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+
+            try? await Task.sleep(nanoseconds: 100_000_000)
+
+            XCTAssertEqual(mockNetworkDetector.detectNetworksCallCount, 1)
+        }
+    }
+
+    // MARK: - Exhaustive Field Update Test
+
+    func test_updateField_allFieldTypes_setsCorrectValues() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateField(.cardholderName, value: "John Doe")
+            scope.updateField(.countryCode, value: "US")
+            scope.updateField(.city, value: "Los Angeles")
+            scope.updateField(.state, value: "CA")
+            scope.updateField(.addressLine1, value: "123 Main St")
+            scope.updateField(.addressLine2, value: "Apt 4B")
+            scope.updateField(.phoneNumber, value: "+1234567890")
+            scope.updateField(.firstName, value: "John")
+            scope.updateField(.lastName, value: "Doe")
+            scope.updateField(.email, value: "john@example.com")
+            scope.updateField(.retailer, value: "Store A")
+            scope.updateField(.otp, value: "123456")
+
+            XCTAssertEqual(scope.getFieldValue(.cardholderName), "John Doe")
+            XCTAssertEqual(scope.getFieldValue(.countryCode), "US")
+            XCTAssertEqual(scope.getFieldValue(.city), "Los Angeles")
+            XCTAssertEqual(scope.getFieldValue(.state), "CA")
+            XCTAssertEqual(scope.getFieldValue(.addressLine1), "123 Main St")
+            XCTAssertEqual(scope.getFieldValue(.addressLine2), "Apt 4B")
+            XCTAssertEqual(scope.getFieldValue(.phoneNumber), "+1234567890")
+            XCTAssertEqual(scope.getFieldValue(.firstName), "John")
+            XCTAssertEqual(scope.getFieldValue(.lastName), "Doe")
+            XCTAssertEqual(scope.getFieldValue(.email), "john@example.com")
+            XCTAssertEqual(scope.getFieldValue(.retailer), "Store A")
+            XCTAssertEqual(scope.getFieldValue(.otp), "123456")
+        }
+    }
+
+    // MARK: - Clear Field Error Tests
+
+    func test_clearFieldError_removesError() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.setFieldError(.cardNumber, message: "Invalid card", errorCode: "INVALID")
+            XCTAssertNotNil(scope.getFieldError(.cardNumber))
+
+            scope.clearFieldError(.cardNumber)
+
+            XCTAssertNil(scope.getFieldError(.cardNumber))
+        }
+    }
+
+    // MARK: - Validation State Tests
+
+    func test_updateValidationState_setsIsValid() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            XCTAssertFalse(scope.structuredState.isValid)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            scope.updateValidationState(
+                cardNumber: true,
+                cvv: true,
+                expiry: true,
+                cardholderName: true
+            )
+
+            XCTAssertTrue(scope.structuredState.isValid)
+        }
+    }
+
+    func test_updateValidationState_invalidField_setsIsValidFalse() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            scope.updateValidationState(
+                cardNumber: false,
+                cvv: true,
+                expiry: true,
+                cardholderName: true
+            )
+
+            XCTAssertFalse(scope.structuredState.isValid)
+        }
+    }
+
+    // MARK: - Expiry Month/Year Tests
+
+    func test_updateExpiryMonth_updatesOnlyMonth() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateExpiryDate("01/25")
+            scope.updateExpiryMonth("12")
+
+            XCTAssertEqual(scope.getFieldValue(.expiryDate), "12/25")
+        }
+    }
+
+    func test_updateExpiryYear_updatesOnlyYear() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateExpiryDate("06/25")
+            scope.updateExpiryYear("30")
+
+            XCTAssertEqual(scope.getFieldValue(.expiryDate), "06/30")
+        }
+    }
+
+    func test_updateExpiryMonth_withEmptyYear_handlesGracefully() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateExpiryMonth("12")
+
+            XCTAssertEqual(scope.getFieldValue(.expiryDate), "12/")
+        }
+    }
+
+    func test_updateExpiryYear_withEmptyMonth_handlesGracefully() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateExpiryYear("30")
+
+            XCTAssertEqual(scope.getFieldValue(.expiryDate), "/30")
+        }
+    }
+
+    // MARK: - Country Code Tests
+
+    func test_updateCountryCode_setsCountryAndSelectedCountry() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCountryCode("US")
+
+            XCTAssertEqual(scope.getFieldValue(.countryCode), "US")
+            XCTAssertNotNil(scope.structuredState.selectedCountry)
+            XCTAssertEqual(scope.structuredState.selectedCountry?.code, "US")
+        }
+    }
+
+    func test_updateCountryCode_withLowercase_normalizesCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCountryCode("gb")
+
+            XCTAssertEqual(scope.getFieldValue(.countryCode), "gb")
+            XCTAssertNotNil(scope.structuredState.selectedCountry)
+        }
+    }
+
+    func test_updateCountryCode_withInvalidCode_handlesGracefully() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCountryCode("INVALID")
+
+            XCTAssertEqual(scope.getFieldValue(.countryCode), "INVALID")
+        }
+    }
+
+    // MARK: - Selected Card Network Tests
+
+    func test_updateSelectedCardNetwork_setsNetworkCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateSelectedCardNetwork("VISA")
+
+            XCTAssertNotNil(scope.structuredState.selectedNetwork)
+            XCTAssertEqual(scope.structuredState.selectedNetwork?.network, .visa)
+        }
+    }
+
+    func test_updateSelectedCardNetwork_withMastercard_setsCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateSelectedCardNetwork("MASTERCARD")
+
+            XCTAssertNotNil(scope.structuredState.selectedNetwork)
+            XCTAssertEqual(scope.structuredState.selectedNetwork?.network, .masterCard)
+        }
+    }
+
+    func test_updateSelectedCardNetwork_withUnknown_clearsNetwork() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateSelectedCardNetwork("VISA")
+            XCTAssertNotNil(scope.structuredState.selectedNetwork)
+
+            scope.updateSelectedCardNetwork("OTHER")
+            XCTAssertNil(scope.structuredState.selectedNetwork)
+        }
+    }
+
+    // MARK: - Individual Validation State Methods Tests
+
+    func test_updateCardNumberValidationState_updatesIsValid() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
+
+            XCTAssertTrue(scope.structuredState.isValid)
+        }
+    }
+
+    func test_updateCvvValidationState_invalidCvv_setsIsValidFalse() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: false)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
+
+            XCTAssertFalse(scope.structuredState.isValid)
+        }
+    }
+
+    func test_updateExpiryValidationState_invalidExpiry_setsIsValidFalse() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: false)
+            scope.updateValidationState(\.cardholderName, isValid: true)
+
+            XCTAssertFalse(scope.structuredState.isValid)
+        }
+    }
+
+    func test_updateCardholderNameValidationState_invalidName_setsIsValidFalse() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: false)
+
+            XCTAssertFalse(scope.structuredState.isValid)
+        }
+    }
+
+    func test_updateBillingFieldValidationStates_doNotAffectIsValid() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
+
+            scope.updateValidationState(\.postalCode, isValid: true)
+            scope.updateValidationState(\.city, isValid: true)
+            scope.updateValidationState(\.state, isValid: true)
+            scope.updateValidationState(\.addressLine1, isValid: true)
+            scope.updateValidationState(\.addressLine2, isValid: true)
+            scope.updateValidationState(\.firstName, isValid: true)
+            scope.updateValidationState(\.lastName, isValid: true)
+            scope.updateValidationState(\.email, isValid: true)
+            scope.updateValidationState(\.phoneNumber, isValid: true)
+            scope.updateValidationState(\.countryCode, isValid: true)
+
+            XCTAssertTrue(scope.structuredState.isValid)
+        }
+    }
+
+    // MARK: - Form Configuration Tests
+
+    func test_getFormConfiguration_returnsDefaultConfiguration() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            let config = scope.getFormConfiguration()
+
+            XCTAssertTrue(config.cardFields.contains(.cardNumber))
+            XCTAssertTrue(config.cardFields.contains(.expiryDate))
+            XCTAssertTrue(config.cardFields.contains(.cvv))
+            XCTAssertTrue(config.cardFields.contains(.cardholderName))
+        }
+    }
+
+    func test_getBillingAddressConfiguration_returnsConfiguration() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            let config = scope.getBillingAddressConfiguration()
+
+            XCTAssertNotNil(config)
+        }
+    }
+
+    // MARK: - Select Country Scope Tests
+
+    func test_selectCountry_returnsScope() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            let selectCountryScope = scope.selectCountry
+
+            XCTAssertNotNil(selectCountryScope)
+        }
+    }
+
+    func test_selectCountry_returnsSameInstance() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            let firstScope = scope.selectCountry
+            let secondScope = scope.selectCountry
+
+            XCTAssertTrue(firstScope === secondScope)
+        }
+    }
+
+    // MARK: - Multiple Field Error Tests
+
+    func test_setFieldError_multipleFields_tracksAll() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.setFieldError(.cardNumber, message: "Invalid card number", errorCode: "INVALID_CARD")
+            scope.setFieldError(.cvv, message: "Invalid CVV", errorCode: "INVALID_CVV")
+            scope.setFieldError(.expiryDate, message: "Invalid expiry", errorCode: "INVALID_EXPIRY")
+
+            XCTAssertEqual(scope.structuredState.fieldErrors.count, 3)
+            XCTAssertNotNil(scope.getFieldError(.cardNumber))
+            XCTAssertNotNil(scope.getFieldError(.cvv))
+            XCTAssertNotNil(scope.getFieldError(.expiryDate))
+        }
+    }
+
+    func test_clearFieldError_onlyRemovesSpecificField() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.setFieldError(.cardNumber, message: "Invalid card number", errorCode: "INVALID_CARD")
+            scope.setFieldError(.cvv, message: "Invalid CVV", errorCode: "INVALID_CVV")
+
+            scope.clearFieldError(.cardNumber)
+
+            XCTAssertNil(scope.getFieldError(.cardNumber))
+            XCTAssertNotNil(scope.getFieldError(.cvv))
+            XCTAssertEqual(scope.structuredState.fieldErrors.count, 1)
+        }
+    }
+
+    func test_setFieldError_withNilErrorCode_setsError() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.setFieldError(.cardNumber, message: "Invalid card", errorCode: nil)
+
+            XCTAssertEqual(scope.getFieldError(.cardNumber), "Invalid card")
+        }
+    }
+
+    // MARK: - Empty Field Value Tests
+
+    func test_updateCardNumber_withEmptyString_clearsField() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            XCTAssertEqual(scope.getFieldValue(.cardNumber), TestData.CardNumbers.validVisa)
+
+            scope.updateCardNumber("")
+            XCTAssertEqual(scope.getFieldValue(.cardNumber), "")
+        }
+    }
+
+    // MARK: - performSubmit Error Handling Tests
+
+    func test_performSubmit_invalidExpiryFormat_handlesError() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("invalid")
+            scope.updateCardholderName("John Doe")
+
+            // When
+            await scope.performSubmit()
+
+            // Then — should handle error gracefully, loading should be reset
+            XCTAssertFalse(scope.structuredState.isLoading)
+        }
+    }
+
+    func test_performSubmit_withTwoDigitYear_convertsToFourDigit() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockPaymentInteractor = MockProcessCardPaymentInteractor()
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                processCardPaymentInteractor: mockPaymentInteractor
+            )
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            // When
+            await scope.performSubmit()
+
+            // Then — payment should be attempted (even if it fails due to mock setup)
+            XCTAssertFalse(scope.structuredState.isLoading)
+        }
+    }
+
+    func test_performSubmit_paymentInteractorFails_handlesError() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockPaymentInteractor = MockProcessCardPaymentInteractor()
+            mockPaymentInteractor.errorToThrow = PrimerError.unknown(message: "Payment failed")
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                processCardPaymentInteractor: mockPaymentInteractor
+            )
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            // When
+            await scope.performSubmit()
+
+            // Then
+            XCTAssertFalse(scope.structuredState.isLoading)
+        }
+    }
+
+    // MARK: - submit Guard Tests
+
+    func test_submit_whenAlreadyLoading_doesNotSubmitAgain() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.structuredState.isLoading = true
+
+            // When
+            scope.submit()
+
+            // Then — should bail out immediately since isLoading is true
+            XCTAssertTrue(scope.structuredState.isLoading)
+        }
+    }
+
+    // MARK: - cancel Tests
+
+    func test_cancel_cancelsNetworkDetectionTask() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            // When
+            scope.cancel()
+
+            // Then — should not crash, tasks should be cancelled
+            XCTAssertTrue(true)
+        }
+    }
+
+    // MARK: - onBack Tests
+
+    func test_onBack_fromPaymentSelection_navigatesBack() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            // When / Then — should not crash
+            scope.onBack()
+        }
+    }
+
+    // MARK: - Billing Address Configuration Tests
+
+    func test_getBillingAddressConfiguration_withBillingFields_reflectsFields() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockConfig = MockConfigurationService.withDefaultConfiguration()
+            mockConfig.billingAddressOptions = PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions(
+                firstName: true,
+                lastName: true,
+                city: true,
+                postalCode: true,
+                addressLine1: true,
+                addressLine2: true,
+                countryCode: true,
+                phoneNumber: false,
+                state: true
+            )
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                configurationService: mockConfig
+            )
+
+            let billingConfig = scope.getBillingAddressConfiguration()
+
+            XCTAssertTrue(billingConfig.showFirstName)
+            XCTAssertTrue(billingConfig.showLastName)
+            XCTAssertTrue(billingConfig.showCity)
+            XCTAssertTrue(billingConfig.showPostalCode)
+            XCTAssertTrue(billingConfig.showAddressLine1)
+            XCTAssertTrue(billingConfig.showAddressLine2)
+            XCTAssertTrue(billingConfig.showCountry)
+            XCTAssertTrue(billingConfig.showState)
+        }
+    }
+
+    func test_getFormConfiguration_withBillingAddress_includesBillingFields() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockConfig = MockConfigurationService.withDefaultConfiguration()
+            mockConfig.billingAddressOptions = PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions(
+                firstName: true,
+                lastName: true,
+                city: true,
+                postalCode: true,
+                addressLine1: true,
+                addressLine2: true,
+                countryCode: true,
+                phoneNumber: nil,
+                state: true
+            )
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                configurationService: mockConfig
+            )
+
+            let config = scope.getFormConfiguration()
+
+            XCTAssertTrue(config.requiresBillingAddress)
+            XCTAssertFalse(config.billingFields.isEmpty)
+            XCTAssertTrue(config.billingFields.contains(.postalCode))
+        }
+    }
+
+    func test_getFormConfiguration_withoutBillingAddress_hasEmptyBillingFields() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let mockConfig = MockConfigurationService.withDefaultConfiguration()
+            mockConfig.billingAddressOptions = nil
+
+            let scope = createCardFormScope(
+                checkoutScope: checkoutScope,
+                configurationService: mockConfig
+            )
+
+            let config = scope.getFormConfiguration()
+
+            XCTAssertFalse(config.requiresBillingAddress)
+            XCTAssertTrue(config.billingFields.isEmpty)
+        }
+    }
+
+    // MARK: - getCardNetworkForCvv Tests
+
+    func test_getCardNetworkForCvv_withSelectedNetwork_returnsSelected() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateSelectedCardNetwork("VISA")
+
+            let network = scope.getCardNetworkForCvv()
+            XCTAssertEqual(network, .visa)
+        }
+    }
+
+    func test_getCardNetworkForCvv_noSelectedNetwork_derivesFromCardNumber() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+
+            let network = scope.getCardNetworkForCvv()
+            XCTAssertEqual(network, .visa)
+        }
+    }
+
+    // MARK: - updateField Default Case Tests
+
+    func test_updateField_unknownType_doesNotCrash() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            // When / Then — unknown type should hit default case
+            scope.updateField(.unknown, value: "test")
+        }
+    }
+
+    // MARK: - Postal Code Update Tests
+
+    func test_updatePostalCode_setsValue() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updatePostalCode("10001")
+
+            XCTAssertEqual(scope.getFieldValue(.postalCode), "10001")
+        }
+    }
+
+    // MARK: - updateField via Switch Cases Tests
+
+    func test_updateField_cardNumber_delegatesToUpdateCardNumber() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateField(.cardNumber, value: TestData.CardNumbers.validVisa)
+
+            XCTAssertEqual(scope.getFieldValue(.cardNumber), TestData.CardNumbers.validVisa)
+        }
+    }
+
+    func test_updateField_cvv_delegatesToUpdateCvv() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateField(.cvv, value: "999")
+
+            XCTAssertEqual(scope.getFieldValue(.cvv), "999")
+        }
+    }
+
+    func test_updateField_expiryDate_delegatesToUpdateExpiryDate() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateField(.expiryDate, value: "12/30")
+
+            XCTAssertEqual(scope.getFieldValue(.expiryDate), "12/30")
+        }
+    }
+
+    func test_updateField_postalCode_delegatesToUpdatePostalCode() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateField(.postalCode, value: "90210")
+
+            XCTAssertEqual(scope.getFieldValue(.postalCode), "90210")
+        }
+    }
+
+    // MARK: - Dismissal Mechanism and Card Form UI Options Tests
+
+    func test_dismissalMechanism_delegatesToCheckoutScope() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            let mechanism = scope.dismissalMechanism
+            XCTAssertNotNil(mechanism)
+        }
+    }
+
+    func test_cardFormUIOptions_delegatesToCheckoutScope() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            // Default PrimerSettings doesn't set cardFormUIOptions
+            XCTAssertNil(scope.cardFormUIOptions)
+        }
+    }
+}
+
+// MARK: - DefaultCardFormScope+Validation Tests
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultCardFormScopeValidationTests: XCTestCase {
+
+    private func createTestContainer() async -> Container {
+        await ContainerTestHelpers.createTestContainer()
+    }
+
+    private func createCardFormScope(
+        checkoutScope: DefaultCheckoutScope
+    ) -> DefaultCardFormScope {
+        DefaultCardFormScope(
+            checkoutScope: checkoutScope,
+            processCardPaymentInteractor: MockProcessCardPaymentInteractor(),
+            validateInputInteractor: MockValidateInputInteractor(),
+            cardNetworkDetectionInteractor: MockCardNetworkDetectionInteractor(),
+            analyticsInteractor: MockAnalyticsInteractor(),
+            configurationService: MockConfigurationService.withDefaultConfiguration()
+        )
+    }
+
+    // MARK: - updateValidationState via KeyPath Tests
+
+    func test_updateValidationState_keyPath_cardNumber_updatesFieldValidationStates() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            // Populate all required fields
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            // When
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
+
+            // Then
+            XCTAssertTrue(scope.fieldValidationStates.cardNumber)
+            XCTAssertTrue(scope.fieldValidationStates.cvv)
+            XCTAssertTrue(scope.fieldValidationStates.expiry)
+            XCTAssertTrue(scope.fieldValidationStates.cardholderName)
+            XCTAssertTrue(scope.structuredState.isValid)
+        }
+    }
+
+    func test_updateValidationState_keyPath_settingFalse_invalidatesForm() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+            scope.updateExpiryDate("12/30")
+            scope.updateCardholderName("John Doe")
+
+            // Set all valid first
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
+            XCTAssertTrue(scope.structuredState.isValid)
+
+            // When — invalidate one field
+            scope.updateValidationState(\.cardNumber, isValid: false)
+
+            // Then
+            XCTAssertFalse(scope.structuredState.isValid)
+        }
+    }
+
+    // MARK: - updateValidationStateIfNeeded Tests
+
+    func test_updateValidationStateIfNeeded_cardNumber_mapsCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            // When
+            scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: true)
+
+            // Then
+            XCTAssertTrue(scope.fieldValidationStates.cardNumber)
+        }
+    }
+
+    func test_updateValidationStateIfNeeded_cvv_mapsCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateValidationStateIfNeeded(for: .cvv, isValid: true)
+
+            XCTAssertTrue(scope.fieldValidationStates.cvv)
+        }
+    }
+
+    func test_updateValidationStateIfNeeded_expiryDate_mapsCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateValidationStateIfNeeded(for: .expiryDate, isValid: true)
+
+            XCTAssertTrue(scope.fieldValidationStates.expiry)
+        }
+    }
+
+    func test_updateValidationStateIfNeeded_cardholderName_mapsCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateValidationStateIfNeeded(for: .cardholderName, isValid: true)
+
+            XCTAssertTrue(scope.fieldValidationStates.cardholderName)
+        }
+    }
+
+    func test_updateValidationStateIfNeeded_billingFields_mapCorrectly() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateValidationStateIfNeeded(for: .email, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .firstName, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .lastName, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .addressLine1, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .addressLine2, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .city, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .state, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .postalCode, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .countryCode, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .phoneNumber, isValid: true)
+
+            XCTAssertTrue(scope.fieldValidationStates.email)
+            XCTAssertTrue(scope.fieldValidationStates.firstName)
+            XCTAssertTrue(scope.fieldValidationStates.lastName)
+            XCTAssertTrue(scope.fieldValidationStates.addressLine1)
+            XCTAssertTrue(scope.fieldValidationStates.addressLine2)
+            XCTAssertTrue(scope.fieldValidationStates.city)
+            XCTAssertTrue(scope.fieldValidationStates.state)
+            XCTAssertTrue(scope.fieldValidationStates.postalCode)
+            XCTAssertTrue(scope.fieldValidationStates.countryCode)
+            XCTAssertTrue(scope.fieldValidationStates.phoneNumber)
+        }
+    }
+
+    func test_updateValidationStateIfNeeded_unmappedType_doesNothing() async throws {
+        let container = await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            // When — retailer, otp, unknown, all have no mapping
+            scope.updateValidationStateIfNeeded(for: .retailer, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .otp, isValid: true)
+            scope.updateValidationStateIfNeeded(for: .unknown, isValid: true)
+
+            // Then — no field validation states should change
+            XCTAssertFalse(scope.fieldValidationStates.cardNumber)
+            XCTAssertFalse(scope.fieldValidationStates.cvv)
+        }
+    }
+}
+
+// MARK: - FieldValidationStates Tests
+
+@available(iOS 15.0, *)
+final class FieldValidationStatesTests: XCTestCase {
+
+    func test_init_allFieldsDefaultToFalse() {
+        // Given / When
+        let states = FieldValidationStates()
+
+        // Then
+        XCTAssertFalse(states.cardNumber)
+        XCTAssertFalse(states.cvv)
+        XCTAssertFalse(states.expiry)
+        XCTAssertFalse(states.cardholderName)
+        XCTAssertFalse(states.postalCode)
+        XCTAssertFalse(states.countryCode)
+        XCTAssertFalse(states.city)
+        XCTAssertFalse(states.state)
+        XCTAssertFalse(states.addressLine1)
+        XCTAssertFalse(states.addressLine2)
+        XCTAssertFalse(states.firstName)
+        XCTAssertFalse(states.lastName)
+        XCTAssertFalse(states.email)
+        XCTAssertFalse(states.phoneNumber)
+    }
+
+    func test_equatable_sameValues_areEqual() {
+        // Given
+        var states1 = FieldValidationStates()
+        states1.cardNumber = true
+        var states2 = FieldValidationStates()
+        states2.cardNumber = true
+
+        // Then
+        XCTAssertEqual(states1, states2)
+    }
+
+    func test_equatable_differentValues_areNotEqual() {
+        // Given
+        var states1 = FieldValidationStates()
+        states1.cardNumber = true
+        let states2 = FieldValidationStates()
+
+        // Then
+        XCTAssertNotEqual(states1, states2)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
@@ -15,8 +15,8 @@ final class DefaultCardFormScopeTests: XCTestCase {
 
     // MARK: - Test Helpers
 
-    private func createTestContainer() async -> Container {
-        await ContainerTestHelpers.createTestContainer()
+    private func createTestContainer() async throws -> Container {
+        try await ContainerTestHelpers.createTestContainer()
     }
 
     private func createCardFormScope(
@@ -40,7 +40,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Card Number Field Validation Tests
 
     func test_cardNumberField_validatesCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -60,7 +60,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_cardNumberField_invalidNumber_setsError() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -84,7 +84,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - CVV Field Validation Tests
 
     func test_cvvField_validatesForCardNetwork() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -108,7 +108,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Expiry Field Validation Tests
 
     func test_expiryField_rejectsExpiredDates() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -130,7 +130,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_expiryField_acceptsValidDate() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -155,7 +155,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Cardholder Name Validation Tests
 
     func test_cardholderNameField_validatesCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -175,7 +175,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_cardholderNameField_invalidName_setsError() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -198,7 +198,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - State Reflects Field Validation Tests
 
     func test_state_reflectsFieldValidation() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -222,7 +222,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Submit Tests
 
     func test_submit_withValidData_triggersPayment() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -260,7 +260,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_onSubmit_callsSubmit() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -280,7 +280,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Co-Badged Card Detection Tests
 
     func test_coBadgedCardDetection_exposesNetworkOptions() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -302,7 +302,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Exhaustive Field Update Test
 
     func test_updateField_allFieldTypes_setsCorrectValues() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -339,7 +339,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Clear Field Error Tests
 
     func test_clearFieldError_removesError() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -357,7 +357,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Validation State Tests
 
     func test_updateValidationState_setsIsValid() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -382,7 +382,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateValidationState_invalidField_setsIsValidFalse() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -407,7 +407,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Expiry Month/Year Tests
 
     func test_updateExpiryMonth_updatesOnlyMonth() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -421,7 +421,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateExpiryYear_updatesOnlyYear() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -435,7 +435,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateExpiryMonth_withEmptyYear_handlesGracefully() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -448,7 +448,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateExpiryYear_withEmptyMonth_handlesGracefully() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -463,7 +463,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Country Code Tests
 
     func test_updateCountryCode_setsCountryAndSelectedCountry() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -478,7 +478,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateCountryCode_withLowercase_normalizesCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -492,7 +492,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateCountryCode_withInvalidCode_handlesGracefully() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -507,7 +507,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Selected Card Network Tests
 
     func test_updateSelectedCardNetwork_setsNetworkCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -521,7 +521,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateSelectedCardNetwork_withMastercard_setsCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -535,7 +535,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateSelectedCardNetwork_withUnknown_clearsNetwork() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -552,7 +552,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Individual Validation State Methods Tests
 
     func test_updateCardNumberValidationState_updatesIsValid() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -573,7 +573,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateCvvValidationState_invalidCvv_setsIsValidFalse() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -594,7 +594,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateExpiryValidationState_invalidExpiry_setsIsValidFalse() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -615,7 +615,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateCardholderNameValidationState_invalidName_setsIsValidFalse() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -636,7 +636,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateBillingFieldValidationStates_doNotAffectIsValid() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -670,7 +670,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Form Configuration Tests
 
     func test_getFormConfiguration_returnsDefaultConfiguration() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -686,7 +686,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_getBillingAddressConfiguration_returnsConfiguration() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -701,7 +701,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Select Country Scope Tests
 
     func test_selectCountry_returnsScope() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -714,7 +714,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_selectCountry_returnsSameInstance() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -730,7 +730,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Multiple Field Error Tests
 
     func test_setFieldError_multipleFields_tracksAll() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -748,7 +748,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_clearFieldError_onlyRemovesSpecificField() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -766,7 +766,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_setFieldError_withNilErrorCode_setsError() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -781,7 +781,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Empty Field Value Tests
 
     func test_updateCardNumber_withEmptyString_clearsField() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -798,7 +798,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - performSubmit Error Handling Tests
 
     func test_performSubmit_invalidExpiryFormat_handlesError() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -818,7 +818,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_performSubmit_withTwoDigitYear_convertsToFourDigit() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -842,7 +842,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_performSubmit_paymentInteractorFails_handlesError() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -870,7 +870,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - submit Guard Tests
 
     func test_submit_whenAlreadyLoading_doesNotSubmitAgain() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -889,7 +889,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - cancel Tests
 
     func test_cancel_cancelsNetworkDetectionTask() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -906,7 +906,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - onBack Tests
 
     func test_onBack_fromPaymentSelection_navigatesBack() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -920,7 +920,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Billing Address Configuration Tests
 
     func test_getBillingAddressConfiguration_withBillingFields_reflectsFields() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -956,7 +956,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_getFormConfiguration_withBillingAddress_includesBillingFields() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -987,7 +987,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_getFormConfiguration_withoutBillingAddress_hasEmptyBillingFields() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1009,7 +1009,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - getCardNetworkForCvv Tests
 
     func test_getCardNetworkForCvv_withSelectedNetwork_returnsSelected() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1023,7 +1023,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_getCardNetworkForCvv_noSelectedNetwork_derivesFromCardNumber() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1039,7 +1039,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - updateField Default Case Tests
 
     func test_updateField_unknownType_doesNotCrash() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1053,7 +1053,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Postal Code Update Tests
 
     func test_updatePostalCode_setsValue() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1068,7 +1068,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - updateField via Switch Cases Tests
 
     func test_updateField_cardNumber_delegatesToUpdateCardNumber() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1081,7 +1081,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateField_cvv_delegatesToUpdateCvv() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1094,7 +1094,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateField_expiryDate_delegatesToUpdateExpiryDate() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1107,7 +1107,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_updateField_postalCode_delegatesToUpdatePostalCode() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1122,7 +1122,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     // MARK: - Dismissal Mechanism and Card Form UI Options Tests
 
     func test_dismissalMechanism_delegatesToCheckoutScope() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1134,7 +1134,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
     }
 
     func test_cardFormUIOptions_delegatesToCheckoutScope() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1152,8 +1152,8 @@ final class DefaultCardFormScopeTests: XCTestCase {
 @MainActor
 final class DefaultCardFormScopeValidationTests: XCTestCase {
 
-    private func createTestContainer() async -> Container {
-        await ContainerTestHelpers.createTestContainer()
+    private func createTestContainer() async throws -> Container {
+        try await ContainerTestHelpers.createTestContainer()
     }
 
     private func createCardFormScope(
@@ -1172,7 +1172,7 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
     // MARK: - updateValidationState via KeyPath Tests
 
     func test_updateValidationState_keyPath_cardNumber_updatesFieldValidationStates() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1200,7 +1200,7 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
     }
 
     func test_updateValidationState_keyPath_settingFalse_invalidatesForm() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1229,7 +1229,7 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
     // MARK: - updateValidationStateIfNeeded Tests
 
     func test_updateValidationStateIfNeeded_cardNumber_mapsCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1244,7 +1244,7 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
     }
 
     func test_updateValidationStateIfNeeded_cvv_mapsCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1257,7 +1257,7 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
     }
 
     func test_updateValidationStateIfNeeded_expiryDate_mapsCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1270,7 +1270,7 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
     }
 
     func test_updateValidationStateIfNeeded_cardholderName_mapsCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1283,7 +1283,7 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
     }
 
     func test_updateValidationStateIfNeeded_billingFields_mapCorrectly() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
@@ -1314,7 +1314,7 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
     }
 
     func test_updateValidationStateIfNeeded_unmappedType_doesNothing() async throws {
-        let container = await createTestContainer()
+        let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
             let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()

--- a/Tests/Primer/CheckoutComponents/Scope/DefaultSelectCountryScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/DefaultSelectCountryScopeTests.swift
@@ -1,0 +1,348 @@
+//
+//  DefaultSelectCountryScopeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultSelectCountryScopeTests: XCTestCase {
+
+    // MARK: - Properties
+
+    private var sut: DefaultSelectCountryScope!
+
+    // MARK: - Setup / Teardown
+
+    override func setUp() {
+        super.setUp()
+        sut = DefaultSelectCountryScope(cardFormScope: nil, checkoutScope: nil)
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - Initialization Tests
+
+    func test_init_loadsCountries() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        XCTAssertFalse(state.countries.isEmpty)
+        XCTAssertEqual(state.countries.count, state.filteredCountries.count)
+    }
+
+    func test_init_countriesAreSortedAlphabetically() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        let names = state.countries.map(\.name)
+        XCTAssertEqual(names, names.sorted())
+    }
+
+    func test_init_searchQueryIsEmpty() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        XCTAssertTrue(state.searchQuery.isEmpty)
+    }
+
+    func test_init_isLoadingIsFalse() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        XCTAssertFalse(state.isLoading)
+    }
+
+    func test_init_selectedCountryIsNil() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        XCTAssertNil(state.selectedCountry)
+    }
+
+    func test_init_countriesHaveValidCodes() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        for country in state.countries {
+            XCTAssertFalse(country.code.isEmpty)
+            XCTAssertEqual(country.code.count, 2, "Country code '\(country.code)' should be 2 chars")
+            XCTAssertEqual(country.code, country.code.uppercased(), "Country code should be uppercase")
+        }
+    }
+
+    func test_init_countriesHaveNonEmptyNames() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        for country in state.countries {
+            XCTAssertFalse(country.name.isEmpty)
+            XCTAssertNotEqual(country.name, "N/A")
+        }
+    }
+
+    func test_init_countriesExcludeInvalidEntries() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        let invalidCountries = state.countries.filter { $0.name == "N/A" || $0.name.isEmpty }
+        XCTAssertTrue(invalidCountries.isEmpty, "Countries with N/A or empty names should be excluded")
+    }
+
+    func test_init_filteredCountriesMatchAllCountries() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        XCTAssertEqual(state.filteredCountries, state.countries)
+    }
+
+    // MARK: - Search Tests
+
+    func test_onSearch_emptyQuery_showsAllCountries() async throws {
+        // Given
+        let initialState = try await awaitFirst(sut.state)
+        let totalCount = initialState.countries.count
+
+        // When
+        sut.onSearch(query: "")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertEqual(state.filteredCountries.count, totalCount)
+        XCTAssertTrue(state.searchQuery.isEmpty)
+    }
+
+    func test_onSearch_byName_filtersCorrectly() async throws {
+        // Given / When
+        sut.onSearch(query: "United")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertFalse(state.filteredCountries.isEmpty)
+        for country in state.filteredCountries {
+            let nameMatch = country.name.localizedCaseInsensitiveContains("United")
+            let codeMatch = country.code.localizedCaseInsensitiveContains("United")
+            let dialMatch = country.dialCode?.contains("United") ?? false
+            XCTAssertTrue(
+                nameMatch || codeMatch || dialMatch,
+                "Country '\(country.name)' should match 'United'"
+            )
+        }
+    }
+
+    func test_onSearch_byCountryCode_filtersCorrectly() async throws {
+        // Given / When
+        sut.onSearch(query: "US")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertFalse(state.filteredCountries.isEmpty)
+        let matchesByCode = state.filteredCountries.contains { $0.code == "US" }
+        XCTAssertTrue(matchesByCode)
+    }
+
+    func test_onSearch_byDialCode_filtersCorrectly() async throws {
+        // Given / When
+        sut.onSearch(query: "+1")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        let matchesByDialCode = state.filteredCountries.contains { $0.dialCode == "+1" }
+        XCTAssertTrue(matchesByDialCode)
+    }
+
+    func test_onSearch_caseInsensitive_returnsResults() async throws {
+        // Given / When
+        sut.onSearch(query: "germany")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        let hasGermany = state.filteredCountries.contains { $0.code == "DE" }
+        XCTAssertTrue(hasGermany)
+    }
+
+    func test_onSearch_diacriticInsensitive_returnsResults() async throws {
+        // Given / When
+        sut.onSearch(query: "Reunion")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        let hasReunion = state.filteredCountries.contains { $0.code == "RE" }
+        XCTAssertTrue(hasReunion)
+    }
+
+    func test_onSearch_noMatch_returnsEmptyFilteredList() async throws {
+        // Given / When
+        sut.onSearch(query: "XYZNONEXISTENT")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertTrue(state.filteredCountries.isEmpty)
+    }
+
+    func test_onSearch_updatesSearchQuery() async throws {
+        // Given
+        let query = "France"
+
+        // When
+        sut.onSearch(query: query)
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertEqual(state.searchQuery, query)
+    }
+
+    func test_onSearch_afterClearingQuery_restoresAllCountries() async throws {
+        // Given
+        let initialState = try await awaitFirst(sut.state)
+        let totalCount = initialState.countries.count
+        sut.onSearch(query: "Germany")
+
+        let filteredState = try await awaitFirst(sut.state)
+        XCTAssertTrue(filteredState.filteredCountries.count < totalCount)
+
+        // When
+        sut.onSearch(query: "")
+
+        // Then
+        let restoredState = try await awaitFirst(sut.state)
+        XCTAssertEqual(restoredState.filteredCountries.count, totalCount)
+    }
+
+    func test_onSearch_sequentialSearches_updatesCorrectly() async throws {
+        // Given / When / Then
+        sut.onSearch(query: "Ger")
+        let state1 = try await awaitFirst(sut.state)
+        let count1 = state1.filteredCountries.count
+
+        sut.onSearch(query: "Germany")
+        let state2 = try await awaitFirst(sut.state)
+        let count2 = state2.filteredCountries.count
+
+        XCTAssertGreaterThanOrEqual(
+            count1,
+            count2,
+            "More specific search should return same or fewer results"
+        )
+    }
+
+    func test_onSearch_doesNotMutateCountriesList() async throws {
+        // Given
+        let initialState = try await awaitFirst(sut.state)
+        let originalCount = initialState.countries.count
+
+        // When
+        sut.onSearch(query: "Germany")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertEqual(state.countries.count, originalCount)
+    }
+
+    // MARK: - Country Selection Tests
+
+    func test_onCountrySelected_withNilCardFormScope_doesNotCrash() {
+        // Given - sut created with nil cardFormScope
+
+        // When / Then - should not crash
+        sut.onCountrySelected(countryCode: "US", countryName: "United States")
+    }
+
+    // MARK: - Cancel Tests
+
+    func test_cancel_doesNotCrash() {
+        // Given / When / Then - cancel is a no-op, should not crash
+        sut.cancel()
+    }
+
+    // MARK: - UI Customization Property Tests
+
+    func test_screen_defaultsToNil() {
+        XCTAssertNil(sut.screen)
+    }
+
+    func test_searchBar_defaultsToNil() {
+        XCTAssertNil(sut.searchBar)
+    }
+
+    func test_countryItem_defaultsToNil() {
+        XCTAssertNil(sut.countryItem)
+    }
+
+    // MARK: - State Stream Tests
+
+    func test_state_emitsCurrentState() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        XCTAssertFalse(state.countries.isEmpty)
+        XCTAssertFalse(state.filteredCountries.isEmpty)
+    }
+
+    func test_state_multipleSubscribers_eachReceivesState() async throws {
+        // Given / When
+        async let state1 = awaitFirst(sut.state)
+        async let state2 = awaitFirst(sut.state)
+
+        // Then
+        let (s1, s2) = try await (state1, state2)
+        XCTAssertEqual(s1.countries.count, s2.countries.count)
+    }
+
+    // MARK: - Country Data Integrity Tests
+
+    func test_countriesContainCommonCountries() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+        let codes = Set(state.countries.map(\.code))
+
+        // Then
+        XCTAssertTrue(codes.contains("US"), "Should contain United States")
+        XCTAssertTrue(codes.contains("GB"), "Should contain United Kingdom")
+        XCTAssertTrue(codes.contains("DE"), "Should contain Germany")
+        XCTAssertTrue(codes.contains("FR"), "Should contain France")
+        XCTAssertTrue(codes.contains("JP"), "Should contain Japan")
+    }
+
+    func test_countriesHaveUniqueCountryCodes() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+        let codes = state.countries.map(\.code)
+        let uniqueCodes = Set(codes)
+
+        // Then
+        XCTAssertEqual(codes.count, uniqueCodes.count, "Country codes should be unique")
+    }
+
+    func test_countriesWithDialCodes_haveValidFormat() async throws {
+        // Given / When
+        let state = try await awaitFirst(sut.state)
+        let countriesWithDialCodes = state.countries.filter { $0.dialCode != nil }
+
+        // Then
+        XCTAssertFalse(countriesWithDialCodes.isEmpty, "Some countries should have dial codes")
+        for country in countriesWithDialCodes {
+            guard let dialCode = country.dialCode else { continue }
+            XCTAssertTrue(
+                dialCode.hasPrefix("+"),
+                "Dial code '\(dialCode)' for \(country.code) should start with +"
+            )
+        }
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Scope/DefaultSelectCountryScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/DefaultSelectCountryScopeTests.swift
@@ -19,7 +19,7 @@ final class DefaultSelectCountryScopeTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        sut = DefaultSelectCountryScope(cardFormScope: nil, checkoutScope: nil)
+        sut = DefaultSelectCountryScope(cardFormScope: nil)
     }
 
     override func tearDown() {
@@ -138,10 +138,8 @@ final class DefaultSelectCountryScopeTests: XCTestCase {
             let nameMatch = country.name.localizedCaseInsensitiveContains("United")
             let codeMatch = country.code.localizedCaseInsensitiveContains("United")
             let dialMatch = country.dialCode?.contains("United") ?? false
-            XCTAssertTrue(
-                nameMatch || codeMatch || dialMatch,
-                "Country '\(country.name)' should match 'United'"
-            )
+            XCTAssertTrue(nameMatch || codeMatch || dialMatch,
+                          "Country '\(country.name)' should match 'United'")
         }
     }
 
@@ -234,11 +232,8 @@ final class DefaultSelectCountryScopeTests: XCTestCase {
         let state2 = try await awaitFirst(sut.state)
         let count2 = state2.filteredCountries.count
 
-        XCTAssertGreaterThanOrEqual(
-            count1,
-            count2,
-            "More specific search should return same or fewer results"
-        )
+        XCTAssertGreaterThanOrEqual(count1, count2,
+                                     "More specific search should return same or fewer results")
     }
 
     func test_onSearch_doesNotMutateCountriesList() async throws {
@@ -339,10 +334,8 @@ final class DefaultSelectCountryScopeTests: XCTestCase {
         XCTAssertFalse(countriesWithDialCodes.isEmpty, "Some countries should have dial codes")
         for country in countriesWithDialCodes {
             guard let dialCode = country.dialCode else { continue }
-            XCTAssertTrue(
-                dialCode.hasPrefix("+"),
-                "Dial code '\(dialCode)' for \(country.code) should start with +"
-            )
+            XCTAssertTrue(dialCode.hasPrefix("+"),
+                          "Dial code '\(dialCode)' for \(country.code) should start with +")
         }
     }
 }

--- a/Tests/Primer/CheckoutComponents/Scope/PrimerCardFormScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/PrimerCardFormScopeTests.swift
@@ -1,0 +1,350 @@
+//
+//  PrimerCardFormScopeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import SwiftUI
+import XCTest
+
+// MARK: - PrimerCardFormScope Protocol Extension Tests
+
+@available(iOS 15.0, *)
+@MainActor
+final class PrimerCardFormScopeTests: XCTestCase {
+
+    // MARK: - Test Doubles
+
+    private class MockCardFormScopeImpl: PrimerCardFormScope {
+        typealias State = PrimerCardFormState
+
+        var updatedFields: [PrimerInputElementType: String] = [:]
+
+        var state: AsyncStream<PrimerCardFormState> {
+            AsyncStream { continuation in
+                continuation.yield(PrimerCardFormState())
+                continuation.finish()
+            }
+        }
+
+        var presentationContext: PresentationContext = .direct
+        var cardFormUIOptions: PrimerCardFormUIOptions?
+        var dismissalMechanism: [DismissalMechanism] = []
+        var selectCountry: PrimerSelectCountryScope { fatalError("Not implemented for test") }
+
+        var title: String?
+        var screen: CardFormScreenComponent?
+        var cobadgedCardsView: (([String], @escaping (String) -> Void) -> any View)?
+        var errorScreen: ErrorComponent?
+        var submitButtonText: String?
+        var showSubmitLoadingIndicator: Bool = false
+
+        var cardNumberConfig: InputFieldConfig?
+        var expiryDateConfig: InputFieldConfig?
+        var cvvConfig: InputFieldConfig?
+        var cardholderNameConfig: InputFieldConfig?
+        var postalCodeConfig: InputFieldConfig?
+        var countryConfig: InputFieldConfig?
+        var cityConfig: InputFieldConfig?
+        var stateConfig: InputFieldConfig?
+        var addressLine1Config: InputFieldConfig?
+        var addressLine2Config: InputFieldConfig?
+        var phoneNumberConfig: InputFieldConfig?
+        var firstNameConfig: InputFieldConfig?
+        var lastNameConfig: InputFieldConfig?
+        var emailConfig: InputFieldConfig?
+        var retailOutletConfig: InputFieldConfig?
+        var otpCodeConfig: InputFieldConfig?
+
+        var cardInputSection: Component?
+        var billingAddressSection: Component?
+        var submitButton: Component?
+
+        func start() {}
+        func submit() {}
+        func onBack() {}
+        func cancel() {}
+
+        func updateCardNumber(_ cardNumber: String) {
+            updatedFields[.cardNumber] = cardNumber
+        }
+
+        func updateCvv(_ cvv: String) {
+            updatedFields[.cvv] = cvv
+        }
+
+        func updateExpiryDate(_ expiryDate: String) {
+            updatedFields[.expiryDate] = expiryDate
+        }
+
+        func updateCardholderName(_ cardholderName: String) {
+            updatedFields[.cardholderName] = cardholderName
+        }
+
+        func updatePostalCode(_ postalCode: String) {
+            updatedFields[.postalCode] = postalCode
+        }
+
+        func updateCity(_ city: String) {
+            updatedFields[.city] = city
+        }
+
+        func updateState(_ state: String) {
+            updatedFields[.state] = state
+        }
+
+        func updateAddressLine1(_ addressLine1: String) {
+            updatedFields[.addressLine1] = addressLine1
+        }
+
+        func updateAddressLine2(_ addressLine2: String) {
+            updatedFields[.addressLine2] = addressLine2
+        }
+
+        func updatePhoneNumber(_ phoneNumber: String) {
+            updatedFields[.phoneNumber] = phoneNumber
+        }
+
+        func updateFirstName(_ firstName: String) {
+            updatedFields[.firstName] = firstName
+        }
+
+        func updateLastName(_ lastName: String) {
+            updatedFields[.lastName] = lastName
+        }
+
+        func updateRetailOutlet(_ retailOutlet: String) {
+            updatedFields[.retailer] = retailOutlet
+        }
+
+        func updateOtpCode(_ otpCode: String) {
+            updatedFields[.otp] = otpCode
+        }
+
+        func updateEmail(_ email: String) {
+            updatedFields[.email] = email
+        }
+
+        func updateExpiryMonth(_ month: String) {}
+        func updateExpiryYear(_ year: String) {}
+        func updateSelectedCardNetwork(_ network: String) {}
+        func updateCountryCode(_ countryCode: String) {
+            updatedFields[.countryCode] = countryCode
+        }
+
+        func PrimerCardNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerExpiryDateField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerCvvField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerCardholderNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerCountryField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerPostalCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerCityField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerStateField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerAddressLine1Field(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerAddressLine2Field(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerFirstNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerLastNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerEmailField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerPhoneNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerRetailOutletField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func PrimerOtpCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+
+        func updateValidationState(cardNumber: Bool, cvv: Bool, expiry: Bool, cardholderName: Bool) {}
+
+        func DefaultCardFormView(styling: PrimerFieldStyling?) -> AnyView {
+            AnyView(EmptyView())
+        }
+    }
+
+    // MARK: - Exhaustive updateField Dispatch Tests
+
+    func test_updateField_allCardFields_dispatchCorrectly() {
+        let scope = MockCardFormScopeImpl()
+        let testValue = "test_value"
+
+        let cardFields: [PrimerInputElementType] = [
+            .cardNumber, .cvv, .expiryDate, .cardholderName,
+        ]
+
+        for field in cardFields {
+            scope.updateField(field, value: testValue)
+            XCTAssertNotNil(scope.updatedFields[field], "Field \(field) should be updated")
+        }
+    }
+
+    func test_updateField_allBillingFields_dispatchCorrectly() {
+        let scope = MockCardFormScopeImpl()
+        let testValue = "test_value"
+
+        let billingFields: [PrimerInputElementType] = [
+            .postalCode, .countryCode, .city, .state,
+            .addressLine1, .addressLine2, .phoneNumber,
+            .firstName, .lastName, .email,
+        ]
+
+        for field in billingFields {
+            scope.updateField(field, value: testValue)
+            XCTAssertNotNil(scope.updatedFields[field], "Field \(field) should be updated")
+        }
+    }
+
+    func test_updateField_otherFields_dispatchCorrectly() {
+        let scope = MockCardFormScopeImpl()
+        let testValue = "test_value"
+
+        scope.updateField(.retailer, value: testValue)
+        XCTAssertNotNil(scope.updatedFields[.retailer])
+
+        scope.updateField(.otp, value: testValue)
+        XCTAssertNotNil(scope.updatedFields[.otp])
+    }
+
+    // MARK: - Boundary Cases
+
+    func test_updateField_unknown_doesNotDispatch() {
+        let scope = MockCardFormScopeImpl()
+
+        scope.updateField(.unknown, value: "test")
+
+        XCTAssertNil(scope.updatedFields[.unknown])
+    }
+
+    func test_updateField_all_doesNotDispatch() {
+        let scope = MockCardFormScopeImpl()
+
+        scope.updateField(.all, value: "test")
+
+        XCTAssertNil(scope.updatedFields[.all])
+    }
+
+    // MARK: - Exhaustive Default Return Value Tests
+
+    func test_getFieldValue_forAllFieldTypes_returnsEmptyString() {
+        let scope = MockCardFormScopeImpl()
+
+        let fieldTypes: [PrimerInputElementType] = [
+            .cardNumber, .cvv, .expiryDate, .cardholderName,
+            .postalCode, .city, .state, .addressLine1,
+            .addressLine2, .phoneNumber, .firstName, .lastName,
+            .email, .countryCode, .retailer, .otp,
+        ]
+
+        for fieldType in fieldTypes {
+            let value = scope.getFieldValue(fieldType)
+            XCTAssertEqual(value, "", "getFieldValue for \(fieldType) should return empty string")
+        }
+    }
+
+    func test_getFieldError_forAllFieldTypes_returnsNil() {
+        let scope = MockCardFormScopeImpl()
+
+        let fieldTypes: [PrimerInputElementType] = [
+            .cardNumber, .cvv, .expiryDate, .cardholderName,
+            .postalCode, .city, .state, .addressLine1,
+            .addressLine2, .phoneNumber, .firstName, .lastName,
+        ]
+
+        for fieldType in fieldTypes {
+            let error = scope.getFieldError(fieldType)
+            XCTAssertNil(error, "getFieldError for \(fieldType) should return nil")
+        }
+    }
+
+    // MARK: - Contract Tests
+
+    func test_getFormConfiguration_defaultImplementation_returnsDefault() {
+        let scope = MockCardFormScopeImpl()
+
+        let config = scope.getFormConfiguration()
+
+        XCTAssertEqual(config, CardFormConfiguration.default)
+    }
+
+    // MARK: - Behavioral Tests
+
+    func test_submit_callsSubmitOnScope() {
+        var submitCalled = false
+
+        final class TrackingScope: MockCardFormScopeImpl {
+            var submitHandler: (() -> Void)?
+
+            override func submit() {
+                submitHandler?()
+            }
+        }
+
+        let scope = TrackingScope()
+        scope.submitHandler = { submitCalled = true }
+
+        scope.submit()
+
+        XCTAssertTrue(submitCalled)
+    }
+
+    func test_cancel_callsCancelOnScope() {
+        var cancelCalled = false
+
+        final class TrackingScope: MockCardFormScopeImpl {
+            var cancelHandler: (() -> Void)?
+
+            override func cancel() {
+                cancelHandler?()
+            }
+        }
+
+        let scope = TrackingScope()
+        scope.cancelHandler = { cancelCalled = true }
+
+        scope.cancel()
+
+        XCTAssertTrue(cancelCalled)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Scope/PrimerPaymentMethodScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/PrimerPaymentMethodScopeTests.swift
@@ -1,0 +1,179 @@
+//
+//  PrimerPaymentMethodScopeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import SwiftUI
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class PrimerPaymentMethodScopeTests: XCTestCase {
+
+    // MARK: - Default Implementation Tests
+
+    func test_defaultPresentationContext_isFromPaymentSelection() {
+        // Given
+        let sut = StubPaymentMethodScope()
+
+        // Then
+        XCTAssertEqual(sut.presentationContext, .fromPaymentSelection)
+    }
+
+    func test_defaultDismissalMechanism_isEmpty() {
+        // Given
+        let sut = StubPaymentMethodScope()
+
+        // Then
+        XCTAssertTrue(sut.dismissalMechanism.isEmpty)
+    }
+
+    func test_onBack_callsCancel() {
+        // Given
+        let sut = StubPaymentMethodScope()
+
+        // When
+        sut.onBack()
+
+        // Then
+        XCTAssertEqual(sut.cancelCallCount, 1)
+    }
+
+    func test_onDismiss_callsCancel() {
+        // Given
+        let sut = StubPaymentMethodScope()
+
+        // When
+        sut.onDismiss()
+
+        // Then
+        XCTAssertEqual(sut.cancelCallCount, 1)
+    }
+
+    func test_onBack_thenOnDismiss_callsCancelTwice() {
+        // Given
+        let sut = StubPaymentMethodScope()
+
+        // When
+        sut.onBack()
+        sut.onDismiss()
+
+        // Then
+        XCTAssertEqual(sut.cancelCallCount, 2)
+    }
+
+    // MARK: - PaymentMethodRegistry Tests
+
+    func test_registry_reset_clearsAllRegistrations() {
+        // Given
+        let registry = PaymentMethodRegistry.shared
+        registry.register(
+            forKey: "TEST_METHOD",
+            scopeCreator: { _, _ in fatalError("Not called") },
+            viewCreator: { _ in nil }
+        )
+        XCTAssertTrue(registry.registeredTypes.contains("TEST_METHOD"))
+
+        // When
+        registry.reset()
+
+        // Then
+        XCTAssertTrue(registry.registeredTypes.isEmpty)
+    }
+
+    func test_registry_createScope_withUnregisteredType_returnsNil() async throws {
+        // Given
+        let registry = PaymentMethodRegistry.shared
+        registry.reset()
+        let checkoutScope = DefaultCheckoutScope(
+            clientToken: TestData.Tokens.valid,
+            settings: PrimerSettings(),
+            diContainer: DIContainer.shared,
+            navigator: CheckoutNavigator()
+        )
+
+        // When
+        let scope: (any PrimerPaymentMethodScope)? = try await registry.createScope(
+            for: "NONEXISTENT",
+            checkoutScope: checkoutScope,
+            diContainer: DIContainer.createContainer()
+        )
+
+        // Then
+        XCTAssertNil(scope)
+    }
+
+    func test_registry_getView_withUnregisteredType_returnsNil() {
+        // Given
+        let registry = PaymentMethodRegistry.shared
+        registry.reset()
+        let checkoutScope = DefaultCheckoutScope(
+            clientToken: TestData.Tokens.valid,
+            settings: PrimerSettings(),
+            diContainer: DIContainer.shared,
+            navigator: CheckoutNavigator()
+        )
+
+        // When
+        let view = registry.getView(for: "NONEXISTENT", checkoutScope: checkoutScope)
+
+        // Then
+        XCTAssertNil(view)
+    }
+
+    func test_registry_registeredTypes_reflectsCurrentState() {
+        // Given
+        let registry = PaymentMethodRegistry.shared
+        registry.reset()
+
+        // When
+        registry.register(
+            forKey: "TYPE_A",
+            scopeCreator: { _, _ in fatalError("Not called") },
+            viewCreator: { _ in nil }
+        )
+        registry.register(
+            forKey: "TYPE_B",
+            scopeCreator: { _, _ in fatalError("Not called") },
+            viewCreator: { _ in nil }
+        )
+
+        // Then
+        XCTAssertEqual(registry.registeredTypes.sorted(), ["TYPE_A", "TYPE_B"])
+    }
+}
+
+// MARK: - Mock Payment Method Scope
+
+@available(iOS 15.0, *)
+@MainActor
+private final class StubPaymentMethodScope: PrimerPaymentMethodScope {
+    typealias State = MockScopeState
+
+    private(set) var cancelCallCount = 0
+    private(set) var startCallCount = 0
+    private(set) var submitCallCount = 0
+
+    var state: AsyncStream<MockScopeState> {
+        AsyncStream { $0.finish() }
+    }
+
+    func start() {
+        startCallCount += 1
+    }
+
+    func submit() {
+        submitCallCount += 1
+    }
+
+    func cancel() {
+        cancelCallCount += 1
+    }
+}
+
+@available(iOS 15.0, *)
+struct MockScopeState: Equatable {
+    var value: String = ""
+}


### PR DESCRIPTION
## Summary
- Adds scope protocols defining the public API surface for each payment method (card form, Apple Pay, ACH, Klarna, PayPal, QR code, web redirect, form redirect)
- Adds `PrimerCheckoutScope` as the top-level entry point for CheckoutComponents
- Adds `PrimerCardFormState` and `PrimerApplePayState` observable state types
- Adds provider protocols (`CardFormProvider`, `PaymentMethodSelectionProvider`, `SelectCountryProvider`) for SwiftUI integration
- Adds `InputFieldConfig`, `PrimerFieldStyling`, `PrimerCheckoutTheme`, and `PrimerEnvironment` for UI configuration
- Includes mock interactors and 6 test files covering scope implementations and state management

## Context
PR 6 of 15 in the CheckoutComponents feature split. Defines the merchant-facing API that SwiftUI views bind to. Depends on PR 5 (#1634).

Tracker: https://www.notion.so/32fca65dc30e81dabf66f33e2b58c3a1

## Test plan
- [ ] Verify scope tests pass (`DefaultCardFormScopeTests`, `PrimerCardFormScopeTests`, `PrimerPaymentMethodScopeTests`, `DefaultSelectCountryScopeTests`)
- [ ] Verify state tests pass (`PrimerCardFormStateTests`, `PrimerApplePayStateTests`)
- [ ] Confirm mock interactors work correctly in test context
- [ ] Run: `xcodebuild -workspace PrimerSDK.xcworkspace -scheme PrimerSDKTests -destination "platform=iOS Simulator,name=iPhone 16" test`