### PR TITLE
feat: Add core interactors, mapper & bridge

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/CheckoutComponentsPaymentMethodsBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/CheckoutComponentsPaymentMethodsBridge.swift
@@ -1,0 +1,195 @@
+//
+//  CheckoutComponentsPaymentMethodsBridge.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+/// Bridge to connect CheckoutComponents to the existing SDK payment methods
+@available(iOS 15.0, *)
+final class CheckoutComponentsPaymentMethodsBridge: GetPaymentMethodsInteractor, LogReporter {
+
+  private let configurationService: ConfigurationService
+
+  init(configurationService: ConfigurationService) {
+    self.configurationService = configurationService
+  }
+
+  func execute() async throws -> [InternalPaymentMethod] {
+    logger.info(message: "[PaymentMethodsBridge] Starting payment methods bridge...")
+
+    guard let configuration = configurationService.apiConfiguration else {
+      logger.error(message: "[PaymentMethodsBridge] No configuration available")
+      throw PrimerError.missingPrimerConfiguration()
+    }
+
+    logger.info(message: "[PaymentMethodsBridge] Configuration found")
+
+    guard let paymentMethods = configuration.paymentMethods, !paymentMethods.isEmpty else {
+      logger.error(message: "[PaymentMethodsBridge] No payment methods in configuration")
+      throw PrimerError.misconfiguredPaymentMethods()
+    }
+
+    logger.info(
+      message:
+        "[PaymentMethodsBridge] Found \(paymentMethods.count) payment methods in configuration"
+    )
+
+    // Filter payment methods based on CheckoutComponents support (only show implemented payment methods)
+    let filteredMethods = await filterPaymentMethodsBySupport(paymentMethods)
+    logger.info(
+      message:
+        "[PaymentMethodsBridge] Filtered to \(filteredMethods.count) payment methods based on CheckoutComponents support"
+    )
+
+    let convertedMethods = filteredMethods.map { primerMethod -> InternalPaymentMethod in
+      let type = primerMethod.type
+
+      logger.debug(message: "[PaymentMethodsBridge] Converting payment method: \(type)")
+
+      // Extract network surcharges for card payment methods
+      let networkSurcharges = extractNetworkSurcharges(for: type)
+
+      let displayButton = primerMethod.displayMetadata?.button
+      let backgroundColor = displayButton?.backgroundColor?.uiColor
+      let textColor = displayButton?.textColor?.uiColor
+      let borderColor = displayButton?.borderColor?.uiColor
+      let borderWidth = displayButton?.borderWidth?.resolvedValue
+      let cornerRadius = displayButton?.cornerRadius.map(CGFloat.init)
+      let buttonText = displayButton?.text
+
+      return InternalPaymentMethod(
+        id: type,
+        type: type,
+        name: primerMethod.name,
+        icon: primerMethod.logo,
+        configId: primerMethod.processorConfigId,
+        isEnabled: true,
+        supportedCurrencies: nil,
+        requiredInputElements: getRequiredInputElements(for: type),
+        metadata: nil,
+        surcharge: primerMethod.surcharge,
+        hasUnknownSurcharge: primerMethod.hasUnknownSurcharge,
+        networkSurcharges: networkSurcharges,
+        backgroundColor: backgroundColor,
+        buttonText: buttonText,
+        textColor: textColor,
+        borderColor: borderColor,
+        borderWidth: borderWidth,
+        cornerRadius: cornerRadius
+      )
+    }
+
+    logger.info(
+      message:
+        "[PaymentMethodsBridge] Successfully converted \(convertedMethods.count) payment methods"
+    )
+
+    for (index, method) in convertedMethods.enumerated() {
+      logger.debug(
+        message: "[PaymentMethodsBridge] Method \(index + 1): \(method.type) - \(method.name)"
+      )
+    }
+
+    return convertedMethods
+  }
+
+  private func extractNetworkSurcharges(for paymentMethodType: String) -> [String: Int]? {
+    guard paymentMethodType == PrimerPaymentMethodType.paymentCard.rawValue else {
+      return nil
+    }
+
+    let session = configurationService.apiConfiguration?.clientSession
+    guard let paymentMethodData = session?.paymentMethod else {
+      return nil
+    }
+
+    guard let options = paymentMethodData.options else {
+      return nil
+    }
+
+    guard
+      let paymentCardOption = options.first(where: { ($0["type"] as? String) == paymentMethodType })
+    else {
+      return nil
+    }
+
+    if let networksArray = paymentCardOption["networks"] as? [[String: Any]] {
+      return extractFromNetworksArray(networksArray)
+    } else if let networksDict = paymentCardOption["networks"] as? [String: [String: Any]] {
+      return extractFromNetworksDict(networksDict)
+    } else {
+      return nil
+    }
+  }
+
+  private func extractFromNetworksArray(_ networksArray: [[String: Any]]) -> [String: Int]? {
+    var networkSurcharges: [String: Int] = [:]
+
+    for networkData in networksArray {
+      guard let networkType = networkData["type"] as? String else {
+        continue
+      }
+
+      if let surchargeData = networkData["surcharge"] as? [String: Any],
+        let surchargeAmount = surchargeData["amount"] as? Int,
+        surchargeAmount > 0 {
+        networkSurcharges[networkType] = surchargeAmount
+      } else if let surcharge = networkData["surcharge"] as? Int,
+        surcharge > 0 {
+        networkSurcharges[networkType] = surcharge
+      }
+    }
+
+    return networkSurcharges.isEmpty ? nil : networkSurcharges
+  }
+
+  private func extractFromNetworksDict(_ networksDict: [String: [String: Any]]) -> [String: Int]? {
+    var networkSurcharges: [String: Int] = [:]
+
+    for (networkType, networkData) in networksDict {
+      if let surchargeData = networkData["surcharge"] as? [String: Any],
+        let surchargeAmount = surchargeData["amount"] as? Int,
+        surchargeAmount > 0 {
+        networkSurcharges[networkType] = surchargeAmount
+      } else if let surcharge = networkData["surcharge"] as? Int,
+        surcharge > 0 {
+        networkSurcharges[networkType] = surcharge
+      }
+    }
+
+    return networkSurcharges.isEmpty ? nil : networkSurcharges
+  }
+
+  private func getRequiredInputElements(for paymentMethodType: String) -> [PrimerInputElementType] {
+    switch paymentMethodType {
+    case PrimerPaymentMethodType.paymentCard.rawValue:
+      [.cardNumber, .cvv, .expiryDate, .cardholderName]
+    default:
+      []
+    }
+  }
+
+  private func filterPaymentMethodsBySupport(_ paymentMethods: [PrimerPaymentMethod]) async
+    -> [PrimerPaymentMethod] {
+      let registeredTypes = Set(await PaymentMethodRegistry.shared.registeredTypes)
+
+      logger.debug(message: "[PaymentMethodsBridge] Registered payment method types: \(registeredTypes)")
+
+      let filtered = paymentMethods.filter { method in
+        let isRegistered = registeredTypes.contains(method.type)
+        if !isRegistered {
+          logger.debug(message: "[PaymentMethodsBridge] Filtering out unregistered payment method: \(method.type)")
+        }
+        return isRegistered
+      }
+
+      logger.debug(
+        message:
+          "[PaymentMethodsBridge] Filtered \(paymentMethods.count) payment methods to \(filtered.count) registered types"
+      )
+
+      return filtered
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/CheckoutComponentsPaymentMethodsBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/CheckoutComponentsPaymentMethodsBridge.swift
@@ -33,8 +33,7 @@ final class CheckoutComponentsPaymentMethodsBridge: GetPaymentMethodsInteractor,
 
     logger.info(
       message:
-        "[PaymentMethodsBridge] Found \(paymentMethods.count) payment methods in configuration"
-    )
+        "[PaymentMethodsBridge] Found \(paymentMethods.count) payment methods in configuration")
 
     // Filter payment methods based on CheckoutComponents support (only show implemented payment methods)
     let filteredMethods = await filterPaymentMethodsBySupport(paymentMethods)
@@ -48,8 +47,8 @@ final class CheckoutComponentsPaymentMethodsBridge: GetPaymentMethodsInteractor,
 
       logger.debug(message: "[PaymentMethodsBridge] Converting payment method: \(type)")
 
-      // Extract network surcharges for card payment methods
-      let networkSurcharges = extractNetworkSurcharges(for: type)
+      let networkSurcharges = NetworkSurchargeExtractor.extractNetworkSurcharges(
+        for: type, from: configurationService)
 
       let displayButton = primerMethod.displayMetadata?.button
       let backgroundColor = displayButton?.backgroundColor?.uiColor
@@ -67,7 +66,7 @@ final class CheckoutComponentsPaymentMethodsBridge: GetPaymentMethodsInteractor,
         configId: primerMethod.processorConfigId,
         isEnabled: true,
         supportedCurrencies: nil,
-        requiredInputElements: getRequiredInputElements(for: type),
+        requiredInputElements: NetworkSurchargeExtractor.getRequiredInputElements(for: type),
         metadata: nil,
         surcharge: primerMethod.surcharge,
         hasUnknownSurcharge: primerMethod.hasUnknownSurcharge,
@@ -83,92 +82,14 @@ final class CheckoutComponentsPaymentMethodsBridge: GetPaymentMethodsInteractor,
 
     logger.info(
       message:
-        "[PaymentMethodsBridge] Successfully converted \(convertedMethods.count) payment methods"
-    )
+        "[PaymentMethodsBridge] Successfully converted \(convertedMethods.count) payment methods")
 
     for (index, method) in convertedMethods.enumerated() {
       logger.debug(
-        message: "[PaymentMethodsBridge] Method \(index + 1): \(method.type) - \(method.name)"
-      )
+        message: "[PaymentMethodsBridge] Method \(index + 1): \(method.type) - \(method.name)")
     }
 
     return convertedMethods
-  }
-
-  private func extractNetworkSurcharges(for paymentMethodType: String) -> [String: Int]? {
-    guard paymentMethodType == PrimerPaymentMethodType.paymentCard.rawValue else {
-      return nil
-    }
-
-    let session = configurationService.apiConfiguration?.clientSession
-    guard let paymentMethodData = session?.paymentMethod else {
-      return nil
-    }
-
-    guard let options = paymentMethodData.options else {
-      return nil
-    }
-
-    guard
-      let paymentCardOption = options.first(where: { ($0["type"] as? String) == paymentMethodType })
-    else {
-      return nil
-    }
-
-    if let networksArray = paymentCardOption["networks"] as? [[String: Any]] {
-      return extractFromNetworksArray(networksArray)
-    } else if let networksDict = paymentCardOption["networks"] as? [String: [String: Any]] {
-      return extractFromNetworksDict(networksDict)
-    } else {
-      return nil
-    }
-  }
-
-  private func extractFromNetworksArray(_ networksArray: [[String: Any]]) -> [String: Int]? {
-    var networkSurcharges: [String: Int] = [:]
-
-    for networkData in networksArray {
-      guard let networkType = networkData["type"] as? String else {
-        continue
-      }
-
-      if let surchargeData = networkData["surcharge"] as? [String: Any],
-        let surchargeAmount = surchargeData["amount"] as? Int,
-        surchargeAmount > 0 {
-        networkSurcharges[networkType] = surchargeAmount
-      } else if let surcharge = networkData["surcharge"] as? Int,
-        surcharge > 0 {
-        networkSurcharges[networkType] = surcharge
-      }
-    }
-
-    return networkSurcharges.isEmpty ? nil : networkSurcharges
-  }
-
-  private func extractFromNetworksDict(_ networksDict: [String: [String: Any]]) -> [String: Int]? {
-    var networkSurcharges: [String: Int] = [:]
-
-    for (networkType, networkData) in networksDict {
-      if let surchargeData = networkData["surcharge"] as? [String: Any],
-        let surchargeAmount = surchargeData["amount"] as? Int,
-        surchargeAmount > 0 {
-        networkSurcharges[networkType] = surchargeAmount
-      } else if let surcharge = networkData["surcharge"] as? Int,
-        surcharge > 0 {
-        networkSurcharges[networkType] = surcharge
-      }
-    }
-
-    return networkSurcharges.isEmpty ? nil : networkSurcharges
-  }
-
-  private func getRequiredInputElements(for paymentMethodType: String) -> [PrimerInputElementType] {
-    switch paymentMethodType {
-    case PrimerPaymentMethodType.paymentCard.rawValue:
-      [.cardNumber, .cvv, .expiryDate, .cardholderName]
-    default:
-      []
-    }
   }
 
   private func filterPaymentMethodsBySupport(_ paymentMethods: [PrimerPaymentMethod]) async

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -17,7 +17,7 @@ extension PrimerPaymentMethodType {
     case .paymentCard: .creditCard
     case .applePay: .appleIcon
     case .goCardless, .stripeAch: .achBank
-    case .googlePay: .appleIcon
+    case .googlePay: .genericCard // TODO: Add .googlePay case to ImageName enum
     default: .genericCard
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -1,0 +1,134 @@
+//
+//  PrimerPaymentMethodType+ImageName.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+@available(iOS 15.0, *)
+extension PrimerPaymentMethodType {
+
+  /// Follows the same pattern as DropIn UI's TokenizationResponse.icon
+  var defaultImageName: ImageName {
+    switch self {
+    case .payPal, .primerTestPayPal: .paypal
+    case .klarna, .primerTestKlarna: .klarna
+    case .paymentCard: .creditCard
+    case .applePay: .appleIcon
+    case .goCardless, .stripeAch: .achBank
+    case .googlePay: .appleIcon
+    default: .genericCard
+    }
+  }
+
+  /// Returns the icon image for this payment method type.
+  /// Provides comprehensive coverage for all payment methods with fallback to generic card.
+  var icon: UIImage? {
+    switch self {
+    // Primary payment methods
+    case .payPal, .primerTestPayPal:
+      UIImage(primerResource: "paypal-icon-colored")
+    case .klarna, .primerTestKlarna:
+      UIImage(primerResource: "klarna-icon-colored")
+    case .goCardless:
+      UIImage(primerResource: "gocardless-logo-colored")
+    case .stripeAch:
+      ImageName.achBank.image
+    case .applePay:
+      UIImage(primerResource: "apple-pay-icon-colored")
+    case .googlePay:
+      UIImage(primerResource: "google-pay-icon")
+    case .paymentCard:
+      ImageName.creditCard.image
+
+    // Alternative payment methods
+    case .hoolah:
+      UIImage(primerResource: "hoolah-icon-colored")
+    case .atome:
+      UIImage(primerResource: "atome-icon-colored")
+    case .coinbase:
+      UIImage(primerResource: "coinbase-icon-colored")
+
+    // Adyen payment methods
+    case .adyenAlipay:
+      UIImage(primerResource: "alipay-icon-colored")
+    case .adyenBlik:
+      UIImage(primerResource: "blik-icon-colored")
+    case .adyenBancontactCard:
+      UIImage(primerResource: "bancontact-card-logo-colored")
+    case .adyenDotPay:
+      UIImage(primerResource: "dotpay-icon-colored")
+    case .adyenGiropay:
+      UIImage(primerResource: "giropay-icon")
+    case .adyenIDeal:
+      UIImage(primerResource: "ideal-icon-colored")
+    case .adyenInterac:
+      UIImage(primerResource: "interac-icon-colored")
+    case .adyenMobilePay:
+      UIImage(primerResource: "mobile-pay-icon")
+    case .adyenMBWay:
+      UIImage(primerResource: "mb-way-icon")
+    case .adyenMultibanco:
+      UIImage(primerResource: "multibanco-logo-colored")
+    case .adyenPayTrail:
+      UIImage(primerResource: "paytrail-icon")
+    case .adyenPayshop:
+      UIImage(primerResource: "payshop-icon-colored")
+    case .adyenSofort, .primerTestSofort:
+      UIImage(primerResource: "sofort-icon-colored")
+    case .adyenTrustly:
+      UIImage(primerResource: "trustly-icon-colored")
+    case .adyenTwint:
+      UIImage(primerResource: "twint-icon-colored")
+    case .adyenVipps:
+      UIImage(primerResource: "vipps-icon-colored")
+
+    // Buckaroo payment methods
+    case .buckarooBancontact:
+      UIImage(primerResource: "bancontact-card-logo-colored")
+    case .buckarooEps:
+      UIImage(primerResource: "eps-icon-colored")
+    case .buckarooGiropay:
+      UIImage(primerResource: "giropay-icon")
+    case .buckarooIdeal:
+      UIImage(primerResource: "ideal-icon-colored")
+    case .buckarooSofort:
+      UIImage(primerResource: "sofort-icon-colored")
+
+    // Mollie payment methods
+    case .mollieBankcontact:
+      UIImage(primerResource: "bancontact-card-logo-colored")
+    case .mollieIdeal:
+      UIImage(primerResource: "ideal-icon-colored")
+
+    // Pay.nl payment methods
+    case .payNLBancontact:
+      UIImage(primerResource: "bancontact-card-logo-colored")
+    case .payNLGiropay:
+      UIImage(primerResource: "giropay-icon")
+    case .payNLIdeal:
+      UIImage(primerResource: "ideal-icon-colored")
+    case .payNLPayconiq:
+      UIImage(primerResource: "payconiq-icon-colored")
+
+    // Rapyd payment methods
+    case .rapydGCash:
+      UIImage(primerResource: "gcash-icon")
+    case .rapydGrabPay:
+      UIImage(primerResource: "grab-pay-icon")
+    case .rapydPromptPay, .omisePromptPay:
+      UIImage(primerResource: "promptpay-logo-colored")
+
+    // Other payment methods
+    case .xfersPayNow:
+      UIImage(primerResource: "paynow-icon-colored")
+    case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
+      UIImage(primerResource: "fintecture-icon")
+
+    // Fallback
+    default:
+      ImageName.genericCard.image
+    }
+  }
+}

--- a/Tests/Primer/CheckoutComponents/Bridge/CheckoutComponentsPaymentMethodsBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/CheckoutComponentsPaymentMethodsBridgeTests.swift
@@ -1,0 +1,392 @@
+//
+//  CheckoutComponentsPaymentMethodsBridgeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class CheckoutComponentsPaymentMethodsBridgeTests: XCTestCase {
+
+    private var mockConfigurationService: MockConfigurationService!
+    private var sut: CheckoutComponentsPaymentMethodsBridge!
+
+    override func setUp() {
+        super.setUp()
+        mockConfigurationService = MockConfigurationService()
+        sut = CheckoutComponentsPaymentMethodsBridge(configurationService: mockConfigurationService)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockConfigurationService = nil
+        super.tearDown()
+    }
+
+    // MARK: - Error Cases
+
+    func test_execute_whenNoConfiguration_throwsMissingPrimerConfiguration() async {
+        // Given
+        mockConfigurationService.apiConfiguration = nil
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch let error as PrimerError {
+            switch error {
+            case .missingPrimerConfiguration:
+                break // Expected error
+            default:
+                XCTFail("Expected missingPrimerConfiguration error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected PrimerError, got \(error)")
+        }
+    }
+
+    func test_execute_whenNoPaymentMethods_throwsMisconfiguredPaymentMethods() async {
+        // Given
+        mockConfigurationService.apiConfiguration = createConfiguration(paymentMethods: nil)
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch let error as PrimerError {
+            switch error {
+            case .misconfiguredPaymentMethods:
+                break // Expected error
+            default:
+                XCTFail("Expected misconfiguredPaymentMethods error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected PrimerError, got \(error)")
+        }
+    }
+
+    func test_execute_whenEmptyPaymentMethods_throwsMisconfiguredPaymentMethods() async {
+        // Given
+        mockConfigurationService.apiConfiguration = createConfiguration(paymentMethods: [])
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch let error as PrimerError {
+            switch error {
+            case .misconfiguredPaymentMethods:
+                break // Expected error
+            default:
+                XCTFail("Expected misconfiguredPaymentMethods error, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected PrimerError, got \(error)")
+        }
+    }
+
+    // MARK: - Success & Field Mapping
+
+    func test_execute_withValidPaymentMethods_mapsAllFieldsCorrectly() async throws {
+        // Given
+        let paymentMethods = [
+            createPaymentMethod(type: "PAYMENT_CARD", name: "Card", processorConfigId: "config-123", surcharge: 150),
+            createPaymentMethod(type: "PAYPAL", name: "PayPal")
+        ]
+        mockConfigurationService.apiConfiguration = createConfiguration(paymentMethods: paymentMethods)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result.count, 2)
+
+        let card = result[0]
+        XCTAssertEqual(card.id, "PAYMENT_CARD")
+        XCTAssertEqual(card.type, "PAYMENT_CARD")
+        XCTAssertEqual(card.name, "Card")
+        XCTAssertEqual(card.configId, "config-123")
+        XCTAssertTrue(card.isEnabled)
+        XCTAssertEqual(card.surcharge, 150)
+
+        let paypal = result[1]
+        XCTAssertEqual(paypal.id, "PAYPAL")
+        XCTAssertEqual(paypal.type, "PAYPAL")
+        XCTAssertEqual(paypal.name, "PayPal")
+    }
+
+    // MARK: - Required Input Elements
+
+    func test_execute_forPaymentCard_setsCardInputElements() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYMENT_CARD", name: "Card")]
+        mockConfigurationService.apiConfiguration = createConfiguration(paymentMethods: paymentMethods)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        let expectedElements: [PrimerInputElementType] = [.cardNumber, .cvv, .expiryDate, .cardholderName]
+        XCTAssertEqual(result.first?.requiredInputElements, expectedElements)
+    }
+
+    func test_execute_forNonCardPaymentMethod_setsEmptyInputElements() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYPAL", name: "PayPal")]
+        mockConfigurationService.apiConfiguration = createConfiguration(paymentMethods: paymentMethods)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertTrue(result.first?.requiredInputElements.isEmpty ?? false)
+    }
+
+    // MARK: - Multiple Payment Methods
+
+    func test_execute_withMultiplePaymentMethods_preservesOrder() async throws {
+        // Given
+        let paymentMethods = [
+            createPaymentMethod(type: "PAYPAL", name: "PayPal"),
+            createPaymentMethod(type: "PAYMENT_CARD", name: "Card"),
+            createPaymentMethod(type: "APPLE_PAY", name: "Apple Pay")
+        ]
+        mockConfigurationService.apiConfiguration = createConfiguration(paymentMethods: paymentMethods)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0].type, "PAYPAL")
+        XCTAssertEqual(result[1].type, "PAYMENT_CARD")
+        XCTAssertEqual(result[2].type, "APPLE_PAY")
+    }
+
+    // MARK: - Network Surcharges
+
+    func test_execute_forNonCardPaymentMethod_networkSurchargesIsNil() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYPAL", name: "PayPal")]
+        mockConfigurationService.apiConfiguration = createConfiguration(paymentMethods: paymentMethods)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertNil(result.first?.networkSurcharges)
+    }
+
+    func test_execute_forPaymentCard_withNoClientSession_networkSurchargesIsNil() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYMENT_CARD", name: "Card")]
+        mockConfigurationService.apiConfiguration = createConfiguration(paymentMethods: paymentMethods)
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertNil(result.first?.networkSurcharges)
+    }
+
+    // MARK: - Network Surcharges Array Format
+
+    func test_execute_forPaymentCard_withNetworksArrayNestedSurcharge_extractsSurcharges() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYMENT_CARD", name: "Card")]
+        let networksArray: [[String: Any]] = [
+            ["type": "VISA", "surcharge": ["amount": 100]],
+            ["type": "MASTERCARD", "surcharge": ["amount": 150]]
+        ]
+        let clientSession = createClientSessionWithNetworks(networksArray: networksArray)
+        mockConfigurationService.apiConfiguration = createConfiguration(
+            paymentMethods: paymentMethods,
+            clientSession: clientSession
+        )
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertNotNil(result.first?.networkSurcharges)
+        XCTAssertEqual(result.first?.networkSurcharges?["VISA"], 100)
+        XCTAssertEqual(result.first?.networkSurcharges?["MASTERCARD"], 150)
+    }
+
+    func test_execute_forPaymentCard_withNetworksArrayDirectSurcharge_extractsSurcharges() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYMENT_CARD", name: "Card")]
+        let networksArray: [[String: Any]] = [
+            ["type": "VISA", "surcharge": 200],
+            ["type": "AMEX", "surcharge": 300]
+        ]
+        let clientSession = createClientSessionWithNetworks(networksArray: networksArray)
+        mockConfigurationService.apiConfiguration = createConfiguration(
+            paymentMethods: paymentMethods,
+            clientSession: clientSession
+        )
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertNotNil(result.first?.networkSurcharges)
+        XCTAssertEqual(result.first?.networkSurcharges?["VISA"], 200)
+        XCTAssertEqual(result.first?.networkSurcharges?["AMEX"], 300)
+    }
+
+    func test_execute_forPaymentCard_withZeroSurcharges_returnsNil() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYMENT_CARD", name: "Card")]
+        let networksArray: [[String: Any]] = [
+            ["type": "VISA", "surcharge": 0],
+            ["type": "MASTERCARD", "surcharge": ["amount": 0]]
+        ]
+        let clientSession = createClientSessionWithNetworks(networksArray: networksArray)
+        mockConfigurationService.apiConfiguration = createConfiguration(
+            paymentMethods: paymentMethods,
+            clientSession: clientSession
+        )
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertNil(result.first?.networkSurcharges)
+    }
+
+    // MARK: - Network Surcharges Dict Format
+
+    func test_execute_forPaymentCard_withNetworksDictNestedSurcharge_extractsSurcharges() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYMENT_CARD", name: "Card")]
+        let networksDict: [String: [String: Any]] = [
+            "VISA": ["surcharge": ["amount": 100]],
+            "MASTERCARD": ["surcharge": ["amount": 200]]
+        ]
+        let clientSession = createClientSessionWithNetworks(networksDict: networksDict)
+        mockConfigurationService.apiConfiguration = createConfiguration(
+            paymentMethods: paymentMethods,
+            clientSession: clientSession
+        )
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertNotNil(result.first?.networkSurcharges)
+        XCTAssertEqual(result.first?.networkSurcharges?["VISA"], 100)
+        XCTAssertEqual(result.first?.networkSurcharges?["MASTERCARD"], 200)
+    }
+
+    func test_execute_forPaymentCard_withNetworksDictDirectSurcharge_extractsSurcharges() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYMENT_CARD", name: "Card")]
+        let networksDict: [String: [String: Any]] = [
+            "VISA": ["surcharge": 150],
+            "DISCOVER": ["surcharge": 250]
+        ]
+        let clientSession = createClientSessionWithNetworks(networksDict: networksDict)
+        mockConfigurationService.apiConfiguration = createConfiguration(
+            paymentMethods: paymentMethods,
+            clientSession: clientSession
+        )
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertNotNil(result.first?.networkSurcharges)
+        XCTAssertEqual(result.first?.networkSurcharges?["VISA"], 150)
+        XCTAssertEqual(result.first?.networkSurcharges?["DISCOVER"], 250)
+    }
+
+    // MARK: - Network Surcharges Edge Cases
+
+    func test_execute_forPaymentCard_withMissingNetworkType_skipsInvalidEntries() async throws {
+        // Given
+        let paymentMethods = [createPaymentMethod(type: "PAYMENT_CARD", name: "Card")]
+        let networksArray: [[String: Any]] = [
+            ["surcharge": 100], // Missing type
+            ["type": "VISA", "surcharge": 200]
+        ]
+        let clientSession = createClientSessionWithNetworks(networksArray: networksArray)
+        mockConfigurationService.apiConfiguration = createConfiguration(
+            paymentMethods: paymentMethods,
+            clientSession: clientSession
+        )
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result.first?.networkSurcharges?.count, 1)
+        XCTAssertEqual(result.first?.networkSurcharges?["VISA"], 200)
+    }
+
+    // MARK: - Helpers
+
+    private func createConfiguration(
+        paymentMethods: [PrimerPaymentMethod]?,
+        clientSession: ClientSession.APIResponse? = nil
+    ) -> PrimerAPIConfiguration {
+        PrimerAPIConfiguration(
+            coreUrl: "https://core.primer.io",
+            pciUrl: "https://pci.primer.io",
+            binDataUrl: "https://bindata.primer.io",
+            assetsUrl: "https://assets.staging.core.primer.io",
+            clientSession: clientSession,
+            paymentMethods: paymentMethods,
+            primerAccountId: nil,
+            keys: nil,
+            checkoutModules: nil
+        )
+    }
+
+    private func createPaymentMethod(
+        type: String,
+        name: String,
+        processorConfigId: String? = nil,
+        surcharge: Int? = nil
+    ) -> PrimerPaymentMethod {
+        PrimerPaymentMethod(
+            id: "pm-\(type)",
+            implementationType: .nativeSdk,
+            type: type,
+            name: name,
+            processorConfigId: processorConfigId,
+            surcharge: surcharge,
+            options: nil,
+            displayMetadata: nil
+        )
+    }
+
+    private func createClientSessionWithNetworks(
+        networksArray: [[String: Any]]? = nil,
+        networksDict: [String: [String: Any]]? = nil
+    ) -> ClientSession.APIResponse {
+        var paymentCardOption: [String: Any] = ["type": "PAYMENT_CARD"]
+        if let networksArray {
+            paymentCardOption["networks"] = networksArray
+        } else if let networksDict {
+            paymentCardOption["networks"] = networksDict
+        }
+
+        let paymentMethod = ClientSession.PaymentMethod(
+            vaultOnSuccess: false,
+            options: [paymentCardOption],
+            orderedAllowedCardNetworks: nil,
+            descriptor: nil
+        )
+
+        return ClientSession.APIResponse(
+            clientSessionId: "cs-123",
+            paymentMethod: paymentMethod,
+            order: nil,
+            customer: nil,
+            testId: nil
+        )
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Interactors/CardNetworkDetectionInteractorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Interactors/CardNetworkDetectionInteractorTests.swift
@@ -1,0 +1,235 @@
+//
+//  CardNetworkDetectionInteractorTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class CardNetworkDetectionInteractorTests: XCTestCase {
+
+    private var sut: CardNetworkDetectionInteractorImpl!
+    private var mockRepository: MockHeadlessRepository!
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockHeadlessRepository()
+        sut = CardNetworkDetectionInteractorImpl(repository: mockRepository)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    func test_networkDetectionStream_emitsInitialValue() async {
+        // Given
+        mockRepository.networkDetectionToReturn = [.visa]
+
+        // When
+        var receivedNetworks: [CardNetwork]?
+        for await networks in sut.networkDetectionStream {
+            receivedNetworks = networks
+            break // Just get the first value
+        }
+
+        // Then
+        XCTAssertEqual(receivedNetworks, [.visa])
+    }
+
+    func test_networkDetectionStream_emitsUpdatedValues() async {
+        // Given
+        mockRepository.networkDetectionToReturn = []
+
+        // Setup expectation for stream values
+        let expectation = XCTestExpectation(description: "Receive network updates")
+        var receivedValues: [[CardNetwork]] = []
+
+        // Create task to collect stream values
+        let task = Task {
+            for await networks in sut.networkDetectionStream {
+                receivedValues.append(networks)
+                if receivedValues.count >= 2 {
+                    expectation.fulfill()
+                    break
+                }
+            }
+        }
+
+        // When - emit a new value
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 second
+        mockRepository.emitNetworkDetection([.visa, .masterCard])
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 2.0)
+        task.cancel()
+
+        XCTAssertEqual(receivedValues.count, 2)
+        XCTAssertEqual(receivedValues[0], []) // Initial empty
+        XCTAssertEqual(receivedValues[1], [.visa, .masterCard]) // Updated
+    }
+
+    func test_detectNetworks_callsRepositoryWithCardNumber() async {
+        // Given
+        let cardNumber = TestData.CardNumbers.validVisa
+
+        // When
+        await sut.detectNetworks(for: cardNumber)
+
+        // Then
+        XCTAssertEqual(mockRepository.updateCardNumberCallCount, 1)
+        XCTAssertEqual(mockRepository.lastCardNumber, cardNumber)
+    }
+
+    func test_detectNetworks_withShortCardNumber_stillCallsRepository() async {
+        // Given - short card number (less than 8 digits)
+        let cardNumber = "4111"
+
+        // When
+        await sut.detectNetworks(for: cardNumber)
+
+        // Then - repository should still be called (it handles the < 8 digit case)
+        XCTAssertEqual(mockRepository.updateCardNumberCallCount, 1)
+        XCTAssertEqual(mockRepository.lastCardNumber, cardNumber)
+    }
+
+    func test_detectNetworks_withEmptyString_callsRepository() async {
+        // Given
+        let cardNumber = ""
+
+        // When
+        await sut.detectNetworks(for: cardNumber)
+
+        // Then
+        XCTAssertEqual(mockRepository.updateCardNumberCallCount, 1)
+        XCTAssertEqual(mockRepository.lastCardNumber, cardNumber)
+    }
+
+    func test_detectNetworks_multipleCalls_updatesEachTime() async {
+        // Given
+        let cardNumbers = ["4111", "41111111", TestData.CardNumbers.validVisa]
+
+        // When
+        for cardNumber in cardNumbers {
+            await sut.detectNetworks(for: cardNumber)
+        }
+
+        // Then
+        XCTAssertEqual(mockRepository.updateCardNumberCallCount, 3)
+        XCTAssertEqual(mockRepository.lastCardNumber, TestData.CardNumbers.validVisa)
+    }
+
+    func test_selectNetwork_callsRepositoryWithNetwork() async {
+        // Given
+        let network = CardNetwork.visa
+
+        // When
+        await sut.selectNetwork(network)
+
+        // Then
+        XCTAssertEqual(mockRepository.selectCardNetworkCallCount, 1)
+        XCTAssertEqual(mockRepository.lastSelectedNetwork, network)
+    }
+
+    func test_coBadgedFlow_detectThenSelect() async {
+        // Given - simulate co-badged card detection
+        mockRepository.networkDetectionToReturn = [.visa, .masterCard]
+
+        // When - detect networks first
+        await sut.detectNetworks(for: TestData.CardNumbers.validVisa)
+
+        // Then - select one network
+        await sut.selectNetwork(.visa)
+
+        // Verify flow
+        XCTAssertEqual(mockRepository.updateCardNumberCallCount, 1)
+        XCTAssertEqual(mockRepository.selectCardNetworkCallCount, 1)
+        XCTAssertEqual(mockRepository.lastSelectedNetwork, .visa)
+    }
+
+    func test_binDataStream_emitsCompleteBinData() async {
+        // Given
+        let binData = PrimerBinData(
+            preferred: PrimerCardNetwork(network: .visa),
+            alternatives: [PrimerCardNetwork(network: .masterCard)],
+            status: .complete,
+            firstDigits: "552266"
+        )
+        mockRepository.binDataToReturn = binData
+
+        // When
+        var receivedBinData: PrimerBinData?
+        for await data in sut.binDataStream {
+            receivedBinData = data
+            break
+        }
+
+        // Then
+        XCTAssertEqual(receivedBinData?.status, .complete)
+        XCTAssertEqual(receivedBinData?.firstDigits, "552266")
+        XCTAssertEqual(receivedBinData?.preferred?.network, .visa)
+        XCTAssertEqual(receivedBinData?.alternatives.count, 1)
+        XCTAssertEqual(receivedBinData?.alternatives.first?.network, .masterCard)
+    }
+
+    func test_binDataStream_emitsPartialBinData() async {
+        // Given
+        let binData = PrimerBinData(
+            preferred: PrimerCardNetwork(network: .visa),
+            alternatives: [],
+            status: .partial,
+            firstDigits: nil
+        )
+        mockRepository.binDataToReturn = binData
+
+        // When
+        var receivedBinData: PrimerBinData?
+        for await data in sut.binDataStream {
+            receivedBinData = data
+            break
+        }
+
+        // Then
+        XCTAssertEqual(receivedBinData?.status, .partial)
+        XCTAssertNil(receivedBinData?.firstDigits)
+        XCTAssertEqual(receivedBinData?.preferred?.network, .visa)
+        XCTAssertTrue(receivedBinData?.alternatives.isEmpty ?? false)
+    }
+
+    func test_binDataStream_emitsUpdatedValues() async {
+        // Given
+        let expectation = XCTestExpectation(description: "Receive bin data update")
+        var receivedValues: [PrimerBinData] = []
+
+        let task = Task {
+            for await data in sut.binDataStream {
+                receivedValues.append(data)
+                if receivedValues.count >= 1 {
+                    expectation.fulfill()
+                    break
+                }
+            }
+        }
+
+        // When - emit a new value
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let binData = PrimerBinData(
+            preferred: PrimerCardNetwork(network: .visa),
+            alternatives: [],
+            status: .complete,
+            firstDigits: "411111"
+        )
+        mockRepository.emitBinData(binData)
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 2.0)
+        task.cancel()
+
+        XCTAssertEqual(receivedValues.count, 1)
+        XCTAssertEqual(receivedValues[0].status, .complete)
+        XCTAssertEqual(receivedValues[0].firstDigits, "411111")
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Interactors/GetPaymentMethodsInteractorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Interactors/GetPaymentMethodsInteractorTests.swift
@@ -1,0 +1,149 @@
+//
+//  GetPaymentMethodsInteractorTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class GetPaymentMethodsInteractorTests: XCTestCase {
+
+    private var sut: GetPaymentMethodsInteractorImpl!
+    private var mockRepository: MockHeadlessRepository!
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockHeadlessRepository()
+        sut = GetPaymentMethodsInteractorImpl(repository: mockRepository)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    func test_execute_returnsPaymentMethodsFromRepository() async throws {
+        // Given
+        let expectedMethods = [
+            InternalPaymentMethod(
+                id: "card-1",
+                type: "PAYMENT_CARD",
+                name: "Credit Card",
+                isEnabled: true
+            ),
+            InternalPaymentMethod(
+                id: "paypal-1",
+                type: "PAYPAL",
+                name: "PayPal",
+                isEnabled: true
+            )
+        ]
+        mockRepository.paymentMethodsToReturn = expectedMethods
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].id, "card-1")
+        XCTAssertEqual(result[0].type, "PAYMENT_CARD")
+        XCTAssertEqual(result[1].id, "paypal-1")
+        XCTAssertEqual(result[1].type, "PAYPAL")
+    }
+
+    func test_execute_withEmptyPaymentMethods_returnsEmptyArray() async throws {
+        // Given
+        mockRepository.paymentMethodsToReturn = []
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_execute_withDisabledPaymentMethods_returnsAllMethods() async throws {
+        // Given
+        mockRepository.paymentMethodsToReturn = [
+            InternalPaymentMethod(
+                id: "card-1",
+                type: "PAYMENT_CARD",
+                name: "Credit Card",
+                isEnabled: true
+            ),
+            InternalPaymentMethod(
+                id: "klarna-1",
+                type: "KLARNA",
+                name: "Klarna",
+                isEnabled: false
+            )
+        ]
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(result.count, 2)
+        XCTAssertTrue(result[0].isEnabled)
+        XCTAssertFalse(result[1].isEnabled)
+    }
+
+    // MARK: - Error Tests
+
+    func test_execute_whenRepositoryThrowsError_propagatesError() async {
+        // Given
+        mockRepository.getPaymentMethodsError = TestError.networkFailure
+
+        // When/Then
+        do {
+            _ = try await sut.execute()
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(error is TestError)
+            XCTAssertEqual(error as? TestError, TestError.networkFailure)
+        }
+    }
+
+    // MARK: - State Change Tests
+
+    func test_execute_repositoryCanReturnDifferentResultsOnSubsequentCalls() async throws {
+        // Given - first call returns one method
+        mockRepository.paymentMethodsToReturn = [
+            InternalPaymentMethod(
+                id: "card-1",
+                type: "PAYMENT_CARD",
+                name: "Credit Card",
+                isEnabled: true
+            )
+        ]
+
+        // When - first call
+        let firstResult = try await sut.execute()
+
+        // Given - update for second call
+        mockRepository.paymentMethodsToReturn = [
+            InternalPaymentMethod(
+                id: "card-1",
+                type: "PAYMENT_CARD",
+                name: "Credit Card",
+                isEnabled: true
+            ),
+            InternalPaymentMethod(
+                id: "paypal-1",
+                type: "PAYPAL",
+                name: "PayPal",
+                isEnabled: true
+            )
+        ]
+
+        // When - second call
+        let secondResult = try await sut.execute()
+
+        // Then
+        XCTAssertEqual(firstResult.count, 1)
+        XCTAssertEqual(secondResult.count, 2)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Interactors/ProcessCardPaymentInteractorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Interactors/ProcessCardPaymentInteractorTests.swift
@@ -1,0 +1,116 @@
+//
+//  ProcessCardPaymentInteractorTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class ProcessCardPaymentInteractorTests: XCTestCase {
+
+    private var sut: ProcessCardPaymentInteractorImpl!
+    private var mockRepository: MockHeadlessRepository!
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockHeadlessRepository()
+        sut = ProcessCardPaymentInteractorImpl(repository: mockRepository)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    // MARK: - Success Tests
+
+    func test_execute_withValidCardData_returnsPaymentResult() async throws {
+        // Given
+        let cardData = createTestCardData()
+        mockRepository.paymentResultToReturn = PaymentResult(
+            paymentId: "test-payment-123",
+            status: .success
+        )
+
+        // When
+        let result = try await sut.execute(cardData: cardData)
+
+        // Then
+        XCTAssertEqual(result.paymentId, "test-payment-123")
+        XCTAssertEqual(result.status, .success)
+    }
+
+    func test_execute_callsRepositoryWithCorrectData() async throws {
+        // Given
+        let cardData = createTestCardData()
+        mockRepository.paymentResultToReturn = PaymentResult(
+            paymentId: "test-payment",
+            status: .success
+        )
+
+        // When
+        _ = try await sut.execute(cardData: cardData)
+
+        // Then
+        XCTAssertEqual(mockRepository.processCardPaymentCallCount, 1)
+        XCTAssertEqual(mockRepository.lastCardNumber, cardData.cardNumber)
+        XCTAssertEqual(mockRepository.lastCVV, cardData.cvv)
+        XCTAssertEqual(mockRepository.lastExpiryMonth, cardData.expiryMonth)
+        XCTAssertEqual(mockRepository.lastExpiryYear, cardData.expiryYear)
+        XCTAssertEqual(mockRepository.lastCardholderName, cardData.cardholderName)
+    }
+
+    func test_execute_withSelectedNetwork_passesNetworkToRepository() async throws {
+        // Given
+        let cardData = CardPaymentData(
+            cardNumber: TestData.CardNumbers.validVisa,
+            cvv: TestData.CVV.valid3Digit,
+            expiryMonth: "12",
+            expiryYear: "2030",
+            cardholderName: TestData.CardholderNames.valid,
+            selectedNetwork: .visa
+        )
+        mockRepository.paymentResultToReturn = PaymentResult(
+            paymentId: "test-payment",
+            status: .success
+        )
+
+        // When
+        _ = try await sut.execute(cardData: cardData)
+
+        // Then
+        XCTAssertEqual(mockRepository.lastSelectedNetwork, .visa)
+    }
+
+    // MARK: - Error Tests
+
+    func test_execute_whenPaymentFails_throwsError() async {
+        // Given
+        let cardData = createTestCardData()
+        mockRepository.processCardPaymentError = TestError.networkFailure
+
+        // When/Then
+        do {
+            _ = try await sut.execute(cardData: cardData)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func createTestCardData() -> CardPaymentData {
+        CardPaymentData(
+            cardNumber: TestData.CardNumbers.validVisa,
+            cvv: TestData.CVV.valid3Digit,
+            expiryMonth: "12",
+            expiryYear: "2030",
+            cardholderName: TestData.CardholderNames.valid,
+            selectedNetwork: nil
+        )
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Interactors/SubmitVaultedPaymentInteractorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Interactors/SubmitVaultedPaymentInteractorTests.swift
@@ -1,0 +1,174 @@
+//
+//  SubmitVaultedPaymentInteractorTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class SubmitVaultedPaymentInteractorTests: XCTestCase {
+
+    // MARK: - Success Tests
+
+    func testExecute_Success_ReturnsPaymentResult() async throws {
+        // Given
+        let expectedResult = PaymentResult(
+            paymentId: "pay_123",
+            status: .success,
+            token: "token_abc",
+            paymentMethodType: "PAYMENT_CARD"
+        )
+        let repository = SpyHeadlessRepository()
+        await repository.setProcessVaultedPaymentResult(.success(expectedResult))
+        let interactor = SubmitVaultedPaymentInteractorImpl(repository: repository)
+
+        // When
+        let result = try await interactor.execute(
+            vaultedPaymentMethodId: "vault_456",
+            paymentMethodType: "PAYMENT_CARD",
+            additionalData: nil
+        )
+
+        // Then
+        XCTAssertEqual(result.paymentId, expectedResult.paymentId)
+        XCTAssertEqual(result.status, .success)
+        XCTAssertEqual(result.paymentMethodType, "PAYMENT_CARD")
+    }
+
+    func testExecute_WithAdditionalData_PassesDataToRepository() async throws {
+        // Given
+        let repository = SpyHeadlessRepository()
+        await repository.setProcessVaultedPaymentResult(.success(PaymentResult(
+            paymentId: "pay_123",
+            status: .success
+        )))
+        let interactor = SubmitVaultedPaymentInteractorImpl(repository: repository)
+        let cvvData = PrimerVaultedCardAdditionalData(cvv: "123")
+
+        // When
+        _ = try await interactor.execute(
+            vaultedPaymentMethodId: "vault_789",
+            paymentMethodType: "PAYMENT_CARD",
+            additionalData: cvvData
+        )
+
+        // Then
+        let call = try await repository.nextProcessVaultedPaymentCall()
+        XCTAssertEqual(call.vaultedPaymentMethodId, "vault_789")
+        XCTAssertEqual(call.paymentMethodType, "PAYMENT_CARD")
+        XCTAssertNotNil(call.additionalData)
+    }
+
+    // MARK: - Error Tests
+
+    func testExecute_RepositoryThrows_PropagatesError() async throws {
+        // Given
+        let expectedError = NSError(domain: "TestError", code: 500, userInfo: [NSLocalizedDescriptionKey: "Payment failed"])
+        let repository = SpyHeadlessRepository()
+        await repository.setProcessVaultedPaymentResult(.failure(expectedError))
+        let interactor = SubmitVaultedPaymentInteractorImpl(repository: repository)
+
+        // When/Then
+        do {
+            _ = try await interactor.execute(
+                vaultedPaymentMethodId: "vault_error",
+                paymentMethodType: "PAYMENT_CARD",
+                additionalData: nil
+            )
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, "TestError")
+            XCTAssertEqual((error as NSError).code, 500)
+        }
+    }
+}
+
+// MARK: - Spy HeadlessRepository
+
+@available(iOS 15.0, *)
+private actor SpyHeadlessRepository: HeadlessRepository {
+
+    struct ProcessVaultedPaymentCall {
+        let vaultedPaymentMethodId: String
+        let paymentMethodType: String
+        let additionalData: PrimerVaultedPaymentMethodAdditionalData?
+    }
+
+    private var processVaultedPaymentResult: Result<PaymentResult, Error> = .success(PaymentResult(paymentId: "", status: .success))
+    private var processVaultedPaymentCalls: [ProcessVaultedPaymentCall] = []
+
+    private enum WaitError: Error {
+        case timeout
+    }
+
+    func setProcessVaultedPaymentResult(_ result: Result<PaymentResult, Error>) {
+        processVaultedPaymentResult = result
+    }
+
+    func nextProcessVaultedPaymentCall(timeout: TimeInterval = 1) async throws -> ProcessVaultedPaymentCall {
+        let deadline = Date().addingTimeInterval(timeout)
+        while processVaultedPaymentCalls.isEmpty {
+            if Date() > deadline {
+                throw WaitError.timeout
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return processVaultedPaymentCalls.removeFirst()
+    }
+
+    // MARK: - HeadlessRepository Protocol - Vault Methods
+
+    func processVaultedPayment(
+        vaultedPaymentMethodId: String,
+        paymentMethodType: String,
+        additionalData: PrimerVaultedPaymentMethodAdditionalData?
+    ) async throws -> PaymentResult {
+        processVaultedPaymentCalls.append(ProcessVaultedPaymentCall(
+            vaultedPaymentMethodId: vaultedPaymentMethodId,
+            paymentMethodType: paymentMethodType,
+            additionalData: additionalData
+        ))
+
+        switch processVaultedPaymentResult {
+        case let .success(result):
+            return result
+        case let .failure(error):
+            throw error
+        }
+    }
+
+    func fetchVaultedPaymentMethods() async throws -> [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] {
+        []
+    }
+
+    func deleteVaultedPaymentMethod(_ id: String) async throws {}
+
+    // MARK: - HeadlessRepository Protocol - Other Methods (stubs)
+
+    func getPaymentMethods() async throws -> [InternalPaymentMethod] { [] }
+
+    func processCardPayment(
+        cardNumber: String,
+        cvv: String,
+        expiryMonth: String,
+        expiryYear: String,
+        cardholderName: String,
+        selectedNetwork: CardNetwork?
+    ) async throws -> PaymentResult {
+        PaymentResult(paymentId: "", status: .success)
+    }
+
+    nonisolated func getNetworkDetectionStream() -> AsyncStream<[CardNetwork]> {
+        AsyncStream { _ in }
+    }
+
+    nonisolated func getBinDataStream() -> AsyncStream<PrimerBinData> {
+        AsyncStream { _ in }
+    }
+
+    func updateCardNumberInRawDataManager(_ cardNumber: String) async {}
+
+    func selectCardNetwork(_ cardNetwork: CardNetwork) async {}
+}

--- a/Tests/Primer/CheckoutComponents/Interactors/ValidateInputInteractorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Interactors/ValidateInputInteractorTests.swift
@@ -1,0 +1,133 @@
+//
+//  ValidateInputInteractorTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class ValidateInputInteractorTests: XCTestCase {
+
+    private var sut: ValidateInputInteractorImpl!
+    private var mockValidationService: MockValidationService!
+
+    override func setUp() {
+        super.setUp()
+        mockValidationService = MockValidationService()
+        sut = ValidateInputInteractorImpl(validationService: mockValidationService)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockValidationService = nil
+        super.tearDown()
+    }
+
+    // MARK: - Single Field Validation Tests
+
+    func test_validate_withValidInput_returnsValidResult() async {
+        // Given
+        mockValidationService.stubbedValidationResult = ValidationResult.valid
+        let value = TestData.CardNumbers.validVisa
+        let type = PrimerInputElementType.cardNumber
+
+        // When
+        let result = await sut.validate(value: value, type: type)
+
+        // Then
+        XCTAssertTrue(result.isValid)
+    }
+
+    func test_validate_withInvalidInput_returnsInvalidResult() async {
+        // Given
+        mockValidationService.stubbedValidationResult = ValidationResult.invalid(
+            code: TestData.ErrorCodes.invalidCard,
+            message: TestData.ErrorMessages.invalidCardNumber
+        )
+        let value = TestData.CardNumbers.tooShort
+        let type = PrimerInputElementType.cardNumber
+
+        // When
+        let result = await sut.validate(value: value, type: type)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.errorCode, TestData.ErrorCodes.invalidCard)
+        XCTAssertEqual(result.errorMessage, TestData.ErrorMessages.invalidCardNumber)
+    }
+
+    // MARK: - Multiple Fields Validation Tests
+
+    func test_validateMultiple_allValid_returnsAllValidResults() async {
+        // Given
+        mockValidationService.stubbedValidationResult = ValidationResult.valid
+        let fields: [PrimerInputElementType: String] = [
+            .cardNumber: TestData.CardNumbers.validVisa,
+            .cvv: TestData.CVV.valid3Digit
+        ]
+
+        // When
+        let results = await sut.validateMultiple(fields: fields)
+
+        // Then
+        XCTAssertTrue(results[.cardNumber]?.isValid ?? false)
+        XCTAssertTrue(results[.cvv]?.isValid ?? false)
+    }
+
+    func test_validateMultiple_withMixedResults_returnsCorrectResults() async {
+        // Given
+        mockValidationService.stubResult(
+            for: .cardNumber,
+            result: ValidationResult.valid
+        )
+        mockValidationService.stubResult(
+            for: .cvv,
+            result: ValidationResult.invalid(code: TestData.ErrorCodes.invalidCVV, message: TestData.ErrorMessages.invalidCVV)
+        )
+
+        let fields: [PrimerInputElementType: String] = [
+            .cardNumber: TestData.CardNumbers.validVisa,
+            .cvv: TestData.CVV.tooShort
+        ]
+
+        // When
+        let results = await sut.validateMultiple(fields: fields)
+
+        // Then
+        XCTAssertTrue(results[.cardNumber]?.isValid ?? false)
+        XCTAssertFalse(results[.cvv]?.isValid ?? true)
+        XCTAssertEqual(results[.cvv]?.errorCode, TestData.ErrorCodes.invalidCVV)
+    }
+
+    func test_validateMultiple_withEmptyFields_returnsEmptyResults() async {
+        // Given
+        let fields: [PrimerInputElementType: String] = [:]
+
+        // When
+        let results = await sut.validateMultiple(fields: fields)
+
+        // Then
+        XCTAssertTrue(results.isEmpty)
+        XCTAssertEqual(mockValidationService.validateFieldCallCount, 0)
+    }
+
+    func test_validateMultiple_preservesFieldKeys() async {
+        // Given
+        let fields: [PrimerInputElementType: String] = [
+            .firstName: TestData.Names.firstName,
+            .lastName: TestData.Names.lastName,
+            .email: TestData.EmailAddresses.valid
+        ]
+
+        // When
+        let results = await sut.validateMultiple(fields: fields)
+
+        // Then
+        XCTAssertNotNil(results[.firstName])
+        XCTAssertNotNil(results[.lastName])
+        XCTAssertNotNil(results[.email])
+        XCTAssertNil(results[.cardNumber]) // Not in input
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockClientSessionActionsModule.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockClientSessionActionsModule.swift
@@ -1,0 +1,58 @@
+//
+//  MockClientSessionActionsModule.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class MockClientSessionActionsModule: ClientSessionActionsProtocol {
+
+    var selectPaymentMethodError: Error?
+    var unselectPaymentMethodError: Error?
+    var dispatchActionsError: Error?
+
+    private(set) var selectPaymentMethodCalls: [(type: String, network: String?)] = []
+    private(set) var unselectPaymentMethodCallCount = 0
+    private(set) var dispatchActionsCalls: [[ClientSession.Action]] = []
+
+    var lastSelectPaymentMethodCall: (type: String, network: String?)? {
+        selectPaymentMethodCalls.last
+    }
+
+    var lastDispatchActionsCall: [ClientSession.Action]? {
+        dispatchActionsCalls.last
+    }
+
+    func reset() {
+        selectPaymentMethodCalls = []
+        unselectPaymentMethodCallCount = 0
+        dispatchActionsCalls = []
+        selectPaymentMethodError = nil
+        unselectPaymentMethodError = nil
+        dispatchActionsError = nil
+    }
+
+    func selectPaymentMethodIfNeeded(_ paymentMethodType: String, cardNetwork: String?) async throws {
+        selectPaymentMethodCalls.append((paymentMethodType, cardNetwork))
+        if let selectPaymentMethodError {
+            throw selectPaymentMethodError
+        }
+    }
+
+    func unselectPaymentMethodIfNeeded() async throws {
+        unselectPaymentMethodCallCount += 1
+        if let unselectPaymentMethodError {
+            throw unselectPaymentMethodError
+        }
+    }
+
+    func dispatch(actions: [ClientSession.Action]) async throws {
+        dispatchActionsCalls.append(actions)
+        if let dispatchActionsError {
+            throw dispatchActionsError
+        }
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockHeadlessRepository.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockHeadlessRepository.swift
@@ -1,0 +1,232 @@
+//
+//  MockHeadlessRepository.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class MockHeadlessRepository: HeadlessRepository {
+
+    // MARK: - Configurable Return Values
+
+    var paymentMethodsToReturn: [InternalPaymentMethod] = []
+    var paymentResultToReturn: PaymentResult?
+    var networkDetectionToReturn: [CardNetwork] = []
+    var vaultedPaymentMethodsToReturn: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
+
+    // MARK: - Error Configuration
+
+    var getPaymentMethodsError: Error?
+    var processCardPaymentError: Error?
+    var fetchVaultedPaymentMethodsError: Error?
+    var processVaultedPaymentError: Error?
+    var deleteVaultedPaymentMethodError: Error?
+
+    // MARK: - Call Tracking
+
+    private(set) var getPaymentMethodsCallCount = 0
+    private(set) var processCardPaymentCallCount = 0
+    private(set) var updateCardNumberCallCount = 0
+    private(set) var selectCardNetworkCallCount = 0
+    private(set) var fetchVaultedPaymentMethodsCallCount = 0
+    private(set) var processVaultedPaymentCallCount = 0
+    private(set) var deleteVaultedPaymentMethodCallCount = 0
+
+    // MARK: - Captured Parameters
+
+    private(set) var lastCardNumber: String?
+    private(set) var lastCVV: String?
+    private(set) var lastExpiryMonth: String?
+    private(set) var lastExpiryYear: String?
+    private(set) var lastCardholderName: String?
+    private(set) var lastSelectedNetwork: CardNetwork?
+    private(set) var lastVaultedPaymentMethodId: String?
+    private(set) var lastVaultedPaymentMethodType: String?
+    private(set) var lastVaultedPaymentAdditionalData: PrimerVaultedPaymentMethodAdditionalData?
+    private(set) var lastDeletedVaultedPaymentMethodId: String?
+
+    // MARK: - Network Detection Stream Support
+
+    private var networkDetectionContinuation: AsyncStream<[CardNetwork]>.Continuation?
+    private var binDataContinuation: AsyncStream<PrimerBinData>.Continuation?
+    var binDataToReturn: PrimerBinData?
+
+    // MARK: - HeadlessRepository Protocol
+
+    func getPaymentMethods() async throws -> [InternalPaymentMethod] {
+        getPaymentMethodsCallCount += 1
+        if let getPaymentMethodsError {
+            throw getPaymentMethodsError
+        }
+        return paymentMethodsToReturn
+    }
+
+    func processCardPayment(
+        cardNumber: String,
+        cvv: String,
+        expiryMonth: String,
+        expiryYear: String,
+        cardholderName: String,
+        selectedNetwork: CardNetwork?
+    ) async throws -> PaymentResult {
+        processCardPaymentCallCount += 1
+
+        lastCardNumber = cardNumber
+        lastCVV = cvv
+        lastExpiryMonth = expiryMonth
+        lastExpiryYear = expiryYear
+        lastCardholderName = cardholderName
+        lastSelectedNetwork = selectedNetwork
+
+        if let processCardPaymentError {
+            throw processCardPaymentError
+        }
+
+        guard let result = paymentResultToReturn else {
+            throw TestError.unknown
+        }
+        return result
+    }
+
+    func getNetworkDetectionStream() -> AsyncStream<[CardNetwork]> {
+        AsyncStream { [self] continuation in
+            networkDetectionContinuation = continuation
+            continuation.yield(networkDetectionToReturn)
+        }
+    }
+
+    func getBinDataStream() -> AsyncStream<PrimerBinData> {
+        AsyncStream { [self] continuation in
+            binDataContinuation = continuation
+            if let binDataToReturn {
+                continuation.yield(binDataToReturn)
+            }
+        }
+    }
+
+    func updateCardNumberInRawDataManager(_ cardNumber: String) async {
+        updateCardNumberCallCount += 1
+        lastCardNumber = cardNumber
+    }
+
+    func selectCardNetwork(_ cardNetwork: CardNetwork) async {
+        selectCardNetworkCallCount += 1
+        lastSelectedNetwork = cardNetwork
+    }
+
+    func fetchVaultedPaymentMethods() async throws -> [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] {
+        fetchVaultedPaymentMethodsCallCount += 1
+        if let fetchVaultedPaymentMethodsError {
+            throw fetchVaultedPaymentMethodsError
+        }
+        return vaultedPaymentMethodsToReturn
+    }
+
+    func processVaultedPayment(
+        vaultedPaymentMethodId: String,
+        paymentMethodType: String,
+        additionalData: PrimerVaultedPaymentMethodAdditionalData?
+    ) async throws -> PaymentResult {
+        processVaultedPaymentCallCount += 1
+
+        lastVaultedPaymentMethodId = vaultedPaymentMethodId
+        lastVaultedPaymentMethodType = paymentMethodType
+        lastVaultedPaymentAdditionalData = additionalData
+
+        if let processVaultedPaymentError {
+            throw processVaultedPaymentError
+        }
+
+        guard let result = paymentResultToReturn else {
+            throw TestError.unknown
+        }
+        return result
+    }
+
+    func deleteVaultedPaymentMethod(_ id: String) async throws {
+        deleteVaultedPaymentMethodCallCount += 1
+        lastDeletedVaultedPaymentMethodId = id
+
+        if let deleteVaultedPaymentMethodError {
+            throw deleteVaultedPaymentMethodError
+        }
+    }
+
+    // MARK: - Test Helpers
+
+    func emitNetworkDetection(_ networks: [CardNetwork]) {
+        networkDetectionContinuation?.yield(networks)
+    }
+
+    func emitBinData(_ binData: PrimerBinData) {
+        binDataContinuation?.yield(binData)
+    }
+
+    func reset() {
+        getPaymentMethodsCallCount = 0
+        processCardPaymentCallCount = 0
+        updateCardNumberCallCount = 0
+        selectCardNetworkCallCount = 0
+        fetchVaultedPaymentMethodsCallCount = 0
+        processVaultedPaymentCallCount = 0
+        deleteVaultedPaymentMethodCallCount = 0
+
+        lastCardNumber = nil
+        lastCVV = nil
+        lastExpiryMonth = nil
+        lastExpiryYear = nil
+        lastCardholderName = nil
+        lastSelectedNetwork = nil
+        lastVaultedPaymentMethodId = nil
+        lastVaultedPaymentMethodType = nil
+        lastVaultedPaymentAdditionalData = nil
+        lastDeletedVaultedPaymentMethodId = nil
+
+        binDataToReturn = nil
+        binDataContinuation = nil
+
+        getPaymentMethodsError = nil
+        processCardPaymentError = nil
+        fetchVaultedPaymentMethodsError = nil
+        processVaultedPaymentError = nil
+        deleteVaultedPaymentMethodError = nil
+    }
+}
+
+// MARK: - Test Data Factory Methods
+
+@available(iOS 15.0, *)
+extension MockHeadlessRepository {
+
+    static func withDefaultPaymentMethods() -> MockHeadlessRepository {
+        let repository = MockHeadlessRepository()
+        let methods: [InternalPaymentMethod] = [
+            InternalPaymentMethod(
+                id: TestData.PaymentMethodIds.cardId,
+                type: TestData.PaymentMethodTypes.card,
+                name: TestData.PaymentMethodNames.cardName,
+                isEnabled: true
+            ),
+            InternalPaymentMethod(
+                id: TestData.PaymentMethodIds.paypalId,
+                type: TestData.PaymentMethodTypes.paypal,
+                name: TestData.PaymentMethodNames.paypalName,
+                isEnabled: true
+            )
+        ]
+        repository.paymentMethodsToReturn = methods
+        return repository
+    }
+
+    static func withSuccessfulPayment() -> MockHeadlessRepository {
+        let repository = MockHeadlessRepository()
+        repository.paymentResultToReturn = PaymentResult(
+            paymentId: TestData.PaymentIds.success,
+            status: .success
+        )
+        return repository
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockRawDataManager.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockRawDataManager.swift
@@ -1,0 +1,183 @@
+//
+//  MockRawDataManager.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class MockRawDataManager: RawDataManagerProtocol {
+
+    // MARK: - Protocol Properties
+
+    weak var delegate: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate?
+    var rawData: PrimerRawData? {
+        didSet {
+            rawDataSetCount += 1
+            rawDataHistory.append(rawData)
+            onRawDataSet?(rawData)
+
+            if autoTriggerValidation {
+                triggerValidationCallback()
+            }
+        }
+    }
+    var isDataValid: Bool = true
+    var requiredInputElementTypes: [PrimerInputElementType] = [.cardNumber, .expiryDate, .cvv]
+
+    // MARK: - Internal Properties
+
+    var onRawDataSet: ((PrimerRawData?) -> Void)?
+    var autoTriggerValidation: Bool = false
+    var validationDelay: TimeInterval = 0.05
+
+    // MARK: - Call Tracking
+
+    private(set) var configureCallCount = 0
+    private(set) var submitCallCount = 0
+    private(set) var rawDataSetCount = 0
+    private(set) var rawDataHistory: [PrimerRawData?] = []
+
+    // MARK: - Configuration
+
+    var configureError: Error?
+    var initializationData: PrimerInitializationData?
+    var validationErrors: [Error]?
+    var onSubmit: (() -> Void)?
+    var simulateSuccessfulPayment = false
+    var paymentError: Error?
+
+    // MARK: - Protocol Implementation
+
+    func configure(completion: @escaping (PrimerInitializationData?, Error?) -> Void) {
+        configureCallCount += 1
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            completion(initializationData, configureError)
+        }
+    }
+
+    func submit() {
+        submitCallCount += 1
+        onSubmit?()
+    }
+
+    // MARK: - Test Helpers
+
+    func triggerValidationCallback() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + validationDelay) { [weak self] in
+            guard let self, let delegate else { return }
+
+            do {
+                let rawDataManager = try PrimerHeadlessUniversalCheckout.RawDataManager(paymentMethodType: "PAYMENT_CARD")
+                delegate.primerRawDataManager?(
+                    rawDataManager,
+                    dataIsValid: isDataValid,
+                    errors: validationErrors
+                )
+            } catch {
+                // Expected in unit tests without full SDK configuration
+            }
+        }
+    }
+
+    func triggerValidationCallback(isValid: Bool, errors: [Error]?) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + validationDelay) { [weak self] in
+            guard let self, let delegate else { return }
+
+            do {
+                let rawDataManager = try PrimerHeadlessUniversalCheckout.RawDataManager(paymentMethodType: "PAYMENT_CARD")
+                delegate.primerRawDataManager?(
+                    rawDataManager,
+                    dataIsValid: isValid,
+                    errors: errors
+                )
+            } catch {
+                // Expected in unit tests without full SDK configuration
+            }
+        }
+    }
+
+    func reset() {
+        delegate = nil
+        rawData = nil
+        isDataValid = true
+        configureCallCount = 0
+        submitCallCount = 0
+        rawDataSetCount = 0
+        rawDataHistory = []
+        configureError = nil
+        initializationData = nil
+        validationErrors = nil
+        onSubmit = nil
+        simulateSuccessfulPayment = false
+        paymentError = nil
+        autoTriggerValidation = false
+        validationDelay = 0.05
+    }
+}
+
+// MARK: - Mock Factory
+
+@available(iOS 15.0, *)
+final class MockRawDataManagerFactory: RawDataManagerFactoryProtocol {
+
+    // MARK: - Configuration
+
+    var mockRawDataManager: MockRawDataManager?
+    var createError: Error?
+    var createMockHandler: ((String, PrimerHeadlessUniversalCheckoutRawDataManagerDelegate?) -> MockRawDataManager)?
+
+    // MARK: - Call Tracking
+
+    private(set) var createCallCount = 0
+    private(set) var createCalls: [(paymentMethodType: String, delegate: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate?)] = []
+
+    // MARK: - Computed Properties
+
+    var lastCreateCall: (paymentMethodType: String, delegate: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate?)? {
+        createCalls.last
+    }
+
+    // MARK: - Protocol Implementation
+
+    func createRawDataManager(
+        paymentMethodType: String,
+        delegate: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate?
+    ) throws -> RawDataManagerProtocol {
+        createCallCount += 1
+        createCalls.append((paymentMethodType, delegate))
+
+        if let createError {
+            throw createError
+        }
+
+        if let createMockHandler {
+            let mock = createMockHandler(paymentMethodType, delegate)
+            mock.delegate = delegate
+            return mock
+        }
+
+        if let mockRawDataManager {
+            mockRawDataManager.delegate = delegate
+            return mockRawDataManager
+        }
+
+        let mock = MockRawDataManager()
+        mock.delegate = delegate
+        return mock
+    }
+
+    // MARK: - Test Helpers
+
+    func reset() {
+        createCallCount = 0
+        createCalls = []
+        mockRawDataManager = nil
+        createError = nil
+        createMockHandler = nil
+    }
+}

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -1,0 +1,284 @@
+//
+//  PrimerPaymentMethodTypeImageNameTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+// MARK: - defaultImageName Tests
+
+@available(iOS 15.0, *)
+final class PrimerPaymentMethodTypeDefaultImageNameTests: XCTestCase {
+
+    // MARK: - Primary Payment Methods
+
+    func test_defaultImageName_payPal_returnsPaypalImage() {
+        XCTAssertEqual(PrimerPaymentMethodType.payPal.defaultImageName, .paypal)
+    }
+
+    func test_defaultImageName_primerTestPayPal_returnsPaypalImage() {
+        XCTAssertEqual(PrimerPaymentMethodType.primerTestPayPal.defaultImageName, .paypal)
+    }
+
+    func test_defaultImageName_klarna_returnsKlarnaImage() {
+        XCTAssertEqual(PrimerPaymentMethodType.klarna.defaultImageName, .klarna)
+    }
+
+    func test_defaultImageName_primerTestKlarna_returnsKlarnaImage() {
+        XCTAssertEqual(PrimerPaymentMethodType.primerTestKlarna.defaultImageName, .klarna)
+    }
+
+    func test_defaultImageName_paymentCard_returnsCreditCardImage() {
+        XCTAssertEqual(PrimerPaymentMethodType.paymentCard.defaultImageName, .creditCard)
+    }
+
+    func test_defaultImageName_applePay_returnsAppleIconImage() {
+        XCTAssertEqual(PrimerPaymentMethodType.applePay.defaultImageName, .appleIcon)
+    }
+
+    func test_defaultImageName_googlePay_returnsAppleIconImage() {
+        // Google Pay uses same icon as Apple Pay
+        XCTAssertEqual(PrimerPaymentMethodType.googlePay.defaultImageName, .appleIcon)
+    }
+
+    // MARK: - ACH Payment Methods
+
+    func test_defaultImageName_goCardless_returnsAchBankImage() {
+        XCTAssertEqual(PrimerPaymentMethodType.goCardless.defaultImageName, .achBank)
+    }
+
+    func test_defaultImageName_stripeAch_returnsAchBankImage() {
+        XCTAssertEqual(PrimerPaymentMethodType.stripeAch.defaultImageName, .achBank)
+    }
+
+    // MARK: - Fallback
+
+    func test_defaultImageName_unknownType_returnsGenericCard() {
+        // Adyen payment methods don't have specific ImageName mappings
+        XCTAssertEqual(PrimerPaymentMethodType.adyenBlik.defaultImageName, .genericCard)
+        XCTAssertEqual(PrimerPaymentMethodType.adyenIDeal.defaultImageName, .genericCard)
+        XCTAssertEqual(PrimerPaymentMethodType.hoolah.defaultImageName, .genericCard)
+    }
+}
+
+// MARK: - icon Property Tests
+
+@available(iOS 15.0, *)
+final class PrimerPaymentMethodTypeIconTests: XCTestCase {
+
+    // MARK: - Primary Payment Methods
+
+    func test_icon_payPal_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.payPal.icon)
+    }
+
+    func test_icon_primerTestPayPal_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.primerTestPayPal.icon)
+    }
+
+    func test_icon_klarna_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.klarna.icon)
+    }
+
+    func test_icon_primerTestKlarna_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.primerTestKlarna.icon)
+    }
+
+    func test_icon_goCardless_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.goCardless.icon)
+    }
+
+    func test_icon_stripeAch_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.stripeAch.icon)
+    }
+
+    func test_icon_applePay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.applePay.icon)
+    }
+
+    func test_icon_googlePay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.googlePay.icon)
+    }
+
+    func test_icon_paymentCard_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.paymentCard.icon)
+    }
+
+    // MARK: - Alternative Payment Methods
+
+    func test_icon_hoolah_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.hoolah.icon)
+    }
+
+    func test_icon_atome_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.atome.icon)
+    }
+
+    func test_icon_coinbase_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.coinbase.icon)
+    }
+
+    // MARK: - Adyen Payment Methods
+
+    func test_icon_adyenAlipay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenAlipay.icon)
+    }
+
+    func test_icon_adyenBlik_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenBlik.icon)
+    }
+
+    func test_icon_adyenBancontactCard_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenBancontactCard.icon)
+    }
+
+    func test_icon_adyenDotPay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenDotPay.icon)
+    }
+
+    func test_icon_adyenGiropay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenGiropay.icon)
+    }
+
+    func test_icon_adyenIDeal_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenIDeal.icon)
+    }
+
+    func test_icon_adyenInterac_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenInterac.icon)
+    }
+
+    func test_icon_adyenMobilePay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenMobilePay.icon)
+    }
+
+    func test_icon_adyenMBWay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenMBWay.icon)
+    }
+
+    func test_icon_adyenMultibanco_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenMultibanco.icon)
+    }
+
+    func test_icon_adyenPayTrail_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenPayTrail.icon)
+    }
+
+    func test_icon_adyenPayshop_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenPayshop.icon)
+    }
+
+    func test_icon_adyenSofort_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenSofort.icon)
+    }
+
+    func test_icon_primerTestSofort_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.primerTestSofort.icon)
+    }
+
+    func test_icon_adyenTrustly_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenTrustly.icon)
+    }
+
+    func test_icon_adyenTwint_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenTwint.icon)
+    }
+
+    func test_icon_adyenVipps_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenVipps.icon)
+    }
+
+    // MARK: - Buckaroo Payment Methods
+
+    func test_icon_buckarooBancontact_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.buckarooBancontact.icon)
+    }
+
+    func test_icon_buckarooEps_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.buckarooEps.icon)
+    }
+
+    func test_icon_buckarooGiropay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.buckarooGiropay.icon)
+    }
+
+    func test_icon_buckarooIdeal_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.buckarooIdeal.icon)
+    }
+
+    func test_icon_buckarooSofort_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.buckarooSofort.icon)
+    }
+
+    // MARK: - Mollie Payment Methods
+
+    func test_icon_mollieBankcontact_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.mollieBankcontact.icon)
+    }
+
+    func test_icon_mollieIdeal_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.mollieIdeal.icon)
+    }
+
+    // MARK: - Pay.nl Payment Methods
+
+    func test_icon_payNLBancontact_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.payNLBancontact.icon)
+    }
+
+    func test_icon_payNLGiropay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.payNLGiropay.icon)
+    }
+
+    func test_icon_payNLIdeal_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.payNLIdeal.icon)
+    }
+
+    func test_icon_payNLPayconiq_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.payNLPayconiq.icon)
+    }
+
+    // MARK: - Rapyd Payment Methods
+
+    func test_icon_rapydGCash_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.rapydGCash.icon)
+    }
+
+    func test_icon_rapydGrabPay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.rapydGrabPay.icon)
+    }
+
+    func test_icon_rapydPromptPay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.rapydPromptPay.icon)
+    }
+
+    func test_icon_omisePromptPay_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.omisePromptPay.icon)
+    }
+
+    // MARK: - Other Payment Methods
+
+    func test_icon_xfersPayNow_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.xfersPayNow.icon)
+    }
+
+    func test_icon_fintechtureSmartTransfer_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.fintechtureSmartTransfer.icon)
+    }
+
+    func test_icon_fintechtureImmediateTransfer_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.fintechtureImmediateTransfer.icon)
+    }
+
+    // MARK: - Fallback
+
+    func test_icon_unmappedPaymentMethod_returnsGenericCardImage() {
+        // Test that payment methods not explicitly mapped in the icon switch statement
+        // fall through to the default case and return the generic card icon.
+        // iPay88Card is a valid case but not explicitly handled in the icon switch.
+        XCTAssertNotNil(PrimerPaymentMethodType.iPay88Card.icon)
+        XCTAssertEqual(PrimerPaymentMethodType.iPay88Card.icon, ImageName.genericCard.image)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -38,9 +38,8 @@ final class PrimerPaymentMethodTypeDefaultImageNameTests: XCTestCase {
         XCTAssertEqual(PrimerPaymentMethodType.applePay.defaultImageName, .appleIcon)
     }
 
-    func test_defaultImageName_googlePay_returnsAppleIconImage() {
-        // Google Pay uses same icon as Apple Pay
-        XCTAssertEqual(PrimerPaymentMethodType.googlePay.defaultImageName, .appleIcon)
+    func test_defaultImageName_googlePay_returnsGenericCard() {
+        XCTAssertEqual(PrimerPaymentMethodType.googlePay.defaultImageName, .genericCard)
     }
 
     // MARK: - ACH Payment Methods


### PR DESCRIPTION
## Summary
- Add `CheckoutComponentsPaymentMethodsBridge` for bridging payment method data between legacy and new architecture
- Add `PaymentMethodMapper` for mapping raw payment method config to domain models
- Add `PrimerPaymentMethodType+ImageName` extension for resolving payment method icons
- Add comprehensive test coverage for core interactors: card network detection, payment methods retrieval, card payment processing, input validation, and vaulted payment submission
- Add test mocks: `MockHeadlessRepository`, `MockRawDataManager`, `MockClientSessionActionsModule`

## Context
PR 10 of 16 in the CheckoutComponents feature split. Depends on [PR 9](https://github.com/primer-io/primer-sdk-ios/pull/1638) (core services & navigation).

[Notion tracker](https://www.notion.so/32fca65dc30e81dabf66f33e2b58c3a1)

## Test plan
- [ ] `CheckoutComponentsPaymentMethodsBridgeTests` — verify payment method bridge data flow
- [ ] `CardNetworkDetectionInteractorTests` — verify card network detection logic
- [ ] `GetPaymentMethodsInteractorTests` — verify payment method retrieval
- [ ] `ProcessCardPaymentInteractorTests` — verify card payment processing
- [ ] `SubmitVaultedPaymentInteractorTests` — verify vaulted payment submission
- [ ] `ValidateInputInteractorTests` — verify input validation rules
- [ ] `PaymentMethodMapperTests` — verify mapping from raw config to domain models
- [ ] `PrimerPaymentMethodTypeImageNameTests` — verify image name resolution