### PR TITLE
feat: Add core services & navigation

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Constants/CheckoutComponentsStrings.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Constants/CheckoutComponentsStrings.swift
@@ -1,0 +1,2169 @@
+//
+//  CheckoutComponentsStrings.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+// swiftlint:disable file_length
+
+import Foundation
+
+/// Centralized strings for CheckoutComponents to make localization easier
+/// Keys use underscore_case format to match Android SDK for cross-platform consistency
+enum CheckoutComponentsStrings {
+  /// The localization table name for CheckoutComponents strings
+  private static let tableName = "CheckoutComponentsStrings"
+
+  // MARK: - Screen Titles
+
+  static let checkoutTitle = NSLocalizedString(
+    "primer_checkout_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Checkout",
+    comment: "Main checkout screen title"
+  )
+
+  static let cardPaymentTitle = NSLocalizedString(
+    "primer_card_form_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Pay with card",
+    comment: "Card Payment screen title"
+  )
+
+  static let billingAddressTitle = NSLocalizedString(
+    "primer_card_form_billing_address_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Billing address",
+    comment: "Billing address section title - Card Form"
+  )
+
+  // MARK: - Buttons
+
+  static let payButton = NSLocalizedString(
+    "primer_common_button_pay",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Pay",
+    comment: "Pay button text"
+  )
+
+  static let addCardButton = NSLocalizedString(
+    "primer_card_form_add_card",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Add card",
+    comment: "Add card button text when storing a new card"
+  )
+
+  static let cancelButton = NSLocalizedString(
+    "primer_common_button_cancel",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Cancel",
+    comment: "Cancel button text"
+  )
+
+  static let retryButton = NSLocalizedString(
+    "primer_common_button_retry",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Retry",
+    comment: "Retry button text"
+  )
+
+  static let chooseOtherPaymentMethod = NSLocalizedString(
+    "primer_checkout_error_button_other_methods",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Choose other payment method",
+    comment: "Button text to select a different payment method after error"
+  )
+
+  static let backButton = NSLocalizedString(
+    "primer_common_back",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Back",
+    comment: "Back navigation button text"
+  )
+
+  // MARK: - Payment Method Selection
+
+  static let choosePaymentMethod = NSLocalizedString(
+    "primer_payment_selection_header",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Choose payment method",
+    comment: "Payment method selection screen subtitle"
+  )
+
+  static let additionalFeeMayApply = NSLocalizedString(
+    "primer_payment_selection_surcharge_may_apply",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Additional fee may apply",
+    comment: "Message shown when a surcharge might be applied"
+  )
+
+  static func paymentAmountTitle(_ amount: String) -> String {
+    let format = NSLocalizedString(
+      "primer_common_button_pay_amount",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "Pay %@",
+      comment: "Payment amount title with formatted amount"
+    )
+    return String(format: format, amount)
+  }
+
+  // MARK: - Card Form Labels
+
+  static let cardNumberLabel = NSLocalizedString(
+    "primer_card_form_label_number",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Card Number",
+    comment: "Card number field label"
+  )
+
+  static let expiryDateLabel = NSLocalizedString(
+    "primer_card_form_label_expiry",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Expiry Date",
+    comment: "Expiry date field label"
+  )
+
+  static let cvvLabel = NSLocalizedString(
+    "primer_card_form_label_cvv",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "CVV",
+    comment: "CVV field label"
+  )
+
+  static let cardholderNameLabel = NSLocalizedString(
+    "primer_card_form_label_name",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Name on card",
+    comment: "Cardholder name field label"
+  )
+
+  // MARK: - Card Form Placeholders
+
+  static let cardNumberPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_number",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "1234 1234 1234 1234",
+    comment: "Card number input placeholder"
+  )
+
+  static let expiryDatePlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_expiry",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "MM/YY",
+    comment: "Expiry date input placeholder"
+  )
+
+  static let cvvPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_cvv",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "CVV",
+    comment: "CVV input placeholder"
+  )
+
+  static let cardholderNamePlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_name",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Full name",
+    comment: "Cardholder name input placeholder"
+  )
+
+  // MARK: - Billing Address Labels
+
+  static let firstNameLabel = NSLocalizedString(
+    "primer_card_form_label_first_name",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "First Name",
+    comment: "First name field label"
+  )
+
+  static let lastNameLabel = NSLocalizedString(
+    "primer_card_form_label_last_name",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Last Name",
+    comment: "Last name field label"
+  )
+
+  static let countryLabel = NSLocalizedString(
+    "primer_card_form_label_country",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Country",
+    comment: "Country field label"
+  )
+
+  static let addressLine1Label = NSLocalizedString(
+    "primer_card_form_label_address1",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Address Line 1",
+    comment: "Address line 1 label"
+  )
+
+  static let addressLine2Label = NSLocalizedString(
+    "primer_card_form_label_address2",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Address Line 2",
+    comment: "Address line 2 label"
+  )
+
+  static let cityLabel = NSLocalizedString(
+    "primer_card_form_label_city",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "City",
+    comment: "City label"
+  )
+
+  static let stateLabel = NSLocalizedString(
+    "primer_card_form_label_state",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "State",
+    comment: "State label"
+  )
+
+  static let postalCodeLabel = NSLocalizedString(
+    "primer_card_form_label_postal",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Postal Code",
+    comment: "Postal code label"
+  )
+
+  static let otpLabel = NSLocalizedString(
+    "primer_card_form_label_otp",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "OTP Code",
+    comment: "OTP code field label"
+  )
+
+  static let retailLabel = NSLocalizedString(
+    "primer_card_form_label_retail",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Retail Outlet",
+    comment: "Retail outlet field label"
+  )
+
+  // MARK: - Billing Address Placeholders
+
+  static let firstNamePlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_first_name",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "John",
+    comment: "First name placeholder"
+  )
+
+  static let lastNamePlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_last_name",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Doe",
+    comment: "Last name placeholder"
+  )
+
+  static let selectCountryPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_country_code",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Select country",
+    comment: "Select country placeholder"
+  )
+
+  static let addressLine1Placeholder = NSLocalizedString(
+    "primer_card_form_placeholder_address1",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "123 Main Street",
+    comment: "Address line 1 placeholder"
+  )
+
+  static let addressLine2Placeholder = NSLocalizedString(
+    "primer_card_form_placeholder_address2",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Apt 4B",
+    comment: "Address line 2 placeholder"
+  )
+
+  static let cityPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_city",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "New York",
+    comment: "City placeholder"
+  )
+
+  static let statePlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_state",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "NY",
+    comment: "State placeholder"
+  )
+
+  static let postalCodePlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_postal",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "12345",
+    comment: "Postal code placeholder"
+  )
+
+  // MARK: - Specialized Placeholders
+
+  static let searchCountriesPlaceholder = NSLocalizedString(
+    "primer_country_placeholder_search",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Search",
+    comment: "Search countries input placeholder"
+  )
+
+  // MARK: - Validation Errors - General
+
+  static let enterValidCardNumber = NSLocalizedString(
+    "primer_card_form_error_number_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid card number",
+    comment: "Card number validation error message"
+  )
+
+  static let enterValidExpiryDate = NSLocalizedString(
+    "primer_card_form_error_expiry_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid date",
+    comment: "Expiry date validation error message"
+  )
+
+  static let enterValidCVV = NSLocalizedString(
+    "primer_card_form_error_cvv_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid CVV",
+    comment: "CVV validation error message"
+  )
+
+  static let enterValidCardholderName = NSLocalizedString(
+    "primer_card_form_error_name_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid Cardholder name",
+    comment: "Cardholder name validation error message"
+  )
+
+  // MARK: - Validation Errors - Form Specific
+
+  static let formErrorCardTypeNotSupported = NSLocalizedString(
+    "primer_card_form_error_card_type_unsupported",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Unsupported card type",
+    comment: "Card type not supported error"
+  )
+
+  static let formErrorCardHolderNameLength = NSLocalizedString(
+    "primer_card_form_error_name_length",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Name must have between 2 and 45 characters",
+    comment: "Card holder name length validation error"
+  )
+
+  // MARK: - Validation Errors - Required Fields
+
+  static let firstNameErrorRequired = NSLocalizedString(
+    "primer_card_form_error_first_name_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "First Name is required",
+    comment: "First name required validation error"
+  )
+
+  static let lastNameErrorRequired = NSLocalizedString(
+    "primer_card_form_error_last_name_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Last Name is required",
+    comment: "Last name required validation error"
+  )
+
+  static let countryCodeErrorRequired = NSLocalizedString(
+    "primer_card_form_error_country_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Country is required",
+    comment: "Country required validation error"
+  )
+
+  static let addressLine1ErrorRequired = NSLocalizedString(
+    "primer_card_form_error_address1_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Address line 1 is required",
+    comment: "Address line 1 required validation error"
+  )
+
+  static let addressLine2ErrorRequired = NSLocalizedString(
+    "primer_card_form_error_address2_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Address line 2 is required",
+    comment: "Address line 2 required validation error"
+  )
+
+  static let cityErrorRequired = NSLocalizedString(
+    "primer_card_form_error_city_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "City is required",
+    comment: "City required validation error"
+  )
+
+  static let stateErrorRequired = NSLocalizedString(
+    "primer_card_form_error_state_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "State, Region or County is required",
+    comment: "State required validation error"
+  )
+
+  static let postalCodeErrorRequired = NSLocalizedString(
+    "primer_card_form_error_postal_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Postal code is required",
+    comment: "Postal code required validation error"
+  )
+
+  // MARK: - Validation Errors - Invalid Fields
+
+  static let firstNameErrorInvalid = NSLocalizedString(
+    "primer_card_form_error_first_name_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid First Name",
+    comment: "First name invalid validation error"
+  )
+
+  static let lastNameErrorInvalid = NSLocalizedString(
+    "primer_card_form_error_last_name_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid Last Name",
+    comment: "Last name invalid validation error"
+  )
+
+  static let countryCodeErrorInvalid = NSLocalizedString(
+    "primer_card_form_error_country_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid Country",
+    comment: "Country invalid validation error"
+  )
+
+  static let addressLine1ErrorInvalid = NSLocalizedString(
+    "primer_card_form_error_address1_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid Address Line 1",
+    comment: "Address line 1 invalid validation error"
+  )
+
+  static let addressLine2ErrorInvalid = NSLocalizedString(
+    "primer_card_form_error_address2_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid Address Line 2",
+    comment: "Address line 2 invalid validation error"
+  )
+
+  static let cityErrorInvalid = NSLocalizedString(
+    "primer_card_form_error_city_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid city",
+    comment: "City invalid validation error"
+  )
+
+  static let stateErrorInvalid = NSLocalizedString(
+    "primer_card_form_error_state_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid State, Region or County",
+    comment: "State invalid validation error"
+  )
+
+  static let postalCodeErrorInvalid = NSLocalizedString(
+    "primer_card_form_error_postal_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid postal code",
+    comment: "Postal code invalid validation error"
+  )
+
+  // MARK: - System Messages
+
+  static let somethingWentWrong = NSLocalizedString(
+    "primer_common_error_generic",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "An unknown error occurred.",
+    comment: "Generic error message"
+  )
+
+  // MARK: - Empty State Messages
+
+  static let noAdditionalFee = NSLocalizedString(
+    "primer_payment_selection_surcharge_none",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "No additional fee",
+    comment: "Message shown when no surcharge applies"
+  )
+
+  // MARK: - Success Screen Details
+
+  static let paymentSuccessful = NSLocalizedString(
+    "primer_checkout_success_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Payment successful",
+    comment: "Success screen title"
+  )
+
+  static let paymentFailed = NSLocalizedString(
+    "primer_checkout_error_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Payment failed",
+    comment: "Error screen title for payment failures"
+  )
+
+  static func paymentMethodDisplayName(_ displayName: String) -> String {
+    let format = NSLocalizedString(
+      "primer_common_button_pay_amount",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "Pay %@",
+      comment: "Payment method display format with method name"
+    )
+    return String(format: format, displayName)
+  }
+
+  // MARK: - CheckoutComponents-Specific Strings
+
+  static let selectNetworkTitle = NSLocalizedString(
+    "primer_card_form_network_selector_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Select Network",
+    comment: "Card network selection title"
+  )
+
+  static let selectCountryTitle = NSLocalizedString(
+    "primer_country_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Select Country",
+    comment: "Country selection screen title"
+  )
+
+  static let expiryDateAlternativePlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_expiry_alt",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "12/25",
+    comment: "Alternative expiry date input placeholder"
+  )
+
+  static let cvvAmexPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_cvv_amex",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "1234",
+    comment: "CVV input placeholder for American Express"
+  )
+
+  static let cvvStandardPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_cvv",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "123",
+    comment: "CVV input placeholder for standard cards"
+  )
+
+  static let fullNamePlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_name",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Full name",
+    comment: "Full name input placeholder"
+  )
+
+  static let emailLabel = NSLocalizedString(
+    "primer_card_form_label_email",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Email",
+    comment: "Email field label"
+  )
+
+  static let phoneNumberLabel = NSLocalizedString(
+    "primer_card_form_label_phone",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Phone Number",
+    comment: "Phone number field label"
+  )
+
+  static let emailPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_email",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "john.doe@example.com",
+    comment: "Email placeholder"
+  )
+
+  static let phoneNumberPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_phone",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "+1 (555) 123–4567",
+    comment: "Phone number placeholder"
+  )
+
+  static let countrySelectorPlaceholder = NSLocalizedString(
+    "primer_country_selector_placeholder",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Country Selector",
+    comment: "Country selector placeholder"
+  )
+
+  static let retailOutletPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_retail",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Select outlet",
+    comment: "Retail outlet input placeholder"
+  )
+
+  static let otpCodePlaceholder = NSLocalizedString(
+    "primer_card_form_label_otp",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "OTP Code",
+    comment: "OTP code input placeholder"
+  )
+
+  static let otpCodeNumericPlaceholder = NSLocalizedString(
+    "primer_card_form_placeholder_otp",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "123456",
+    comment: "Numeric OTP code input placeholder"
+  )
+
+  static let enterValidPhoneNumber = NSLocalizedString(
+    "primer_card_form_error_phone_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter a valid phone number",
+    comment: "Phone number validation error message"
+  )
+
+  static let emailErrorRequired = NSLocalizedString(
+    "primer_card_form_error_email_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Email is required",
+    comment: "Email required validation error"
+  )
+
+  static let emailErrorInvalid = NSLocalizedString(
+    "primer_card_form_error_email_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid email",
+    comment: "Email invalid validation error"
+  )
+
+  static let formErrorCardExpired = NSLocalizedString(
+    "primer_card_form_error_card_expired",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Card has expired",
+    comment: "Card expired validation error"
+  )
+
+  static let loadingSecureCheckout = NSLocalizedString(
+    "primer_checkout_splash_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Loading your secure checkout",
+    comment: "Main loading message for secure checkout"
+  )
+
+  static let loadingWontTakeLong = NSLocalizedString(
+    "primer_checkout_splash_subtitle",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "This won't take long",
+    comment: "Secondary loading message indicating quick loading time"
+  )
+
+  /// Simple "Loading" text shown in the default loading screen during payment processing.
+  /// Matches Android SDK naming convention.
+  static let loading = NSLocalizedString(
+    "primer_checkout_loading_indicator",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Loading",
+    comment: "Simple loading text shown during payment processing"
+  )
+
+  static let processingPayment = NSLocalizedString(
+    "primer_checkout_processing_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Processing your payment",
+    comment: "Main message shown while payment is being processed"
+  )
+
+  static let processingPleaseWait = NSLocalizedString(
+    "primer_checkout_processing_subtitle",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Please wait...",
+    comment: "Secondary message shown while payment is being processed"
+  )
+
+  static let dismissingMessage = NSLocalizedString(
+    "primer_checkout_dismissing",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Dismissing...",
+    comment: "Message shown while dismissing checkout"
+  )
+
+  static let unexpectedError = NSLocalizedString(
+    "primer_common_error_unexpected",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "An unexpected error occurred.",
+    comment: "Unexpected error message"
+  )
+
+  static let paymentSystemError = NSLocalizedString(
+    "primer_checkout_system_error_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Payment System Error",
+    comment: "Error title when payment system initialization fails"
+  )
+
+  static let checkoutScopeNotAvailable = NSLocalizedString(
+    "primer_checkout_scope_unavailable",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Checkout scope not available",
+    comment: "Error when checkout scope is not accessible"
+  )
+
+  static let noPaymentMethodsAvailable = NSLocalizedString(
+    "primer_payment_selection_empty",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "No payment methods available",
+    comment: "Empty state message when no payment methods are available"
+  )
+
+  // MARK: - Saved Payment Methods Section
+
+  static let savedPaymentMethods = NSLocalizedString(
+    "primer_vault_section_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Saved payment methods",
+    comment: "Section title for saved/vaulted payment methods"
+  )
+
+  static let showAll = NSLocalizedString(
+    "primer_vault_button_show_all",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Show all",
+    comment: "Button text to show all saved payment methods"
+  )
+
+  static let showOtherWaysToPay = NSLocalizedString(
+    "primer_vault_selected_button_other",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Show other ways to pay",
+    comment: "Button text to expand and show all available payment methods"
+  )
+
+  static let a11yShowOtherWaysToPay = NSLocalizedString(
+    "accessibility_payment_selection_show_other_ways_to_pay",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Show other ways to pay",
+    comment: "VoiceOver label for button to expand payment methods"
+  )
+
+  static let allSavedPaymentMethods = NSLocalizedString(
+    "primer_vault_manage_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "All saved payment methods",
+    comment: "Title for the vaulted payment methods list screen"
+  )
+
+  static let editButton = NSLocalizedString(
+    "primer_vault_manage_button_edit",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Edit",
+    comment: "Edit button placeholder text"
+  )
+
+  static let doneButton = NSLocalizedString(
+    "primer_vault_manage_button_done",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Done",
+    comment: "Done button text for finishing edit mode"
+  )
+
+  static let deleteButton = NSLocalizedString(
+    "primer_vault_delete_button_confirm",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Delete",
+    comment: "Delete button text for confirming deletion"
+  )
+
+  static let deletePaymentMethodConfirmation = NSLocalizedString(
+    "primer_vault_delete_message",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Are you sure you want to delete this payment method?",
+    comment: "Confirmation message shown when deleting a saved payment method"
+  )
+
+  static let cardHolder = NSLocalizedString(
+    "primer_vault_default_cardholder",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Cardholder",
+    comment: "Default placeholder text when cardholder name is not available"
+  )
+
+  static func expiresDate(month: String, year: String) -> String {
+    let format = NSLocalizedString(
+      "primer_vault_format_expires",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "Expires %1$@/%2$@",
+      comment:
+        "Expiry date text for saved card. First parameter is month, second is year (e.g., '12/26')"
+    )
+    return String(format: format, month, year)
+  }
+
+  // MARK: - Vaulted Payment Method Brand Names
+
+  static let paypalBrandName = NSLocalizedString(
+    "primer_vault_default_paypal",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "PayPal account",
+    comment: "PayPal brand name for vaulted payment methods"
+  )
+
+  static let achSuffix = NSLocalizedString(
+    "primer_vault_default_bank",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Bank account",
+    comment: "Default text for vaulted bank account payment methods"
+  )
+
+  static func maskedCardNumberFormatted(_ last4: String) -> String {
+    let format = NSLocalizedString(
+      "primer_vault_format_masked",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "•••• %@",
+      comment: "Masked card number format. Parameter is the last 4 digits."
+    )
+    return String(format: format, last4)
+  }
+
+  // MARK: - Vaulted Card CVV Recapture
+
+  static let cvvPlaceholderDigit = NSLocalizedString(
+    "primer_vault_cvv_placeholder_digit",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "0",
+    comment: "Single digit used to build CVV placeholder (e.g., '000' for 3-digit CVV)"
+  )
+
+  static let cvvRecaptureInstruction = NSLocalizedString(
+    "primer_vault_cvv_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Input the card CVV for a secure payment.",
+    comment: "Instruction text shown when CVV is required for vaulted card payment"
+  )
+
+  static let cvvInvalidError = NSLocalizedString(
+    "primer_vault_cvv_error_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Please enter a valid CVV.",
+    comment: "Error message when CVV is invalid"
+  )
+
+  static let a11yVaultCVVLabel = NSLocalizedString(
+    "accessibility_vault_cvv_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "CVV input field",
+    comment: "VoiceOver label for CVV input field in vault payment flow"
+  )
+
+  static func a11yVaultCVVHint(length: Int) -> String {
+    let format = NSLocalizedString(
+      "accessibility_vault_cvv_hint",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "Enter %d digit security code",
+      comment:
+        "VoiceOver hint for CVV field with expected length. Parameter is the number of digits (3 or 4)"
+    )
+    return String(format: format, length)
+  }
+
+  static let noCountriesFound = NSLocalizedString(
+    "primer_country_no_results",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "No countries found",
+    comment: "Message when country search returns no results"
+  )
+
+  static let autoDismissMessage = NSLocalizedString(
+    "primer_checkout_auto_dismiss_message",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "This screen will close automatically in 3 seconds",
+    comment: "Auto-dismiss message on success and error screens"
+  )
+
+  static let redirectConfirmationMessage = NSLocalizedString(
+    "primer_checkout_success_subtitle",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "You'll be redirected to the order confirmation page soon.",
+    comment: "Message shown on success screen about upcoming redirect"
+  )
+
+  static let implementationComingSoon = NSLocalizedString(
+    "primer_misc_coming_soon",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Implementation coming soon",
+    comment: "Placeholder message for features under development"
+  )
+
+  static let retailOutletRequired = NSLocalizedString(
+    "primer_card_form_error_retail_outlet_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Retail outlet is required",
+    comment: "Retail outlet required validation error"
+  )
+
+  static let retailOutletInvalid = NSLocalizedString(
+    "primer_card_form_error_retail_outlet_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid retail outlet",
+    comment: "Retail outlet invalid validation error"
+  )
+
+  static let retailOutletNotImplemented = NSLocalizedString(
+    "primer_card_form_retail_not_implemented",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Retail outlet selection not yet implemented",
+    comment: "Message for retail outlet feature not yet available"
+  )
+
+  // MARK: - Vaulted Payment Method Accessibility
+
+  static func a11yVaultedCard(network: String, last4: String, expiry: String, name: String?)
+    -> String {
+    if let name {
+      let format = NSLocalizedString(
+        "accessibility_vaulted_card_full",
+        tableName: tableName,
+        bundle: .primerResources,
+        value: "%@ card ending in %@, expires %@, %@",
+        comment:
+          "Full VoiceOver label for vaulted card with name. Parameters: network, last4, expiry, name"
+      )
+      return String(format: format, network, last4, expiry, name)
+    } else {
+      let format = NSLocalizedString(
+        "accessibility_vaulted_card_no_name",
+        tableName: tableName,
+        bundle: .primerResources,
+        value: "%@ card ending in %@, expires %@",
+        comment: "VoiceOver label for vaulted card without name. Parameters: network, last4, expiry"
+      )
+      return String(format: format, network, last4, expiry)
+    }
+  }
+
+  static func a11yVaultedPayPal(email: String?, name: String?) -> String {
+    if let email {
+      let format = NSLocalizedString(
+        "accessibility_vaulted_paypal_email",
+        tableName: tableName,
+        bundle: .primerResources,
+        value: "PayPal, %@",
+        comment: "VoiceOver label for vaulted PayPal with email"
+      )
+      return String(format: format, email)
+    } else {
+      return NSLocalizedString(
+        "accessibility_vaulted_paypal",
+        tableName: tableName,
+        bundle: .primerResources,
+        value: "PayPal",
+        comment: "VoiceOver label for vaulted PayPal without email"
+      )
+    }
+  }
+
+  static func a11yVaultedKlarna(email: String?) -> String {
+    if let email {
+      let format = NSLocalizedString(
+        "accessibility_vaulted_klarna_email",
+        tableName: tableName,
+        bundle: .primerResources,
+        value: "Klarna, %@",
+        comment: "VoiceOver label for vaulted Klarna with email"
+      )
+      return String(format: format, email)
+    } else {
+      return NSLocalizedString(
+        "accessibility_vaulted_klarna",
+        tableName: tableName,
+        bundle: .primerResources,
+        value: "Klarna",
+        comment: "VoiceOver label for vaulted Klarna without email"
+      )
+    }
+  }
+
+  static func a11yVaultedACH(bankName: String, last4: String?) -> String {
+    if let last4 {
+      let format = NSLocalizedString(
+        "accessibility_vaulted_ach_full",
+        tableName: tableName,
+        bundle: .primerResources,
+        value: "%@ bank account ending in %@",
+        comment: "VoiceOver label for vaulted ACH with last4. Parameters: bank name, last4"
+      )
+      return String(format: format, bankName, last4)
+    } else {
+      let format = NSLocalizedString(
+        "accessibility_vaulted_ach",
+        tableName: tableName,
+        bundle: .primerResources,
+        value: "%@ bank account",
+        comment: "VoiceOver label for vaulted ACH without last4. Parameter: bank name"
+      )
+      return String(format: format, bankName)
+    }
+  }
+
+  // MARK: - PayPal Strings
+
+  static let payPalTitle = NSLocalizedString(
+    "primer_paypal_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "PayPal",
+    comment: "PayPal payment screen title"
+  )
+
+  static let payPalContinueButton = NSLocalizedString(
+    "primer_paypal_button_continue",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Continue with PayPal",
+    comment: "PayPal continue button text"
+  )
+
+  static let payPalRedirectDescription = NSLocalizedString(
+    "primer_paypal_redirect_description",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "You will be redirected to PayPal to complete your payment securely.",
+    comment: "PayPal redirect description text"
+  )
+
+  // MARK: - Klarna Strings
+
+  static let klarnaBrandName = NSLocalizedString(
+    "primer_vault_default_klarna",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Klarna",
+    comment: "Klarna brand name"
+  )
+
+  static let klarnaAuthorizeButton = NSLocalizedString(
+    "primer_klarna_button_authorize",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Continue",
+    comment: "Klarna authorize button text"
+  )
+
+  static let klarnaFinalizeButton = NSLocalizedString(
+    "primer_klarna_button_finalize",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Pay",
+    comment: "Klarna finalize button text"
+  )
+
+  static let klarnaSelectCategoryDescription = NSLocalizedString(
+    "primer_klarna_select_category_description",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Choose how you'd like to pay",
+    comment: "Klarna category selection hint text"
+  )
+
+  static let klarnaLoadingTitle = NSLocalizedString(
+    "primer_klarna_loading_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Loading",
+    comment: "Klarna loading spinner title"
+  )
+
+  static let klarnaLoadingSubtitle = NSLocalizedString(
+    "primer_klarna_loading_subtitle",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "This may take a few seconds.",
+    comment: "Klarna loading subtitle text"
+  )
+
+  // MARK: Klarna Accessibility Strings
+
+  static func a11yKlarnaCategory(_ categoryName: String) -> String {
+    let format = NSLocalizedString(
+      "accessibility_klarna_category",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "%@ payment option",
+      comment: "VoiceOver label for Klarna payment category. Parameter is category name."
+    )
+    return String(format: format, categoryName)
+  }
+
+  static func a11yKlarnaCategorySelected(_ categoryName: String) -> String {
+    let format = NSLocalizedString(
+      "accessibility_klarna_category_selected",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "%@ payment option, selected",
+      comment: "VoiceOver label for selected Klarna payment category. Parameter is category name."
+    )
+    return String(format: format, categoryName)
+  }
+
+  static let a11yKlarnaPaymentView = NSLocalizedString(
+    "accessibility_klarna_payment_view",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Klarna payment form",
+    comment: "VoiceOver label for Klarna SDK payment view"
+  )
+
+  static let a11yKlarnaAuthorizeHint = NSLocalizedString(
+    "accessibility_klarna_authorize_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Double tap to continue with Klarna",
+    comment: "VoiceOver hint for Klarna authorize button"
+  )
+
+  static let a11yKlarnaFinalizeHint = NSLocalizedString(
+    "accessibility_klarna_finalize_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Double tap to complete payment",
+    comment: "VoiceOver hint for Klarna finalize button"
+  )
+
+  // MARK: - Form Redirect Strings (BLIK, MBWay)
+
+  static let blikOtpLabel = NSLocalizedString(
+    "primer_form_redirect_blik_otp_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "6 digit code",
+    comment: "BLIK OTP field label"
+  )
+
+  static let blikOtpPlaceholder = NSLocalizedString(
+    "primer_form_redirect_blik_otp_placeholder",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "000000",
+    comment: "BLIK OTP field placeholder"
+  )
+
+  static let blikOtpHelper = NSLocalizedString(
+    "primer_form_redirect_blik_otp_helper",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Open your banking app and generate a BLIK code.",
+    comment: "BLIK OTP field helper text"
+  )
+
+  static let formRedirectPendingTitle = NSLocalizedString(
+    "primer_form_redirect_pending_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Complete your payment",
+    comment: "Form redirect pending screen title"
+  )
+
+  static let formRedirectPendingMessage = NSLocalizedString(
+    "primer_form_redirect_pending_message",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Complete your payment in the app",
+    comment: "Form redirect pending screen message"
+  )
+
+  static let formRedirectBlikPendingMessage = NSLocalizedString(
+    "primer_form_redirect_blik_pending_message",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Complete your payment in Blik app",
+    comment: "BLIK pending screen message"
+  )
+
+  static let formRedirectMBWayPendingMessage = NSLocalizedString(
+    "primer_form_redirect_mbway_pending_message",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Complete your payment in the MB WAY app",
+    comment: "MBWay pending screen message"
+  )
+
+  static let otpCodeRequired = NSLocalizedString(
+    "primer_form_redirect_otp_code_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "OTP code is required",
+    comment: "OTP code required error message"
+  )
+
+  static let otpCodeInvalid = NSLocalizedString(
+    "primer_form_redirect_otp_code_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter a valid 6-digit code",
+    comment: "OTP code invalid error message"
+  )
+
+  // MARK: Form Redirect Accessibility Strings
+
+  static let a11yFormRedirectOtpLabel = NSLocalizedString(
+    "accessibility_form_redirect_otp_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "6 digit BLIK code, required",
+    comment: "VoiceOver label for BLIK OTP field"
+  )
+
+  static let a11yFormRedirectOtpHint = NSLocalizedString(
+    "accessibility_form_redirect_otp_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter the 6-digit code from your banking app",
+    comment: "VoiceOver hint for BLIK OTP field"
+  )
+
+  static let a11yFormRedirectPhoneLabel = NSLocalizedString(
+    "accessibility_form_redirect_phone_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Phone number, required",
+    comment: "VoiceOver label for MBWay phone number field"
+  )
+
+  static let a11yFormRedirectPhoneHint = NSLocalizedString(
+    "accessibility_form_redirect_phone_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter your phone number registered with MBWay",
+    comment: "VoiceOver hint for MBWay phone number field"
+  )
+
+  static let payWithBlik = NSLocalizedString(
+    "primer_form_redirect_blik_submit_button",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Pay with BLIK",
+    comment: "BLIK submit button text"
+  )
+
+  static let payWithMBWay = NSLocalizedString(
+    "primer_form_redirect_mbway_submit_button",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Pay with MB WAY",
+    comment: "MBWay submit button text"
+  )
+
+  // MARK: - Accessibility Strings
+
+  // VoiceOver labels, hints, and announcements for CheckoutComponents accessibility support
+  // Keys use underscore_case format to match Android SDK for cross-platform consistency
+
+  // MARK: Card Form Accessibility Labels
+
+  static let a11yCardNumberLabel = NSLocalizedString(
+    "accessibility_card_form_card_number_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Card number, required",
+    comment: "VoiceOver label for card number field (includes required indicator)"
+  )
+
+  static let a11yExpiryLabel = NSLocalizedString(
+    "accessibility_card_form_expiry_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Expiry date, required",
+    comment: "VoiceOver label for expiry date field (includes required indicator)"
+  )
+
+  static let a11yCVCLabel = NSLocalizedString(
+    "accessibility_card_form_cvc_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Security code, required",
+    comment: "VoiceOver label for CVC/CVV field (includes required indicator)"
+  )
+
+  static let a11yCardholderNameLabel = NSLocalizedString(
+    "accessibility_card_form_cardholder_name_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Cardholder name",
+    comment: "VoiceOver label for cardholder name field"
+  )
+
+  // MARK: Card Form Accessibility Hints
+
+  static let a11yCardNumberHint = NSLocalizedString(
+    "accessibility_card_form_card_number_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter your card number",
+    comment: "VoiceOver hint for card number field"
+  )
+
+  static let a11yExpiryHint = NSLocalizedString(
+    "accessibility_card_form_expiry_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter expiry date in MM/YY format",
+    comment: "VoiceOver hint for expiry date field"
+  )
+
+  static let a11yCVCHint = NSLocalizedString(
+    "accessibility_card_form_cvc_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "3 or 4 digit code on back of card",
+    comment: "VoiceOver hint for CVC/CVV field"
+  )
+
+  static let a11yCardholderNameHint = NSLocalizedString(
+    "accessibility_card_form_cardholder_name_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter name as shown on card",
+    comment: "VoiceOver hint for cardholder name field"
+  )
+
+  // MARK: Billing Address Accessibility Hints
+
+  static let a11yBillingAddressCityHint = NSLocalizedString(
+    "accessibility_card_form_billing_address_city_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter city name",
+    comment: "VoiceOver hint for billing address city field"
+  )
+
+  static let a11yBillingAddressPostalCodeHint = NSLocalizedString(
+    "accessibility_card_form_billing_address_postal_code_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter postal or ZIP code",
+    comment: "VoiceOver hint for billing address postal code field"
+  )
+
+  static let a11yBillingAddressHint = NSLocalizedString(
+    "accessibility_card_form_billing_address_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter your address",
+    comment: "VoiceOver hint for billing address field"
+  )
+
+  static let a11yBillingAddressStateHint = NSLocalizedString(
+    "accessibility_card_form_billing_address_state_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter state or province",
+    comment: "VoiceOver hint for billing address state field"
+  )
+
+  static let a11yNameFieldHint = NSLocalizedString(
+    "accessibility_card_form_name_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter your name",
+    comment: "VoiceOver hint for name field"
+  )
+
+  static let a11yEmailFieldHint = NSLocalizedString(
+    "accessibility_card_form_email_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter your email address",
+    comment: "VoiceOver hint for email field"
+  )
+
+  static let a11yOtpFieldHint = NSLocalizedString(
+    "accessibility_card_form_otp_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter one-time passcode",
+    comment: "VoiceOver hint for OTP code field"
+  )
+
+  // MARK: Inline Network Selector Accessibility
+
+  static let a11yInlineNetworkButtonHint = NSLocalizedString(
+    "accessibility_card_form_network_selector_inline_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Double tap to select this network",
+    comment: "VoiceOver hint for inline network selector button"
+  )
+
+  // MARK: Dropdown Network Selector Accessibility
+
+  static let a11yDropdownNetworkSelectorLabel = NSLocalizedString(
+    "accessibility_card_form_network_selector_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Card network selector",
+    comment: "VoiceOver label for dropdown network selector"
+  )
+
+  static let a11yDropdownNetworkSelectorHint = NSLocalizedString(
+    "accessibility_card_form_network_selector_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Double tap to select a different card network",
+    comment: "VoiceOver hint for dropdown network selector"
+  )
+
+  // MARK: Card Form Accessibility Error Messages
+
+  static let a11yCardNumberErrorInvalid = NSLocalizedString(
+    "accessibility_card_form_card_number_error_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid card number. Please check and try again.",
+    comment: "VoiceOver error announcement for invalid card number"
+  )
+
+  static let a11yCardNumberErrorEmpty = NSLocalizedString(
+    "accessibility_card_form_card_number_error_empty",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Card number is required.",
+    comment: "VoiceOver error announcement for empty card number"
+  )
+
+  static let a11yExpiryErrorInvalid = NSLocalizedString(
+    "accessibility_card_form_expiry_error_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid expiry date.",
+    comment: "VoiceOver error announcement for invalid expiry"
+  )
+
+  static let a11yCVCErrorInvalid = NSLocalizedString(
+    "accessibility_card_form_cvc_error_invalid",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Invalid security code.",
+    comment: "VoiceOver error announcement for invalid CVC"
+  )
+
+  // MARK: Submit Button Accessibility
+
+  static let a11ySubmitButtonLabel = NSLocalizedString(
+    "accessibility_card_form_submit_label",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Submit payment",
+    comment: "VoiceOver label for submit payment button"
+  )
+
+  static let a11ySubmitButtonHint = NSLocalizedString(
+    "accessibility_card_form_submit_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Double-tap to submit payment",
+    comment: "VoiceOver hint for submit payment button"
+  )
+
+  static let a11ySubmitButtonLoading = NSLocalizedString(
+    "accessibility_card_form_submit_loading",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Processing payment, please wait",
+    comment: "VoiceOver announcement during payment processing"
+  )
+
+  static let a11ySubmitButtonDisabled = NSLocalizedString(
+    "accessibility_card_form_submit_disabled",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Button disabled. Complete all required fields to enable payment",
+    comment: "VoiceOver hint when submit button is disabled due to validation errors"
+  )
+
+  // MARK: Payment Selection Accessibility
+
+  static let a11ySavedCardMasked = NSLocalizedString(
+    "accessibility_payment_selection_card_masked",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "card ending in masked digits",
+    comment: "VoiceOver label for saved card with masked last 4 digits (privacy protection)"
+  )
+
+  static func a11ySavedCardLabel(cardType: String, expiry: String) -> String {
+    let format = NSLocalizedString(
+      "accessibility_payment_selection_card_full",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "%@ card ending in %@, expires %@",
+      comment: "VoiceOver full saved card announcement with card type, last 4 digits, and expiry"
+    )
+    return String(format: format, cardType, expiry)
+  }
+
+  // MARK: PayPal Accessibility
+
+  static let a11yPayPalLogo = NSLocalizedString(
+    "accessibility_paypal_logo",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "PayPal",
+    comment: "VoiceOver label for PayPal logo"
+  )
+
+  // MARK: Custom Actions for VoiceOver Rotor
+
+  static let a11yActionEdit = NSLocalizedString(
+    "accessibility_action_edit",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Edit card details",
+    comment: "VoiceOver custom action to edit saved card"
+  )
+
+  static let a11yActionDelete = NSLocalizedString(
+    "accessibility_action_delete",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Delete payment method",
+    comment: "VoiceOver custom action to delete saved card"
+  )
+
+  static let a11yActionSetDefault = NSLocalizedString(
+    "accessibility_action_set_default",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Set as default payment method",
+    comment: "VoiceOver custom action to set default payment method"
+  )
+
+  // MARK: Common Accessibility Strings
+
+  static let a11yRequired = NSLocalizedString(
+    "accessibility_common_required",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "required",
+    comment: "VoiceOver indicator that field is required"
+  )
+
+  static let a11yOptional = NSLocalizedString(
+    "accessibility_common_optional",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "optional",
+    comment: "VoiceOver indicator that field is optional"
+  )
+
+  static let a11yLoading = NSLocalizedString(
+    "accessibility_common_loading",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Loading, please wait",
+    comment: "VoiceOver loading announcement"
+  )
+
+  static let a11yProcessingPayment = NSLocalizedString(
+    "accessibility_common_processing_payment",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Processing payment, please wait",
+    comment: "VoiceOver announcement during payment processing"
+  )
+
+  static let a11yClose = NSLocalizedString(
+    "accessibility_common_close",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Close",
+    comment: "VoiceOver label for close button"
+  )
+
+  static let a11yCancel = NSLocalizedString(
+    "accessibility_common_cancel",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Cancel",
+    comment: "VoiceOver label for cancel button"
+  )
+
+  static let a11yBack = NSLocalizedString(
+    "accessibility_common_back",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Go back",
+    comment: "VoiceOver label for back button"
+  )
+
+  static let a11yEdit = NSLocalizedString(
+    "accessibility_action_edit",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Edit saved payment methods",
+    comment: "VoiceOver label for edit button"
+  )
+
+  static let a11yDone = NSLocalizedString(
+    "primer_vault_manage_button_done",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Done editing saved payment methods",
+    comment: "VoiceOver label for done button"
+  )
+
+  static let a11yDelete = NSLocalizedString(
+    "accessibility_action_delete",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Delete",
+    comment: "VoiceOver label for delete button"
+  )
+
+  static let a11yDeletePaymentMethod = NSLocalizedString(
+    "accessibility_vault_delete_payment_method",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Delete this payment method",
+    comment: "VoiceOver label for delete payment method button on card"
+  )
+
+  static let a11yShowAll = NSLocalizedString(
+    "accessibility_common_show_all",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Show all saved payment methods",
+    comment: "VoiceOver label for show all button"
+  )
+
+  static func a11yVaultedPaymentMethod(_ name: String) -> String {
+    let format = NSLocalizedString(
+      "accessibility_vaulted_payment_method",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "Saved payment method: %@",
+      comment:
+        "VoiceOver label for vaulted payment method card. Parameter is the payment method name."
+    )
+    return String(format: format, name)
+  }
+
+  static let a11yDismiss = NSLocalizedString(
+    "accessibility_common_dismiss",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Dismiss",
+    comment: "VoiceOver label for dismiss button"
+  )
+
+  // MARK: Payment Method Selection
+
+  static func a11yPaymentMethodButton(_ name: String) -> String {
+    let format = NSLocalizedString(
+      "accessibility_payment_method_button",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "Pay with %@",
+      comment: "VoiceOver label for payment method button. Parameter is the payment method name."
+    )
+    return String(format: format, name)
+  }
+
+  // MARK: Screen Change Announcements
+
+  static func a11yScreenPaymentMethod(_ paymentMethodName: String) -> String {
+    let format = NSLocalizedString(
+      "accessibility_screen_payment_method",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "%@ payment method",
+      comment:
+        "VoiceOver screen change announcement for payment method screens. Parameter is the payment method name (e.g., 'PayPal', 'Apple Pay')"
+    )
+    return String(format: format, paymentMethodName)
+  }
+
+  static let a11yScreenSuccess = NSLocalizedString(
+    "accessibility_screen_success",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Payment successful",
+    comment: "VoiceOver screen change announcement for success screen"
+  )
+
+  static let a11yScreenError = NSLocalizedString(
+    "accessibility_screen_error",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Payment error occurred",
+    comment: "VoiceOver screen change announcement for error screen"
+  )
+
+  static let a11yScreenCountrySelection = NSLocalizedString(
+    "accessibility_screen_country_selection",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Select country",
+    comment: "VoiceOver screen change announcement for country selection"
+  )
+
+  static let a11yScreenProcessingPayment = NSLocalizedString(
+    "accessibility_screen_processing_payment",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Processing payment",
+    comment: "VoiceOver screen change announcement for payment processing"
+  )
+
+  static let a11yScreenLoadingPaymentMethods = NSLocalizedString(
+    "accessibility_screen_loading_payment_methods",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Loading payment methods",
+    comment: "VoiceOver screen change announcement for loading payment methods"
+  )
+
+  // MARK: Error Announcements
+
+  static func a11yMultipleErrors(_ count: Int) -> String {
+    let format = NSLocalizedString(
+      "accessibility_error_multiple_errors",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "%d errors found",
+      comment: "VoiceOver announcement for multiple validation errors"
+    )
+    return String(format: format, count)
+  }
+
+  static let a11yGenericError = NSLocalizedString(
+    "accessibility_error_generic",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "An error occurred. Please try again.",
+    comment: "VoiceOver generic error announcement"
+  )
+
+  static let a11yErrorIcon = NSLocalizedString(
+    "accessibility_error_icon",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Error",
+    comment: "VoiceOver label for error icon"
+  )
+
+  static let a11yRetry = NSLocalizedString(
+    "accessibility_retry",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Retry payment",
+    comment: "VoiceOver label for retry button"
+  )
+
+  static let a11yChooseOtherPaymentMethod = NSLocalizedString(
+    "accessibility_choose_other_payment_method",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Choose another payment method",
+    comment: "VoiceOver label for choose other payment method button"
+  )
+
+  // MARK: - ACH Strings
+
+  static let achTitle = NSLocalizedString(
+    "primer_ach_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Bank Account",
+    comment: "ACH payment screen title"
+  )
+
+  static let achPayWithTitle = NSLocalizedString(
+    "primer_ach_pay_with_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Pay with ACH",
+    comment: "ACH payment screen title matching Web/Drop-In"
+  )
+
+  static let achUserDetailsTitle = NSLocalizedString(
+    "primer_ach_user_details_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Enter your details to connect your bank account",
+    comment: "ACH user details collection description"
+  )
+
+  static let achPersonalDetailsSubtitle = NSLocalizedString(
+    "primer_ach_personal_details_subtitle",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Your personal details",
+    comment: "ACH user details section header matching Web/Drop-In"
+  )
+
+  static let achEmailDisclaimer = NSLocalizedString(
+    "primer_ach_email_disclaimer",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "We'll only use this to keep you updated about your payment",
+    comment: "ACH email field disclaimer text"
+  )
+
+  static let achContinueButton = NSLocalizedString(
+    "primer_ach_button_continue",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Continue",
+    comment: "ACH continue button text"
+  )
+
+  static let achMandateTitle = NSLocalizedString(
+    "primer_ach_mandate_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Authorization",
+    comment: "ACH mandate screen title"
+  )
+
+  static let achMandateAcceptButton = NSLocalizedString(
+    "primer_ach_mandate_button_accept",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "I Agree",
+    comment: "ACH mandate accept button text"
+  )
+
+  static let achMandateDeclineButton = NSLocalizedString(
+    "primer_ach_mandate_button_decline",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Cancel",
+    comment: "ACH mandate decline button text"
+  )
+
+  static func achMandateTemplate(merchantName: String) -> String {
+    let format = NSLocalizedString(
+      "primer_ach_mandate_template",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "By clicking \"I Agree\", you authorize %@ to debit the bank account specified above for any amount owed for charges arising from your use of %@'s services and/or purchase of products from %@, pursuant to %@'s website and terms, until this authorization is revoked. You may amend or cancel this authorization at any time by providing notice to %@ with 30 (thirty) days notice.",
+      comment: "ACH mandate template text. Parameter is merchant name."
+    )
+    return String(format: format, merchantName, merchantName, merchantName, merchantName, merchantName)
+  }
+
+  // MARK: ACH Accessibility Strings
+
+  static let a11yAchContinueHint = NSLocalizedString(
+    "accessibility_ach_continue_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Double tap to continue to bank account selection",
+    comment: "VoiceOver hint for ACH continue button"
+  )
+
+  static let a11yAchMandateAcceptHint = NSLocalizedString(
+    "accessibility_ach_mandate_accept_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Double tap to accept the authorization and complete payment",
+    comment: "VoiceOver hint for ACH mandate accept button"
+  )
+
+  static let a11yAchMandateDeclineHint = NSLocalizedString(
+    "accessibility_ach_mandate_decline_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Double tap to decline and cancel the payment",
+    comment: "VoiceOver hint for ACH mandate decline button"
+  )
+
+  // MARK: - Web Redirect Strings
+
+  static func webRedirectButtonContinue(_ methodName: String) -> String {
+    let format = NSLocalizedString(
+      "primer_web_redirect_button_continue",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "Continue with %@",
+      comment: "Web redirect submit button text with payment method name"
+    )
+    return String(format: format, methodName)
+  }
+
+  static let webRedirectDescription = NSLocalizedString(
+    "primer_web_redirect_description",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "You will be redirected to complete your payment",
+    comment: "Web redirect screen description text"
+  )
+
+  // MARK: - Web Redirect Accessibility
+
+  static func a11yWebRedirectSubmitButton(_ methodName: String) -> String {
+    let format = NSLocalizedString(
+      "accessibility_web_redirect_submit_button",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "Pay with %@",
+      comment: "VoiceOver label for web redirect pay button"
+    )
+    return String(format: format, methodName)
+  }
+
+  static let a11yWebRedirectLoading = NSLocalizedString(
+    "accessibility_web_redirect_loading",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Processing payment",
+    comment: "VoiceOver announcement when web redirect payment is processing"
+  )
+
+  static let a11yWebRedirectRedirecting = NSLocalizedString(
+    "accessibility_web_redirect_redirecting",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Opening payment page",
+    comment: "VoiceOver announcement when redirecting to payment provider"
+  )
+
+  static let a11yWebRedirectPolling = NSLocalizedString(
+    "accessibility_web_redirect_polling",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Waiting for payment confirmation",
+    comment: "VoiceOver announcement when polling for payment status"
+  )
+
+  static let a11yWebRedirectSuccess = NSLocalizedString(
+    "accessibility_web_redirect_success",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Payment successful",
+    comment: "VoiceOver announcement when web redirect payment succeeds"
+  )
+
+  static func a11yWebRedirectFailure(_ message: String) -> String {
+    let format = NSLocalizedString(
+      "accessibility_web_redirect_failure",
+      tableName: tableName,
+      bundle: .primerResources,
+      value: "Payment failed: %@",
+      comment: "VoiceOver announcement when web redirect payment fails"
+    )
+    return String(format: format, message)
+  }
+
+  // MARK: - QR Code Strings
+
+  static let qrCodeScanInstruction = NSLocalizedString(
+    "primer_qr_code_scan_instruction",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Scan to pay or take a screenshot",
+    comment: "QR code scanning instruction text"
+  )
+
+  static let qrCodeUploadInstruction = NSLocalizedString(
+    "primer_qr_code_upload_instruction",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Upload the screenshot in your banking app",
+    comment: "QR code upload instruction text"
+  )
+
+  // MARK: - QR Code Accessibility Strings
+
+  static let a11yQrCodeImage = NSLocalizedString(
+    "accessibility_qr_code_image",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "QR code for payment",
+    comment: "VoiceOver label for QR code image"
+  )
+
+  static let a11yQrCodeScanHint = NSLocalizedString(
+    "accessibility_qr_code_scan_hint",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Take a screenshot to save the QR code",
+    comment: "VoiceOver hint for QR code image"
+  )
+
+  static let a11yQrCodeSuccessIcon = NSLocalizedString(
+    "accessibility_qr_code_success_icon",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Payment successful",
+    comment: "VoiceOver label for QR code payment success icon"
+  )
+
+  static let a11yQrCodeFailureIcon = NSLocalizedString(
+    "accessibility_qr_code_failure_icon",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Payment failed",
+    comment: "VoiceOver label for QR code payment failure icon"
+  )
+
+  // MARK: - Apple Pay
+
+  static let applePayTitle = NSLocalizedString(
+    "primer_apple_pay_title",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Apple Pay",
+    comment: "Apple Pay screen title"
+  )
+
+  static let applePayDescription = NSLocalizedString(
+    "primer_apple_pay_description",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Pay securely with Apple Pay",
+    comment: "Apple Pay available state description"
+  )
+
+  static let applePayProcessing = NSLocalizedString(
+    "primer_apple_pay_processing",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Processing...",
+    comment: "Apple Pay processing state label"
+  )
+
+  static let applePayUnavailable = NSLocalizedString(
+    "primer_apple_pay_unavailable",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Apple Pay Unavailable",
+    comment: "Apple Pay unavailable state title"
+  )
+
+  static let applePayChooseOther = NSLocalizedString(
+    "primer_apple_pay_choose_other",
+    tableName: tableName,
+    bundle: .primerResources,
+    value: "Choose Another Payment Method",
+    comment: "Button to return to payment selection when Apple Pay is unavailable"
+  )
+}
+
+// swiftlint:enable file_length

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Constants/CheckoutComponentsStrings.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Constants/CheckoutComponentsStrings.swift
@@ -569,7 +569,7 @@ enum CheckoutComponentsStrings {
 
   static func paymentMethodDisplayName(_ displayName: String) -> String {
     let format = NSLocalizedString(
-      "primer_common_button_pay_amount",
+      "primer_common_display_name_pay_amount",
       tableName: tableName,
       bundle: .primerResources,
       value: "Pay %@",
@@ -613,7 +613,7 @@ enum CheckoutComponentsStrings {
   )
 
   static let cvvStandardPlaceholder = NSLocalizedString(
-    "primer_card_form_placeholder_cvv",
+    "primer_card_form_placeholder_cvv_standard",
     tableName: tableName,
     bundle: .primerResources,
     value: "123",
@@ -621,7 +621,7 @@ enum CheckoutComponentsStrings {
   )
 
   static let fullNamePlaceholder = NSLocalizedString(
-    "primer_card_form_placeholder_name",
+    "primer_card_form_placeholder_full_name",
     tableName: tableName,
     bundle: .primerResources,
     value: "Full name",
@@ -677,7 +677,7 @@ enum CheckoutComponentsStrings {
   )
 
   static let otpCodePlaceholder = NSLocalizedString(
-    "primer_card_form_label_otp",
+    "primer_card_form_placeholder_otp_code",
     tableName: tableName,
     bundle: .primerResources,
     value: "OTP Code",

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Core/Services/ErrorMessageResolver.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Core/Services/ErrorMessageResolver.swift
@@ -1,0 +1,348 @@
+//
+//  ErrorMessageResolver.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+final class ErrorMessageResolver {
+
+  static func resolveErrorMessage(for error: ValidationError) -> String? {
+    // Resolution priority:
+    // 1. Try formatted error with field name placeholder
+    if let formatKey = error.errorFormatKey,
+      let fieldNameKey = error.fieldNameKey {
+      let fieldName = getLocalizedFieldName(fieldNameKey)
+      let formatString = getLocalizedString(formatKey)
+      return String(format: formatString, fieldName)
+    }
+
+    // 2. Try direct error message key
+    if let messageKey = error.errorMessageKey {
+      return getLocalizedString(messageKey)
+    }
+
+    // 3. Fall back to error ID
+    return error.errorId
+  }
+
+  private static func getLocalizedString(_ key: String) -> String {
+    // Check for form validation errors first
+    if let formError = getFormValidationError(for: key) {
+      return formError
+    }
+
+    // Check for field required errors
+    if let requiredError = getRequiredFieldError(for: key) {
+      return requiredError
+    }
+
+    // Check for field invalid errors
+    if let invalidError = getInvalidFieldError(for: key) {
+      return invalidError
+    }
+
+    // Check for result screen messages
+    if let resultError = getResultScreenMessage(for: key) {
+      return resultError
+    }
+
+    // Default fallback
+    return CheckoutComponentsStrings.unexpectedError
+  }
+
+  private static func getFormValidationError(for key: String) -> String? {
+    switch key {
+    case "form_error_card_type_not_supported":
+      CheckoutComponentsStrings.formErrorCardTypeNotSupported
+    case "form_error_card_holder_name_length":
+      CheckoutComponentsStrings.formErrorCardHolderNameLength
+    case "form_error_card_expired":
+      CheckoutComponentsStrings.formErrorCardExpired
+    default:
+      nil
+    }
+  }
+
+  private static func getRequiredFieldError(for key: String) -> String? {
+    switch key {
+    case "checkout_components_first_name_required":
+      CheckoutComponentsStrings.firstNameErrorRequired
+    case "checkout_components_last_name_required":
+      CheckoutComponentsStrings.lastNameErrorRequired
+    case "checkout_components_email_required":
+      CheckoutComponentsStrings.emailErrorRequired
+    case "checkout_components_country_required":
+      CheckoutComponentsStrings.countryCodeErrorRequired
+    case "checkout_components_address_line_1_required":
+      CheckoutComponentsStrings.addressLine1ErrorRequired
+    case "checkout_components_address_line_2_required":
+      CheckoutComponentsStrings.addressLine2ErrorRequired
+    case "checkout_components_city_required":
+      CheckoutComponentsStrings.cityErrorRequired
+    case "checkout_components_state_required":
+      CheckoutComponentsStrings.stateErrorRequired
+    case "checkout_components_postal_code_required":
+      CheckoutComponentsStrings.postalCodeErrorRequired
+    case "checkout_components_phone_number_required":
+      CheckoutComponentsStrings.enterValidPhoneNumber
+    case "checkout_components_otp_code_required":
+      CheckoutComponentsStrings.otpCodeRequired
+    case "checkout_components_retail_outlet_required":
+      CheckoutComponentsStrings.retailOutletRequired
+    default:
+      nil
+    }
+  }
+
+  private static func getInvalidFieldError(for key: String) -> String? {
+    switch key {
+    // Card field validation errors
+    case "checkout_components_card_number_invalid":
+      CheckoutComponentsStrings.enterValidCardNumber
+    case "checkout_components_cvv_invalid":
+      CheckoutComponentsStrings.enterValidCVV
+    case "checkout_components_expiry_date_invalid":
+      CheckoutComponentsStrings.enterValidExpiryDate
+    case "checkout_components_cardholder_name_invalid":
+      CheckoutComponentsStrings.enterValidCardholderName
+    // Billing address field validation errors
+    case "checkout_components_first_name_invalid":
+      CheckoutComponentsStrings.firstNameErrorInvalid
+    case "checkout_components_last_name_invalid":
+      CheckoutComponentsStrings.lastNameErrorInvalid
+    case "checkout_components_email_invalid":
+      CheckoutComponentsStrings.emailErrorInvalid
+    case "checkout_components_country_invalid":
+      CheckoutComponentsStrings.countryCodeErrorInvalid
+    case "checkout_components_address_line_1_invalid":
+      CheckoutComponentsStrings.addressLine1ErrorInvalid
+    case "checkout_components_address_line_2_invalid":
+      CheckoutComponentsStrings.addressLine2ErrorInvalid
+    case "checkout_components_city_invalid":
+      CheckoutComponentsStrings.cityErrorInvalid
+    case "checkout_components_state_invalid":
+      CheckoutComponentsStrings.stateErrorInvalid
+    case "checkout_components_postal_code_invalid":
+      CheckoutComponentsStrings.postalCodeErrorInvalid
+    case "checkout_components_phone_number_invalid":
+      CheckoutComponentsStrings.enterValidPhoneNumber
+    case "checkout_components_otp_code_invalid":
+      CheckoutComponentsStrings.otpCodeInvalid
+    case "checkout_components_retail_outlet_invalid":
+      CheckoutComponentsStrings.retailOutletInvalid
+    default:
+      nil
+    }
+  }
+
+  private static func getResultScreenMessage(for key: String) -> String? {
+    switch key {
+    case "payment_successful":
+      CheckoutComponentsStrings.paymentSuccessful
+    case "payment_failed":
+      CheckoutComponentsStrings.paymentFailed
+    default:
+      nil
+    }
+  }
+
+  private static func getLocalizedFieldName(_ key: String) -> String {
+    // Check for personal information field names first
+    if let personalFieldName = getPersonalFieldName(for: key) {
+      return personalFieldName
+    }
+
+    // Check for address field names
+    if let addressFieldName = getAddressFieldName(for: key) {
+      return addressFieldName
+    }
+
+    // Check for card field names
+    if let cardFieldName = getCardFieldName(for: key) {
+      return cardFieldName
+    }
+
+    // Generic fallback
+    return "Field"
+  }
+
+  private static func getPersonalFieldName(for key: String) -> String? {
+    switch key {
+    case "first_name_field":
+      CheckoutComponentsStrings.firstNameLabel
+    case "last_name_field":
+      CheckoutComponentsStrings.lastNameLabel
+    case "email_field":
+      CheckoutComponentsStrings.emailLabel
+    case "phone_number_field":
+      CheckoutComponentsStrings.phoneNumberLabel
+    default:
+      nil
+    }
+  }
+
+  private static func getAddressFieldName(for key: String) -> String? {
+    switch key {
+    case "country_field":
+      CheckoutComponentsStrings.countryLabel
+    case "address_line_1_field":
+      CheckoutComponentsStrings.addressLine1Label
+    case "address_line_2_field":
+      CheckoutComponentsStrings.addressLine2Label
+    case "city_field":
+      CheckoutComponentsStrings.cityLabel
+    case "state_field":
+      CheckoutComponentsStrings.stateLabel
+    case "postal_code_field":
+      CheckoutComponentsStrings.postalCodeLabel
+    default:
+      nil
+    }
+  }
+
+  private static func getCardFieldName(for key: String) -> String? {
+    switch key {
+    case "card_number_field":
+      NSLocalizedString(
+        "primer-form-text-field-title-card-number", bundle: Bundle.primerResources,
+        value: "Card number", comment: "Card number field name"
+      )
+    case "cvv_field":
+      NSLocalizedString(
+        "primer-card-form-cvv", bundle: Bundle.primerResources, value: "CVV",
+        comment: "CVV field name"
+      )
+    case "expiry_date_field":
+      NSLocalizedString(
+        "primer-form-text-field-title-expiry-date", bundle: Bundle.primerResources,
+        value: "Expiry date", comment: "Expiry date field name"
+      )
+    case "cardholder_name_field":
+      NSLocalizedString(
+        "primer-card-form-name", bundle: Bundle.primerResources, value: "Name",
+        comment: "Cardholder name field name"
+      )
+    case "otp_code_field":
+      NSLocalizedString(
+        "primer-otp-code-field", bundle: Bundle.primerResources, value: "OTP code",
+        comment: "OTP code field name"
+      )
+    default:
+      nil
+    }
+  }
+}
+
+// MARK: - Convenience Extensions
+
+extension ErrorMessageResolver {
+
+  static func createRequiredFieldError(for inputElementType: ValidationError.InputElementType)
+    -> ValidationError {
+    let errorMessageKey = requiredErrorMessageKey(for: inputElementType)
+    let errorId = "\(inputElementType.rawValue.lowercased())_required"
+
+    return ValidationError(
+      inputElementType: inputElementType,
+      errorId: errorId,
+      fieldNameKey: nil,
+      errorMessageKey: errorMessageKey,
+      errorFormatKey: nil,
+      code: "invalid-\(inputElementType.rawValue.lowercased())",
+      message: "Field is required"  // Default fallback
+    )
+  }
+
+  static func createInvalidFieldError(for inputElementType: ValidationError.InputElementType)
+    -> ValidationError {
+    let errorMessageKey = invalidErrorMessageKey(for: inputElementType)
+    let errorId = "\(inputElementType.rawValue.lowercased())_invalid"
+
+    return ValidationError(
+      inputElementType: inputElementType,
+      errorId: errorId,
+      fieldNameKey: nil,
+      errorMessageKey: errorMessageKey,
+      errorFormatKey: nil,
+      code: "invalid-\(inputElementType.rawValue.lowercased())",
+      message: "Field is invalid"  // Default fallback
+    )
+  }
+
+  private static func requiredErrorMessageKey(
+    for inputElementType: ValidationError.InputElementType
+  ) -> String {
+    switch inputElementType {
+    case .firstName:
+      "checkout_components_first_name_required"
+    case .lastName:
+      "checkout_components_last_name_required"
+    case .email:
+      "checkout_components_email_required"
+    case .countryCode:
+      "checkout_components_country_required"
+    case .addressLine1:
+      "checkout_components_address_line_1_required"
+    case .addressLine2:
+      "checkout_components_address_line_2_required"
+    case .city:
+      "checkout_components_city_required"
+    case .state:
+      "checkout_components_state_required"
+    case .postalCode:
+      "checkout_components_postal_code_required"
+    case .phoneNumber:
+      "checkout_components_phone_number_required"
+    case .otpCode:
+      "checkout_components_otp_code_required"
+    case .retailOutlet:
+      "checkout_components_retail_outlet_required"
+    default:
+      "form_error_required"
+    }
+  }
+
+  private static func invalidErrorMessageKey(for inputElementType: ValidationError.InputElementType)
+    -> String {
+    switch inputElementType {
+    // Card field validation error keys
+    case .cardNumber:
+      "checkout_components_card_number_invalid"
+    case .cvv:
+      "checkout_components_cvv_invalid"
+    case .expiryDate:
+      "checkout_components_expiry_date_invalid"
+    case .cardholderName:
+      "checkout_components_cardholder_name_invalid"
+    // Billing address field validation error keys
+    case .firstName:
+      "checkout_components_first_name_invalid"
+    case .lastName:
+      "checkout_components_last_name_invalid"
+    case .email:
+      "checkout_components_email_invalid"
+    case .countryCode:
+      "checkout_components_country_invalid"
+    case .addressLine1:
+      "checkout_components_address_line_1_invalid"
+    case .addressLine2:
+      "checkout_components_address_line_2_invalid"
+    case .city:
+      "checkout_components_city_invalid"
+    case .state:
+      "checkout_components_state_invalid"
+    case .postalCode:
+      "checkout_components_postal_code_invalid"
+    case .phoneNumber:
+      "checkout_components_phone_number_invalid"
+    case .otpCode:
+      "checkout_components_otp_code_invalid"
+    case .retailOutlet:
+      "checkout_components_retail_outlet_invalid"
+    default:
+      "form_error_invalid"
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/BackportedNavigationStack.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/BackportedNavigationStack.swift
@@ -1,0 +1,30 @@
+//
+//  BackportedNavigationStack.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct BackportedNavigationStack<Content: View>: View {
+
+  private let content: () -> Content
+
+  init(@ViewBuilder content: @escaping () -> Content) {
+    self.content = content
+  }
+
+  var body: some View {
+    if #available(iOS 16.0, *) {
+      NavigationStack {
+        content()
+      }
+    } else {
+      NavigationView {
+        content()
+      }
+      .navigationViewStyle(.stack)
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/CheckoutCoordinator.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/CheckoutCoordinator.swift
@@ -1,0 +1,57 @@
+//
+//  CheckoutCoordinator.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+final class CheckoutCoordinator: ObservableObject, LogReporter {
+
+  @Published var navigationStack: [CheckoutRoute] = []
+  private(set) var lastPaymentMethodRoute: CheckoutRoute?
+
+  var currentRoute: CheckoutRoute {
+    navigationStack.last ?? .splash
+  }
+
+  func navigate(to route: CheckoutRoute) {
+    guard currentRoute != route else { return }
+
+    let previousRoute = currentRoute
+
+    if case .paymentMethod = previousRoute {
+      lastPaymentMethodRoute = previousRoute
+    }
+
+    switch route.navigationBehavior {
+    case .push:
+      navigationStack.append(route)
+    case .reset:
+      navigationStack = route == .splash ? [] : [route]
+    case .replace:
+      if !navigationStack.isEmpty {
+        navigationStack[navigationStack.count - 1] = route
+      } else {
+        navigationStack = [route]
+      }
+    }
+
+    logger.debug(message: "[CheckoutCoordinator] \(previousRoute) -> \(route)")
+  }
+
+  func goBack() {
+    guard !navigationStack.isEmpty else { return }
+    navigationStack.removeLast()
+  }
+
+  func dismiss() {
+    navigationStack = []
+  }
+
+  func handlePaymentFailure(_ error: PrimerError) {
+    navigate(to: .failure(error))
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/CheckoutNavigator.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/CheckoutNavigator.swift
@@ -1,0 +1,81 @@
+//
+//  CheckoutNavigator.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+final class CheckoutNavigator: ObservableObject, LogReporter {
+
+  private let coordinator: CheckoutCoordinator
+
+  var navigationEvents: AsyncStream<CheckoutRoute> {
+    AsyncStream { continuation in
+      let task = Task { @MainActor [self] in
+        for await _ in coordinator.$navigationStack.values {
+          continuation.yield(coordinator.currentRoute)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  var checkoutCoordinator: CheckoutCoordinator {
+    coordinator
+  }
+
+  init(coordinator: CheckoutCoordinator? = nil) {
+    self.coordinator = coordinator ?? CheckoutCoordinator()
+  }
+
+  func navigateToLoading() {
+    coordinator.navigate(to: .loading)
+  }
+
+  func navigateToPaymentSelection() {
+    coordinator.navigate(to: .paymentMethodSelection)
+  }
+
+  func navigateToVaultedPaymentMethods() {
+    coordinator.navigate(to: .vaultedPaymentMethods)
+  }
+
+  func navigateToDeleteVaultedPaymentMethodConfirmation(
+    _ method: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
+  ) {
+    coordinator.navigate(to: .deleteVaultedPaymentMethodConfirmation(method))
+  }
+
+  func navigateToPaymentMethod(
+    _ paymentMethodType: String, context: PresentationContext = .fromPaymentSelection
+  ) {
+    coordinator.navigate(to: .paymentMethod(paymentMethodType, context))
+  }
+
+  func navigateToProcessing() {
+    coordinator.navigate(to: .processing)
+  }
+
+  func navigateToError(_ error: PrimerError) {
+    coordinator.handlePaymentFailure(error)
+  }
+
+  func handleOtherPaymentMethods() {
+    coordinator.navigate(to: .paymentMethodSelection)
+  }
+
+  func navigateBack() {
+    coordinator.goBack()
+  }
+
+  func dismiss() {
+    coordinator.dismiss()
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/CheckoutRoute.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Navigation/CheckoutRoute.swift
@@ -1,0 +1,74 @@
+//
+//  CheckoutRoute.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+public enum PresentationContext {
+  case direct
+  case fromPaymentSelection
+
+  var shouldShowBackButton: Bool {
+    self == .fromPaymentSelection
+  }
+}
+
+@available(iOS 15.0, *)
+enum NavigationBehavior {
+  case push
+  case reset
+  case replace
+}
+
+@available(iOS 15.0, *)
+enum CheckoutRoute: Hashable, Identifiable {
+  case splash
+  case loading
+  case paymentMethodSelection
+  case vaultedPaymentMethods
+  case deleteVaultedPaymentMethodConfirmation(PrimerHeadlessUniversalCheckout.VaultedPaymentMethod)
+  case processing
+  case success(PaymentResult)
+  case failure(PrimerError)
+  case paymentMethod(String, PresentationContext)
+
+  var id: String {
+    switch self {
+    case .splash: "splash"
+    case .loading: "loading"
+    case .paymentMethodSelection: "payment-method-selection"
+    case .vaultedPaymentMethods: "vaulted-payment-methods"
+    case let .deleteVaultedPaymentMethodConfirmation(method):
+      "delete-vaulted-payment-method-confirmation-\(method.id)"
+    case .processing: "processing"
+    case let .paymentMethod(type, context):
+      "payment-method-\(type)-\(context == .direct ? "direct" : "selection")"
+    case .success: "success"
+    case .failure: "failure"
+    }
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+  }
+
+  static func == (lhs: CheckoutRoute, rhs: CheckoutRoute) -> Bool {
+    lhs.id == rhs.id
+  }
+
+  var navigationBehavior: NavigationBehavior {
+    switch self {
+    case .splash: .reset
+    case .loading: .replace
+    case .paymentMethodSelection: .reset
+    case .vaultedPaymentMethods: .push
+    case .deleteVaultedPaymentMethodConfirmation: .push
+    case .paymentMethod: .push
+    case .processing: .replace
+    case .success, .failure: .replace
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/AnalyticsSessionConfigProviding.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/AnalyticsSessionConfigProviding.swift
@@ -1,0 +1,15 @@
+//
+//  AnalyticsSessionConfigProviding.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+protocol AnalyticsSessionConfigProviding {
+  func makeAnalyticsSessionConfig(
+    checkoutSessionId: String,
+    clientToken: String,
+    sdkVersion: String
+  ) -> AnalyticsSessionConfig?
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/CheckoutSDKInitializer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/CheckoutSDKInitializer.swift
@@ -1,0 +1,161 @@
+//
+//  CheckoutSDKInitializer.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+@MainActor
+final class CheckoutSDKInitializer {
+
+  // MARK: - Types
+
+  struct InitializationResult {
+    let checkoutScope: DefaultCheckoutScope
+  }
+
+  // MARK: - Properties
+
+  private let clientToken: String
+  private let primerSettings: PrimerSettings
+  private let primerTheme: PrimerCheckoutTheme
+  private let diContainer: DIContainer
+  private let navigator: CheckoutNavigator
+  private let presentationContext: PresentationContext
+  private let configurationModule:
+    (PrimerAPIConfigurationModuleProtocol & AnalyticsSessionConfigProviding)
+  private var analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+
+  // MARK: - Initialization
+
+  init(
+    clientToken: String,
+    primerSettings: PrimerSettings,
+    primerTheme: PrimerCheckoutTheme = PrimerCheckoutTheme(),
+    diContainer: DIContainer,
+    navigator: CheckoutNavigator,
+    presentationContext: PresentationContext,
+    configurationModule: (PrimerAPIConfigurationModuleProtocol & AnalyticsSessionConfigProviding) =
+      PrimerAPIConfigurationModule()
+  ) {
+    self.clientToken = clientToken
+    self.primerSettings = primerSettings
+    self.primerTheme = primerTheme
+    self.diContainer = diContainer
+    self.navigator = navigator
+    self.presentationContext = presentationContext
+    self.configurationModule = configurationModule
+  }
+
+  // MARK: - Public Methods
+
+  func initialize() async throws -> InitializationResult {
+    setupSDKIntegration()
+
+    // Bridge: Register settings in old DI for core SDK compatibility
+    // Core SDK (KlarnaHelpers, ACHHelpers, 3DS, etc.) uses PrimerSettings.current
+    DependencyContainer.register(primerSettings)
+
+    let composableContainer = ComposableContainer(
+      settings: primerSettings,
+      theme: primerTheme
+    )
+    await composableContainer.configure()
+
+    // Resolve analytics interactor
+    if let container = await DIContainer.current {
+      analyticsInteractor = try? await container.resolve(
+        CheckoutComponentsAnalyticsInteractorProtocol.self
+      )
+    }
+
+    // Track SDK initialization start - after DI container is ready, before BE calls
+    await trackSDKInitStart()
+
+    try await initializeAPIConfiguration()
+
+    // Initialize analytics session
+    await initializeAnalytics()
+
+    // Track SDK initialization end - after all API calls complete
+    await trackSDKInitEnd()
+
+    let checkoutScope = createCheckoutScope()
+
+    // Note: Navigation is handled by DefaultCheckoutScope.loadPaymentMethods() which:
+    // - Waits for payment methods from server
+    // - If single payment method: navigates directly to it (any type, not just cards)
+    // - If multiple payment methods: shows payment method selection screen
+
+    return InitializationResult(checkoutScope: checkoutScope)
+  }
+
+  func cleanup() {
+    ValidationResultCache.shared.clear()
+    Task {
+      await DIContainer.clearContainer()
+    }
+  }
+
+  // MARK: - Private Methods
+
+  private func setupSDKIntegration() {
+    PrimerInternal.shared.sdkIntegrationType = .checkoutComponents
+    PrimerInternal.shared.intent = .checkout
+    PrimerInternal.shared.checkoutSessionId = UUID().uuidString
+  }
+
+  private func initializeAPIConfiguration() async throws {
+    try await configurationModule.setupSession(
+      forClientToken: clientToken,
+      requestDisplayMetadata: true,
+      requestClientTokenValidation: false,
+      requestVaultedPaymentMethods: false
+    )
+  }
+
+  private func createCheckoutScope() -> DefaultCheckoutScope {
+    DefaultCheckoutScope(
+      clientToken: clientToken,
+      settings: primerSettings,
+      diContainer: diContainer,
+      navigator: navigator,
+      presentationContext: presentationContext
+    )
+  }
+
+  // MARK: - Analytics Initialization
+
+  private func initializeAnalytics() async {
+    let checkoutSessionId = PrimerInternal.shared.checkoutSessionId ?? UUID().uuidString
+    let sdkVersion = VersionUtils.releaseVersionNumber ?? "unknown"
+
+    guard
+      let analyticsConfig = configurationModule.makeAnalyticsSessionConfig(
+        checkoutSessionId: checkoutSessionId,
+        clientToken: clientToken,
+        sdkVersion: sdkVersion
+      )
+    else {
+      return
+    }
+
+    guard let container = await DIContainer.current else { return }
+
+    if let analyticsService = try? await container.resolve(
+      CheckoutComponentsAnalyticsServiceProtocol.self
+    ) {
+      await analyticsService.initialize(config: analyticsConfig)
+    }
+  }
+
+  private func trackSDKInitStart() async {
+    await analyticsInteractor?.trackEvent(.sdkInitStart, metadata: nil)
+  }
+
+  private func trackSDKInitEnd() async {
+    await analyticsInteractor?.trackEvent(.sdkInitEnd, metadata: nil)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/CheckoutSDKInitializer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/CheckoutSDKInitializer.swift
@@ -59,16 +59,14 @@ final class CheckoutSDKInitializer {
     DependencyContainer.register(primerSettings)
 
     let composableContainer = ComposableContainer(
-      settings: primerSettings,
-      theme: primerTheme
+      settings: primerSettings
     )
     await composableContainer.configure()
 
     // Resolve analytics interactor
     if let container = await DIContainer.current {
       analyticsInteractor = try? await container.resolve(
-        CheckoutComponentsAnalyticsInteractorProtocol.self
-      )
+        CheckoutComponentsAnalyticsInteractorProtocol.self)
     }
 
     // Track SDK initialization start - after DI container is ready, before BE calls
@@ -93,7 +91,6 @@ final class CheckoutSDKInitializer {
   }
 
   func cleanup() {
-    ValidationResultCache.shared.clear()
     Task {
       await DIContainer.clearContainer()
     }
@@ -145,8 +142,7 @@ final class CheckoutSDKInitializer {
     guard let container = await DIContainer.current else { return }
 
     if let analyticsService = try? await container.resolve(
-      CheckoutComponentsAnalyticsServiceProtocol.self
-    ) {
+      CheckoutComponentsAnalyticsServiceProtocol.self) {
       await analyticsService.initialize(config: analyticsConfig)
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/ConfigurationService.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/ConfigurationService.swift
@@ -1,0 +1,49 @@
+//
+//  ConfigurationService.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+protocol ConfigurationService {
+  var apiConfiguration: PrimerAPIConfiguration? { get }
+  var checkoutModules: [PrimerAPIConfiguration.CheckoutModule]? { get }
+  var billingAddressOptions: PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions? { get }
+  var currency: Currency? { get }
+  var amount: Int? { get }
+  var captureVaultedCardCvv: Bool { get }
+}
+
+@available(iOS 15.0, *)
+final class DefaultConfigurationService: ConfigurationService {
+  var apiConfiguration: PrimerAPIConfiguration? {
+    PrimerAPIConfigurationModule.apiConfiguration
+  }
+
+  var checkoutModules: [PrimerAPIConfiguration.CheckoutModule]? {
+    apiConfiguration?.checkoutModules
+  }
+
+  var billingAddressOptions: PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions? {
+    checkoutModules?
+      .first(where: { $0.type == "BILLING_ADDRESS" })?
+      .options as? PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions
+  }
+
+  var currency: Currency? {
+    apiConfiguration?.clientSession?.order?.currencyCode
+  }
+
+  var amount: Int? {
+    apiConfiguration?.clientSession?.order?.merchantAmount
+      ?? apiConfiguration?.clientSession?.order?.totalOrderAmount
+  }
+
+  var captureVaultedCardCvv: Bool {
+    let cardPaymentMethod = apiConfiguration?.paymentMethods?
+      .first { $0.type == PrimerPaymentMethodType.paymentCard.rawValue }
+    return (cardPaymentMethod?.options as? CardOptions)?.captureVaultedCardCvv == true
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/RawDataManagerProtocol.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/RawDataManagerProtocol.swift
@@ -1,0 +1,43 @@
+//
+//  RawDataManagerProtocol.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+protocol RawDataManagerProtocol: AnyObject {
+  var delegate: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate? { get set }
+  var rawData: PrimerRawData? { get set }
+  var isDataValid: Bool { get }
+  var requiredInputElementTypes: [PrimerInputElementType] { get }
+  func configure(completion: @escaping (PrimerInitializationData?, Error?) -> Void)
+  func submit()
+}
+
+@available(iOS 15.0, *)
+protocol RawDataManagerFactoryProtocol {
+  func createRawDataManager(
+    paymentMethodType: String,
+    delegate: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate?
+  ) throws -> RawDataManagerProtocol
+}
+
+@available(iOS 15.0, *)
+final class DefaultRawDataManagerFactory: RawDataManagerFactoryProtocol {
+  func createRawDataManager(
+    paymentMethodType: String,
+    delegate: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate?
+  ) throws -> RawDataManagerProtocol {
+    try PrimerHeadlessUniversalCheckout.RawDataManager(
+      paymentMethodType: paymentMethodType,
+      delegate: delegate
+    )
+  }
+}
+
+// MARK: - RawDataManager Conformance
+
+@available(iOS 15.0, *)
+extension PrimerHeadlessUniversalCheckout.RawDataManager: RawDataManagerProtocol {}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/VaultManagerProtocol.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/VaultManagerProtocol.swift
@@ -1,0 +1,28 @@
+//
+//  VaultManagerProtocol.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+protocol VaultManagerProtocol: AnyObject {
+    func configure() throws
+    func fetchVaultedPaymentMethods(
+        completion: @escaping ([PrimerHeadlessUniversalCheckout.VaultedPaymentMethod]?, Error?) -> Void
+    )
+    func startPaymentFlow(
+        vaultedPaymentMethodId: String,
+        vaultedPaymentMethodAdditionalData: PrimerVaultedPaymentMethodAdditionalData?
+    )
+    func deleteVaultedPaymentMethod(
+        id: String,
+        completion: @escaping (Error?) -> Void
+    )
+}
+
+// MARK: - VaultManager Conformance
+
+@available(iOS 15.0, *)
+extension PrimerHeadlessUniversalCheckout.VaultManager: VaultManagerProtocol {}

--- a/Tests/Primer/CheckoutComponents/Core/AnalyticsSessionConfigProviderTests.swift
+++ b/Tests/Primer/CheckoutComponents/Core/AnalyticsSessionConfigProviderTests.swift
@@ -1,0 +1,171 @@
+//
+//  AnalyticsSessionConfigProviderTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class AnalyticsSessionConfigProviderTests: XCTestCase {
+
+    private let tokenWithIds = AnalyticsTestTokens.withIds
+    private let tokenWithoutIds = AnalyticsTestTokens.withoutIds
+
+    override func tearDown() {
+        super.tearDown()
+        PrimerAPIConfigurationModule.clientToken = nil
+        PrimerAPIConfigurationModule.apiConfiguration = nil
+    }
+
+    func test_makeAnalyticsSessionConfig_fallsBackToClientTokenPayload() {
+        // Given
+        let module = PrimerAPIConfigurationModule()
+        PrimerAPIConfigurationModule.clientToken = tokenWithIds
+        PrimerAPIConfigurationModule.apiConfiguration = nil
+
+        // When
+        let result = module.makeAnalyticsSessionConfig(
+            checkoutSessionId: TestData.Analytics.checkoutSessionId,
+            clientToken: tokenWithIds,
+            sdkVersion: TestData.Analytics.sdkVersion
+        )
+
+        // Then
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.clientSessionId, TestData.Analytics.tokenSessionId)
+        XCTAssertEqual(result?.primerAccountId, TestData.Analytics.tokenAccountId)
+        XCTAssertEqual(result?.environment, .sandbox)
+    }
+
+    func test_makeAnalyticsSessionConfig_returnsNilWhenIdentifiersMissing() {
+        // Given
+        let module = PrimerAPIConfigurationModule()
+        PrimerAPIConfigurationModule.clientToken = tokenWithoutIds
+        PrimerAPIConfigurationModule.apiConfiguration = nil
+
+        // When
+        let result = module.makeAnalyticsSessionConfig(
+            checkoutSessionId: TestData.Analytics.checkoutSessionId,
+            clientToken: tokenWithoutIds,
+            sdkVersion: TestData.Analytics.sdkVersion
+        )
+
+        // Then
+        XCTAssertNil(result)
+    }
+}
+
+@available(iOS 15.0, *)
+@MainActor
+final class CheckoutSDKInitializerAnalyticsProviderTests: XCTestCase {
+
+    private let tokenWithIds = AnalyticsTestTokens.withIds
+
+    override func tearDown() {
+        super.tearDown()
+        PrimerInternal.shared.checkoutSessionId = nil
+        PrimerInternal.shared.sdkIntegrationType = nil
+        PrimerInternal.shared.intent = nil
+    }
+
+    func test_initialize_withValidToken_invokesAnalyticsConfigProvider() async throws {
+        // Given
+        let configurationModule = StubConfigurationModule()
+        let initializer = CheckoutSDKInitializer(
+            clientToken: tokenWithIds,
+            primerSettings: PrimerSettings(),
+            diContainer: DIContainer.shared,
+            navigator: CheckoutNavigator(),
+            presentationContext: .fromPaymentSelection,
+            configurationModule: configurationModule
+        )
+
+        // When
+        _ = try await initializer.initialize()
+
+        // Then
+        XCTAssertEqual(configurationModule.setupSessionCallCount, 1)
+        XCTAssertEqual(configurationModule.capturedConfigParameters?.clientToken, tokenWithIds)
+        XCTAssertEqual(configurationModule.capturedConfigParameters?.checkoutSessionId, PrimerInternal.shared.checkoutSessionId)
+        XCTAssertFalse(configurationModule.capturedConfigParameters?.sdkVersion.isEmpty ?? true)
+    }
+}
+
+private final class StubConfigurationModule: PrimerAPIConfigurationModuleProtocol, AnalyticsSessionConfigProviding {
+
+    static var apiClient: PrimerAPIClientProtocol?
+    static var clientToken: JWTToken?
+    static var decodedJWTToken: DecodedJWTToken?
+    static var apiConfiguration: PrimerAPIConfiguration?
+
+    static func resetSession() {}
+
+    var setupSessionCallCount = 0
+    var capturedConfigParameters: (checkoutSessionId: String, clientToken: String, sdkVersion: String)?
+
+    func setupSession(
+        forClientToken clientToken: String,
+        requestDisplayMetadata: Bool,
+        requestClientTokenValidation: Bool,
+        requestVaultedPaymentMethods: Bool
+    ) async throws {
+        setupSessionCallCount += 1
+    }
+
+    func updateSession(withActions actionsRequest: ClientSessionUpdateRequest) async throws {}
+
+    func storeRequiredActionClientToken(_ newClientToken: String) async throws {}
+
+    func makeAnalyticsSessionConfig(
+        checkoutSessionId: String,
+        clientToken: String,
+        sdkVersion: String
+    ) -> AnalyticsSessionConfig? {
+        capturedConfigParameters = (checkoutSessionId, clientToken, sdkVersion)
+        return nil
+    }
+}
+
+@available(iOS 15.0, *)
+private enum AnalyticsTestTokens {
+
+    static let withIds = JWTTestTokenFactory.makeJWT(payload: [
+        "env": TestData.JWT.sandboxEnv,
+        "clientSessionId": TestData.Analytics.tokenSessionId,
+        "primerAccountId": TestData.Analytics.tokenAccountId
+    ])
+
+    static let withoutIds = JWTTestTokenFactory.makeJWT(payload: [
+        "env": TestData.JWT.productionEnv
+    ])
+}
+
+private enum JWTTestTokenFactory {
+
+    static func makeJWT(
+        header: [String: Any] = ["alg": "HS256", "typ": "JWT"],
+        payload: [String: Any]
+    ) -> String {
+        let headerSegment = encode(json: header)
+        let payloadSegment = encode(json: payload)
+        let signatureSegment = base64URLEncode(Data("signature".utf8))
+        return [headerSegment, payloadSegment, signatureSegment].joined(separator: ".")
+    }
+
+    private static func encode(json: [String: Any]) -> String {
+        guard JSONSerialization.isValidJSONObject(json),
+              let data = try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys]) else {
+            preconditionFailure("Failed to serialize JWT segment for tests.")
+        }
+        return base64URLEncode(data)
+    }
+
+    private static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Core/ErrorMessageResolverFieldErrorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Core/ErrorMessageResolverFieldErrorTests.swift
@@ -1,0 +1,209 @@
+//
+//  ErrorMessageResolverFieldErrorTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class ErrorMessageResolverFieldErrorTests: XCTestCase {
+
+    // MARK: - Test Data
+
+    private let requiredErrorMessageKeys: [ValidationError.InputElementType: String] = [
+        .firstName: TestData.ErrorMessageKeys.firstNameRequired,
+        .lastName: TestData.ErrorMessageKeys.lastNameRequired,
+        .email: TestData.ErrorMessageKeys.emailRequired,
+        .countryCode: TestData.ErrorMessageKeys.countryRequired,
+        .addressLine1: TestData.ErrorMessageKeys.addressLine1Required,
+        .addressLine2: TestData.ErrorMessageKeys.addressLine2Required,
+        .city: TestData.ErrorMessageKeys.cityRequired,
+        .state: TestData.ErrorMessageKeys.stateRequired,
+        .postalCode: TestData.ErrorMessageKeys.postalCodeRequired,
+        .phoneNumber: TestData.ErrorMessageKeys.phoneNumberRequired,
+        .retailOutlet: TestData.ErrorMessageKeys.retailOutletRequired
+    ]
+
+    private let invalidErrorMessageKeys: [ValidationError.InputElementType: String] = [
+        .cardNumber: TestData.ErrorMessageKeys.cardNumberInvalid,
+        .cvv: TestData.ErrorMessageKeys.cvvInvalid,
+        .expiryDate: TestData.ErrorMessageKeys.expiryDateInvalid,
+        .cardholderName: TestData.ErrorMessageKeys.cardholderNameInvalid,
+        .firstName: TestData.ErrorMessageKeys.firstNameInvalid,
+        .lastName: TestData.ErrorMessageKeys.lastNameInvalid,
+        .email: TestData.ErrorMessageKeys.emailInvalid,
+        .countryCode: TestData.ErrorMessageKeys.countryInvalid,
+        .addressLine1: TestData.ErrorMessageKeys.addressLine1Invalid,
+        .addressLine2: TestData.ErrorMessageKeys.addressLine2Invalid,
+        .city: TestData.ErrorMessageKeys.cityInvalid,
+        .state: TestData.ErrorMessageKeys.stateInvalid,
+        .postalCode: TestData.ErrorMessageKeys.postalCodeInvalid,
+        .phoneNumber: TestData.ErrorMessageKeys.phoneNumberInvalid,
+        .retailOutlet: TestData.ErrorMessageKeys.retailOutletInvalid
+    ]
+
+    private var typesWithRequiredErrors: [ValidationError.InputElementType] {
+        Array(requiredErrorMessageKeys.keys)
+    }
+
+    private var typesWithInvalidErrors: [ValidationError.InputElementType] {
+        Array(invalidErrorMessageKeys.keys)
+    }
+
+    // MARK: - Helper Methods
+
+    private func assertRequiredFieldError(
+        for type: ValidationError.InputElementType,
+        expectedMessageKey: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let error = ErrorMessageResolver.createRequiredFieldError(for: type)
+
+        XCTAssertEqual(error.inputElementType, type, file: file, line: line)
+        XCTAssertEqual(
+            error.errorMessageKey,
+            expectedMessageKey,
+            "Expected message key '\(expectedMessageKey)' for \(type), got '\(error.errorMessageKey ?? "nil")'",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(error.errorId, "\(type.rawValue.lowercased())_required", file: file, line: line)
+        XCTAssertEqual(error.code, "invalid-\(type.rawValue.lowercased())", file: file, line: line)
+        XCTAssertEqual(error.message, TestData.ErrorMessages.fieldRequired, file: file, line: line)
+    }
+
+    private func assertInvalidFieldError(
+        for type: ValidationError.InputElementType,
+        expectedMessageKey: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let error = ErrorMessageResolver.createInvalidFieldError(for: type)
+
+        XCTAssertEqual(error.inputElementType, type, file: file, line: line)
+        XCTAssertEqual(
+            error.errorMessageKey,
+            expectedMessageKey,
+            "Expected message key '\(expectedMessageKey)' for \(type), got '\(error.errorMessageKey ?? "nil")'",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(error.errorId, "\(type.rawValue.lowercased())_invalid", file: file, line: line)
+        XCTAssertEqual(error.code, "invalid-\(type.rawValue.lowercased())", file: file, line: line)
+        XCTAssertEqual(error.message, TestData.ErrorMessages.fieldInvalid, file: file, line: line)
+    }
+
+    // MARK: - createRequiredFieldError Tests
+
+    func test_createRequiredFieldError_forAllSupportedTypes_createsCorrectErrors() {
+        for (type, expectedMessageKey) in requiredErrorMessageKeys {
+            assertRequiredFieldError(for: type, expectedMessageKey: expectedMessageKey)
+        }
+    }
+
+    func test_createRequiredFieldError_forUnknown_usesGenericKey() {
+        let error = ErrorMessageResolver.createRequiredFieldError(for: .unknown)
+
+        XCTAssertEqual(error.inputElementType, .unknown)
+        XCTAssertEqual(error.errorMessageKey, TestData.ErrorMessageKeys.genericRequired)
+    }
+
+    // MARK: - createInvalidFieldError Tests
+
+    func test_createInvalidFieldError_forAllSupportedTypes_createsCorrectErrors() {
+        for (type, expectedMessageKey) in invalidErrorMessageKeys {
+            assertInvalidFieldError(for: type, expectedMessageKey: expectedMessageKey)
+        }
+    }
+
+    func test_createInvalidFieldError_forUnknown_usesGenericKey() {
+        let error = ErrorMessageResolver.createInvalidFieldError(for: .unknown)
+
+        XCTAssertEqual(error.inputElementType, .unknown)
+        XCTAssertEqual(error.errorMessageKey, TestData.ErrorMessageKeys.genericInvalid)
+    }
+
+    // MARK: - Integration Tests
+
+    func test_createdRequiredError_resolvesToCorrectMessage() {
+        // Given
+        let error = ErrorMessageResolver.createRequiredFieldError(for: .firstName)
+
+        // When
+        let message = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(message, CheckoutComponentsStrings.firstNameErrorRequired)
+    }
+
+    func test_createdInvalidError_resolvesToCorrectMessage() {
+        // Given
+        let error = ErrorMessageResolver.createInvalidFieldError(for: .cardNumber)
+
+        // When
+        let message = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(message, CheckoutComponentsStrings.enterValidCardNumber)
+    }
+
+    // MARK: - All Input Element Types Coverage
+
+    func test_allInputElementTypes_haveRequiredErrorKeys() {
+        // Test all cases except those that don't support required errors (card-related types and otpCode)
+        let unsupportedTypes: Set<ValidationError.InputElementType> = [
+            .cardNumber, .cvv, .expiryDate, .cardholderName, .otpCode, .unknown
+        ]
+
+        for type in ValidationError.InputElementType.allCases where !unsupportedTypes.contains(type) {
+            let error = ErrorMessageResolver.createRequiredFieldError(for: type)
+            let message = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+            XCTAssertNotEqual(
+                message,
+                CheckoutComponentsStrings.unexpectedError,
+                "Type \(type) should have a valid required error message"
+            )
+        }
+    }
+
+    func test_allInputElementTypes_haveInvalidErrorKeys() {
+        // Test all cases except those that don't support invalid errors (otpCode and unknown)
+        let unsupportedTypes: Set<ValidationError.InputElementType> = [.otpCode, .unknown]
+
+        for type in ValidationError.InputElementType.allCases where !unsupportedTypes.contains(type) {
+            let error = ErrorMessageResolver.createInvalidFieldError(for: type)
+            let message = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+            XCTAssertNotEqual(
+                message,
+                CheckoutComponentsStrings.unexpectedError,
+                "Type \(type) should have a valid invalid error message"
+            )
+        }
+    }
+
+    // MARK: - Exhaustive Coverage Test
+
+    func test_allInputElementTypes_areHandled() {
+        // Ensure we've considered all InputElementType cases
+        // This test will fail if a new case is added to the enum without updating the tests
+        let allTypes = Set(ValidationError.InputElementType.allCases)
+        let handledInRequired = Set(typesWithRequiredErrors + [.unknown, .cardNumber, .cvv, .expiryDate, .cardholderName, .otpCode])
+        let handledInInvalid = Set(typesWithInvalidErrors + [.unknown, .otpCode])
+
+        XCTAssertEqual(
+            allTypes,
+            handledInRequired,
+            "All InputElementTypes should be handled in required error tests"
+        )
+        XCTAssertEqual(
+            allTypes,
+            handledInInvalid,
+            "All InputElementTypes should be handled in invalid error tests"
+        )
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Core/ErrorMessageResolverTests.swift
+++ b/Tests/Primer/CheckoutComponents/Core/ErrorMessageResolverTests.swift
@@ -1,0 +1,434 @@
+//
+//  ErrorMessageResolverTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class ErrorMessageResolverTests: XCTestCase {
+
+    // MARK: - resolveErrorMessage Tests
+
+    // MARK: Form Validation Errors
+
+    func test_resolveErrorMessage_withCardTypeNotSupported_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "form_error_card_type_not_supported")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.formErrorCardTypeNotSupported)
+    }
+
+    func test_resolveErrorMessage_withCardHolderNameLength_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "form_error_card_holder_name_length")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.formErrorCardHolderNameLength)
+    }
+
+    func test_resolveErrorMessage_withCardExpired_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "form_error_card_expired")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.formErrorCardExpired)
+    }
+
+    // MARK: Required Field Errors
+
+    func test_resolveErrorMessage_withFirstNameRequired_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_first_name_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.firstNameErrorRequired)
+    }
+
+    func test_resolveErrorMessage_withLastNameRequired_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_last_name_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.lastNameErrorRequired)
+    }
+
+    func test_resolveErrorMessage_withEmailRequired_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_email_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.emailErrorRequired)
+    }
+
+    func test_resolveErrorMessage_withCountryRequired_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_country_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.countryCodeErrorRequired)
+    }
+
+    func test_resolveErrorMessage_withAddressLine1Required_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_address_line_1_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.addressLine1ErrorRequired)
+    }
+
+    func test_resolveErrorMessage_withAddressLine2Required_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_address_line_2_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.addressLine2ErrorRequired)
+    }
+
+    func test_resolveErrorMessage_withCityRequired_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_city_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.cityErrorRequired)
+    }
+
+    func test_resolveErrorMessage_withStateRequired_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_state_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.stateErrorRequired)
+    }
+
+    func test_resolveErrorMessage_withPostalCodeRequired_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_postal_code_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.postalCodeErrorRequired)
+    }
+
+    func test_resolveErrorMessage_withPhoneNumberRequired_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_phone_number_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.enterValidPhoneNumber)
+    }
+
+    func test_resolveErrorMessage_withRetailOutletRequired_returnsHardcodedString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_retail_outlet_required")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, TestData.ErrorMessages.retailOutletRequired)
+    }
+
+    // MARK: Invalid Field Errors - Card Fields
+
+    func test_resolveErrorMessage_withCardNumberInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_card_number_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.enterValidCardNumber)
+    }
+
+    func test_resolveErrorMessage_withCVVInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_cvv_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.enterValidCVV)
+    }
+
+    func test_resolveErrorMessage_withExpiryDateInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_expiry_date_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.enterValidExpiryDate)
+    }
+
+    func test_resolveErrorMessage_withCardholderNameInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_cardholder_name_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.enterValidCardholderName)
+    }
+
+    // MARK: Invalid Field Errors - Billing Address Fields
+
+    func test_resolveErrorMessage_withFirstNameInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_first_name_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.firstNameErrorInvalid)
+    }
+
+    func test_resolveErrorMessage_withLastNameInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_last_name_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.lastNameErrorInvalid)
+    }
+
+    func test_resolveErrorMessage_withEmailInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_email_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.emailErrorInvalid)
+    }
+
+    func test_resolveErrorMessage_withCountryInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_country_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.countryCodeErrorInvalid)
+    }
+
+    func test_resolveErrorMessage_withAddressLine1Invalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_address_line_1_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.addressLine1ErrorInvalid)
+    }
+
+    func test_resolveErrorMessage_withAddressLine2Invalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_address_line_2_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.addressLine2ErrorInvalid)
+    }
+
+    func test_resolveErrorMessage_withCityInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_city_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.cityErrorInvalid)
+    }
+
+    func test_resolveErrorMessage_withStateInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_state_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.stateErrorInvalid)
+    }
+
+    func test_resolveErrorMessage_withPostalCodeInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_postal_code_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.postalCodeErrorInvalid)
+    }
+
+    func test_resolveErrorMessage_withPhoneNumberInvalid_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_phone_number_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.enterValidPhoneNumber)
+    }
+
+    func test_resolveErrorMessage_withRetailOutletInvalid_returnsHardcodedString() {
+        // Given
+        let error = createError(messageKey: "checkout_components_retail_outlet_invalid")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, TestData.ErrorMessages.retailOutletInvalid)
+    }
+
+    // MARK: Result Screen Messages
+
+    func test_resolveErrorMessage_withPaymentSuccessful_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "payment_successful")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.paymentSuccessful)
+    }
+
+    func test_resolveErrorMessage_withPaymentFailed_returnsCorrectString() {
+        // Given
+        let error = createError(messageKey: "payment_failed")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.paymentFailed)
+    }
+
+    // MARK: Fallback Behavior
+
+    func test_resolveErrorMessage_withUnknownKey_returnsUnexpectedError() {
+        // Given
+        let error = createError(messageKey: "unknown_error_key")
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, CheckoutComponentsStrings.unexpectedError)
+    }
+
+    func test_resolveErrorMessage_withNoMessageKey_returnsErrorId() {
+        // Given
+        let error = ValidationError(
+            inputElementType: .unknown,
+            errorId: "custom_error_id",
+            fieldNameKey: nil,
+            errorMessageKey: nil,
+            errorFormatKey: nil,
+            code: "test-code",
+            message: "Test message"
+        )
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then
+        XCTAssertEqual(result, "custom_error_id")
+    }
+
+    // MARK: Format String Resolution (Priority 1)
+
+    func test_resolveErrorMessage_withFormatKeyAndFieldNameKey_returnsFormattedString() {
+        // Given - This tests the highest priority path (format key + field name key)
+        // Note: This requires valid format and field name keys to produce a meaningful result
+        let error = ValidationError(
+            inputElementType: .firstName,
+            errorId: "test_error",
+            fieldNameKey: "first_name_field",
+            errorMessageKey: nil,
+            errorFormatKey: "form_error_card_type_not_supported", // Using existing key as format
+            code: "test-code",
+            message: "Test"
+        )
+
+        // When
+        let result = ErrorMessageResolver.resolveErrorMessage(for: error)
+
+        // Then - Should use format string interpolation
+        XCTAssertNotNil(result)
+        // The result will be a formatted string with the field name
+    }
+
+    // MARK: - Helper Methods
+
+    private func createError(messageKey: String) -> ValidationError {
+        ValidationError(
+            inputElementType: .unknown,
+            errorId: TestData.TestFixtures.defaultErrorId,
+            fieldNameKey: nil,
+            errorMessageKey: messageKey,
+            errorFormatKey: nil,
+            code: TestData.TestFixtures.defaultCode,
+            message: TestData.TestFixtures.defaultMessage
+        )
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockAnalyticsInteractor.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockAnalyticsInteractor.swift
@@ -1,0 +1,14 @@
+//
+//  MockAnalyticsInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+actor MockAnalyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol {
+
+    func trackEvent(_ eventType: AnalyticsEventType, metadata: AnalyticsEventMetadata?) async {}
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockConfigurationService.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockConfigurationService.swift
@@ -1,0 +1,51 @@
+//
+//  MockConfigurationService.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class MockConfigurationService: ConfigurationService {
+
+    var apiConfiguration: PrimerAPIConfiguration?
+    var checkoutModules: [PrimerAPIConfiguration.CheckoutModule]?
+    var billingAddressOptions: PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions?
+    var currency: Currency?
+    var amount: Int?
+    var captureVaultedCardCvv: Bool = false
+
+    init(
+        apiConfiguration: PrimerAPIConfiguration? = nil,
+        checkoutModules: [PrimerAPIConfiguration.CheckoutModule]? = nil,
+        billingAddressOptions: PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions? = nil,
+        currency: Currency? = nil,
+        amount: Int? = nil,
+        captureVaultedCardCvv: Bool = false
+    ) {
+        self.apiConfiguration = apiConfiguration
+        self.checkoutModules = checkoutModules
+        self.billingAddressOptions = billingAddressOptions
+        self.currency = currency
+        self.amount = amount
+        self.captureVaultedCardCvv = captureVaultedCardCvv
+    }
+
+    func reset() {
+        apiConfiguration = nil
+        checkoutModules = nil
+        billingAddressOptions = nil
+        currency = nil
+        amount = nil
+        captureVaultedCardCvv = false
+    }
+
+    static func withDefaultConfiguration() -> MockConfigurationService {
+        let mock = MockConfigurationService()
+        mock.currency = Currency(code: TestData.Currencies.usd, decimalDigits: TestData.Currencies.defaultDecimalDigits)
+        mock.amount = TestData.Amounts.standard
+        return mock
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockTrackingAnalyticsInteractor.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockTrackingAnalyticsInteractor.swift
@@ -1,0 +1,34 @@
+//
+//  MockTrackingAnalyticsInteractor.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+actor MockTrackingAnalyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol {
+
+    // MARK: - Call Tracking
+
+    private(set) var trackedEvents: [(eventType: AnalyticsEventType, metadata: AnalyticsEventMetadata?)] = []
+
+    var trackEventCallCount: Int { trackedEvents.count }
+
+    // MARK: - CheckoutComponentsAnalyticsInteractorProtocol
+
+    func trackEvent(_ eventType: AnalyticsEventType, metadata: AnalyticsEventMetadata?) async {
+        trackedEvents.append((eventType: eventType, metadata: metadata))
+    }
+
+    // MARK: - Test Helpers
+
+    func hasTracked(_ eventType: AnalyticsEventType) -> Bool {
+        trackedEvents.contains { $0.eventType == eventType }
+    }
+
+    func reset() {
+        trackedEvents.removeAll()
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockUIAccessibilityNotificationPublisher.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockUIAccessibilityNotificationPublisher.swift
@@ -1,0 +1,37 @@
+//
+//  MockUIAccessibilityNotificationPublisher.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import UIKit
+
+@available(iOS 15.0, *)
+final class MockUIAccessibilityNotificationPublisher: UIAccessibilityNotificationPublisher {
+
+    // MARK: - Captured State
+
+    private(set) var postCallCount = 0
+    private(set) var lastNotificationType: UIAccessibility.Notification?
+    private(set) var lastMessage: String?
+    private(set) var allNotifications: [(notification: UIAccessibility.Notification, message: String?)] = []
+
+    // MARK: - UIAccessibilityNotificationPublisher
+
+    func post(notification: UIAccessibility.Notification, argument: Any?) {
+        postCallCount += 1
+        lastNotificationType = notification
+        lastMessage = argument as? String
+        allNotifications.append((notification: notification, message: argument as? String))
+    }
+
+    // MARK: - Test Helpers
+
+    func reset() {
+        postCallCount = 0
+        lastNotificationType = nil
+        lastMessage = nil
+        allNotifications.removeAll()
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Navigation/CheckoutCoordinatorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Navigation/CheckoutCoordinatorTests.swift
@@ -1,0 +1,185 @@
+//
+//  CheckoutCoordinatorTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class CheckoutCoordinatorTests: XCTestCase {
+
+    private var sut: CheckoutCoordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        sut = CheckoutCoordinator()
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Navigation Behavior Tests
+
+    func test_navigate_toPaymentMethod_pushesToStack() {
+        // Given - navigate to payment selection first
+        sut.navigate(to: .paymentMethodSelection)
+
+        // When
+        sut.navigate(to: .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+
+        // Then - pushed to stack
+        XCTAssertEqual(sut.navigationStack.count, 2)
+        XCTAssertEqual(sut.currentRoute, .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+    }
+
+    func test_navigate_toProcessing_replacesCurrentRoute() {
+        // Given - navigate to payment method first
+        sut.navigate(to: .paymentMethodSelection)
+        sut.navigate(to: .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+        XCTAssertEqual(sut.navigationStack.count, 2)
+
+        // When
+        sut.navigate(to: .processing)
+
+        // Then - replaces payment method, stack count unchanged
+        XCTAssertEqual(sut.navigationStack.count, 2)
+        XCTAssertEqual(sut.currentRoute, .processing)
+    }
+
+    func test_navigate_toSameRoute_doesNotDuplicate() {
+        // Given
+        sut.navigate(to: .loading)
+
+        // When - navigate to same route
+        sut.navigate(to: .loading)
+
+        // Then - still only one item
+        XCTAssertEqual(sut.navigationStack.count, 1)
+    }
+
+    func test_navigate_toSplash_resetsEntireStack() {
+        // Given - build up navigation stack
+        sut.navigate(to: .loading)
+        sut.navigate(to: .paymentMethodSelection)
+        sut.navigate(to: .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+
+        // When
+        sut.navigate(to: .splash)
+
+        // Then - stack is completely cleared
+        XCTAssertTrue(sut.navigationStack.isEmpty)
+        XCTAssertEqual(sut.currentRoute, .splash)
+    }
+
+    // MARK: - GoBack Tests
+
+    func test_goBack_removesLastRoute() {
+        // Given
+        sut.navigate(to: .paymentMethodSelection)
+        sut.navigate(to: .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+        XCTAssertEqual(sut.navigationStack.count, 2)
+
+        // When
+        sut.goBack()
+
+        // Then
+        XCTAssertEqual(sut.navigationStack.count, 1)
+        XCTAssertEqual(sut.currentRoute, .paymentMethodSelection)
+    }
+
+    func test_goBack_withEmptyStack_doesNothing() {
+        // Given - empty stack
+
+        // When
+        sut.goBack()
+
+        // Then - still empty, no crash
+        XCTAssertTrue(sut.navigationStack.isEmpty)
+    }
+
+    func test_goBack_multipleTimes_removesMultipleRoutes() {
+        // Given - build a deeper stack without replace behavior
+        sut.navigate(to: .paymentMethodSelection) // reset -> 1 item
+        sut.navigate(to: .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection)) // push -> 2 items
+        sut.navigate(to: .paymentMethod(TestData.PaymentMethodTypes.applePay, .fromPaymentSelection)) // push -> 3 items
+
+        // When
+        sut.goBack() // -> 2 items
+        sut.goBack() // -> 1 item
+
+        // Then - back to payment method selection
+        XCTAssertEqual(sut.navigationStack.count, 1)
+        XCTAssertEqual(sut.currentRoute, .paymentMethodSelection)
+    }
+
+    // MARK: - LastPaymentMethodRoute Tests
+
+    func test_lastPaymentMethodRoute_tracksPaymentMethod() {
+        // Given
+        sut.navigate(to: .paymentMethodSelection)
+        let paymentRoute = CheckoutRoute.paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection)
+        sut.navigate(to: paymentRoute)
+
+        // When - navigate away from payment method
+        sut.navigate(to: .processing)
+
+        // Then - last payment method is tracked
+        XCTAssertEqual(sut.lastPaymentMethodRoute, paymentRoute)
+    }
+
+    // MARK: - Complex Navigation Flow Tests
+
+    func test_fullCheckoutFlow_maintainsCorrectState() {
+        // Simulate a complete checkout flow
+        // 1. Initial state - splash
+        XCTAssertEqual(sut.currentRoute, .splash)
+
+        // 2. Loading
+        sut.navigate(to: .loading)
+        XCTAssertEqual(sut.currentRoute, .loading)
+
+        // 3. Payment method selection
+        sut.navigate(to: .paymentMethodSelection)
+        XCTAssertEqual(sut.currentRoute, .paymentMethodSelection)
+
+        // 4. Select card payment
+        sut.navigate(to: .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+        XCTAssertEqual(sut.currentRoute, .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+        XCTAssertEqual(sut.navigationStack.count, 2)
+
+        // 5. Processing
+        sut.navigate(to: .processing)
+        XCTAssertEqual(sut.currentRoute, .processing)
+        XCTAssertEqual(sut.navigationStack.count, 2)
+
+        // 6. Success
+        let result = PaymentResult(paymentId: TestData.PaymentIds.success, status: .success)
+        sut.navigate(to: .success(result))
+        XCTAssertEqual(sut.currentRoute, .success(result))
+    }
+
+    func test_retryFlow_afterFailure() {
+        // Simulate failure and retry
+        // 1. Setup to processing
+        sut.navigate(to: .paymentMethodSelection)
+        sut.navigate(to: .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+        sut.navigate(to: .processing)
+
+        // 2. Failure
+        let error = PrimerError.invalidValue(key: TestData.ErrorKeys.test, value: nil, reason: nil, diagnosticsId: TestData.DiagnosticsIds.test)
+        sut.handlePaymentFailure(error)
+        XCTAssertEqual(sut.currentRoute, .failure(error))
+
+        // 3. lastPaymentMethodRoute should be tracked
+        XCTAssertEqual(sut.lastPaymentMethodRoute, .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+
+        // 4. User can navigate back to retry
+        sut.navigate(to: .paymentMethodSelection)
+        XCTAssertEqual(sut.currentRoute, .paymentMethodSelection)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Navigation/CheckoutNavigatorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Navigation/CheckoutNavigatorTests.swift
@@ -1,0 +1,195 @@
+//
+//  CheckoutNavigatorTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class CheckoutNavigatorTests: XCTestCase {
+
+    private var sut: CheckoutNavigator!
+    private var coordinator: CheckoutCoordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        coordinator = CheckoutCoordinator()
+        sut = CheckoutNavigator(coordinator: coordinator)
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        coordinator = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - NavigationEvents Stream Tests
+
+    func test_navigationEvents_emitsInitialRoute() async {
+        // Given
+        let expectation = XCTestExpectation(description: "Receive initial route")
+
+        // When - subscribe to navigation events
+        let task = Task {
+            for await route in sut.navigationEvents {
+                // Then - first emission should be splash (empty stack)
+                XCTAssertEqual(route, .splash)
+                expectation.fulfill()
+                break
+            }
+        }
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+        task.cancel()
+    }
+
+    func test_navigationEvents_emitsRouteChanges() async {
+        // Given
+        let expectation = XCTestExpectation(description: "Receive navigation updates")
+        var receivedRoutes: [CheckoutRoute] = []
+
+        // When - subscribe and make navigation changes
+        let task = Task {
+            for await route in sut.navigationEvents {
+                receivedRoutes.append(route)
+                if receivedRoutes.count >= 3 {
+                    expectation.fulfill()
+                    break
+                }
+            }
+        }
+
+        // Give stream time to start
+        try? await Task.sleep(nanoseconds: 50_000_000) // 0.05 seconds
+
+        // Navigate
+        sut.navigateToLoading()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        sut.navigateToPaymentSelection()
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+        task.cancel()
+
+        // Then - should have received splash, loading, paymentMethodSelection
+        XCTAssertGreaterThanOrEqual(receivedRoutes.count, 3)
+        XCTAssertEqual(receivedRoutes[0], .splash)
+        XCTAssertEqual(receivedRoutes[1], .loading)
+        XCTAssertEqual(receivedRoutes[2], .paymentMethodSelection)
+    }
+
+    func test_navigationEvents_stopsEmittingAfterCancellation() async {
+        // Given
+        let expectation = XCTestExpectation(description: "Task cancelled")
+        var receivedCount = 0
+
+        // When - subscribe then cancel
+        let task = Task {
+            for await _ in sut.navigationEvents {
+                receivedCount += 1
+                if receivedCount == 1 {
+                    break
+                }
+            }
+            expectation.fulfill()
+        }
+
+        await fulfillment(of: [expectation], timeout: 2.0)
+        task.cancel()
+
+        // Navigate after cancellation
+        let countBeforeNavigation = receivedCount
+        sut.navigateToLoading()
+
+        // Small delay to ensure no more emissions
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then - count should not have increased significantly
+        // (the stream was broken out of)
+        XCTAssertEqual(receivedCount, countBeforeNavigation)
+    }
+
+    func test_navigationEvents_multipleSubscribers() async {
+        // Given
+        let expectation1 = XCTestExpectation(description: "Subscriber 1 receives")
+        let expectation2 = XCTestExpectation(description: "Subscriber 2 receives")
+        var routes1: [CheckoutRoute] = []
+        var routes2: [CheckoutRoute] = []
+
+        // When - create two subscribers
+        let task1 = Task {
+            for await route in sut.navigationEvents {
+                routes1.append(route)
+                if routes1.count >= 2 {
+                    expectation1.fulfill()
+                    break
+                }
+            }
+        }
+
+        let task2 = Task {
+            for await route in sut.navigationEvents {
+                routes2.append(route)
+                if routes2.count >= 2 {
+                    expectation2.fulfill()
+                    break
+                }
+            }
+        }
+
+        // Give streams time to start
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // Navigate
+        sut.navigateToLoading()
+
+        await fulfillment(of: [expectation1, expectation2], timeout: 2.0)
+        task1.cancel()
+        task2.cancel()
+
+        // Then - both subscribers should receive routes
+        XCTAssertGreaterThanOrEqual(routes1.count, 2)
+        XCTAssertGreaterThanOrEqual(routes2.count, 2)
+    }
+
+    func test_navigationEvents_emitsCorrectRouteAfterMultipleChanges() async {
+        // Given
+        let expectation = XCTestExpectation(description: "Receive all routes")
+        var receivedRoutes: [CheckoutRoute] = []
+
+        // When
+        let task = Task {
+            for await route in sut.navigationEvents {
+                receivedRoutes.append(route)
+                if receivedRoutes.count >= 5 {
+                    expectation.fulfill()
+                    break
+                }
+            }
+        }
+
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // Full navigation flow
+        sut.navigateToLoading()
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        sut.navigateToPaymentSelection()
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        sut.navigateToPaymentMethod(TestData.PaymentMethodTypes.card)
+        try? await Task.sleep(nanoseconds: 30_000_000)
+        sut.navigateToProcessing()
+
+        await fulfillment(of: [expectation], timeout: 3.0)
+        task.cancel()
+
+        // Then - verify the sequence
+        XCTAssertGreaterThanOrEqual(receivedRoutes.count, 5)
+        XCTAssertEqual(receivedRoutes[0], .splash)
+        XCTAssertEqual(receivedRoutes[1], .loading)
+        XCTAssertEqual(receivedRoutes[2], .paymentMethodSelection)
+        XCTAssertEqual(receivedRoutes[3], .paymentMethod(TestData.PaymentMethodTypes.card, .fromPaymentSelection))
+        XCTAssertEqual(receivedRoutes[4], .processing)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Services/ConfigurationServiceTests.swift
+++ b/Tests/Primer/CheckoutComponents/Services/ConfigurationServiceTests.swift
@@ -1,0 +1,329 @@
+//
+//  ConfigurationServiceTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class ConfigurationServiceTests: XCTestCase {
+
+    private var sut: DefaultConfigurationService!
+
+    override func setUp() {
+        super.setUp()
+        sut = DefaultConfigurationService()
+    }
+
+    override func tearDown() {
+        SDKSessionHelper.tearDown()
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - apiConfiguration
+
+    func test_apiConfiguration_whenNil_returnsNil() {
+        // Given - no SDKSessionHelper setup
+
+        // When
+        let result = sut.apiConfiguration
+
+        // Then
+        XCTAssertNil(result)
+    }
+
+    func test_apiConfiguration_whenSet_returnsConfiguration() {
+        // Given
+        SDKSessionHelper.setUp()
+
+        // When
+        let result = sut.apiConfiguration
+
+        // Then
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.coreUrl, "core_url")
+    }
+
+    // MARK: - checkoutModules
+
+    func test_checkoutModules_whenConfigNil_returnsNil() {
+        // Given - no SDKSessionHelper setup
+
+        // When
+        let result = sut.checkoutModules
+
+        // Then
+        XCTAssertNil(result)
+    }
+
+    func test_checkoutModules_whenModulesPresent_returnsModules() {
+        // Given
+        let modules = [makeBillingAddressModule()]
+        SDKSessionHelper.setUp(checkoutModules: modules)
+
+        // When
+        let result = sut.checkoutModules
+
+        // Then
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.type, "BILLING_ADDRESS")
+    }
+
+    // MARK: - billingAddressOptions
+
+    func test_billingAddressOptions_whenNoBillingModule_returnsNil() {
+        // Given
+        let modules = [makeCheckoutModule(type: "CARD_INFORMATION")]
+        SDKSessionHelper.setUp(checkoutModules: modules)
+
+        // When
+        let result = sut.billingAddressOptions
+
+        // Then
+        XCTAssertNil(result)
+    }
+
+    func test_billingAddressOptions_whenBillingModulePresent_returnsOptions() {
+        // Given
+        let modules = [makeBillingAddressModule()]
+        SDKSessionHelper.setUp(checkoutModules: modules)
+
+        // When
+        let result = sut.billingAddressOptions
+
+        // Then
+        XCTAssertNotNil(result)
+    }
+
+    // MARK: - currency
+
+    func test_currency_whenConfigNil_returnsNil() {
+        // Given - no SDKSessionHelper setup
+
+        // When
+        let result = sut.currency
+
+        // Then
+        XCTAssertNil(result)
+    }
+
+    func test_currency_whenOrderHasCurrency_returnsCurrency() {
+        // Given
+        let order = makeOrder(
+            currencyCode: Currency(
+                code: TestData.Currencies.usd,
+                decimalDigits: TestData.Currencies.defaultDecimalDigits
+            )
+        )
+        SDKSessionHelper.setUp(order: order)
+
+        // When
+        let result = sut.currency
+
+        // Then
+        XCTAssertEqual(result?.code, TestData.Currencies.usd)
+    }
+
+    // MARK: - amount
+
+    func test_amount_whenConfigNil_returnsNil() {
+        // Given - no SDKSessionHelper setup
+
+        // When
+        let result = sut.amount
+
+        // Then
+        XCTAssertNil(result)
+    }
+
+    func test_amount_prefersMerchantAmountOverTotalOrderAmount() {
+        // Given
+        let order = makeOrder(
+            merchantAmount: TestData.Amounts.standard,
+            totalOrderAmount: TestData.Amounts.large
+        )
+        SDKSessionHelper.setUp(order: order)
+
+        // When
+        let result = sut.amount
+
+        // Then
+        XCTAssertEqual(result, TestData.Amounts.standard)
+    }
+
+    func test_amount_fallsBackToTotalOrderAmount_whenMerchantAmountNil() {
+        // Given
+        let order = makeOrder(merchantAmount: nil, totalOrderAmount: TestData.Amounts.large)
+        SDKSessionHelper.setUp(order: order)
+
+        // When
+        let result = sut.amount
+
+        // Then
+        XCTAssertEqual(result, TestData.Amounts.large)
+    }
+
+    func test_amount_returnsNil_whenBothAmountsNil() {
+        // Given
+        let order = makeOrder(merchantAmount: nil, totalOrderAmount: nil)
+        SDKSessionHelper.setUp(order: order)
+
+        // When
+        let result = sut.amount
+
+        // Then
+        XCTAssertNil(result)
+    }
+
+    // MARK: - captureVaultedCardCvv
+
+    func test_captureVaultedCardCvv_whenNoPaymentMethods_returnsFalse() {
+        // Given
+        SDKSessionHelper.setUp(withPaymentMethods: [])
+
+        // When
+        let result = sut.captureVaultedCardCvv
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    func test_captureVaultedCardCvv_whenCardOptionsTrue_returnsTrue() {
+        // Given
+        let cardMethod = PrimerPaymentMethod(
+            id: TestData.PaymentMethodIds.cardId,
+            implementationType: .nativeSdk,
+            type: PrimerPaymentMethodType.paymentCard.rawValue,
+            name: TestData.PaymentMethodNames.cardName,
+            processorConfigId: nil,
+            surcharge: nil,
+            options: CardOptions(
+                threeDSecureEnabled: false,
+                threeDSecureToken: nil,
+                threeDSecureInitUrl: nil,
+                threeDSecureProvider: "NETCETERA",
+                processorConfigId: nil,
+                captureVaultedCardCvv: true
+            ),
+            displayMetadata: nil
+        )
+        SDKSessionHelper.setUp(withPaymentMethods: [cardMethod])
+
+        // When
+        let result = sut.captureVaultedCardCvv
+
+        // Then
+        XCTAssertTrue(result)
+    }
+
+    func test_captureVaultedCardCvv_whenCardOptionsFalse_returnsFalse() {
+        // Given
+        let cardMethod = PrimerPaymentMethod(
+            id: TestData.PaymentMethodIds.cardId,
+            implementationType: .nativeSdk,
+            type: PrimerPaymentMethodType.paymentCard.rawValue,
+            name: TestData.PaymentMethodNames.cardName,
+            processorConfigId: nil,
+            surcharge: nil,
+            options: CardOptions(
+                threeDSecureEnabled: false,
+                threeDSecureToken: nil,
+                threeDSecureInitUrl: nil,
+                threeDSecureProvider: "NETCETERA",
+                processorConfigId: nil,
+                captureVaultedCardCvv: false
+            ),
+            displayMetadata: nil
+        )
+        SDKSessionHelper.setUp(withPaymentMethods: [cardMethod])
+
+        // When
+        let result = sut.captureVaultedCardCvv
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    func test_captureVaultedCardCvv_whenNoCardPaymentMethod_returnsFalse() {
+        // Given
+        let paypalMethod = PrimerPaymentMethod(
+            id: TestData.PaymentMethodIds.paypalId,
+            implementationType: .nativeSdk,
+            type: "PAYPAL",
+            name: TestData.PaymentMethodNames.paypalName,
+            processorConfigId: nil,
+            surcharge: nil,
+            options: nil,
+            displayMetadata: nil
+        )
+        SDKSessionHelper.setUp(withPaymentMethods: [paypalMethod])
+
+        // When
+        let result = sut.captureVaultedCardCvv
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    func test_captureVaultedCardCvv_whenConfigNil_returnsFalse() {
+        // Given - no SDKSessionHelper setup
+
+        // When
+        let result = sut.captureVaultedCardCvv
+
+        // Then
+        XCTAssertFalse(result)
+    }
+}
+
+// MARK: - Helpers
+
+@available(iOS 15.0, *)
+private extension ConfigurationServiceTests {
+
+    func makeOrder(
+        merchantAmount: Int? = nil,
+        totalOrderAmount: Int? = nil,
+        currencyCode: Currency? = nil
+    ) -> ClientSession.Order {
+        ClientSession.Order(
+            id: "order-123",
+            merchantAmount: merchantAmount,
+            totalOrderAmount: totalOrderAmount,
+            totalTaxAmount: nil,
+            countryCode: nil,
+            currencyCode: currencyCode,
+            fees: nil,
+            lineItems: nil
+        )
+    }
+
+    func makeBillingAddressModule() -> PrimerAPIConfiguration.CheckoutModule {
+        PrimerAPIConfiguration.CheckoutModule(
+            type: "BILLING_ADDRESS",
+            requestUrlStr: nil,
+            options: PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions(
+                firstName: true,
+                lastName: true,
+                city: true,
+                postalCode: true,
+                addressLine1: true,
+                addressLine2: false,
+                countryCode: true,
+                phoneNumber: false,
+                state: false
+            )
+        )
+    }
+
+    func makeCheckoutModule(type: String) -> PrimerAPIConfiguration.CheckoutModule {
+        PrimerAPIConfiguration.CheckoutModule(
+            type: type,
+            requestUrlStr: nil,
+            options: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ConfigurationService` for fetching and caching checkout configuration
- Add `ErrorMessageResolver` for mapping validation errors to user-facing messages
- Add navigation system: `CheckoutCoordinator`, `CheckoutNavigator`, `BackportedNavigationStack`, and `CheckoutRoute`
- Add service protocols: `RawDataManagerProtocol`, `VaultManagerProtocol`, `AnalyticsSessionConfigProviding`
- Add `CheckoutComponentsStrings` constants for localized string keys

## Context
PR 9 of 16 in the CheckoutComponents feature split. Depends on PR 8 (analytics, logging & accessibility).

[Notion tracker](https://www.notion.so/32fca65dc30e81dabf66f33e2b58c3a1)

## Test plan
- [ ] `ConfigurationServiceTests` — verify config fetch, caching, and error handling
- [ ] `ErrorMessageResolverTests` / `ErrorMessageResolverFieldErrorTests` — verify error-to-message mapping
- [ ] `CheckoutCoordinatorTests` — verify route coordination
- [ ] `CheckoutNavigatorTests` — verify navigation stack management
- [ ] `AnalyticsSessionConfigProviderTests` — verify session config generation