### PR TITLE
feat: Add presentation scopes & container wiring

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
@@ -11,15 +11,10 @@ final class ComposableContainer: LogReporter {
 
   private let container: Container
   private let settings: PrimerSettings
-  private let theme: PrimerCheckoutTheme
 
-  init(
-    settings: PrimerSettings,
-    theme: PrimerCheckoutTheme = PrimerCheckoutTheme()
-  ) {
+  init(settings: PrimerSettings) {
     container = Container()
     self.settings = settings
-    self.theme = theme
   }
 
   func configure() async {
@@ -28,7 +23,6 @@ final class ComposableContainer: LogReporter {
     await registerInteractors()
     await registerPaymentInteractors()
     await registerData()
-    await registerLogging()
 
     await DIContainer.setContainer(container)
 
@@ -47,8 +41,9 @@ final class ComposableContainer: LogReporter {
 @available(iOS 15.0, *)
 extension ComposableContainer {
 
-  /// Safely registers a dependency, logging errors instead of silently swallowing them.
-  fileprivate func safeRegister<T>(
+  /// Guards registration-time errors (e.g. duplicate keys) without crashing.
+  /// Factory execution errors are thrown later at resolution time, not caught here.
+  fileprivate func guardedRegister<T>(
     _ type: T.Type,
     _ registration: () async throws -> Void
   ) async {
@@ -67,26 +62,13 @@ extension ComposableContainer {
 
   fileprivate func registerInfrastructure() async {
     let settings = settings
-    await safeRegister(PrimerSettings.self) {
+    await guardedRegister(PrimerSettings.self) {
       _ = try await container.register(PrimerSettings.self)
         .asSingleton()
         .with { _ in settings }
     }
 
-    let theme = theme
-    await safeRegister(PrimerCheckoutTheme.self) {
-      _ = try await container.register(PrimerCheckoutTheme.self)
-        .asSingleton()
-        .with { _ in theme }
-    }
-
-    await safeRegister(DesignTokensManager.self) {
-      _ = try await container.register(DesignTokensManager.self)
-        .asSingleton()
-        .with { _ in await MainActor.run { DesignTokensManager() } }
-    }
-
-    await safeRegister(CheckoutComponentsAnalyticsServiceProtocol.self) {
+    await guardedRegister(CheckoutComponentsAnalyticsServiceProtocol.self) {
       _ = try await container.register(CheckoutComponentsAnalyticsServiceProtocol.self)
         .asSingleton()
         .with { _ in
@@ -96,7 +78,7 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(CheckoutComponentsAnalyticsInteractorProtocol.self) {
+    await guardedRegister(CheckoutComponentsAnalyticsInteractorProtocol.self) {
       _ = try await container.register(CheckoutComponentsAnalyticsInteractorProtocol.self)
         .asSingleton()
         .with { resolver in
@@ -106,13 +88,13 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(AccessibilityAnnouncementService.self) {
+    await guardedRegister(AccessibilityAnnouncementService.self) {
       _ = try await container.register(AccessibilityAnnouncementService.self)
         .asSingleton()
         .with { _ in DefaultAccessibilityAnnouncementService() }
     }
 
-    await safeRegister(ConfigurationService.self) {
+    await guardedRegister(ConfigurationService.self) {
       _ = try await container.register(ConfigurationService.self)
         .asSingleton()
         .with { _ in DefaultConfigurationService() }
@@ -120,34 +102,17 @@ extension ComposableContainer {
   }
 
   fileprivate func registerValidation() async {
-    await safeRegister(RulesFactory.self) {
-      _ = try await container.register(RulesFactory.self)
-        .asSingleton()
-        .with { _ in DefaultRulesFactory() }
-    }
-
-    await safeRegister(ValidationService.self) {
+    await guardedRegister(ValidationService.self) {
       _ = try await container.register(ValidationService.self)
         .asSingleton()
-        .with { resolver in
-          let factory = try await resolver.resolve(RulesFactory.self)
-          return DefaultValidationService(rulesFactory: factory)
+        .with { _ in
+          DefaultValidationService(rulesFactory: DefaultRulesFactory())
         }
     }
   }
 
   fileprivate func registerInteractors() async {
-    await safeRegister(GetPaymentMethodsInteractor.self) {
-      _ = try await container.register(GetPaymentMethodsInteractor.self)
-        .asTransient()
-        .with { resolver in
-          GetPaymentMethodsInteractorImpl(
-            repository: try await resolver.resolve(HeadlessRepository.self)
-          )
-        }
-    }
-
-    await safeRegister(ProcessCardPaymentInteractor.self) {
+    await guardedRegister(ProcessCardPaymentInteractor.self) {
       _ = try await container.register(ProcessCardPaymentInteractor.self)
         .asTransient()
         .with { resolver in
@@ -157,7 +122,7 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(ValidateInputInteractor.self) {
+    await guardedRegister(ValidateInputInteractor.self) {
       _ = try await container.register(ValidateInputInteractor.self)
         .asTransient()
         .with { resolver in
@@ -167,7 +132,7 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(CardNetworkDetectionInteractor.self) {
+    await guardedRegister(CardNetworkDetectionInteractor.self) {
       _ = try await container.register(CardNetworkDetectionInteractor.self)
         .asTransient()
         .with { resolver in
@@ -177,7 +142,7 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(SubmitVaultedPaymentInteractor.self) {
+    await guardedRegister(SubmitVaultedPaymentInteractor.self) {
       _ = try await container.register(SubmitVaultedPaymentInteractor.self)
         .asTransient()
         .with { resolver in
@@ -189,7 +154,7 @@ extension ComposableContainer {
   }
 
   fileprivate func registerPaymentInteractors() async {
-    await safeRegister(ProcessPayPalPaymentInteractor.self) {
+    await guardedRegister(ProcessPayPalPaymentInteractor.self) {
       _ = try await container.register(ProcessPayPalPaymentInteractor.self)
         .asTransient()
         .with { resolver in
@@ -199,7 +164,7 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(ProcessKlarnaPaymentInteractor.self) {
+    await guardedRegister(ProcessKlarnaPaymentInteractor.self) {
       _ = try await container.register(ProcessKlarnaPaymentInteractor.self)
         .asTransient()
         .with { resolver in
@@ -209,7 +174,7 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(ProcessWebRedirectPaymentInteractor.self) {
+    await guardedRegister(ProcessWebRedirectPaymentInteractor.self) {
       _ = try await container.register(ProcessWebRedirectPaymentInteractor.self)
         .asTransient()
         .with { resolver in
@@ -219,20 +184,19 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(ProcessApplePayPaymentInteractor.self) {
+    await guardedRegister(ProcessApplePayPaymentInteractor.self) {
       _ = try await container.register(ProcessApplePayPaymentInteractor.self)
         .asTransient()
         .with { _ in
           ProcessApplePayPaymentInteractorImpl(
             tokenizationService: TokenizationService(),
             createPaymentService: CreateResumePaymentService(
-              paymentMethodType: PrimerPaymentMethodType.applePay.rawValue
-            )
+              paymentMethodType: PrimerPaymentMethodType.applePay.rawValue)
           )
         }
     }
 
-    await safeRegister(ProcessAchPaymentInteractor.self) {
+    await guardedRegister(ProcessAchPaymentInteractor.self) {
       _ = try await container.register(ProcessAchPaymentInteractor.self)
         .asTransient()
         .with { resolver in
@@ -242,7 +206,7 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(ProcessFormRedirectPaymentInteractor.self) {
+    await guardedRegister(ProcessFormRedirectPaymentInteractor.self) {
       _ = try await container.register(ProcessFormRedirectPaymentInteractor.self)
         .asTransient()
         .with { resolver in
@@ -251,20 +215,27 @@ extension ComposableContainer {
           )
         }
     }
+
+    await guardedRegister(ProcessQRCodePaymentInteractor.self) {
+      _ = try await container.register(ProcessQRCodePaymentInteractor.self)
+        .asTransient()
+        .with { resolver in
+          ProcessQRCodePaymentInteractorImpl(
+            repository: try await resolver.resolve(QRCodeRepository.self),
+            paymentMethodType: ""
+          )
+        }
+    }
   }
 
   fileprivate func registerData() async {
-    // HeadlessRepository uses transient scope to ensure each checkout session gets a fresh instance.
-    // This prevents stale state (e.g., cached card networks, validation handlers) from leaking
-    // between checkout sessions when the user dismisses and re-presents the checkout UI.
-    // Note: VaultManager is lazily initialized within HeadlessRepositoryImpl for vault payments.
-    await safeRegister(HeadlessRepository.self) {
+    await guardedRegister(HeadlessRepository.self) {
       _ = try await container.register(HeadlessRepository.self)
-        .asTransient()
+        .asSingleton()
         .with { _ in await HeadlessRepositoryImpl() }
     }
 
-    await safeRegister(PaymentMethodMapper.self) {
+    await guardedRegister(PaymentMethodMapper.self) {
       _ = try await container.register(PaymentMethodMapper.self)
         .asSingleton()
         .with { container in
@@ -273,72 +244,40 @@ extension ComposableContainer {
         }
     }
 
-    await safeRegister(PayPalRepository.self) {
+    await guardedRegister(PayPalRepository.self) {
       _ = try await container.register(PayPalRepository.self)
         .asTransient()
         .with { _ in PayPalRepositoryImpl() }
     }
 
-    await safeRegister(KlarnaRepository.self) {
+    await guardedRegister(KlarnaRepository.self) {
       _ = try await container.register(KlarnaRepository.self)
         .asTransient()
         .with { _ in await KlarnaRepositoryImpl() }
     }
 
-    await safeRegister(AchRepository.self) {
+    await guardedRegister(AchRepository.self) {
       _ = try await container.register(AchRepository.self)
         .asTransient()
         .with { _ in await AchRepositoryImpl() }
     }
 
-    await safeRegister(WebRedirectRepository.self) {
+    await guardedRegister(WebRedirectRepository.self) {
       _ = try await container.register(WebRedirectRepository.self)
         .asTransient()
         .with { _ in WebRedirectRepositoryImpl() }
     }
 
-    await safeRegister(FormRedirectRepository.self) {
+    await guardedRegister(FormRedirectRepository.self) {
       _ = try await container.register(FormRedirectRepository.self)
         .asTransient()
         .with { _ in FormRedirectRepositoryImpl() }
     }
 
-    await safeRegister(QRCodeRepository.self) {
+    await guardedRegister(QRCodeRepository.self) {
       _ = try await container.register(QRCodeRepository.self)
         .asTransient()
         .with { _ in QRCodeRepositoryImpl() }
-    }
-  }
-
-  fileprivate func registerLogging() async {
-    await safeRegister(LogNetworkClient.self) {
-      _ = try await container.register(LogNetworkClient.self)
-        .asSingleton()
-        .with { _ in LogNetworkClient() }
-    }
-
-    await safeRegister(SensitiveDataMasker.self) {
-      _ = try await container.register(SensitiveDataMasker.self)
-        .asSingleton()
-        .with { _ in SensitiveDataMasker() }
-    }
-
-    await safeRegister(LogPayloadBuilding.self) {
-      _ = try await container.register(LogPayloadBuilding.self)
-        .asSingleton()
-        .with { _ in LogPayloadBuilder() }
-    }
-
-    await safeRegister(LoggingService.self) {
-      _ = try await container.register(LoggingService.self)
-        .asSingleton()
-        .with { resolver in
-          LoggingService(
-            networkClient: try await resolver.resolve(LogNetworkClient.self),
-            payloadBuilder: try await resolver.resolve(LogPayloadBuilding.self),
-            masker: try await resolver.resolve(SensitiveDataMasker.self)
-          )
-        }
     }
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
@@ -1,0 +1,361 @@
+//
+//  ComposableContainer.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+final class ComposableContainer: LogReporter {
+
+  private let container: Container
+  private let settings: PrimerSettings
+  private let theme: PrimerCheckoutTheme
+
+  init(
+    settings: PrimerSettings,
+    theme: PrimerCheckoutTheme = PrimerCheckoutTheme()
+  ) {
+    container = Container()
+    self.settings = settings
+    self.theme = theme
+  }
+
+  func configure() async {
+    await registerInfrastructure()
+    await registerValidation()
+    await registerInteractors()
+    await registerPaymentInteractors()
+    await registerData()
+    await registerLogging()
+
+    await DIContainer.setContainer(container)
+
+    #if DEBUG
+      await performHealthCheck()
+    #endif
+  }
+
+  var diContainer: Container {
+    container
+  }
+}
+
+// MARK: - Registration Helpers
+
+@available(iOS 15.0, *)
+extension ComposableContainer {
+
+  /// Safely registers a dependency, logging errors instead of silently swallowing them.
+  fileprivate func safeRegister<T>(
+    _ type: T.Type,
+    _ registration: () async throws -> Void
+  ) async {
+    do {
+      try await registration()
+    } catch {
+      logger.error(message: "Failed to register \(type): \(error)")
+    }
+  }
+}
+
+// MARK: - Registration Methods
+
+@available(iOS 15.0, *)
+extension ComposableContainer {
+
+  fileprivate func registerInfrastructure() async {
+    let settings = settings
+    await safeRegister(PrimerSettings.self) {
+      _ = try await container.register(PrimerSettings.self)
+        .asSingleton()
+        .with { _ in settings }
+    }
+
+    let theme = theme
+    await safeRegister(PrimerCheckoutTheme.self) {
+      _ = try await container.register(PrimerCheckoutTheme.self)
+        .asSingleton()
+        .with { _ in theme }
+    }
+
+    await safeRegister(DesignTokensManager.self) {
+      _ = try await container.register(DesignTokensManager.self)
+        .asSingleton()
+        .with { _ in await MainActor.run { DesignTokensManager() } }
+    }
+
+    await safeRegister(CheckoutComponentsAnalyticsServiceProtocol.self) {
+      _ = try await container.register(CheckoutComponentsAnalyticsServiceProtocol.self)
+        .asSingleton()
+        .with { _ in
+          AnalyticsEventService.create(
+            environmentProvider: AnalyticsEnvironmentProvider()
+          )
+        }
+    }
+
+    await safeRegister(CheckoutComponentsAnalyticsInteractorProtocol.self) {
+      _ = try await container.register(CheckoutComponentsAnalyticsInteractorProtocol.self)
+        .asSingleton()
+        .with { resolver in
+          DefaultAnalyticsInteractor(
+            eventService: try await resolver.resolve(CheckoutComponentsAnalyticsServiceProtocol.self)
+          )
+        }
+    }
+
+    await safeRegister(AccessibilityAnnouncementService.self) {
+      _ = try await container.register(AccessibilityAnnouncementService.self)
+        .asSingleton()
+        .with { _ in DefaultAccessibilityAnnouncementService() }
+    }
+
+    await safeRegister(ConfigurationService.self) {
+      _ = try await container.register(ConfigurationService.self)
+        .asSingleton()
+        .with { _ in DefaultConfigurationService() }
+    }
+  }
+
+  fileprivate func registerValidation() async {
+    await safeRegister(RulesFactory.self) {
+      _ = try await container.register(RulesFactory.self)
+        .asSingleton()
+        .with { _ in DefaultRulesFactory() }
+    }
+
+    await safeRegister(ValidationService.self) {
+      _ = try await container.register(ValidationService.self)
+        .asSingleton()
+        .with { resolver in
+          let factory = try await resolver.resolve(RulesFactory.self)
+          return DefaultValidationService(rulesFactory: factory)
+        }
+    }
+  }
+
+  fileprivate func registerInteractors() async {
+    await safeRegister(GetPaymentMethodsInteractor.self) {
+      _ = try await container.register(GetPaymentMethodsInteractor.self)
+        .asTransient()
+        .with { resolver in
+          GetPaymentMethodsInteractorImpl(
+            repository: try await resolver.resolve(HeadlessRepository.self)
+          )
+        }
+    }
+
+    await safeRegister(ProcessCardPaymentInteractor.self) {
+      _ = try await container.register(ProcessCardPaymentInteractor.self)
+        .asTransient()
+        .with { resolver in
+          ProcessCardPaymentInteractorImpl(
+            repository: try await resolver.resolve(HeadlessRepository.self)
+          )
+        }
+    }
+
+    await safeRegister(ValidateInputInteractor.self) {
+      _ = try await container.register(ValidateInputInteractor.self)
+        .asTransient()
+        .with { resolver in
+          ValidateInputInteractorImpl(
+            validationService: try await resolver.resolve(ValidationService.self)
+          )
+        }
+    }
+
+    await safeRegister(CardNetworkDetectionInteractor.self) {
+      _ = try await container.register(CardNetworkDetectionInteractor.self)
+        .asTransient()
+        .with { resolver in
+          CardNetworkDetectionInteractorImpl(
+            repository: try await resolver.resolve(HeadlessRepository.self)
+          )
+        }
+    }
+
+    await safeRegister(SubmitVaultedPaymentInteractor.self) {
+      _ = try await container.register(SubmitVaultedPaymentInteractor.self)
+        .asTransient()
+        .with { resolver in
+          SubmitVaultedPaymentInteractorImpl(
+            repository: try await resolver.resolve(HeadlessRepository.self)
+          )
+        }
+    }
+  }
+
+  fileprivate func registerPaymentInteractors() async {
+    await safeRegister(ProcessPayPalPaymentInteractor.self) {
+      _ = try await container.register(ProcessPayPalPaymentInteractor.self)
+        .asTransient()
+        .with { resolver in
+          ProcessPayPalPaymentInteractorImpl(
+            repository: try await resolver.resolve(PayPalRepository.self)
+          )
+        }
+    }
+
+    await safeRegister(ProcessKlarnaPaymentInteractor.self) {
+      _ = try await container.register(ProcessKlarnaPaymentInteractor.self)
+        .asTransient()
+        .with { resolver in
+          ProcessKlarnaPaymentInteractorImpl(
+            repository: try await resolver.resolve(KlarnaRepository.self)
+          )
+        }
+    }
+
+    await safeRegister(ProcessWebRedirectPaymentInteractor.self) {
+      _ = try await container.register(ProcessWebRedirectPaymentInteractor.self)
+        .asTransient()
+        .with { resolver in
+          ProcessWebRedirectPaymentInteractorImpl(
+            repository: try await resolver.resolve(WebRedirectRepository.self)
+          )
+        }
+    }
+
+    await safeRegister(ProcessApplePayPaymentInteractor.self) {
+      _ = try await container.register(ProcessApplePayPaymentInteractor.self)
+        .asTransient()
+        .with { _ in
+          ProcessApplePayPaymentInteractorImpl(
+            tokenizationService: TokenizationService(),
+            createPaymentService: CreateResumePaymentService(
+              paymentMethodType: PrimerPaymentMethodType.applePay.rawValue
+            )
+          )
+        }
+    }
+
+    await safeRegister(ProcessAchPaymentInteractor.self) {
+      _ = try await container.register(ProcessAchPaymentInteractor.self)
+        .asTransient()
+        .with { resolver in
+          ProcessAchPaymentInteractorImpl(
+            repository: try await resolver.resolve(AchRepository.self)
+          )
+        }
+    }
+
+    await safeRegister(ProcessFormRedirectPaymentInteractor.self) {
+      _ = try await container.register(ProcessFormRedirectPaymentInteractor.self)
+        .asTransient()
+        .with { resolver in
+          ProcessFormRedirectPaymentInteractorImpl(
+            formRedirectRepository: try await resolver.resolve(FormRedirectRepository.self)
+          )
+        }
+    }
+  }
+
+  fileprivate func registerData() async {
+    // HeadlessRepository uses transient scope to ensure each checkout session gets a fresh instance.
+    // This prevents stale state (e.g., cached card networks, validation handlers) from leaking
+    // between checkout sessions when the user dismisses and re-presents the checkout UI.
+    // Note: VaultManager is lazily initialized within HeadlessRepositoryImpl for vault payments.
+    await safeRegister(HeadlessRepository.self) {
+      _ = try await container.register(HeadlessRepository.self)
+        .asTransient()
+        .with { _ in await HeadlessRepositoryImpl() }
+    }
+
+    await safeRegister(PaymentMethodMapper.self) {
+      _ = try await container.register(PaymentMethodMapper.self)
+        .asSingleton()
+        .with { container in
+          let configService = try await container.resolve(ConfigurationService.self)
+          return PaymentMethodMapperImpl(configurationService: configService)
+        }
+    }
+
+    await safeRegister(PayPalRepository.self) {
+      _ = try await container.register(PayPalRepository.self)
+        .asTransient()
+        .with { _ in PayPalRepositoryImpl() }
+    }
+
+    await safeRegister(KlarnaRepository.self) {
+      _ = try await container.register(KlarnaRepository.self)
+        .asTransient()
+        .with { _ in await KlarnaRepositoryImpl() }
+    }
+
+    await safeRegister(AchRepository.self) {
+      _ = try await container.register(AchRepository.self)
+        .asTransient()
+        .with { _ in await AchRepositoryImpl() }
+    }
+
+    await safeRegister(WebRedirectRepository.self) {
+      _ = try await container.register(WebRedirectRepository.self)
+        .asTransient()
+        .with { _ in WebRedirectRepositoryImpl() }
+    }
+
+    await safeRegister(FormRedirectRepository.self) {
+      _ = try await container.register(FormRedirectRepository.self)
+        .asTransient()
+        .with { _ in FormRedirectRepositoryImpl() }
+    }
+
+    await safeRegister(QRCodeRepository.self) {
+      _ = try await container.register(QRCodeRepository.self)
+        .asTransient()
+        .with { _ in QRCodeRepositoryImpl() }
+    }
+  }
+
+  fileprivate func registerLogging() async {
+    await safeRegister(LogNetworkClient.self) {
+      _ = try await container.register(LogNetworkClient.self)
+        .asSingleton()
+        .with { _ in LogNetworkClient() }
+    }
+
+    await safeRegister(SensitiveDataMasker.self) {
+      _ = try await container.register(SensitiveDataMasker.self)
+        .asSingleton()
+        .with { _ in SensitiveDataMasker() }
+    }
+
+    await safeRegister(LogPayloadBuilding.self) {
+      _ = try await container.register(LogPayloadBuilding.self)
+        .asSingleton()
+        .with { _ in LogPayloadBuilder() }
+    }
+
+    await safeRegister(LoggingService.self) {
+      _ = try await container.register(LoggingService.self)
+        .asSingleton()
+        .with { resolver in
+          LoggingService(
+            networkClient: try await resolver.resolve(LogNetworkClient.self),
+            payloadBuilder: try await resolver.resolve(LogPayloadBuilding.self),
+            masker: try await resolver.resolve(SensitiveDataMasker.self)
+          )
+        }
+    }
+  }
+
+  #if DEBUG
+    fileprivate func performHealthCheck() async {
+      let diagnostics = await container.getDiagnostics()
+      logger.debug(
+        message:
+          "Container diagnostics - Total registrations: \(diagnostics.totalRegistrations), Singletons: \(diagnostics.singletonInstances), Weak refs: \(diagnostics.weakReferences)/\(diagnostics.activeWeakReferences)"
+      )
+
+      let healthReport = await container.performHealthCheck()
+      if healthReport.status == .healthy {
+        logger.debug(message: "Container is healthy")
+      } else {
+        logger.warn(message: "Health issues: \(healthReport.issues)")
+      }
+    }
+  #endif
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultAchScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultAchScope.swift
@@ -1,0 +1,408 @@
+//
+//  DefaultAchScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+@available(iOS 15.0, *)
+@MainActor
+public final class DefaultAchScope: PrimerAchScope, ObservableObject, LogReporter {
+
+  public var screen: AchScreenComponent?
+  public var userDetailsScreen: AchScreenComponent?
+  public var mandateScreen: AchScreenComponent?
+  public var submitButton: AchButtonComponent?
+
+  public private(set) var presentationContext: PresentationContext
+  public private(set) var bankCollectorViewController: UIViewController?
+
+  public var dismissalMechanism: [DismissalMechanism] {
+    checkoutScope?.dismissalMechanism ?? []
+  }
+
+  public var state: AsyncStream<PrimerAchState> {
+    AsyncStream { continuation in
+      let task = Task { @MainActor in
+        for await _ in self.$internalState.values {
+          continuation.yield(self.internalState)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  private weak var checkoutScope: DefaultCheckoutScope?
+  private let processAchInteractor: ProcessAchPaymentInteractor
+  private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+
+  @Published private var internalState = PrimerAchState()
+
+  private var currentFirstName = ""
+  private var currentLastName = ""
+  private var currentEmailAddress = ""
+
+  private var stripeData: AchStripeData?
+
+  init(
+    checkoutScope: DefaultCheckoutScope,
+    presentationContext: PresentationContext = .fromPaymentSelection,
+    processAchInteractor: ProcessAchPaymentInteractor,
+    analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil
+  ) {
+    self.checkoutScope = checkoutScope
+    self.presentationContext = presentationContext
+    self.processAchInteractor = processAchInteractor
+    self.analyticsInteractor = analyticsInteractor
+  }
+
+  public func start() {
+    logger.debug(message: "ACH scope started")
+    Task { [self] in
+      await loadInitialUserDetails()
+    }
+  }
+
+  public func submit() {
+    submitUserDetails()
+  }
+
+  public func cancel() {
+    logger.debug(message: "ACH payment cancelled")
+    guard let checkoutScope else {
+      logger.warn(message: "ACH checkout scope was deallocated during cancel")
+      return
+    }
+    checkoutScope.onDismiss()
+  }
+
+  public func updateFirstName(_ value: String) {
+    currentFirstName = value
+    validateAndUpdateState()
+  }
+
+  public func updateLastName(_ value: String) {
+    currentLastName = value
+    validateAndUpdateState()
+  }
+
+  public func updateEmailAddress(_ value: String) {
+    currentEmailAddress = value
+    validateAndUpdateState()
+  }
+
+  public func submitUserDetails() {
+    guard validateUserDetails() else {
+      logger.warn(message: "Cannot submit user details: validation failed")
+      return
+    }
+
+    logger.debug(message: "Submitting ACH user details")
+
+    Task { [self] in
+      await patchUserDetailsAndCreateBankCollector()
+    }
+  }
+
+  public func acceptMandate() {
+    guard internalState.step == .mandateAcceptance else {
+      logger.warn(message: "Cannot accept mandate in current step: \(internalState.step)")
+      return
+    }
+
+    logger.debug(message: "ACH mandate accepted")
+
+    internalState = PrimerAchState(
+      step: .processing,
+      userDetails: internalState.userDetails,
+      mandateText: internalState.mandateText,
+      isSubmitEnabled: false
+    )
+
+    Task { [self] in
+      do {
+        try await checkoutScope?.invokeBeforePaymentCreate(
+          paymentMethodType: PrimerPaymentMethodType.stripeAch.rawValue
+        )
+      } catch {
+        handleError(error, context: "before payment create")
+        return
+      }
+
+      internalState = PrimerAchState(
+        step: .processing,
+        userDetails: internalState.userDetails,
+        mandateText: internalState.mandateText,
+        isSubmitEnabled: false
+      )
+
+      await processPayment()
+    }
+  }
+
+  public func declineMandate() {
+    logger.debug(message: "ACH mandate declined")
+
+    let error = ACHHelpers.getCancelledError(paymentMethodType: PrimerPaymentMethodType.stripeAch.rawValue)
+    guard let checkoutScope else {
+      logger.warn(message: "ACH checkout scope was deallocated during mandate decline")
+      return
+    }
+    checkoutScope.handlePaymentError(error)
+  }
+
+  public func onBack() {
+    guard presentationContext.shouldShowBackButton else { return }
+    guard let checkoutScope else {
+      logger.warn(message: "ACH checkout scope was deallocated during navigation back")
+      return
+    }
+    checkoutScope.checkoutNavigator.navigateBack()
+  }
+
+  private func loadInitialUserDetails() async {
+    internalState = PrimerAchState(step: .loading)
+
+    do {
+      try await processAchInteractor.validate()
+
+      let userDetailsResult = try await processAchInteractor.loadUserDetails()
+
+      currentFirstName = userDetailsResult.firstName
+      currentLastName = userDetailsResult.lastName
+      currentEmailAddress = userDetailsResult.emailAddress
+
+      let userDetails = PrimerAchState.UserDetails(
+        firstName: userDetailsResult.firstName,
+        lastName: userDetailsResult.lastName,
+        emailAddress: userDetailsResult.emailAddress
+      )
+
+      let isSubmitEnabled = validateCurrentFields()
+
+      internalState = PrimerAchState(
+        step: .userDetailsCollection,
+        userDetails: userDetails,
+        isSubmitEnabled: isSubmitEnabled
+      )
+
+      logger.debug(message: "ACH user details loaded successfully")
+    } catch {
+      handleError(error, context: "user details loading")
+    }
+  }
+
+  private func validateAndUpdateState() {
+    let isSubmitEnabled = validateCurrentFields()
+    let fieldValidation = getFieldErrors()
+
+    let userDetails = PrimerAchState.UserDetails(
+      firstName: currentFirstName,
+      lastName: currentLastName,
+      emailAddress: currentEmailAddress
+    )
+
+    internalState = PrimerAchState(
+      step: internalState.step,
+      userDetails: userDetails,
+      fieldValidation: fieldValidation,
+      mandateText: internalState.mandateText,
+      isSubmitEnabled: isSubmitEnabled
+    )
+  }
+
+  private func validateUserDetails() -> Bool {
+    validateCurrentFields()
+  }
+
+  private func validateCurrentFields() -> Bool {
+    ACHUserDetailsCollectableData.firstName(currentFirstName).isValid
+      && ACHUserDetailsCollectableData.lastName(currentLastName).isValid
+      && ACHUserDetailsCollectableData.emailAddress(currentEmailAddress).isValid
+  }
+
+  private func getFieldErrors() -> PrimerAchState.FieldValidation? {
+    var firstNameError: String?
+    var lastNameError: String?
+    var emailError: String?
+
+    if !currentFirstName.isEmpty, !ACHUserDetailsCollectableData.firstName(currentFirstName).isValid {
+      firstNameError = CheckoutComponentsStrings.firstNameErrorInvalid
+    }
+
+    if !currentLastName.isEmpty, !ACHUserDetailsCollectableData.lastName(currentLastName).isValid {
+      lastNameError = CheckoutComponentsStrings.lastNameErrorInvalid
+    }
+
+    if !currentEmailAddress.isEmpty, !ACHUserDetailsCollectableData.emailAddress(currentEmailAddress).isValid {
+      emailError = CheckoutComponentsStrings.emailErrorInvalid
+    }
+
+    if firstNameError == nil, lastNameError == nil, emailError == nil {
+      return nil
+    }
+
+    return PrimerAchState.FieldValidation(
+      firstNameError: firstNameError,
+      lastNameError: lastNameError,
+      emailError: emailError
+    )
+  }
+
+  private func patchUserDetailsAndCreateBankCollector() async {
+    guard checkoutScope != nil else {
+      logger.warn(message: "ACH checkout scope was deallocated before patching user details")
+      return
+    }
+
+    internalState = PrimerAchState(
+      step: .loading,
+      userDetails: internalState.userDetails,
+      isSubmitEnabled: false
+    )
+
+    do {
+      try await processAchInteractor.patchUserDetails(
+        firstName: currentFirstName,
+        lastName: currentLastName,
+        emailAddress: currentEmailAddress
+      )
+
+      let stripeData = try await processAchInteractor.startPaymentAndGetStripeData()
+      self.stripeData = stripeData
+
+      let collectorVC = try await processAchInteractor.createBankCollector(
+        firstName: currentFirstName,
+        lastName: currentLastName,
+        emailAddress: currentEmailAddress,
+        clientSecret: stripeData.stripeClientSecret,
+        delegate: self
+      )
+
+      bankCollectorViewController = collectorVC
+
+      let userDetails = PrimerAchState.UserDetails(
+        firstName: currentFirstName,
+        lastName: currentLastName,
+        emailAddress: currentEmailAddress
+      )
+
+      internalState = PrimerAchState(
+        step: .bankAccountCollection,
+        userDetails: userDetails,
+        isSubmitEnabled: false
+      )
+
+      logger.debug(message: "ACH bank collector created, transitioning to bank account collection")
+    } catch {
+      handleError(error, context: "payment creation and bank collector setup")
+    }
+  }
+
+  private func transitionToMandateAcceptance() async {
+    do {
+      let mandateResult = try await processAchInteractor.getMandateData()
+
+      let mandateText: String
+      if let fullText = mandateResult.fullMandateText {
+        mandateText = fullText
+      } else if let merchantName = mandateResult.templateMandateText {
+        mandateText = CheckoutComponentsStrings.achMandateTemplate(merchantName: merchantName)
+      } else {
+        throw PrimerError.merchantError(message: "No mandate data available")
+      }
+
+      internalState = PrimerAchState(
+        step: .mandateAcceptance,
+        userDetails: internalState.userDetails,
+        mandateText: mandateText,
+        isSubmitEnabled: true
+      )
+
+      logger.debug(message: "ACH transitioned to mandate acceptance")
+    } catch {
+      handleError(error, context: "mandate loading")
+    }
+  }
+
+  private func processPayment() async {
+    guard let checkoutScope else {
+      logger.warn(message: "ACH checkout scope was deallocated before payment processing")
+      return
+    }
+
+    guard let stripeData else {
+      handleError(
+        PrimerError.invalidClientToken(reason: "Stripe data not available for payment completion"),
+        context: "payment completion"
+      )
+      return
+    }
+
+    await analyticsInteractor?.trackEvent(
+      .paymentSubmitted,
+      metadata: .payment(PaymentEvent(paymentMethod: PrimerPaymentMethodType.stripeAch.rawValue))
+    )
+
+    await analyticsInteractor?.trackEvent(
+      .paymentProcessingStarted,
+      metadata: .payment(PaymentEvent(paymentMethod: PrimerPaymentMethodType.stripeAch.rawValue))
+    )
+
+    do {
+      let result = try await processAchInteractor.completePayment(stripeData: stripeData)
+      checkoutScope.handlePaymentSuccess(result)
+    } catch {
+      handleError(error, context: "payment completion")
+    }
+  }
+
+  private func handleError(_ error: Error, context: String) {
+    logger.error(message: "ACH \(context) failed: \(error.localizedDescription)")
+    guard let checkoutScope else {
+      logger.error(message: "ACH checkout scope was deallocated during \(context)")
+      return
+    }
+    let primerError = error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+    checkoutScope.handlePaymentError(primerError)
+  }
+}
+
+@available(iOS 15.0, *)
+extension DefaultAchScope: AchBankCollectorDelegate {
+
+  func achBankCollectorDidSucceed(paymentId: String) {
+    logger.debug(message: "ACH bank collector succeeded with paymentId: \(paymentId)")
+    bankCollectorViewController = nil
+    Task { @MainActor in
+      await transitionToMandateAcceptance()
+    }
+  }
+
+  func achBankCollectorDidCancel() {
+    logger.debug(message: "ACH bank collector cancelled")
+    bankCollectorViewController = nil
+    let error = ACHHelpers.getCancelledError(paymentMethodType: PrimerPaymentMethodType.stripeAch.rawValue)
+    guard let checkoutScope else {
+      logger.error(message: "ACH checkout scope was deallocated during bank collector cancellation")
+      return
+    }
+    checkoutScope.handlePaymentError(error)
+  }
+
+  func achBankCollectorDidFail(error: PrimerError) {
+    logger.error(message: "ACH bank collector failed: \(error.localizedDescription)")
+    bankCollectorViewController = nil
+    guard let checkoutScope else {
+      logger.error(message: "ACH checkout scope was deallocated during bank collector failure")
+      return
+    }
+    checkoutScope.handlePaymentError(error)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultAchScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultAchScope.swift
@@ -9,25 +9,25 @@ import UIKit
 
 @available(iOS 15.0, *)
 @MainActor
-public final class DefaultAchScope: PrimerAchScope, ObservableObject, LogReporter {
+final class DefaultAchScope: PrimerAchScope, ObservableObject, LogReporter {
 
-  public var screen: AchScreenComponent?
-  public var userDetailsScreen: AchScreenComponent?
-  public var mandateScreen: AchScreenComponent?
-  public var submitButton: AchButtonComponent?
+  var screen: AchScreenComponent?
+  var userDetailsScreen: AchScreenComponent?
+  var mandateScreen: AchScreenComponent?
+  var submitButton: AchButtonComponent?
 
-  public private(set) var presentationContext: PresentationContext
-  public private(set) var bankCollectorViewController: UIViewController?
+  private(set) var presentationContext: PresentationContext
+  private(set) var bankCollectorViewController: UIViewController?
 
-  public var dismissalMechanism: [DismissalMechanism] {
+  var dismissalMechanism: [DismissalMechanism] {
     checkoutScope?.dismissalMechanism ?? []
   }
 
-  public var state: AsyncStream<PrimerAchState> {
+  var state: AsyncStream<PrimerAchState> {
     AsyncStream { continuation in
-      let task = Task { @MainActor in
-        for await _ in self.$internalState.values {
-          continuation.yield(self.internalState)
+      let task = Task { [self] in
+        for await _ in $internalState.values {
+          continuation.yield(internalState)
         }
         continuation.finish()
       }
@@ -62,18 +62,18 @@ public final class DefaultAchScope: PrimerAchScope, ObservableObject, LogReporte
     self.analyticsInteractor = analyticsInteractor
   }
 
-  public func start() {
+  func start() {
     logger.debug(message: "ACH scope started")
     Task { [self] in
       await loadInitialUserDetails()
     }
   }
 
-  public func submit() {
+  func submit() {
     submitUserDetails()
   }
 
-  public func cancel() {
+  func cancel() {
     logger.debug(message: "ACH payment cancelled")
     guard let checkoutScope else {
       logger.warn(message: "ACH checkout scope was deallocated during cancel")
@@ -82,22 +82,22 @@ public final class DefaultAchScope: PrimerAchScope, ObservableObject, LogReporte
     checkoutScope.onDismiss()
   }
 
-  public func updateFirstName(_ value: String) {
+  func updateFirstName(_ value: String) {
     currentFirstName = value
     validateAndUpdateState()
   }
 
-  public func updateLastName(_ value: String) {
+  func updateLastName(_ value: String) {
     currentLastName = value
     validateAndUpdateState()
   }
 
-  public func updateEmailAddress(_ value: String) {
+  func updateEmailAddress(_ value: String) {
     currentEmailAddress = value
     validateAndUpdateState()
   }
 
-  public func submitUserDetails() {
+  func submitUserDetails() {
     guard validateUserDetails() else {
       logger.warn(message: "Cannot submit user details: validation failed")
       return
@@ -110,7 +110,7 @@ public final class DefaultAchScope: PrimerAchScope, ObservableObject, LogReporte
     }
   }
 
-  public func acceptMandate() {
+  func acceptMandate() {
     guard internalState.step == .mandateAcceptance else {
       logger.warn(message: "Cannot accept mandate in current step: \(internalState.step)")
       return
@@ -146,7 +146,7 @@ public final class DefaultAchScope: PrimerAchScope, ObservableObject, LogReporte
     }
   }
 
-  public func declineMandate() {
+  func declineMandate() {
     logger.debug(message: "ACH mandate declined")
 
     let error = ACHHelpers.getCancelledError(paymentMethodType: PrimerPaymentMethodType.stripeAch.rawValue)
@@ -157,7 +157,7 @@ public final class DefaultAchScope: PrimerAchScope, ObservableObject, LogReporte
     checkoutScope.handlePaymentError(error)
   }
 
-  public func onBack() {
+  func onBack() {
     guard presentationContext.shouldShowBackButton else { return }
     guard let checkoutScope else {
       logger.warn(message: "ACH checkout scope was deallocated during navigation back")

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultApplePayScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultApplePayScope.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 @MainActor
-public final class DefaultApplePayScope: PrimerApplePayScope, ObservableObject {
+final class DefaultApplePayScope: PrimerApplePayScope, ObservableObject {
 
   @Published var structuredState: PrimerApplePayState
 
-  public var state: AsyncStream<PrimerApplePayState> {
+  var state: AsyncStream<PrimerApplePayState> {
     AsyncStream { continuation in
       let task = Task { [self] in
         continuation.yield(structuredState)
@@ -30,10 +30,10 @@ public final class DefaultApplePayScope: PrimerApplePayScope, ObservableObject {
     }
   }
 
-  public var screen: ((_ scope: any PrimerApplePayScope) -> any View)?
-  public var applePayButton: ((_ action: @escaping () -> Void) -> any View)?
+  var screen: ApplePayScreenComponent?
+  var applePayButton: ApplePayButtonComponent?
 
-  public private(set) var presentationContext: PresentationContext = .fromPaymentSelection
+  private(set) var presentationContext: PresentationContext = .fromPaymentSelection
 
   private weak var checkoutScope: DefaultCheckoutScope?
   private var processPaymentInteractor: ProcessApplePayPaymentInteractor?
@@ -79,7 +79,7 @@ public final class DefaultApplePayScope: PrimerApplePayScope, ObservableObject {
     }
   }
 
-  public func start() {
+  func start() {
     if applePayPresentationManager.isPresentable {
       structuredState = .available(
         buttonStyle: structuredState.buttonStyle,
@@ -91,24 +91,24 @@ public final class DefaultApplePayScope: PrimerApplePayScope, ObservableObject {
     }
   }
 
-  public func cancel() {
+  func cancel() {
     structuredState.isLoading = false
     if presentationContext.shouldShowBackButton {
       checkoutScope?.checkoutNavigator.navigateBack()
     }
   }
 
-  public func onBack() {
+  func onBack() {
     if presentationContext.shouldShowBackButton {
       checkoutScope?.checkoutNavigator.navigateBack()
     }
   }
 
-  public func onDismiss() {
+  func onDismiss() {
     checkoutScope?.onDismiss()
   }
 
-  public func submit() {
+  func submit() {
     guard structuredState.isAvailable, !structuredState.isLoading else { return }
 
     Task { [self] in
@@ -189,7 +189,7 @@ public final class DefaultApplePayScope: PrimerApplePayScope, ObservableObject {
 
   // swiftlint:disable identifier_name
 
-  public func PrimerApplePayButton(action: @escaping () -> Void) -> AnyView {
+  func PrimerApplePayButton(action: @escaping () -> Void) -> AnyView {
     AnyView(
       ApplePayButtonView(
         style: structuredState.buttonStyle,
@@ -211,17 +211,10 @@ public final class DefaultApplePayScope: PrimerApplePayScope, ObservableObject {
 @MainActor
 final class ApplePayAuthorizationCoordinator: NSObject, PKPaymentAuthorizationControllerDelegate {
 
-  // MARK: - Continuations
-
   private var authorizationContinuation: CheckedContinuation<PKPayment, Error>?
   private var completionHandler: ((PKPaymentAuthorizationResult) -> Void)?
-
-  // MARK: - State
-
   private var isCancelled = true
   private var didTimeout = false
-
-  // MARK: - Authorization
 
   func authorize(
     with request: ApplePayRequest,
@@ -250,8 +243,7 @@ final class ApplePayAuthorizationCoordinator: NSObject, PKPaymentAuthorizationCo
 
     if isCancelled {
       let error = PrimerError.cancelled(
-        paymentMethodType: PrimerPaymentMethodType.applePay.rawValue
-      )
+        paymentMethodType: PrimerPaymentMethodType.applePay.rawValue)
       authorizationContinuation?.resume(throwing: error)
       authorizationContinuation = nil
     } else if didTimeout {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultApplePayScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultApplePayScope.swift
@@ -1,0 +1,282 @@
+//
+//  DefaultApplePayScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@preconcurrency import PassKit
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+public final class DefaultApplePayScope: PrimerApplePayScope, ObservableObject {
+
+  @Published var structuredState: PrimerApplePayState
+
+  public var state: AsyncStream<PrimerApplePayState> {
+    AsyncStream { continuation in
+      let task = Task { [self] in
+        continuation.yield(structuredState)
+
+        for await _ in $structuredState.values {
+          continuation.yield(structuredState)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  public var screen: ((_ scope: any PrimerApplePayScope) -> any View)?
+  public var applePayButton: ((_ action: @escaping () -> Void) -> any View)?
+
+  public private(set) var presentationContext: PresentationContext = .fromPaymentSelection
+
+  private weak var checkoutScope: DefaultCheckoutScope?
+  private var processPaymentInteractor: ProcessApplePayPaymentInteractor?
+  private let applePayPresentationManager: ApplePayPresenting
+  private var authorizationCoordinator: ApplePayAuthorizationCoordinator?
+
+  private let clientSessionActionsFactory: () -> ClientSessionActionsProtocol
+  private let applePayRequestFactory: () throws -> ApplePayRequest
+  private let authorizationCoordinatorFactory: @MainActor () -> ApplePayAuthorizationCoordinator
+
+  init(
+    checkoutScope: DefaultCheckoutScope,
+    presentationContext: PresentationContext = .fromPaymentSelection,
+    applePayPresentationManager: ApplePayPresenting = ApplePayPresentationManager(),
+    clientSessionActionsFactory: @escaping () -> ClientSessionActionsProtocol = { ClientSessionActionsModule() },
+    applePayRequestFactory: @escaping () throws -> ApplePayRequest = { try ApplePayRequestBuilder.build() },
+    authorizationCoordinatorFactory: @MainActor @escaping () -> ApplePayAuthorizationCoordinator = { ApplePayAuthorizationCoordinator() }
+  ) {
+    self.checkoutScope = checkoutScope
+    self.presentationContext = presentationContext
+    self.applePayPresentationManager = applePayPresentationManager
+    self.clientSessionActionsFactory = clientSessionActionsFactory
+    self.applePayRequestFactory = applePayRequestFactory
+    self.authorizationCoordinatorFactory = authorizationCoordinatorFactory
+
+    structuredState = applePayPresentationManager.isPresentable
+      ? .available()
+      : .unavailable(error: applePayPresentationManager.errorForDisplay.localizedDescription)
+
+    Task { [self] in
+      await setupInteractors()
+    }
+  }
+
+  private func setupInteractors() async {
+    do {
+      guard let container = await DIContainer.current else {
+        throw ContainerError.containerUnavailable
+      }
+      processPaymentInteractor = try await container.resolve(ProcessApplePayPaymentInteractor.self)
+    } catch {
+      // Interactor resolution failed - will be retried lazily during payment
+    }
+  }
+
+  public func start() {
+    if applePayPresentationManager.isPresentable {
+      structuredState = .available(
+        buttonStyle: structuredState.buttonStyle,
+        buttonType: structuredState.buttonType,
+        cornerRadius: structuredState.cornerRadius
+      )
+    } else {
+      structuredState = .unavailable(error: applePayPresentationManager.errorForDisplay.localizedDescription)
+    }
+  }
+
+  public func cancel() {
+    structuredState.isLoading = false
+    if presentationContext.shouldShowBackButton {
+      checkoutScope?.checkoutNavigator.navigateBack()
+    }
+  }
+
+  public func onBack() {
+    if presentationContext.shouldShowBackButton {
+      checkoutScope?.checkoutNavigator.navigateBack()
+    }
+  }
+
+  public func onDismiss() {
+    checkoutScope?.onDismiss()
+  }
+
+  public func submit() {
+    guard structuredState.isAvailable, !structuredState.isLoading else { return }
+
+    Task { [self] in
+      await performPayment()
+    }
+  }
+
+  private func performPayment() async {
+    structuredState.isLoading = true
+
+    do {
+      try await checkoutScope?.invokeBeforePaymentCreate(
+        paymentMethodType: PrimerPaymentMethodType.applePay.rawValue
+      )
+
+      let clientSessionActions = clientSessionActionsFactory()
+      try await clientSessionActions.selectPaymentMethodIfNeeded(
+        PrimerPaymentMethodType.applePay.rawValue,
+        cardNetwork: nil
+      )
+
+      let applePayRequest = try applePayRequestFactory()
+
+      let coordinator = authorizationCoordinatorFactory()
+      authorizationCoordinator = coordinator
+
+      let payment = try await coordinator.authorize(
+        with: applePayRequest,
+        presentationManager: applePayPresentationManager
+      )
+
+      var interactor = processPaymentInteractor
+      if interactor == nil {
+        if let container = await DIContainer.current {
+          interactor = try? await container.resolve(ProcessApplePayPaymentInteractor.self)
+          processPaymentInteractor = interactor
+        }
+      }
+
+      guard let interactor else {
+        throw PrimerError.invalidArchitecture(
+          description: "ProcessApplePayPaymentInteractor not initialized",
+          recoverSuggestion: "Ensure proper SDK initialization"
+        )
+      }
+
+      let result = try await interactor.execute(payment: payment)
+      await handlePaymentSuccess(result)
+
+    } catch let error as PrimerError {
+      if case .cancelled = error {
+        structuredState.isLoading = false
+        return
+      }
+      await handlePaymentError(error)
+
+    } catch {
+      await handlePaymentError(error)
+    }
+  }
+
+  private func handlePaymentSuccess(_ result: PaymentResult) async {
+    structuredState.isLoading = false
+
+    guard let checkoutScope else { return }
+    checkoutScope.handlePaymentSuccess(result)
+  }
+
+  private func handlePaymentError(_ error: Error) async {
+    structuredState.isLoading = false
+
+    let primerError =
+      error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+
+    guard let checkoutScope else { return }
+    checkoutScope.handlePaymentError(primerError)
+  }
+
+  // swiftlint:disable identifier_name
+
+  public func PrimerApplePayButton(action: @escaping () -> Void) -> AnyView {
+    AnyView(
+      ApplePayButtonView(
+        style: structuredState.buttonStyle,
+        type: structuredState.buttonType,
+        cornerRadius: structuredState.cornerRadius,
+        action: action
+      )
+    )
+  }
+
+  // swiftlint:enable identifier_name
+}
+
+// MARK: - Apple Pay Authorization Coordinator
+
+/// Coordinator that handles PKPaymentAuthorizationControllerDelegate callbacks.
+/// Bridges PassKit delegate pattern to async/await.
+@available(iOS 15.0, *)
+@MainActor
+final class ApplePayAuthorizationCoordinator: NSObject, PKPaymentAuthorizationControllerDelegate {
+
+  // MARK: - Continuations
+
+  private var authorizationContinuation: CheckedContinuation<PKPayment, Error>?
+  private var completionHandler: ((PKPaymentAuthorizationResult) -> Void)?
+
+  // MARK: - State
+
+  private var isCancelled = true
+  private var didTimeout = false
+
+  // MARK: - Authorization
+
+  func authorize(
+    with request: ApplePayRequest,
+    presentationManager: ApplePayPresenting
+  ) async throws -> PKPayment {
+    try await withCheckedThrowingContinuation { continuation in
+      self.authorizationContinuation = continuation
+      self.isCancelled = true
+      self.didTimeout = false
+
+      Task { @MainActor in
+        do {
+          try await presentationManager.present(withRequest: request, delegate: self)
+        } catch {
+          self.authorizationContinuation?.resume(throwing: error)
+          self.authorizationContinuation = nil
+        }
+      }
+    }
+  }
+
+  // MARK: - PKPaymentAuthorizationControllerDelegate
+
+  func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
+    controller.dismiss(completion: nil)
+
+    if isCancelled {
+      let error = PrimerError.cancelled(
+        paymentMethodType: PrimerPaymentMethodType.applePay.rawValue
+      )
+      authorizationContinuation?.resume(throwing: error)
+      authorizationContinuation = nil
+    } else if didTimeout {
+      let error = PrimerError.applePayTimedOut()
+      authorizationContinuation?.resume(throwing: error)
+      authorizationContinuation = nil
+    }
+  }
+
+  func paymentAuthorizationController(
+    _ controller: PKPaymentAuthorizationController,
+    didAuthorizePayment payment: PKPayment,
+    handler completion: @escaping (PKPaymentAuthorizationResult) -> Void
+  ) {
+    isCancelled = false
+    didTimeout = false
+
+    // Complete the authorization with success
+    completion(PKPaymentAuthorizationResult(status: .success, errors: nil))
+
+    // Capture and clear continuation before dismiss to avoid @MainActor access in @Sendable closure
+    let continuation = authorizationContinuation
+    authorizationContinuation = nil
+    controller.dismiss {
+      continuation?.resume(returning: payment)
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope+FieldBuilders.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope+FieldBuilders.swift
@@ -1,0 +1,183 @@
+//
+//  DefaultCardFormScope+FieldBuilders.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+// swiftlint:disable identifier_name
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+extension DefaultCardFormScope {
+
+  public func PrimerCardNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    CardNumberInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.cardNumberPlaceholder,
+      scope: self,
+      selectedNetwork: structuredState.selectedNetwork?.network,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerExpiryDateField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    ExpiryDateInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.expiryDateAlternativePlaceholder,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerCvvField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    CVVInputField(
+      label: label,
+      placeholder: getCardNetworkForCvv() == .amex
+        ? CheckoutComponentsStrings.cvvAmexPlaceholder
+        : CheckoutComponentsStrings.cvvStandardPlaceholder,
+      scope: self,
+      cardNetwork: structuredState.selectedNetwork?.network ?? getCardNetworkForCvv(),
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerCardholderNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    CardholderNameInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.fullNamePlaceholder,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerCountryField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    CountryInputFieldWrapper(
+      scope: self,
+      label: label,
+      placeholder: CheckoutComponentsStrings.selectCountryPlaceholder,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerPostalCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    PostalCodeInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.postalCodePlaceholder,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerCityField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    CityInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.cityPlaceholder,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerStateField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    StateInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.statePlaceholder,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerAddressLine1Field(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    AddressLineInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.addressLine1Placeholder,
+      isRequired: true,
+      inputType: .addressLine1,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerAddressLine2Field(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    AddressLineInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.addressLine2Placeholder,
+      isRequired: false,
+      inputType: .addressLine2,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerFirstNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    NameInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.firstNamePlaceholder,
+      inputType: .firstName,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerLastNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    NameInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.lastNamePlaceholder,
+      inputType: .lastName,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerEmailField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    EmailInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.emailPlaceholder,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerPhoneNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    NameInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.phoneNumberPlaceholder,
+      inputType: .phoneNumber,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerRetailOutletField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    NameInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.retailOutletPlaceholder,
+      inputType: .retailer,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  public func PrimerOtpCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+    OTPCodeInputField(
+      label: label,
+      placeholder: CheckoutComponentsStrings.otpCodePlaceholder,
+      scope: self,
+      styling: styling
+    ).asAny()
+  }
+
+  /// Returns a complete card form view with all card and billing address fields.
+  /// This provides an embeddable card form for custom payment selection screens.
+  /// - Parameter styling: Optional styling configuration for fields. Default: nil (uses SDK default styling)
+  /// - Returns: A view containing all card form fields based on current configuration.
+  public func DefaultCardFormView(styling: PrimerFieldStyling?) -> AnyView {
+    CardFormFieldsView(scope: self, styling: styling).asAny()
+  }
+}
+
+extension View {
+  fileprivate func asAny() -> AnyView { AnyView(self) }
+}
+
+// swiftlint:enable identifier_name

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope+Validation.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope+Validation.swift
@@ -1,0 +1,54 @@
+//
+//  DefaultCardFormScope+Validation.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+extension DefaultCardFormScope {
+
+  /// Updates the validation state for a specific field using a KeyPath.
+  ///
+  /// Required when using custom field components via `InputFieldConfig(component:)`.
+  /// The SDK uses this to track which fields are valid and determine overall form validity.
+  ///
+  /// ```swift
+  /// scope.updateValidationState(\.cvv, isValid: true)
+  /// scope.updateValidationState(\.cardNumber, isValid: false)
+  /// ```
+  public func updateValidationState(_ field: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool) {
+    fieldValidationStates[keyPath: field] = isValid
+    updateFieldValidationState()
+  }
+
+  public func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool) {
+    guard let keyPath = field.validationKeyPath else { return }
+    updateValidationState(keyPath, isValid: isValid)
+  }
+}
+
+// MARK: - PrimerInputElementType to FieldValidationStates KeyPath Mapping
+
+private extension PrimerInputElementType {
+  var validationKeyPath: WritableKeyPath<FieldValidationStates, Bool>? {
+    switch self {
+    case .cardNumber: \.cardNumber
+    case .cvv: \.cvv
+    case .expiryDate: \.expiry
+    case .cardholderName: \.cardholderName
+    case .email: \.email
+    case .firstName: \.firstName
+    case .lastName: \.lastName
+    case .addressLine1: \.addressLine1
+    case .addressLine2: \.addressLine2
+    case .city: \.city
+    case .state: \.state
+    case .postalCode: \.postalCode
+    case .countryCode: \.countryCode
+    case .phoneNumber: \.phoneNumber
+    case .retailer, .otp, .unknown, .all: nil
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
@@ -6,38 +6,38 @@
 
 import SwiftUI
 
-public struct FieldValidationStates: Equatable {
-  public var cardNumber: Bool = false
-  public var cvv: Bool = false
-  public var expiry: Bool = false
-  public var cardholderName: Bool = false
-  public var postalCode: Bool = false
-  public var countryCode: Bool = false
-  public var city: Bool = false
-  public var state: Bool = false
-  public var addressLine1: Bool = false
-  public var addressLine2: Bool = false
-  public var firstName: Bool = false
-  public var lastName: Bool = false
-  public var email: Bool = false
-  public var phoneNumber: Bool = false
+struct FieldValidationStates: Equatable {
+  var cardNumber: Bool = false
+  var cvv: Bool = false
+  var expiry: Bool = false
+  var cardholderName: Bool = false
+  var postalCode: Bool = false
+  var countryCode: Bool = false
+  var city: Bool = false
+  var state: Bool = false
+  var addressLine1: Bool = false
+  var addressLine2: Bool = false
+  var firstName: Bool = false
+  var lastName: Bool = false
+  var email: Bool = false
+  var phoneNumber: Bool = false
 }
 
 @available(iOS 15.0, *)
 @MainActor
-public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, LogReporter {
+final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, LogReporter {
 
-  public private(set) var presentationContext: PresentationContext = .fromPaymentSelection
+  private(set) var presentationContext: PresentationContext = .fromPaymentSelection
 
-  public var cardFormUIOptions: PrimerCardFormUIOptions? {
+  var cardFormUIOptions: PrimerCardFormUIOptions? {
     checkoutScope?.cardFormUIOptions
   }
 
-  public var dismissalMechanism: [DismissalMechanism] {
+  var dismissalMechanism: [DismissalMechanism] {
     checkoutScope?.dismissalMechanism ?? []
   }
 
-  public var state: AsyncStream<PrimerCardFormState> {
+  var state: AsyncStream<PrimerCardFormState> {
     AsyncStream { continuation in
       let task = Task { [self] in
         for await _ in $structuredState.values {
@@ -52,32 +52,32 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     }
   }
 
-  public var title: String?
-  public var screen: CardFormScreenComponent?
-  public var cobadgedCardsView:
+  var title: String?
+  var screen: CardFormScreenComponent?
+  var cobadgedCardsView:
     ((_ availableNetworks: [String], _ selectNetwork: @escaping (String) -> Void) -> any View)?
-  public var errorScreen: ErrorComponent?
-  public var submitButtonText: String?
-  public var showSubmitLoadingIndicator: Bool = true
-  public var cardNumberConfig: InputFieldConfig?
-  public var expiryDateConfig: InputFieldConfig?
-  public var cvvConfig: InputFieldConfig?
-  public var cardholderNameConfig: InputFieldConfig?
-  public var postalCodeConfig: InputFieldConfig?
-  public var countryConfig: InputFieldConfig?
-  public var cityConfig: InputFieldConfig?
-  public var stateConfig: InputFieldConfig?
-  public var addressLine1Config: InputFieldConfig?
-  public var addressLine2Config: InputFieldConfig?
-  public var phoneNumberConfig: InputFieldConfig?
-  public var firstNameConfig: InputFieldConfig?
-  public var lastNameConfig: InputFieldConfig?
-  public var emailConfig: InputFieldConfig?
-  public var retailOutletConfig: InputFieldConfig?
-  public var otpCodeConfig: InputFieldConfig?
-  public var cardInputSection: Component?
-  public var billingAddressSection: Component?
-  public var submitButton: Component?
+  var errorScreen: ErrorComponent?
+  var submitButtonText: String?
+  var showSubmitLoadingIndicator: Bool = true
+  var cardNumberConfig: InputFieldConfig?
+  var expiryDateConfig: InputFieldConfig?
+  var cvvConfig: InputFieldConfig?
+  var cardholderNameConfig: InputFieldConfig?
+  var postalCodeConfig: InputFieldConfig?
+  var countryConfig: InputFieldConfig?
+  var cityConfig: InputFieldConfig?
+  var stateConfig: InputFieldConfig?
+  var addressLine1Config: InputFieldConfig?
+  var addressLine2Config: InputFieldConfig?
+  var phoneNumberConfig: InputFieldConfig?
+  var firstNameConfig: InputFieldConfig?
+  var lastNameConfig: InputFieldConfig?
+  var emailConfig: InputFieldConfig?
+  var retailOutletConfig: InputFieldConfig?
+  var otpCodeConfig: InputFieldConfig?
+  var cardInputSection: Component?
+  var billingAddressSection: Component?
+  var submitButton: Component?
 
   @Published var structuredState = PrimerCardFormState()
   var fieldValidationStates = FieldValidationStates()
@@ -194,7 +194,7 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     }
   }
 
-  public func updateField(_ fieldType: PrimerInputElementType, value: String) {
+  func updateField(_ fieldType: PrimerInputElementType, value: String) {
     switch fieldType {
     case .cardNumber:
       updateCardNumber(value)
@@ -233,7 +233,7 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     }
   }
 
-  public func updateCardNumber(_ cardNumber: String) {
+  func updateCardNumber(_ cardNumber: String) {
     structuredState.data[.cardNumber] = cardNumber
     updateCardData()
 
@@ -247,17 +247,17 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     await interactor.detectNetworks(for: cardNumber)
   }
 
-  public func updateCvv(_ cvv: String) {
+  func updateCvv(_ cvv: String) {
     structuredState.data[.cvv] = cvv
     updateCardData()
   }
 
-  public func updateExpiryDate(_ expiryDate: String) {
+  func updateExpiryDate(_ expiryDate: String) {
     structuredState.data[.expiryDate] = expiryDate
     updateCardData()
   }
 
-  public func updateExpiryMonth(_ month: String) {
+  func updateExpiryMonth(_ month: String) {
     let currentExpiry = structuredState.data[.expiryDate]
     let components = currentExpiry.components(separatedBy: "/")
     let year = components.count >= 2 ? components[1] : ""
@@ -265,7 +265,7 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     updateCardData()
   }
 
-  public func updateExpiryYear(_ year: String) {
+  func updateExpiryYear(_ year: String) {
     let currentExpiry = structuredState.data[.expiryDate]
     let components = currentExpiry.components(separatedBy: "/")
     let month = components.count >= 1 ? components[0] : ""
@@ -273,48 +273,48 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     updateCardData()
   }
 
-  public func updateCardholderName(_ name: String) {
+  func updateCardholderName(_ name: String) {
     structuredState.data[.cardholderName] = name
     updateCardData()
   }
 
-  public func updateFirstName(_ firstName: String) {
+  func updateFirstName(_ firstName: String) {
     structuredState.data[.firstName] = firstName
   }
 
-  public func updateLastName(_ lastName: String) {
+  func updateLastName(_ lastName: String) {
     structuredState.data[.lastName] = lastName
   }
 
-  public func updateEmail(_ email: String) {
+  func updateEmail(_ email: String) {
     structuredState.data[.email] = email
   }
 
-  public func updatePhoneNumber(_ phoneNumber: String) {
+  func updatePhoneNumber(_ phoneNumber: String) {
     structuredState.data[.phoneNumber] = phoneNumber
   }
 
-  public func updateAddressLine1(_ addressLine1: String) {
+  func updateAddressLine1(_ addressLine1: String) {
     structuredState.data[.addressLine1] = addressLine1
   }
 
-  public func updateAddressLine2(_ addressLine2: String) {
+  func updateAddressLine2(_ addressLine2: String) {
     structuredState.data[.addressLine2] = addressLine2
   }
 
-  public func updateCity(_ city: String) {
+  func updateCity(_ city: String) {
     structuredState.data[.city] = city
   }
 
-  public func updateState(_ state: String) {
+  func updateState(_ state: String) {
     structuredState.data[.state] = state
   }
 
-  public func updatePostalCode(_ postalCode: String) {
+  func updatePostalCode(_ postalCode: String) {
     structuredState.data[.postalCode] = postalCode
   }
 
-  public func updateCountryCode(_ countryCode: String) {
+  func updateCountryCode(_ countryCode: String) {
     structuredState.data[.countryCode] = countryCode
 
     if let country = CountryCode.phoneNumberCountryCodes.first(where: {
@@ -332,11 +332,11 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     objectWillChange.send()
   }
 
-  public func updateOtpCode(_ otpCode: String) {
+  func updateOtpCode(_ otpCode: String) {
     structuredState.data[.otp] = otpCode
   }
 
-  public func updateSelectedCardNetwork(_ network: String) {
+  func updateSelectedCardNetwork(_ network: String) {
     if let cardNetwork = CardNetwork(rawValue: network) {
       if cardNetwork == .unknown {
         structuredState.selectedNetwork = nil
@@ -363,24 +363,26 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     await interactor.selectNetwork(cardNetwork)
   }
 
-  public func updateRetailOutlet(_ retailOutlet: String) {
+  func updateRetailOutlet(_ retailOutlet: String) {
     structuredState.data[.retailer] = retailOutlet
   }
 
-  public func submit() {
+  func start() {}
+
+  func submit() {
     guard !structuredState.isLoading else { return }
     Task { [self] in
       await performSubmit()
     }
   }
 
-  public func onBack() {
+  func onBack() {
     if presentationContext.shouldShowBackButton {
       checkoutScope?.checkoutNavigator.navigateBack()
     }
   }
 
-  public func cancel() {
+  func cancel() {
     networkDetectionTask?.cancel()
     networkDetectionTask = nil
     binDataTask?.cancel()
@@ -389,11 +391,11 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
   }
 
   private var _selectCountry: DefaultSelectCountryScope?
-  public var selectCountry: PrimerSelectCountryScope {
+  var selectCountry: PrimerSelectCountryScope {
     if let existing = _selectCountry {
       return existing
     }
-    let scope = DefaultSelectCountryScope(cardFormScope: self, checkoutScope: checkoutScope)
+    let scope = DefaultSelectCountryScope(cardFormScope: self)
     _selectCountry = scope
     return scope
   }
@@ -438,8 +440,7 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
 
     await analyticsInteractor?.trackEvent(
       .paymentSubmitted,
-      metadata: .payment(PaymentEvent(paymentMethod: PrimerPaymentMethodType.paymentCard.rawValue))
-    )
+      metadata: .payment(PaymentEvent(paymentMethod: PrimerPaymentMethodType.paymentCard.rawValue)))
 
     do {
       try await checkoutScope?.invokeBeforePaymentCreate(
@@ -451,9 +452,7 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
       await analyticsInteractor?.trackEvent(
         .paymentProcessingStarted,
         metadata: .payment(
-          PaymentEvent(paymentMethod: PrimerPaymentMethodType.paymentCard.rawValue)
-        )
-      )
+          PaymentEvent(paymentMethod: PrimerPaymentMethodType.paymentCard.rawValue)))
 
       let result = try await processCardPayment(cardData: cardData)
       await handlePaymentSuccess(result)
@@ -537,7 +536,7 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
     structuredState.surchargeAmount = formattedSurcharge
   }
 
-  public func updateValidationState(cardNumber: Bool, cvv: Bool, expiry: Bool, cardholderName: Bool) {
+  func updateValidationState(cardNumber: Bool, cvv: Bool, expiry: Bool, cardholderName: Bool) {
     let hasValidCardNumber =
       cardNumber
       && !structuredState.data[.cardNumber].replacingOccurrences(of: " ", with: "").isEmpty
@@ -558,34 +557,32 @@ public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, 
           await analyticsInteractor?.trackEvent(
             .paymentDetailsEntered,
             metadata: .payment(
-              PaymentEvent(paymentMethod: PrimerPaymentMethodType.paymentCard.rawValue)
-            )
-          )
+              PaymentEvent(paymentMethod: PrimerPaymentMethodType.paymentCard.rawValue)))
         }
       }
     }
   }
 
-  public func getFieldValue(_ fieldType: PrimerInputElementType) -> String {
+  func getFieldValue(_ fieldType: PrimerInputElementType) -> String {
     structuredState.data[fieldType]
   }
 
-  public func setFieldError(
+  func setFieldError(
     _ fieldType: PrimerInputElementType, message: String, errorCode: String? = nil
   ) {
     structuredState.setError(message, for: fieldType, errorCode: errorCode)
     announceFieldErrors()
   }
 
-  public func clearFieldError(_ fieldType: PrimerInputElementType) {
+  func clearFieldError(_ fieldType: PrimerInputElementType) {
     structuredState.clearError(for: fieldType)
   }
 
-  public func getFieldError(_ fieldType: PrimerInputElementType) -> String? {
+  func getFieldError(_ fieldType: PrimerInputElementType) -> String? {
     structuredState.errorMessage(for: fieldType)
   }
 
-  public func getFormConfiguration() -> CardFormConfiguration {
+  func getFormConfiguration() -> CardFormConfiguration {
     formConfiguration
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
@@ -1,0 +1,633 @@
+//
+//  DefaultCardFormScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+public struct FieldValidationStates: Equatable {
+  public var cardNumber: Bool = false
+  public var cvv: Bool = false
+  public var expiry: Bool = false
+  public var cardholderName: Bool = false
+  public var postalCode: Bool = false
+  public var countryCode: Bool = false
+  public var city: Bool = false
+  public var state: Bool = false
+  public var addressLine1: Bool = false
+  public var addressLine2: Bool = false
+  public var firstName: Bool = false
+  public var lastName: Bool = false
+  public var email: Bool = false
+  public var phoneNumber: Bool = false
+}
+
+@available(iOS 15.0, *)
+@MainActor
+public final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, LogReporter {
+
+  public private(set) var presentationContext: PresentationContext = .fromPaymentSelection
+
+  public var cardFormUIOptions: PrimerCardFormUIOptions? {
+    checkoutScope?.cardFormUIOptions
+  }
+
+  public var dismissalMechanism: [DismissalMechanism] {
+    checkoutScope?.dismissalMechanism ?? []
+  }
+
+  public var state: AsyncStream<PrimerCardFormState> {
+    AsyncStream { continuation in
+      let task = Task { [self] in
+        for await _ in $structuredState.values {
+          continuation.yield(structuredState)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  public var title: String?
+  public var screen: CardFormScreenComponent?
+  public var cobadgedCardsView:
+    ((_ availableNetworks: [String], _ selectNetwork: @escaping (String) -> Void) -> any View)?
+  public var errorScreen: ErrorComponent?
+  public var submitButtonText: String?
+  public var showSubmitLoadingIndicator: Bool = true
+  public var cardNumberConfig: InputFieldConfig?
+  public var expiryDateConfig: InputFieldConfig?
+  public var cvvConfig: InputFieldConfig?
+  public var cardholderNameConfig: InputFieldConfig?
+  public var postalCodeConfig: InputFieldConfig?
+  public var countryConfig: InputFieldConfig?
+  public var cityConfig: InputFieldConfig?
+  public var stateConfig: InputFieldConfig?
+  public var addressLine1Config: InputFieldConfig?
+  public var addressLine2Config: InputFieldConfig?
+  public var phoneNumberConfig: InputFieldConfig?
+  public var firstNameConfig: InputFieldConfig?
+  public var lastNameConfig: InputFieldConfig?
+  public var emailConfig: InputFieldConfig?
+  public var retailOutletConfig: InputFieldConfig?
+  public var otpCodeConfig: InputFieldConfig?
+  public var cardInputSection: Component?
+  public var billingAddressSection: Component?
+  public var submitButton: Component?
+
+  @Published var structuredState = PrimerCardFormState()
+  var fieldValidationStates = FieldValidationStates()
+
+  private weak var checkoutScope: DefaultCheckoutScope?
+  private let processCardPaymentInteractor: ProcessCardPaymentInteractor
+  private let validateInputInteractor: ValidateInputInteractor?
+  private let cardNetworkDetectionInteractor: CardNetworkDetectionInteractor?
+  private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+  private let configurationService: ConfigurationService
+  private var billingAddressSent = false
+  private var networkDetectionTask: Task<Void, Never>?
+  private var binDataTask: Task<Void, Never>?
+  private var preferredNetwork: CardNetwork?
+  private var currentCardData: PrimerCardData?
+  private var formConfiguration: CardFormConfiguration = .default
+
+  private func buildBillingAddressFields() -> [PrimerInputElementType] {
+    guard let options = configurationService.billingAddressOptions,
+      options.postalCode == true
+    else {
+      return []
+    }
+
+    var fields: [PrimerInputElementType] = []
+
+    if options.countryCode != false { fields.append(.countryCode) }
+    if options.firstName != false { fields.append(.firstName) }
+    if options.lastName != false { fields.append(.lastName) }
+    if options.addressLine1 != false { fields.append(.addressLine1) }
+    if options.addressLine2 != false { fields.append(.addressLine2) }
+    fields.append(.postalCode)
+    if options.city != false { fields.append(.city) }
+    if options.state != false { fields.append(.state) }
+
+    return fields
+  }
+
+  init(
+    checkoutScope: DefaultCheckoutScope,
+    presentationContext: PresentationContext = .fromPaymentSelection,
+    processCardPaymentInteractor: ProcessCardPaymentInteractor,
+    validateInputInteractor: ValidateInputInteractor? = nil,
+    cardNetworkDetectionInteractor: CardNetworkDetectionInteractor? = nil,
+    analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil,
+    configurationService: ConfigurationService
+  ) {
+    self.checkoutScope = checkoutScope
+    self.presentationContext = presentationContext
+    self.processCardPaymentInteractor = processCardPaymentInteractor
+    self.validateInputInteractor = validateInputInteractor
+    self.cardNetworkDetectionInteractor = cardNetworkDetectionInteractor
+    self.analyticsInteractor = analyticsInteractor
+    self.configurationService = configurationService
+
+    let billingFields = buildBillingAddressFields()
+    formConfiguration = CardFormConfiguration(
+      cardFields: [.cardNumber, .expiryDate, .cvv, .cardholderName],
+      billingFields: billingFields,
+      requiresBillingAddress: !billingFields.isEmpty
+    )
+
+    if cardNetworkDetectionInteractor != nil {
+      setupNetworkDetectionStream()
+      setupBinDataStream()
+    }
+  }
+
+  func getCardNetworkForCvv() -> CardNetwork {
+    if let selectedNetwork = structuredState.selectedNetwork {
+      selectedNetwork.network
+    } else {
+      CardNetwork(cardNumber: structuredState.data[.cardNumber])
+    }
+  }
+
+  func updateFieldValidationState() {
+    updateValidationState(
+      cardNumber: fieldValidationStates.cardNumber,
+      cvv: fieldValidationStates.cvv,
+      expiry: fieldValidationStates.expiry,
+      cardholderName: fieldValidationStates.cardholderName
+    )
+  }
+
+  private func setupNetworkDetectionStream() {
+    guard let interactor = cardNetworkDetectionInteractor else { return }
+
+    networkDetectionTask = Task { [weak self] in
+      for await networks in interactor.networkDetectionStream {
+        guard let self else { return }
+        structuredState.availableNetworks = networks.map { PrimerCardNetwork(network: $0) }
+
+        if let firstNetwork = networks.first {
+          structuredState.selectedNetwork = PrimerCardNetwork(network: firstNetwork)
+          updateSurchargeAmount(for: networks.count == 1 ? firstNetwork : nil)
+        } else {
+          structuredState.selectedNetwork = nil
+          updateSurchargeAmount(for: nil)
+        }
+        preferredNetwork = nil
+      }
+    }
+  }
+
+  private func setupBinDataStream() {
+    guard let cardNetworkDetectionInteractor else { return }
+
+    binDataTask = Task { [weak self] in
+      for await binData in cardNetworkDetectionInteractor.binDataStream {
+        guard let self else { return }
+        structuredState.binData = binData
+      }
+    }
+  }
+
+  public func updateField(_ fieldType: PrimerInputElementType, value: String) {
+    switch fieldType {
+    case .cardNumber:
+      updateCardNumber(value)
+    case .cvv:
+      updateCvv(value)
+    case .expiryDate:
+      updateExpiryDate(value)
+    case .cardholderName:
+      updateCardholderName(value)
+    case .postalCode:
+      updatePostalCode(value)
+    case .countryCode:
+      updateCountryCode(value)
+    case .city:
+      updateCity(value)
+    case .state:
+      updateState(value)
+    case .addressLine1:
+      updateAddressLine1(value)
+    case .addressLine2:
+      updateAddressLine2(value)
+    case .phoneNumber:
+      updatePhoneNumber(value)
+    case .firstName:
+      updateFirstName(value)
+    case .lastName:
+      updateLastName(value)
+    case .email:
+      updateEmail(value)
+    case .retailer:
+      updateRetailOutlet(value)
+    case .otp:
+      updateOtpCode(value)
+    default:
+      break
+    }
+  }
+
+  public func updateCardNumber(_ cardNumber: String) {
+    structuredState.data[.cardNumber] = cardNumber
+    updateCardData()
+
+    Task {
+      await triggerNetworkDetection(for: cardNumber)
+    }
+  }
+
+  private func triggerNetworkDetection(for cardNumber: String) async {
+    guard let interactor = cardNetworkDetectionInteractor else { return }
+    await interactor.detectNetworks(for: cardNumber)
+  }
+
+  public func updateCvv(_ cvv: String) {
+    structuredState.data[.cvv] = cvv
+    updateCardData()
+  }
+
+  public func updateExpiryDate(_ expiryDate: String) {
+    structuredState.data[.expiryDate] = expiryDate
+    updateCardData()
+  }
+
+  public func updateExpiryMonth(_ month: String) {
+    let currentExpiry = structuredState.data[.expiryDate]
+    let components = currentExpiry.components(separatedBy: "/")
+    let year = components.count >= 2 ? components[1] : ""
+    structuredState.data[.expiryDate] = "\(month)/\(year)"
+    updateCardData()
+  }
+
+  public func updateExpiryYear(_ year: String) {
+    let currentExpiry = structuredState.data[.expiryDate]
+    let components = currentExpiry.components(separatedBy: "/")
+    let month = components.count >= 1 ? components[0] : ""
+    structuredState.data[.expiryDate] = "\(month)/\(year)"
+    updateCardData()
+  }
+
+  public func updateCardholderName(_ name: String) {
+    structuredState.data[.cardholderName] = name
+    updateCardData()
+  }
+
+  public func updateFirstName(_ firstName: String) {
+    structuredState.data[.firstName] = firstName
+  }
+
+  public func updateLastName(_ lastName: String) {
+    structuredState.data[.lastName] = lastName
+  }
+
+  public func updateEmail(_ email: String) {
+    structuredState.data[.email] = email
+  }
+
+  public func updatePhoneNumber(_ phoneNumber: String) {
+    structuredState.data[.phoneNumber] = phoneNumber
+  }
+
+  public func updateAddressLine1(_ addressLine1: String) {
+    structuredState.data[.addressLine1] = addressLine1
+  }
+
+  public func updateAddressLine2(_ addressLine2: String) {
+    structuredState.data[.addressLine2] = addressLine2
+  }
+
+  public func updateCity(_ city: String) {
+    structuredState.data[.city] = city
+  }
+
+  public func updateState(_ state: String) {
+    structuredState.data[.state] = state
+  }
+
+  public func updatePostalCode(_ postalCode: String) {
+    structuredState.data[.postalCode] = postalCode
+  }
+
+  public func updateCountryCode(_ countryCode: String) {
+    structuredState.data[.countryCode] = countryCode
+
+    if let country = CountryCode.phoneNumberCountryCodes.first(where: {
+      $0.code.uppercased() == countryCode.uppercased()
+    }),
+      let countryCodeEnum = CountryCode(rawValue: country.code) {
+      structuredState.selectedCountry = PrimerCountry(
+        code: country.code,
+        name: country.name,
+        flag: countryCodeEnum.flag,
+        dialCode: country.dialCode
+      )
+    }
+
+    objectWillChange.send()
+  }
+
+  public func updateOtpCode(_ otpCode: String) {
+    structuredState.data[.otp] = otpCode
+  }
+
+  public func updateSelectedCardNetwork(_ network: String) {
+    if let cardNetwork = CardNetwork(rawValue: network) {
+      if cardNetwork == .unknown {
+        structuredState.selectedNetwork = nil
+        preferredNetwork = nil
+        updateSurchargeAmount(for: nil)
+      } else {
+        structuredState.selectedNetwork = PrimerCardNetwork(network: cardNetwork)
+        preferredNetwork = cardNetwork
+        updateSurchargeAmount(for: cardNetwork)
+      }
+    }
+
+    updateCardData()
+
+    Task {
+      await handleNetworkSelection(network)
+    }
+  }
+
+  private func handleNetworkSelection(_ networkString: String) async {
+    guard let interactor = cardNetworkDetectionInteractor,
+      let cardNetwork = CardNetwork(rawValue: networkString)
+    else { return }
+    await interactor.selectNetwork(cardNetwork)
+  }
+
+  public func updateRetailOutlet(_ retailOutlet: String) {
+    structuredState.data[.retailer] = retailOutlet
+  }
+
+  public func submit() {
+    guard !structuredState.isLoading else { return }
+    Task { [self] in
+      await performSubmit()
+    }
+  }
+
+  public func onBack() {
+    if presentationContext.shouldShowBackButton {
+      checkoutScope?.checkoutNavigator.navigateBack()
+    }
+  }
+
+  public func cancel() {
+    networkDetectionTask?.cancel()
+    networkDetectionTask = nil
+    binDataTask?.cancel()
+    binDataTask = nil
+    checkoutScope?.onDismiss()
+  }
+
+  private var _selectCountry: DefaultSelectCountryScope?
+  public var selectCountry: PrimerSelectCountryScope {
+    if let existing = _selectCountry {
+      return existing
+    }
+    let scope = DefaultSelectCountryScope(cardFormScope: self, checkoutScope: checkoutScope)
+    _selectCountry = scope
+    return scope
+  }
+
+  private func updateCardData() {
+    let cardData = PrimerCardData(
+      cardNumber: structuredState.data[.cardNumber].replacingOccurrences(of: " ", with: ""),
+      expiryDate: structuredState.data[.expiryDate],
+      cvv: structuredState.data[.cvv],
+      cardholderName: structuredState.data[.cardholderName].isEmpty
+        ? nil : structuredState.data[.cardholderName]
+    )
+
+    if let preferredNetwork {
+      cardData.cardNetwork = preferredNetwork
+    }
+
+    currentCardData = cardData
+  }
+
+  private func createBillingAddress() -> ClientSession.Address? {
+    guard !structuredState.data[.postalCode].isEmpty else { return nil }
+
+    return ClientSession.Address(
+      firstName: structuredState.data[.firstName].isEmpty ? nil : structuredState.data[.firstName],
+      lastName: structuredState.data[.lastName].isEmpty ? nil : structuredState.data[.lastName],
+      addressLine1: structuredState.data[.addressLine1].isEmpty
+        ? nil : structuredState.data[.addressLine1],
+      addressLine2: structuredState.data[.addressLine2].isEmpty
+        ? nil : structuredState.data[.addressLine2],
+      city: structuredState.data[.city].isEmpty ? nil : structuredState.data[.city],
+      postalCode: structuredState.data[.postalCode],
+      state: structuredState.data[.state].isEmpty ? nil : structuredState.data[.state],
+      countryCode: structuredState.data[.countryCode].isEmpty
+        ? nil : CountryCode(rawValue: structuredState.data[.countryCode])
+    )
+  }
+
+  func performSubmit() async {
+    structuredState.isLoading = true
+    checkoutScope?.startProcessing()
+
+    await analyticsInteractor?.trackEvent(
+      .paymentSubmitted,
+      metadata: .payment(PaymentEvent(paymentMethod: PrimerPaymentMethodType.paymentCard.rawValue))
+    )
+
+    do {
+      try await checkoutScope?.invokeBeforePaymentCreate(
+        paymentMethodType: PrimerPaymentMethodType.paymentCard.rawValue
+      )
+      try await sendBillingAddressIfNeeded()
+      let cardData = try await prepareCardPaymentData()
+
+      await analyticsInteractor?.trackEvent(
+        .paymentProcessingStarted,
+        metadata: .payment(
+          PaymentEvent(paymentMethod: PrimerPaymentMethodType.paymentCard.rawValue)
+        )
+      )
+
+      let result = try await processCardPayment(cardData: cardData)
+      await handlePaymentSuccess(result)
+    } catch {
+      await handlePaymentError(error)
+    }
+  }
+
+  private func sendBillingAddressIfNeeded() async throws {
+    guard !billingAddressSent, let billingAddress = createBillingAddress() else { return }
+    try await ClientSessionActionsModule
+      .updateBillingAddressViaClientSessionActionWithAddressIfNeeded(billingAddress)
+    billingAddressSent = true
+  }
+
+  private func prepareCardPaymentData() async throws -> CardPaymentData {
+    let (expiryMonth, fullYear) = try parseExpiryComponents()
+
+    return CardPaymentData(
+      cardNumber: structuredState.data[.cardNumber].replacingOccurrences(of: " ", with: ""),
+      cvv: structuredState.data[.cvv],
+      expiryMonth: expiryMonth,
+      expiryYear: fullYear,
+      cardholderName: structuredState.data[.cardholderName],
+      selectedNetwork: preferredNetwork
+    )
+  }
+
+  private func parseExpiryComponents() throws -> (month: String, year: String) {
+    let expiryComponents = structuredState.data[.expiryDate].components(separatedBy: "/")
+    guard expiryComponents.count == 2 else {
+      throw PrimerError.invalidValue(
+        key: "expiryDate",
+        value: structuredState.data[.expiryDate],
+        reason: "Invalid expiry date format. Expected MM/YY or MM/YYYY"
+      )
+    }
+
+    let expiryMonth = expiryComponents[0]
+    let expiryYear = expiryComponents[1]
+    let fullYear = expiryYear.count == 2 ? "20\(expiryYear)" : expiryYear
+
+    return (expiryMonth, fullYear)
+  }
+
+  private func processCardPayment(cardData: CardPaymentData) async throws -> PaymentResult {
+    try await processCardPaymentInteractor.execute(cardData: cardData)
+  }
+
+  private func handlePaymentError(_ error: Error) async {
+    structuredState.isLoading = false
+    billingAddressSent = false
+    let primerError =
+      error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+    checkoutScope?.handlePaymentError(primerError)
+  }
+
+  private func handlePaymentSuccess(_ result: PaymentResult) async {
+    structuredState.isLoading = false
+    checkoutScope?.handlePaymentSuccess(result)
+  }
+
+  private func updateSurchargeAmount(for network: CardNetwork?) {
+    guard let network else {
+      structuredState.surchargeAmountRaw = nil
+      structuredState.surchargeAmount = nil
+      return
+    }
+
+    guard let surcharge = network.surcharge,
+      configurationService.apiConfiguration?.clientSession?.order?.merchantAmount == nil,
+      let currency = configurationService.currency
+    else {
+      structuredState.surchargeAmountRaw = nil
+      structuredState.surchargeAmount = nil
+      return
+    }
+
+    let formattedSurcharge = "+ \(surcharge.toCurrencyString(currency: currency))"
+    structuredState.surchargeAmountRaw = surcharge
+    structuredState.surchargeAmount = formattedSurcharge
+  }
+
+  public func updateValidationState(cardNumber: Bool, cvv: Bool, expiry: Bool, cardholderName: Bool) {
+    let hasValidCardNumber =
+      cardNumber
+      && !structuredState.data[.cardNumber].replacingOccurrences(of: " ", with: "").isEmpty
+    let hasValidCvv = cvv && !structuredState.data[.cvv].isEmpty
+    let hasValidExpiry = expiry && !structuredState.data[.expiryDate].isEmpty
+    let hasValidCardholderName = cardholderName && !structuredState.data[.cardholderName].isEmpty
+
+    let wasValid = structuredState.isValid
+
+    structuredState.isValid =
+      hasValidCardNumber && hasValidCvv && hasValidExpiry && hasValidCardholderName
+
+    if structuredState.isValid {
+      structuredState.fieldErrors.removeAll()
+
+      if !wasValid {
+        Task { [self] in
+          await analyticsInteractor?.trackEvent(
+            .paymentDetailsEntered,
+            metadata: .payment(
+              PaymentEvent(paymentMethod: PrimerPaymentMethodType.paymentCard.rawValue)
+            )
+          )
+        }
+      }
+    }
+  }
+
+  public func getFieldValue(_ fieldType: PrimerInputElementType) -> String {
+    structuredState.data[fieldType]
+  }
+
+  public func setFieldError(
+    _ fieldType: PrimerInputElementType, message: String, errorCode: String? = nil
+  ) {
+    structuredState.setError(message, for: fieldType, errorCode: errorCode)
+    announceFieldErrors()
+  }
+
+  public func clearFieldError(_ fieldType: PrimerInputElementType) {
+    structuredState.clearError(for: fieldType)
+  }
+
+  public func getFieldError(_ fieldType: PrimerInputElementType) -> String? {
+    structuredState.errorMessage(for: fieldType)
+  }
+
+  public func getFormConfiguration() -> CardFormConfiguration {
+    formConfiguration
+  }
+
+  func getBillingAddressConfiguration() -> BillingAddressConfiguration {
+    let fields = formConfiguration.billingFields
+    return BillingAddressConfiguration(
+      showFirstName: fields.contains(.firstName),
+      showLastName: fields.contains(.lastName),
+      showEmail: fields.contains(.email),
+      showPhoneNumber: fields.contains(.phoneNumber),
+      showAddressLine1: fields.contains(.addressLine1),
+      showAddressLine2: fields.contains(.addressLine2),
+      showCity: fields.contains(.city),
+      showState: fields.contains(.state),
+      showPostalCode: fields.contains(.postalCode),
+      showCountry: fields.contains(.countryCode)
+    )
+  }
+
+  private func announceFieldErrors() {
+    guard let container = DIContainer.currentSync,
+      let announcementService = try? container.resolveSync(AccessibilityAnnouncementService.self)
+    else {
+      return
+    }
+
+    let errorCount = structuredState.fieldErrors.count
+
+    guard errorCount > 0 else { return }
+
+    if errorCount == 1 {
+      // Single error - announce the error message directly
+      if let firstError = structuredState.fieldErrors.first {
+        announcementService.announceError(firstError.message)
+      }
+    } else {
+      // Multiple errors - announce count first, then first error details
+      let countMessage = CheckoutComponentsStrings.a11yMultipleErrors(errorCount)
+      let firstErrorMessage = structuredState.fieldErrors.first?.message ?? ""
+      let combinedMessage = "\(countMessage). \(firstErrorMessage)"
+      announcementService.announceError(combinedMessage)
+    }
+  }
+
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -1,0 +1,614 @@
+//
+//  DefaultCheckoutScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogReporter {
+
+  enum NavigationState: Equatable {
+    case loading
+    case paymentMethodSelection
+    case vaultedPaymentMethods
+    case deleteVaultedPaymentMethodConfirmation(
+      PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
+    )
+    case paymentMethod(String)
+    case processing
+    case success(PaymentResult)
+    case failure(PrimerError)
+    case dismissed
+
+    static func == (lhs: NavigationState, rhs: NavigationState) -> Bool {
+      switch (lhs, rhs) {
+      case (.loading, .loading),
+        (.paymentMethodSelection, .paymentMethodSelection),
+        (.vaultedPaymentMethods, .vaultedPaymentMethods),
+        (.processing, .processing),
+        (.dismissed, .dismissed):
+        true
+      case let (
+        .deleteVaultedPaymentMethodConfirmation(lhsMethod),
+        .deleteVaultedPaymentMethodConfirmation(rhsMethod)
+      ):
+        lhsMethod.id == rhsMethod.id
+      case let (.paymentMethod(lhsType), .paymentMethod(rhsType)):
+        lhsType == rhsType
+      case let (.success(lhsResult), .success(rhsResult)):
+        lhsResult.paymentId == rhsResult.paymentId
+      case let (.failure(lhsError), .failure(rhsError)):
+        lhsError.localizedDescription == rhsError.localizedDescription
+      default:
+        false
+      }
+    }
+  }
+
+  @Published private var internalState = PrimerCheckoutState.initializing
+  @Published var navigationState = NavigationState.loading
+
+  public var onBeforePaymentCreate: BeforePaymentCreateHandler?
+  public var container: ContainerComponent?
+  public var splashScreen: Component?
+  public var loadingScreen: Component?
+  public var successScreen: ((_ result: PaymentResult) -> AnyView)?
+  public var errorScreen: ErrorComponent?
+  public var paymentMethodSelectionScreen: PaymentMethodSelectionScreenComponent?
+
+  public var paymentHandling: PrimerPaymentHandling {
+    settings.paymentHandling
+  }
+
+  public var state: AsyncStream<PrimerCheckoutState> {
+    AsyncStream { continuation in
+      let task = Task { [self] in
+        for await value in $internalState.values {
+          continuation.yield(value)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  var currentState: PrimerCheckoutState { internalState }
+
+  var checkoutNavigator: CheckoutNavigator { navigator }
+
+  var availablePaymentMethods: [InternalPaymentMethod] = []
+
+  @Published private(set) var vaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
+  @Published private(set) var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod?
+
+  var isInitScreenEnabled: Bool { settings.uiOptions.isInitScreenEnabled }
+  var isSuccessScreenEnabled: Bool { settings.uiOptions.isSuccessScreenEnabled }
+  var isErrorScreenEnabled: Bool { settings.uiOptions.isErrorScreenEnabled }
+  var cardFormUIOptions: PrimerCardFormUIOptions? { settings.uiOptions.cardFormUIOptions }
+  var dismissalMechanism: [DismissalMechanism] { settings.uiOptions.dismissalMechanism }
+  var is3DSSanityCheckEnabled: Bool { settings.debugOptions.is3DSSanityCheckEnabled }
+
+  let presentationContext: PresentationContext
+
+  private var cachedPaymentMethodSelection: PrimerPaymentMethodSelectionScope?
+  public var paymentMethodSelection: PrimerPaymentMethodSelectionScope {
+    if let cachedPaymentMethodSelection { return cachedPaymentMethodSelection }
+    let scope = DefaultPaymentMethodSelectionScope(
+      checkoutScope: self,
+      analyticsInteractor: analyticsInteractor
+    )
+    cachedPaymentMethodSelection = scope
+    return scope
+  }
+
+  private var currentPaymentMethodScope: (any PrimerPaymentMethodScope)?
+  private var paymentMethodScopeCache: [String: any PrimerPaymentMethodScope] = [:]
+  private var navigationObservationTask: Task<Void, Never>?
+  private let navigator: CheckoutNavigator
+  private var configurationService: ConfigurationService?
+  private var paymentMethodsInteractor: GetPaymentMethodsInteractor?
+  private var analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+  private var accessibilityAnnouncementService: AccessibilityAnnouncementService?
+  private var selectedPaymentMethodName: String?
+  private let clientToken: String
+  private let settings: PrimerSettings
+
+  init(
+    clientToken: String,
+    settings: PrimerSettings,
+    diContainer: DIContainer,
+    navigator: CheckoutNavigator,
+    presentationContext: PresentationContext = .fromPaymentSelection
+  ) {
+    self.clientToken = clientToken
+    self.settings = settings
+    self.navigator = navigator
+    self.presentationContext = presentationContext
+
+    registerPaymentMethods()
+
+    Task { [self] in
+      await setupInteractors()
+      await loadPaymentMethods()
+    }
+
+    observeNavigationEvents()
+  }
+
+  private func registerPaymentMethods() {
+    CardPaymentMethod.register()
+    PayPalPaymentMethod.register()
+    ApplePayPaymentMethod.register()
+    KlarnaPaymentMethod.register()
+    AchPaymentMethod.register()
+    FormRedirectPaymentMethod.register()
+    QRCodePaymentMethod.registerAll([.xfersPayNow, .rapydPromptPay, .omisePromptPay])
+
+    let webRedirectTypes = PrimerAPIConfigurationModule.apiConfiguration?
+      .paymentMethods?
+      .filter { $0.implementationType == .webRedirect }
+      .map(\.type) ?? []
+    WebRedirectPaymentMethod.register(types: webRedirectTypes)
+  }
+
+  private func setupInteractors() async {
+    do {
+      guard let container = await DIContainer.current else {
+        throw ContainerError.containerUnavailable
+      }
+
+      let configService = try await container.resolve(ConfigurationService.self)
+      configurationService = configService
+      paymentMethodsInteractor = CheckoutComponentsPaymentMethodsBridge(
+        configurationService: configService
+      )
+
+      analyticsInteractor = try? await container.resolve(
+        CheckoutComponentsAnalyticsInteractorProtocol.self
+      )
+
+      accessibilityAnnouncementService = try? await container.resolve(
+        AccessibilityAnnouncementService.self
+      )
+    } catch {
+      let primerError = PrimerError.invalidArchitecture(
+        description: "Failed to setup interactors: \(error.localizedDescription)",
+        recoverSuggestion: "Ensure proper SDK initialization"
+      )
+      logger.error(message: "Failed to setup interactors: \(primerError)", error: primerError)
+      updateNavigationState(.failure(primerError))
+      updateState(.failure(primerError))
+    }
+  }
+
+  private func loadPaymentMethods() async {
+    if settings.uiOptions.isInitScreenEnabled {
+      updateNavigationState(.loading)
+    }
+
+    do {
+      try await Task.sleep(nanoseconds: 500_000_000)
+
+      guard let interactor = paymentMethodsInteractor else {
+        throw PrimerError.invalidArchitecture(
+          description: "GetPaymentMethodsInteractor not resolved",
+          recoverSuggestion: "Ensure proper SDK initialization and dependency injection setup"
+        )
+      }
+
+      availablePaymentMethods = try await interactor.execute()
+
+      await preloadPaymentMethodScopes()
+
+      if availablePaymentMethods.isEmpty {
+        let error = PrimerError.missingPrimerConfiguration()
+        updateNavigationState(.failure(error))
+        updateState(.failure(error))
+      } else {
+          let totalAmount = configurationService?.amount ?? 0
+        let currencyCode = configurationService?.currency?.code ?? ""
+        updateState(.ready(totalAmount: totalAmount, currencyCode: currencyCode))
+
+        if availablePaymentMethods.count == 1,
+          let singlePaymentMethod = availablePaymentMethods.first {
+          updateNavigationState(.paymentMethod(singlePaymentMethod.type))
+        } else {
+          updateNavigationState(.paymentMethodSelection)
+        }
+      }
+    } catch {
+      let primerError =
+        error as? PrimerError
+        ?? PrimerError.unknown(
+          message: error.localizedDescription
+        )
+
+      updateNavigationState(.failure(primerError))
+      updateState(.failure(primerError))
+    }
+  }
+
+  private func preloadPaymentMethodScopes() async {
+    guard let container = await DIContainer.current else { return }
+
+    for type in PaymentMethodRegistry.shared.registeredTypes {
+      do {
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+          for: type,
+          checkoutScope: self,
+          diContainer: container
+        )
+        if let scope {
+          paymentMethodScopeCache[type] = scope
+        }
+      } catch {
+        logger.warn(
+          message: "Failed to pre-load scope for \(type): \(error.localizedDescription)"
+        )
+      }
+    }
+  }
+
+  private func updateState(_ newState: PrimerCheckoutState) {
+    internalState = newState
+
+    Task { [self] in
+      await trackStateChange(newState)
+    }
+  }
+
+  private func trackStateChange(_ state: PrimerCheckoutState) async {
+    switch state {
+    case .ready:
+      await analyticsInteractor?.trackEvent(.checkoutFlowStarted, metadata: .general())
+      let initDuration = await LoggingSessionContext.shared.calculateInitDuration()
+      let message = initDuration.map { "Checkout initialized (\($0)ms)" } ?? "Checkout initialized"
+      logger.info(
+        message: message,
+        event: "checkout-initialized",
+        userInfo: initDuration.map { ["init_duration_ms": $0] }
+      )
+
+    case let .success(result):
+      if let paymentMethod = result.paymentMethodType {
+        await analyticsInteractor?.trackEvent(
+          .paymentSuccess,
+          metadata: .payment(
+            PaymentEvent(
+              paymentMethod: paymentMethod,
+              paymentId: result.paymentId
+            )
+          )
+        )
+      } else {
+        // No payment method type available, use general event
+        await analyticsInteractor?.trackEvent(.paymentSuccess, metadata: .general())
+      }
+
+    case let .failure(error):
+      await analyticsInteractor?.trackEvent(
+        .paymentFailure, metadata: extractFailureMetadata(from: error)
+      )
+
+    case .dismissed:
+      await analyticsInteractor?.trackEvent(.paymentFlowExited, metadata: .general())
+
+    default:
+      break
+    }
+  }
+
+  private func extractFailureMetadata(from error: PrimerError) -> AnalyticsEventMetadata {
+    if case let .paymentFailed(paymentMethodType, paymentId, _, _, _) = error,
+      let paymentMethod = paymentMethodType {
+      return .payment(
+        PaymentEvent(
+          paymentMethod: paymentMethod,
+          paymentId: paymentId
+        )
+      )
+    }
+
+    // For other error types, just include userLocale
+    return .general()
+  }
+
+  func updateNavigationState(_ newState: NavigationState, syncToNavigator: Bool = true) {
+    navigationState = newState
+
+    announceScreenChange(for: newState)
+
+    // Update navigation based on state (only if not syncing from navigator to avoid loops)
+    if syncToNavigator {
+      switch newState {
+      case .loading:
+        navigator.navigateToLoading()
+      case .paymentMethodSelection:
+        navigator.navigateToPaymentSelection()
+      case .vaultedPaymentMethods:
+        navigator.navigateToVaultedPaymentMethods()
+      case let .deleteVaultedPaymentMethodConfirmation(method):
+        navigator.navigateToDeleteVaultedPaymentMethodConfirmation(method)
+      case let .paymentMethod(paymentMethodType):
+        navigator.navigateToPaymentMethod(paymentMethodType, context: presentationContext)
+      case .processing:
+        navigator.navigateToProcessing()
+      case .success:
+        // Success handling is now done via the view's switch statement, not the navigator
+        break
+      case let .failure(error):
+        navigator.navigateToError(error)
+      case .dismissed:
+        // Dismissal is handled by the view layer through onCompletion callback
+        break
+      }
+    }
+  }
+
+  private func announceScreenChange(for state: NavigationState) {
+    guard let service = accessibilityAnnouncementService else { return }
+
+    let message: String?
+    switch state {
+    case .loading:
+      message = CheckoutComponentsStrings.a11yScreenLoadingPaymentMethods
+    case .paymentMethodSelection:
+      message = CheckoutComponentsStrings.choosePaymentMethod
+    case .vaultedPaymentMethods:
+      message = CheckoutComponentsStrings.allSavedPaymentMethods
+    case .deleteVaultedPaymentMethodConfirmation:
+      message = CheckoutComponentsStrings.deletePaymentMethodConfirmation
+    case let .paymentMethod(type):
+      if let name = selectedPaymentMethodName {
+        message = CheckoutComponentsStrings.a11yScreenPaymentMethod(name)
+      } else {
+        // Fallback: Format raw payment method type for display
+        // This should rarely be used as API always provides display names
+        let displayName =
+          type
+          .replacingOccurrences(of: "_", with: " ")
+          .capitalized
+        message = CheckoutComponentsStrings.a11yScreenPaymentMethod(displayName)
+      }
+    case .processing:
+      message = CheckoutComponentsStrings.a11yScreenProcessingPayment
+    case .success:
+      message = CheckoutComponentsStrings.a11yScreenSuccess
+      selectedPaymentMethodName = nil
+    case .failure:
+      message = CheckoutComponentsStrings.a11yScreenError
+      selectedPaymentMethodName = nil
+    case .dismissed:
+      message = nil
+      selectedPaymentMethodName = nil
+    }
+
+    if let message {
+      service.announceScreenChange(message)
+      logger.debug(message: "[A11Y] Screen change announcement: \(message)")
+    }
+  }
+
+  // MARK: - Navigation Events Observer
+
+  private func observeNavigationEvents() {
+    navigationObservationTask = Task { @MainActor [weak self] in
+      guard let self else { return }
+      for await route in navigator.navigationEvents {
+        let newNavigationState: NavigationState
+        switch route {
+        case .loading:
+          newNavigationState = .loading
+        case .paymentMethodSelection:
+          newNavigationState = .paymentMethodSelection
+        case .vaultedPaymentMethods:
+          newNavigationState = .vaultedPaymentMethods
+        case let .deleteVaultedPaymentMethodConfirmation(method):
+          newNavigationState = .deleteVaultedPaymentMethodConfirmation(method)
+        case let .paymentMethod(paymentMethodType, _):
+          newNavigationState = .paymentMethod(paymentMethodType)
+        case .processing:
+          newNavigationState = .processing
+        case let .failure(primerError):
+          newNavigationState = .failure(primerError)
+        default:
+          continue
+        }
+
+        // Only update if the state has actually changed to avoid loops
+        if case let .failure(currentError) = navigationState,
+          case let .failure(newError) = newNavigationState {
+          // For error states, compare messages to avoid redundant updates
+          if currentError.localizedDescription != newError.localizedDescription {
+            updateNavigationState(newNavigationState, syncToNavigator: false)
+          }
+        } else if !navigationStateEquals(navigationState, newNavigationState) {
+          updateNavigationState(newNavigationState, syncToNavigator: false)
+        }
+      }
+    }
+  }
+
+  private func navigationStateEquals(_ lhs: NavigationState, _ rhs: NavigationState) -> Bool {
+    switch (lhs, rhs) {
+    case (.loading, .loading),
+      (.paymentMethodSelection, .paymentMethodSelection),
+      (.vaultedPaymentMethods, .vaultedPaymentMethods),
+      (.processing, .processing):
+      true
+    case let (
+      .deleteVaultedPaymentMethodConfirmation(lhsMethod),
+      .deleteVaultedPaymentMethodConfirmation(rhsMethod)
+    ):
+      lhsMethod.id == rhsMethod.id
+    case let (.paymentMethod(lhsType), .paymentMethod(rhsType)):
+      lhsType == rhsType
+    case let (.failure(lhsError), .failure(rhsError)):
+      lhsError.localizedDescription == rhsError.localizedDescription
+    default:
+      false
+    }
+  }
+
+  // MARK: - Public Methods
+
+  public func getPaymentMethodScope<T: PrimerPaymentMethodScope>(
+    for paymentMethodType: String
+  ) -> T? {
+    guard let scope = paymentMethodScopeCache[paymentMethodType] as? T else { return nil }
+    currentPaymentMethodScope = scope
+    return scope
+  }
+
+  public func getPaymentMethodScope<T: PrimerPaymentMethodScope>(_ scopeType: T.Type) -> T? {
+    guard let scope = paymentMethodScopeCache.values.first(where: { $0 is T }) as? T else {
+      return nil
+    }
+    currentPaymentMethodScope = scope
+    return scope
+  }
+
+  public func getPaymentMethodScope<T: PrimerPaymentMethodScope>(
+    for methodType: PrimerPaymentMethodType
+  ) -> T? {
+    getPaymentMethodScope(for: methodType.rawValue)
+  }
+
+  public func onDismiss() {
+    // Ensure state updates happen on main thread for SwiftUI observation
+    Task { @MainActor in
+      updateState(.dismissed)
+      updateNavigationState(.dismissed)
+
+      cachedPaymentMethodSelection = nil
+      currentPaymentMethodScope = nil
+      paymentMethodScopeCache.removeAll()
+
+      navigationObservationTask?.cancel()
+      navigationObservationTask = nil
+
+      navigator.dismiss()
+    }
+  }
+
+  // MARK: - Internal Methods
+
+  func handlePaymentMethodSelection(_ method: InternalPaymentMethod) {
+    selectedPaymentMethodName = method.name
+
+    if let scope = paymentMethodScopeCache[method.type] {
+      currentPaymentMethodScope = scope
+      scope.start()
+      updateNavigationState(.paymentMethod(method.type))
+    } else {
+      logger.debug(
+        message:
+          "⚠️ [DefaultCheckoutScope] Payment method \(method.type) not implemented, showing placeholder"
+      )
+      updateNavigationState(.paymentMethod(method.type))
+    }
+  }
+
+  /// Invokes the onBeforePaymentCreate callback if set, stores the idempotency key, and returns.
+  /// Throws if the merchant aborts payment creation.
+  ///
+  /// - Note: Uses `PrimerInternal.shared.currentIdempotencyKey` singleton for storage because the key
+  ///   must flow to `PrimerAPI.headers` (an enum computed property in the core networking layer).
+  ///   This matches the pattern used in Drop-In and Headless flows. A proper DI solution would require
+  ///   refactoring the networking layer to use injected dependencies instead of the enum pattern.
+  func invokeBeforePaymentCreate(paymentMethodType: String) async throws {
+    guard let callback = onBeforePaymentCreate else { return }
+
+    let decision = await withCheckedContinuation { (continuation: CheckedContinuation<PrimerPaymentCreationDecision, Never>) in
+      let data = PrimerCheckoutPaymentMethodData(
+        type: PrimerCheckoutPaymentMethodType(type: paymentMethodType)
+      )
+      callback(data) { decision in
+        continuation.resume(returning: decision)
+      }
+    }
+
+    switch decision.type {
+    case let .abort(errorMessage):
+      throw PrimerError.merchantError(message: errorMessage ?? "Payment creation aborted")
+    case let .continue(idempotencyKey):
+      // TODO: Refactor to use DI when networking layer is updated to support injected dependencies
+      PrimerInternal.shared.currentIdempotencyKey = idempotencyKey
+    }
+  }
+
+  func handlePaymentSuccess(_ result: PaymentResult) {
+    updateState(.success(result))
+    updateNavigationState(.success(result))
+  }
+
+  func handlePaymentError(_ error: PrimerError) {
+    updateState(.failure(error))
+    // Note: Error callback is invoked via navigateToError in updateNavigationState
+    updateNavigationState(.failure(error))
+  }
+
+  func startProcessing() {
+    updateNavigationState(.processing)
+  }
+
+  func handleAutoDismiss() {
+    // This will be handled by the parent view (PrimerCheckout) to dismiss the entire checkout
+    Task { @MainActor in
+      updateState(.dismissed)
+    }
+  }
+
+  func retryPayment() {
+    // Track payment reattempted event with payment method metadata if available
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      let metadata = extractRetryMetadata()
+      await analyticsInteractor?.trackEvent(.paymentReattempted, metadata: metadata)
+    }
+
+    currentPaymentMethodScope?.submit()
+  }
+
+  private func extractRetryMetadata() -> AnalyticsEventMetadata {
+    // Extract payment method info from the current failure state if available
+    if case let .failure(error) = navigationState {
+      return extractFailureMetadata(from: error)
+    }
+    return .general()
+  }
+
+  // MARK: - Vaulted Payment Methods Methods
+
+  func setVaultedPaymentMethods(_ methods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod]) {
+    vaultedPaymentMethods = methods
+
+    // Clear selection if the selected method was deleted
+    if let selectedId = selectedVaultedPaymentMethod?.id,
+      !methods.contains(where: { $0.id == selectedId }) {
+      selectedVaultedPaymentMethod = nil
+    }
+
+    // Set first as default if none selected
+    if selectedVaultedPaymentMethod == nil, let first = methods.first {
+      selectedVaultedPaymentMethod = first
+    }
+  }
+
+  func setSelectedVaultedPaymentMethod(
+    _ method: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod?
+  ) {
+    selectedVaultedPaymentMethod = method
+    // Notify payment method selection scope to sync from source of truth
+    if let selectionScope = cachedPaymentMethodSelection as? DefaultPaymentMethodSelectionScope {
+      selectionScope.syncSelectedVaultedPaymentMethod()
+    }
+  }
+
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -83,6 +83,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
   var checkoutNavigator: CheckoutNavigator { navigator }
 
   var availablePaymentMethods: [InternalPaymentMethod] = []
+  var paymentMethodScopeCache: [String: any PrimerPaymentMethodScope] = [:]
 
   @Published private(set) var vaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
   @Published private(set) var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod?
@@ -108,7 +109,6 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
   }
 
   private var currentPaymentMethodScope: (any PrimerPaymentMethodScope)?
-  private var paymentMethodScopeCache: [String: any PrimerPaymentMethodScope] = [:]
   private var navigationObservationTask: Task<Void, Never>?
   private let navigator: CheckoutNavigator
   private var configurationService: ConfigurationService?

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -15,8 +15,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     case paymentMethodSelection
     case vaultedPaymentMethods
     case deleteVaultedPaymentMethodConfirmation(
-      PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
-    )
+      PrimerHeadlessUniversalCheckout.VaultedPaymentMethod)
     case paymentMethod(String)
     case processing
     case success(PaymentResult)
@@ -51,19 +50,19 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
   @Published private var internalState = PrimerCheckoutState.initializing
   @Published var navigationState = NavigationState.loading
 
-  public var onBeforePaymentCreate: BeforePaymentCreateHandler?
-  public var container: ContainerComponent?
-  public var splashScreen: Component?
-  public var loadingScreen: Component?
-  public var successScreen: ((_ result: PaymentResult) -> AnyView)?
-  public var errorScreen: ErrorComponent?
-  public var paymentMethodSelectionScreen: PaymentMethodSelectionScreenComponent?
+  var onBeforePaymentCreate: BeforePaymentCreateHandler?
+  var container: ContainerComponent?
+  var splashScreen: Component?
+  var loadingScreen: Component?
+  var successScreen: ((_ result: PaymentResult) -> AnyView)?
+  var errorScreen: ErrorComponent?
+  var paymentMethodSelectionScreen: PaymentMethodSelectionScreenComponent?
 
-  public var paymentHandling: PrimerPaymentHandling {
+  var paymentHandling: PrimerPaymentHandling {
     settings.paymentHandling
   }
 
-  public var state: AsyncStream<PrimerCheckoutState> {
+  var state: AsyncStream<PrimerCheckoutState> {
     AsyncStream { continuation in
       let task = Task { [self] in
         for await value in $internalState.values {
@@ -98,7 +97,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
   let presentationContext: PresentationContext
 
   private var cachedPaymentMethodSelection: PrimerPaymentMethodSelectionScope?
-  public var paymentMethodSelection: PrimerPaymentMethodSelectionScope {
+  var paymentMethodSelection: PrimerPaymentMethodSelectionScope {
     if let cachedPaymentMethodSelection { return cachedPaymentMethodSelection }
     let scope = DefaultPaymentMethodSelectionScope(
       checkoutScope: self,
@@ -166,16 +165,13 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
       let configService = try await container.resolve(ConfigurationService.self)
       configurationService = configService
       paymentMethodsInteractor = CheckoutComponentsPaymentMethodsBridge(
-        configurationService: configService
-      )
+        configurationService: configService)
 
       analyticsInteractor = try? await container.resolve(
-        CheckoutComponentsAnalyticsInteractorProtocol.self
-      )
+        CheckoutComponentsAnalyticsInteractorProtocol.self)
 
       accessibilityAnnouncementService = try? await container.resolve(
-        AccessibilityAnnouncementService.self
-      )
+        AccessibilityAnnouncementService.self)
     } catch {
       let primerError = PrimerError.invalidArchitecture(
         description: "Failed to setup interactors: \(error.localizedDescription)",
@@ -193,7 +189,9 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     }
 
     do {
-      try await Task.sleep(nanoseconds: 500_000_000)
+      if isInitScreenEnabled {
+        try await Task.sleep(nanoseconds: 500_000_000)
+      }
 
       guard let interactor = paymentMethodsInteractor else {
         throw PrimerError.invalidArchitecture(
@@ -256,6 +254,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
   }
 
   private func updateState(_ newState: PrimerCheckoutState) {
+    if case .dismissed = internalState { return }
     internalState = newState
 
     Task { [self] in
@@ -283,9 +282,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
             PaymentEvent(
               paymentMethod: paymentMethod,
               paymentId: result.paymentId
-            )
-          )
-        )
+            )))
       } else {
         // No payment method type available, use general event
         await analyticsInteractor?.trackEvent(.paymentSuccess, metadata: .general())
@@ -293,8 +290,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
 
     case let .failure(error):
       await analyticsInteractor?.trackEvent(
-        .paymentFailure, metadata: extractFailureMetadata(from: error)
-      )
+        .paymentFailure, metadata: extractFailureMetadata(from: error))
 
     case .dismissed:
       await analyticsInteractor?.trackEvent(.paymentFlowExited, metadata: .general())
@@ -311,8 +307,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
         PaymentEvent(
           paymentMethod: paymentMethod,
           paymentId: paymentId
-        )
-      )
+        ))
     }
 
     // For other error types, just include userLocale
@@ -395,8 +390,6 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     }
   }
 
-  // MARK: - Navigation Events Observer
-
   private func observeNavigationEvents() {
     navigationObservationTask = Task { @MainActor [weak self] in
       guard let self else { return }
@@ -421,44 +414,14 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
           continue
         }
 
-        // Only update if the state has actually changed to avoid loops
-        if case let .failure(currentError) = navigationState,
-          case let .failure(newError) = newNavigationState {
-          // For error states, compare messages to avoid redundant updates
-          if currentError.localizedDescription != newError.localizedDescription {
-            updateNavigationState(newNavigationState, syncToNavigator: false)
-          }
-        } else if !navigationStateEquals(navigationState, newNavigationState) {
+        if navigationState != newNavigationState {
           updateNavigationState(newNavigationState, syncToNavigator: false)
         }
       }
     }
   }
 
-  private func navigationStateEquals(_ lhs: NavigationState, _ rhs: NavigationState) -> Bool {
-    switch (lhs, rhs) {
-    case (.loading, .loading),
-      (.paymentMethodSelection, .paymentMethodSelection),
-      (.vaultedPaymentMethods, .vaultedPaymentMethods),
-      (.processing, .processing):
-      true
-    case let (
-      .deleteVaultedPaymentMethodConfirmation(lhsMethod),
-      .deleteVaultedPaymentMethodConfirmation(rhsMethod)
-    ):
-      lhsMethod.id == rhsMethod.id
-    case let (.paymentMethod(lhsType), .paymentMethod(rhsType)):
-      lhsType == rhsType
-    case let (.failure(lhsError), .failure(rhsError)):
-      lhsError.localizedDescription == rhsError.localizedDescription
-    default:
-      false
-    }
-  }
-
-  // MARK: - Public Methods
-
-  public func getPaymentMethodScope<T: PrimerPaymentMethodScope>(
+  func getPaymentMethodScope<T: PrimerPaymentMethodScope>(
     for paymentMethodType: String
   ) -> T? {
     guard let scope = paymentMethodScopeCache[paymentMethodType] as? T else { return nil }
@@ -466,7 +429,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     return scope
   }
 
-  public func getPaymentMethodScope<T: PrimerPaymentMethodScope>(_ scopeType: T.Type) -> T? {
+  func getPaymentMethodScope<T: PrimerPaymentMethodScope>(_ scopeType: T.Type) -> T? {
     guard let scope = paymentMethodScopeCache.values.first(where: { $0 is T }) as? T else {
       return nil
     }
@@ -474,30 +437,25 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     return scope
   }
 
-  public func getPaymentMethodScope<T: PrimerPaymentMethodScope>(
+  func getPaymentMethodScope<T: PrimerPaymentMethodScope>(
     for methodType: PrimerPaymentMethodType
   ) -> T? {
     getPaymentMethodScope(for: methodType.rawValue)
   }
 
-  public func onDismiss() {
-    // Ensure state updates happen on main thread for SwiftUI observation
-    Task { @MainActor in
-      updateState(.dismissed)
-      updateNavigationState(.dismissed)
+  func onDismiss() {
+    updateState(.dismissed)
+    updateNavigationState(.dismissed)
 
-      cachedPaymentMethodSelection = nil
-      currentPaymentMethodScope = nil
-      paymentMethodScopeCache.removeAll()
+    cachedPaymentMethodSelection = nil
+    currentPaymentMethodScope = nil
+    paymentMethodScopeCache.removeAll()
 
-      navigationObservationTask?.cancel()
-      navigationObservationTask = nil
+    navigationObservationTask?.cancel()
+    navigationObservationTask = nil
 
-      navigator.dismiss()
-    }
+    navigator.dismiss()
   }
-
-  // MARK: - Internal Methods
 
   func handlePaymentMethodSelection(_ method: InternalPaymentMethod) {
     selectedPaymentMethodName = method.name
@@ -508,8 +466,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
       updateNavigationState(.paymentMethod(method.type))
     } else {
       logger.debug(
-        message:
-          "⚠️ [DefaultCheckoutScope] Payment method \(method.type) not implemented, showing placeholder"
+        message: "Payment method \(method.type) not implemented, showing placeholder"
       )
       updateNavigationState(.paymentMethod(method.type))
     }
@@ -584,8 +541,6 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     return .general()
   }
 
-  // MARK: - Vaulted Payment Methods Methods
-
   func setVaultedPaymentMethods(_ methods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod]) {
     vaultedPaymentMethods = methods
 
@@ -609,6 +564,17 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     if let selectionScope = cachedPaymentMethodSelection as? DefaultPaymentMethodSelectionScope {
       selectionScope.syncSelectedVaultedPaymentMethod()
     }
+  }
+
+  static func validated(from checkoutScope: any PrimerCheckoutScope) throws -> (DefaultCheckoutScope, PresentationContext) {
+    guard let scope = checkoutScope as? DefaultCheckoutScope else {
+      throw PrimerError.invalidArchitecture(
+        description: "Expected DefaultCheckoutScope but received \(type(of: checkoutScope))",
+        recoverSuggestion: "Use the SDK-provided checkout scope"
+      )
+    }
+    let context: PresentationContext = scope.availablePaymentMethods.count > 1 ? .fromPaymentSelection : .direct
+    return (scope, context)
   }
 
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultFormRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultFormRedirectScope.swift
@@ -8,9 +8,7 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 @MainActor
-public final class DefaultFormRedirectScope: PrimerFormRedirectScope, ObservableObject, LogReporter {
-
-    // MARK: - Constants
+final class DefaultFormRedirectScope: PrimerFormRedirectScope, ObservableObject, LogReporter {
 
     private enum Constants {
         static let blikOtpLength = 6
@@ -18,17 +16,15 @@ public final class DefaultFormRedirectScope: PrimerFormRedirectScope, Observable
         static let defaultCountryFlag = "🇵🇹"
     }
 
-    // MARK: - Public Properties
+    let paymentMethodType: String
 
-    public let paymentMethodType: String
+    private(set) var presentationContext: PresentationContext
 
-    public private(set) var presentationContext: PresentationContext
-
-    public var dismissalMechanism: [DismissalMechanism] {
+    var dismissalMechanism: [DismissalMechanism] {
         checkoutScope?.dismissalMechanism ?? []
     }
 
-    public var state: AsyncStream<PrimerFormRedirectState> {
+    var state: AsyncStream<PrimerFormRedirectState> {
         AsyncStream { continuation in
             let task = Task { @MainActor in
                 for await _ in $internalState.values {
@@ -43,14 +39,10 @@ public final class DefaultFormRedirectScope: PrimerFormRedirectScope, Observable
         }
     }
 
-    // MARK: - UI Customization Properties
-
-    public var screen: FormRedirectScreenComponent?
-    public var formSection: FormRedirectFormSectionComponent?
-    public var submitButton: FormRedirectButtonComponent?
-    public var submitButtonText: String?
-
-    // MARK: - Private Properties
+    var screen: FormRedirectScreenComponent?
+    var formSection: FormRedirectFormSectionComponent?
+    var submitButton: FormRedirectButtonComponent?
+    var submitButtonText: String?
 
     private weak var checkoutScope: DefaultCheckoutScope?
     private let processPaymentInteractor: ProcessFormRedirectPaymentInteractor
@@ -63,14 +55,12 @@ public final class DefaultFormRedirectScope: PrimerFormRedirectScope, Observable
     private var hasStarted = false
     private var hasTrackedDetailsEntered = false
 
-    // MARK: - Initialization
-
     init(
         paymentMethodType: String,
-        checkoutScope: DefaultCheckoutScope,
+        checkoutScope: DefaultCheckoutScope? = nil,
         presentationContext: PresentationContext = .fromPaymentSelection,
         processPaymentInteractor: ProcessFormRedirectPaymentInteractor,
-        validationService: ValidationService,
+        validationService: ValidationService = DefaultValidationService(),
         analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil
     ) {
         self.paymentMethodType = paymentMethodType
@@ -82,25 +72,7 @@ public final class DefaultFormRedirectScope: PrimerFormRedirectScope, Observable
         configureFieldsForPaymentMethod()
     }
 
-    init(
-        paymentMethodType: String,
-        presentationContext: PresentationContext = .fromPaymentSelection,
-        processPaymentInteractor: ProcessFormRedirectPaymentInteractor,
-        validationService: ValidationService = DefaultValidationService(),
-        analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil
-    ) {
-        self.paymentMethodType = paymentMethodType
-        checkoutScope = nil
-        self.presentationContext = presentationContext
-        self.processPaymentInteractor = processPaymentInteractor
-        self.validationService = validationService
-        self.analyticsInteractor = analyticsInteractor
-        configureFieldsForPaymentMethod()
-    }
-
-    // MARK: - PrimerPaymentMethodScope Methods
-
-    public func start() {
+    func start() {
         guard !hasStarted else { return }
         hasStarted = true
         logger.debug(message: "Form redirect scope started for \(paymentMethodType)")
@@ -110,7 +82,7 @@ public final class DefaultFormRedirectScope: PrimerFormRedirectScope, Observable
         }
     }
 
-    public func submit() {
+    func submit() {
         guard internalState.isSubmitEnabled else {
             logger.warn(message: "Submit called but form is not valid")
             return

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultFormRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultFormRedirectScope.swift
@@ -1,0 +1,316 @@
+//
+//  DefaultFormRedirectScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+public final class DefaultFormRedirectScope: PrimerFormRedirectScope, ObservableObject, LogReporter {
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let blikOtpLength = 6
+        static let defaultDialCode = "+351"
+        static let defaultCountryFlag = "🇵🇹"
+    }
+
+    // MARK: - Public Properties
+
+    public let paymentMethodType: String
+
+    public private(set) var presentationContext: PresentationContext
+
+    public var dismissalMechanism: [DismissalMechanism] {
+        checkoutScope?.dismissalMechanism ?? []
+    }
+
+    public var state: AsyncStream<PrimerFormRedirectState> {
+        AsyncStream { continuation in
+            let task = Task { @MainActor in
+                for await _ in $internalState.values {
+                    continuation.yield(internalState)
+                }
+                continuation.finish()
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    // MARK: - UI Customization Properties
+
+    public var screen: FormRedirectScreenComponent?
+    public var formSection: FormRedirectFormSectionComponent?
+    public var submitButton: FormRedirectButtonComponent?
+    public var submitButtonText: String?
+
+    // MARK: - Private Properties
+
+    private weak var checkoutScope: DefaultCheckoutScope?
+    private let processPaymentInteractor: ProcessFormRedirectPaymentInteractor
+    private let validationService: ValidationService
+    private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+
+    @Published private var internalState = PrimerFormRedirectState()
+
+    private var paymentTask: Task<Void, Never>?
+    private var hasStarted = false
+    private var hasTrackedDetailsEntered = false
+
+    // MARK: - Initialization
+
+    init(
+        paymentMethodType: String,
+        checkoutScope: DefaultCheckoutScope,
+        presentationContext: PresentationContext = .fromPaymentSelection,
+        processPaymentInteractor: ProcessFormRedirectPaymentInteractor,
+        validationService: ValidationService,
+        analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil
+    ) {
+        self.paymentMethodType = paymentMethodType
+        self.checkoutScope = checkoutScope
+        self.presentationContext = presentationContext
+        self.processPaymentInteractor = processPaymentInteractor
+        self.validationService = validationService
+        self.analyticsInteractor = analyticsInteractor
+        configureFieldsForPaymentMethod()
+    }
+
+    init(
+        paymentMethodType: String,
+        presentationContext: PresentationContext = .fromPaymentSelection,
+        processPaymentInteractor: ProcessFormRedirectPaymentInteractor,
+        validationService: ValidationService = DefaultValidationService(),
+        analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil
+    ) {
+        self.paymentMethodType = paymentMethodType
+        checkoutScope = nil
+        self.presentationContext = presentationContext
+        self.processPaymentInteractor = processPaymentInteractor
+        self.validationService = validationService
+        self.analyticsInteractor = analyticsInteractor
+        configureFieldsForPaymentMethod()
+    }
+
+    // MARK: - PrimerPaymentMethodScope Methods
+
+    public func start() {
+        guard !hasStarted else { return }
+        hasStarted = true
+        logger.debug(message: "Form redirect scope started for \(paymentMethodType)")
+
+        Task {
+            try? await ClientSessionActionsModule().selectPaymentMethodIfNeeded(paymentMethodType, cardNetwork: nil)
+        }
+    }
+
+    public func submit() {
+        guard internalState.isSubmitEnabled else {
+            logger.warn(message: "Submit called but form is not valid")
+            return
+        }
+
+        paymentTask = Task {
+            await performPayment()
+        }
+    }
+
+    public func cancel() {
+        logger.debug(message: "Form redirect payment cancelled")
+        cancelPaymentProcessing()
+        checkoutScope?.onDismiss()
+    }
+
+    // MARK: - Field Management
+
+    public func updateField(_ fieldType: PrimerFormFieldState.FieldType, value: String) {
+        guard let index = internalState.fields.firstIndex(where: { $0.fieldType == fieldType }) else {
+            logger.warn(message: "Field type \(fieldType) not found in state")
+            return
+        }
+
+        let filteredValue = filterInput(value, for: fieldType)
+        let validationResult = validateField(filteredValue, for: fieldType)
+
+        internalState.fields[index].value = filteredValue
+        internalState.fields[index].isValid = validationResult.isValid
+        internalState.fields[index].errorMessage = validationResult.error
+
+        if internalState.isSubmitEnabled, !hasTrackedDetailsEntered {
+            hasTrackedDetailsEntered = true
+            Task {
+                await analyticsInteractor?.trackEvent(
+                    .paymentDetailsEntered,
+                    metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+                )
+            }
+        }
+    }
+
+    // MARK: - Navigation Methods
+
+    public func onBack() {
+        if presentationContext.shouldShowBackButton {
+            cancelPaymentProcessing()
+            checkoutScope?.checkoutNavigator.navigateBack()
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func configureFieldsForPaymentMethod() {
+        switch paymentMethodType {
+        case PrimerPaymentMethodType.adyenBlik.rawValue:
+            configureBlikField()
+
+        case PrimerPaymentMethodType.adyenMBWay.rawValue:
+            configureMBWayField()
+
+        default:
+            logger.error(message: "Unsupported form redirect payment method type: \(paymentMethodType)")
+            let errorMessage = "Unsupported payment method type: \(paymentMethodType)"
+            internalState.status = .failure(errorMessage)
+        }
+    }
+
+    private func configureBlikField() {
+        let field = PrimerFormFieldState.blikOtpField()
+        internalState.fields = [field]
+        internalState.pendingMessage = CheckoutComponentsStrings.formRedirectBlikPendingMessage
+    }
+
+    private func configureMBWayField() {
+        let countryCode = PrimerAPIConfigurationModule.apiConfiguration?.clientSession?.order?.countryCode
+
+        let phoneData = CountryCode.phoneNumberCountryCodes.first {
+            $0.code == countryCode?.rawValue
+        }
+
+        let dialCode = phoneData?.dialCode ?? Constants.defaultDialCode
+        let flag = countryCode?.flag ?? Constants.defaultCountryFlag
+
+        let field = PrimerFormFieldState.mbwayPhoneField(
+            countryCodePrefix: "\(flag) \(dialCode)",
+            dialCode: dialCode
+        )
+
+        internalState.fields = [field]
+        internalState.pendingMessage = CheckoutComponentsStrings.formRedirectMBWayPendingMessage
+    }
+
+    private func filterInput(_ input: String, for fieldType: PrimerFormFieldState.FieldType) -> String {
+        let numericOnly = input.filter(\.isNumber)
+
+        switch fieldType {
+        case .otpCode:
+            return String(numericOnly.prefix(Constants.blikOtpLength))
+
+        case .phoneNumber:
+            return numericOnly
+        }
+    }
+
+    private func validateField(_ value: String, for fieldType: PrimerFormFieldState.FieldType) -> (isValid: Bool, error: String?) {
+        guard !value.isEmpty else {
+            return (false, nil)
+        }
+
+        let inputType: PrimerInputElementType = switch fieldType {
+        case .otpCode: .otp
+        case .phoneNumber: .phoneNumber
+        }
+
+        // Submit button is disabled when invalid, so error messages are not needed
+        let result = validationService.validateField(type: inputType, value: value)
+        return (result.isValid, nil)
+    }
+
+    private func performPayment() async {
+        logger.debug(message: "Starting form redirect payment for \(paymentMethodType)")
+
+        internalState.status = .submitting
+        checkoutScope?.startProcessing()
+
+        await analyticsInteractor?.trackEvent(
+            .paymentSubmitted,
+            metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+        )
+
+        do {
+            try await checkoutScope?.invokeBeforePaymentCreate(
+                paymentMethodType: paymentMethodType
+            )
+
+            let sessionInfo = try buildSessionInfo()
+
+            await analyticsInteractor?.trackEvent(
+                .paymentProcessingStarted,
+                metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+            )
+
+            let result = try await processPaymentInteractor.execute(
+                paymentMethodType: paymentMethodType,
+                sessionInfo: sessionInfo,
+                onPollingStarted: { [self] in
+                    Task { @MainActor in
+                        internalState.status = .awaitingExternalCompletion
+                        await analyticsInteractor?.trackEvent(
+                            .paymentRedirectToThirdParty,
+                            metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+                        )
+                    }
+                }
+            )
+
+            internalState.status = .success
+            checkoutScope?.handlePaymentSuccess(result)
+
+        } catch {
+            logger.error(message: "Form redirect payment failed: \(error.localizedDescription)")
+
+            internalState.status = .failure(error.localizedDescription)
+
+            let primerError = error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+            checkoutScope?.handlePaymentError(primerError)
+        }
+    }
+
+    private func buildSessionInfo() throws -> any OffSessionPaymentSessionInfo {
+        switch paymentMethodType {
+        case PrimerPaymentMethodType.adyenBlik.rawValue:
+            let blikCode = internalState.otpField?.value ?? ""
+            return BlikSessionInfo(
+                blikCode: blikCode,
+                locale: PrimerSettings.current.localeData.localeCode
+            )
+
+        case PrimerPaymentMethodType.adyenMBWay.rawValue:
+            let phoneField = internalState.phoneField
+            let dialCode = phoneField?.dialCode ?? ""
+            let phoneNumber = phoneField?.value ?? ""
+            return InputPhonenumberSessionInfo(
+                phoneNumber: "\(dialCode)\(phoneNumber)"
+            )
+
+        default:
+            let error = PrimerError.invalidValue(
+                key: "paymentMethodType",
+                reason: "Unsupported form redirect payment method type: \(paymentMethodType)"
+            )
+            ErrorHandler.handle(error: error)
+            throw error
+        }
+    }
+
+    private func cancelPaymentProcessing() {
+        paymentTask?.cancel()
+        paymentTask = nil
+        processPaymentInteractor.cancelPolling(paymentMethodType: paymentMethodType)
+    }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultKlarnaScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultKlarnaScope.swift
@@ -1,0 +1,327 @@
+//
+//  DefaultKlarnaScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogReporter {
+
+  // MARK: - Public Properties
+
+  public private(set) var presentationContext: PresentationContext
+
+  public var dismissalMechanism: [DismissalMechanism] {
+    checkoutScope?.dismissalMechanism ?? []
+  }
+
+  public private(set) var paymentView: UIView?
+
+  public var state: AsyncStream<PrimerKlarnaState> {
+    AsyncStream { continuation in
+      let task = Task { @MainActor in
+        for await _ in $internalState.values {
+          continuation.yield(internalState)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  // MARK: - UI Customization Properties
+
+  public var screen: KlarnaScreenComponent?
+  public var authorizeButton: KlarnaButtonComponent?
+  public var finalizeButton: KlarnaButtonComponent?
+
+  // MARK: - Private Properties
+
+  private weak var checkoutScope: DefaultCheckoutScope?
+  private let processKlarnaInteractor: ProcessKlarnaPaymentInteractor
+  private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+
+  @Published private var internalState = PrimerKlarnaState()
+
+  private var klarnaClientToken: String?
+
+  private var authorizationToken: String?
+
+  // MARK: - Initialization
+
+  init(
+    checkoutScope: DefaultCheckoutScope,
+    presentationContext: PresentationContext = .fromPaymentSelection,
+    processKlarnaInteractor: ProcessKlarnaPaymentInteractor,
+    analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil
+  ) {
+    self.checkoutScope = checkoutScope
+    self.presentationContext = presentationContext
+    self.processKlarnaInteractor = processKlarnaInteractor
+    self.analyticsInteractor = analyticsInteractor
+  }
+
+  // MARK: - PrimerPaymentMethodScope Methods
+
+  public func start() {
+    logger.debug(message: "Klarna scope started")
+    Task { [self] in
+      await createSession()
+    }
+  }
+
+  public func submit() {
+    authorizePayment()
+  }
+
+  public func cancel() {
+    logger.debug(message: "Klarna payment cancelled")
+    guard let checkoutScope else {
+      logger.warn(message: "Klarna checkout scope was deallocated during cancel")
+      return
+    }
+    checkoutScope.onDismiss()
+  }
+
+  // MARK: - Klarna Flow Actions
+
+  public func selectPaymentCategory(_ categoryId: String) {
+    guard internalState.categories.contains(where: { $0.id == categoryId }) else {
+      logger.warn(message: "Invalid category ID: \(categoryId)")
+      return
+    }
+
+    internalState = PrimerKlarnaState(
+      step: .categorySelection,
+      categories: internalState.categories,
+      selectedCategoryId: categoryId
+    )
+    paymentView = nil
+
+    Task { [self] in
+      await loadPaymentView(for: categoryId)
+    }
+  }
+
+  public func authorizePayment() {
+    guard internalState.step == .viewReady || internalState.step == .categorySelection else {
+      logger.warn(message: "Cannot authorize in current step: \(internalState.step)")
+      return
+    }
+
+    internalState = PrimerKlarnaState(
+      step: .authorizationStarted,
+      categories: internalState.categories,
+      selectedCategoryId: internalState.selectedCategoryId
+    )
+
+    Task { [self] in
+      await performAuthorization()
+    }
+  }
+
+  public func finalizePayment() {
+    guard internalState.step == .awaitingFinalization else {
+      logger.warn(message: "Cannot finalize in current step: \(internalState.step)")
+      return
+    }
+
+    Task { [self] in
+      await performFinalization()
+    }
+  }
+
+  // MARK: - Navigation Methods
+
+  public func onBack() {
+    guard presentationContext.shouldShowBackButton else { return }
+    guard let checkoutScope else {
+      logger.warn(message: "Klarna checkout scope was deallocated during navigation back")
+      return
+    }
+    checkoutScope.checkoutNavigator.navigateBack()
+  }
+
+  // MARK: - Private Flow Methods
+
+  private func handleError(_ error: Error, context: String) {
+    logger.error(message: "Klarna \(context) failed: \(error.localizedDescription)")
+    let primerError =
+      error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+    guard let checkoutScope else {
+      logger.error(message: "Klarna checkout scope was deallocated during \(context)")
+      return
+    }
+    checkoutScope.handlePaymentError(primerError)
+  }
+
+  private func createSession() async {
+    internalState = PrimerKlarnaState(step: .loading)
+
+    do {
+      let sessionResult = try await processKlarnaInteractor.createSession()
+      klarnaClientToken = sessionResult.clientToken
+
+      internalState = PrimerKlarnaState(
+        step: .categorySelection,
+        categories: sessionResult.categories
+      )
+
+      logger.debug(
+        message: "Klarna session created with \(sessionResult.categories.count) categories"
+      )
+    } catch {
+      handleError(error, context: "session creation")
+    }
+  }
+
+  private func loadPaymentView(for categoryId: String) async {
+    guard let klarnaClientToken else {
+      logger.error(message: "Klarna client token not available")
+      handleError(
+        PrimerError.klarnaError(
+          message: "Payment session not properly initialized",
+          diagnosticsId: UUID().uuidString
+        ),
+        context: "view loading"
+      )
+      return
+    }
+
+    do {
+      let view = try await processKlarnaInteractor.configureForCategory(
+        clientToken: klarnaClientToken,
+        categoryId: categoryId
+      )
+
+      // Guard against race condition: user may have switched categories while loading
+      guard internalState.selectedCategoryId == categoryId else { return }
+
+      paymentView = view
+      internalState = PrimerKlarnaState(
+        step: .viewReady,
+        categories: internalState.categories,
+        selectedCategoryId: internalState.selectedCategoryId
+      )
+    } catch {
+      logger.error(message: "Failed to load Klarna payment view: \(error.localizedDescription)")
+      guard internalState.selectedCategoryId == categoryId else { return }
+      handleError(error, context: "view loading")
+    }
+  }
+
+  private func performAuthorization() async {
+    guard let checkoutScope else {
+      logger.warn(message: "Klarna checkout scope was deallocated before authorization")
+      return
+    }
+
+    do {
+      try await checkoutScope.invokeBeforePaymentCreate(
+        paymentMethodType: PrimerPaymentMethodType.klarna.rawValue
+      )
+    } catch {
+      handleError(error, context: "before payment create")
+      return
+    }
+
+    checkoutScope.startProcessing()
+
+    await analyticsInteractor?.trackEvent(
+      .paymentSubmitted,
+      metadata: .payment(PaymentEvent(paymentMethod: PrimerPaymentMethodType.klarna.rawValue))
+    )
+
+    await analyticsInteractor?.trackEvent(
+      .paymentProcessingStarted,
+      metadata: .payment(PaymentEvent(paymentMethod: PrimerPaymentMethodType.klarna.rawValue))
+    )
+
+    do {
+      let result = try await processKlarnaInteractor.authorize()
+
+      switch result {
+      case let .approved(authToken):
+        authorizationToken = authToken
+        await processPayment(authToken: authToken)
+
+      case let .finalizationRequired(authToken):
+        authorizationToken = authToken
+        internalState = PrimerKlarnaState(
+          step: .awaitingFinalization,
+          categories: internalState.categories,
+          selectedCategoryId: internalState.selectedCategoryId
+        )
+
+      case .declined:
+        let primerError = PrimerError.klarnaError(
+          message: "Klarna payment was declined",
+          diagnosticsId: UUID().uuidString
+        )
+        checkoutScope.handlePaymentError(primerError)
+      }
+    } catch {
+      handleError(error, context: "authorization")
+    }
+  }
+
+  private func performFinalization() async {
+    guard let checkoutScope else {
+      logger.warn(message: "Klarna checkout scope was deallocated before finalization")
+      return
+    }
+    checkoutScope.startProcessing()
+
+    do {
+      let result = try await processKlarnaInteractor.finalize()
+
+      switch result {
+      case let .approved(authToken):
+        authorizationToken = authToken
+        await processPayment(authToken: authToken)
+
+      case .finalizationRequired:
+        logger.error(message: "Unexpected finalizationRequired after finalize()")
+        guard let authToken = authorizationToken else {
+          handleError(
+            PrimerError.klarnaError(
+              message: "Authorization token not available after finalization",
+              diagnosticsId: UUID().uuidString
+            ),
+            context: "finalization"
+          )
+          return
+        }
+        await processPayment(authToken: authToken)
+
+      case .declined:
+        let primerError = PrimerError.klarnaError(
+          message: "Klarna finalization was declined",
+          diagnosticsId: UUID().uuidString
+        )
+        checkoutScope.handlePaymentError(primerError)
+      }
+    } catch {
+      handleError(error, context: "finalization")
+    }
+  }
+
+  private func processPayment(authToken: String) async {
+    do {
+      let result = try await processKlarnaInteractor.tokenize(authToken: authToken)
+      guard let checkoutScope else {
+        logger.error(message: "Klarna checkout scope was deallocated during payment processing")
+        return
+      }
+      checkoutScope.handlePaymentSuccess(result)
+    } catch {
+      handleError(error, context: "payment processing")
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultKlarnaScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultKlarnaScope.swift
@@ -8,19 +8,17 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 @MainActor
-public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogReporter {
+final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogReporter {
 
-  // MARK: - Public Properties
+  private(set) var presentationContext: PresentationContext
 
-  public private(set) var presentationContext: PresentationContext
-
-  public var dismissalMechanism: [DismissalMechanism] {
+  var dismissalMechanism: [DismissalMechanism] {
     checkoutScope?.dismissalMechanism ?? []
   }
 
-  public private(set) var paymentView: UIView?
+  private(set) var paymentView: UIView?
 
-  public var state: AsyncStream<PrimerKlarnaState> {
+  var state: AsyncStream<PrimerKlarnaState> {
     AsyncStream { continuation in
       let task = Task { @MainActor in
         for await _ in $internalState.values {
@@ -35,13 +33,9 @@ public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogR
     }
   }
 
-  // MARK: - UI Customization Properties
-
-  public var screen: KlarnaScreenComponent?
-  public var authorizeButton: KlarnaButtonComponent?
-  public var finalizeButton: KlarnaButtonComponent?
-
-  // MARK: - Private Properties
+  var screen: KlarnaScreenComponent?
+  var authorizeButton: KlarnaButtonComponent?
+  var finalizeButton: KlarnaButtonComponent?
 
   private weak var checkoutScope: DefaultCheckoutScope?
   private let processKlarnaInteractor: ProcessKlarnaPaymentInteractor
@@ -52,8 +46,6 @@ public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogR
   private var klarnaClientToken: String?
 
   private var authorizationToken: String?
-
-  // MARK: - Initialization
 
   init(
     checkoutScope: DefaultCheckoutScope,
@@ -67,20 +59,18 @@ public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogR
     self.analyticsInteractor = analyticsInteractor
   }
 
-  // MARK: - PrimerPaymentMethodScope Methods
-
-  public func start() {
+  func start() {
     logger.debug(message: "Klarna scope started")
     Task { [self] in
       await createSession()
     }
   }
 
-  public func submit() {
+  func submit() {
     authorizePayment()
   }
 
-  public func cancel() {
+  func cancel() {
     logger.debug(message: "Klarna payment cancelled")
     guard let checkoutScope else {
       logger.warn(message: "Klarna checkout scope was deallocated during cancel")
@@ -89,9 +79,7 @@ public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogR
     checkoutScope.onDismiss()
   }
 
-  // MARK: - Klarna Flow Actions
-
-  public func selectPaymentCategory(_ categoryId: String) {
+  func selectPaymentCategory(_ categoryId: String) {
     guard internalState.categories.contains(where: { $0.id == categoryId }) else {
       logger.warn(message: "Invalid category ID: \(categoryId)")
       return
@@ -109,7 +97,7 @@ public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogR
     }
   }
 
-  public func authorizePayment() {
+  func authorizePayment() {
     guard internalState.step == .viewReady || internalState.step == .categorySelection else {
       logger.warn(message: "Cannot authorize in current step: \(internalState.step)")
       return
@@ -126,7 +114,7 @@ public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogR
     }
   }
 
-  public func finalizePayment() {
+  func finalizePayment() {
     guard internalState.step == .awaitingFinalization else {
       logger.warn(message: "Cannot finalize in current step: \(internalState.step)")
       return
@@ -137,9 +125,7 @@ public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogR
     }
   }
 
-  // MARK: - Navigation Methods
-
-  public func onBack() {
+  func onBack() {
     guard presentationContext.shouldShowBackButton else { return }
     guard let checkoutScope else {
       logger.warn(message: "Klarna checkout scope was deallocated during navigation back")
@@ -147,8 +133,6 @@ public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogR
     }
     checkoutScope.checkoutNavigator.navigateBack()
   }
-
-  // MARK: - Private Flow Methods
 
   private func handleError(_ error: Error, context: String) {
     logger.error(message: "Klarna \(context) failed: \(error.localizedDescription)")
@@ -174,8 +158,7 @@ public final class DefaultKlarnaScope: PrimerKlarnaScope, ObservableObject, LogR
       )
 
       logger.debug(
-        message: "Klarna session created with \(sessionResult.categories.count) categories"
-      )
+        message: "Klarna session created with \(sessionResult.categories.count) categories")
     } catch {
       handleError(error, context: "session creation")
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultPayPalScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultPayPalScope.swift
@@ -1,0 +1,126 @@
+//
+//  DefaultPayPalScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+public final class DefaultPayPalScope: PrimerPayPalScope, ObservableObject, LogReporter {
+
+  // MARK: - Public Properties
+
+  public private(set) var presentationContext: PresentationContext
+
+  public var dismissalMechanism: [DismissalMechanism] {
+    checkoutScope?.dismissalMechanism ?? []
+  }
+
+  public var state: AsyncStream<PrimerPayPalState> {
+    AsyncStream { continuation in
+      let task = Task { @MainActor in
+        for await _ in $internalState.values {
+          continuation.yield(internalState)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  // MARK: - UI Customization Properties
+
+  public var screen: PayPalScreenComponent?
+  public var payButton: PayPalButtonComponent?
+  public var submitButtonText: String?
+
+  // MARK: - Private Properties
+
+  private weak var checkoutScope: DefaultCheckoutScope?
+  private let processPayPalInteractor: ProcessPayPalPaymentInteractor
+  private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+
+  @Published private var internalState = PrimerPayPalState()
+
+  // MARK: - Initialization
+
+  init(
+    checkoutScope: DefaultCheckoutScope,
+    presentationContext: PresentationContext = .fromPaymentSelection,
+    processPayPalInteractor: ProcessPayPalPaymentInteractor,
+    analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil
+  ) {
+    self.checkoutScope = checkoutScope
+    self.presentationContext = presentationContext
+    self.processPayPalInteractor = processPayPalInteractor
+    self.analyticsInteractor = analyticsInteractor
+  }
+
+  // MARK: - PrimerPaymentMethodScope Methods
+
+  public func start() {
+    logger.debug(message: "PayPal scope started")
+    internalState.step = .idle
+  }
+
+  public func submit() {
+    Task {
+      await performPayment()
+    }
+  }
+
+  public func cancel() {
+    logger.debug(message: "PayPal payment cancelled")
+    checkoutScope?.onDismiss()
+  }
+
+  // MARK: - Navigation Methods
+
+  public func onBack() {
+    if presentationContext.shouldShowBackButton {
+      checkoutScope?.checkoutNavigator.navigateBack()
+    }
+  }
+
+  // MARK: - Private Methods
+
+  private func performPayment() async {
+    internalState.step = .loading
+    checkoutScope?.startProcessing()
+
+    await analyticsInteractor?.trackEvent(
+      .paymentSubmitted,
+      metadata: .payment(PaymentEvent(paymentMethod: PrimerPaymentMethodType.payPal.rawValue))
+    )
+
+    do {
+      try await checkoutScope?.invokeBeforePaymentCreate(
+        paymentMethodType: PrimerPaymentMethodType.payPal.rawValue
+      )
+
+      internalState.step = .redirecting
+
+      await analyticsInteractor?.trackEvent(
+        .paymentProcessingStarted,
+        metadata: .payment(PaymentEvent(paymentMethod: PrimerPaymentMethodType.payPal.rawValue))
+      )
+
+      let result = try await processPayPalInteractor.execute()
+
+      internalState.step = .success
+      checkoutScope?.handlePaymentSuccess(result)
+    } catch {
+      logger.error(message: "PayPal payment failed: \(error.localizedDescription)")
+      internalState.step = .failure(error.localizedDescription)
+
+      let primerError =
+        error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+      checkoutScope?.handlePaymentError(primerError)
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultPayPalScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultPayPalScope.swift
@@ -8,17 +8,15 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 @MainActor
-public final class DefaultPayPalScope: PrimerPayPalScope, ObservableObject, LogReporter {
+final class DefaultPayPalScope: PrimerPayPalScope, ObservableObject, LogReporter {
 
-  // MARK: - Public Properties
+  private(set) var presentationContext: PresentationContext
 
-  public private(set) var presentationContext: PresentationContext
-
-  public var dismissalMechanism: [DismissalMechanism] {
+  var dismissalMechanism: [DismissalMechanism] {
     checkoutScope?.dismissalMechanism ?? []
   }
 
-  public var state: AsyncStream<PrimerPayPalState> {
+  var state: AsyncStream<PrimerPayPalState> {
     AsyncStream { continuation in
       let task = Task { @MainActor in
         for await _ in $internalState.values {
@@ -33,21 +31,15 @@ public final class DefaultPayPalScope: PrimerPayPalScope, ObservableObject, LogR
     }
   }
 
-  // MARK: - UI Customization Properties
-
-  public var screen: PayPalScreenComponent?
-  public var payButton: PayPalButtonComponent?
-  public var submitButtonText: String?
-
-  // MARK: - Private Properties
+  var screen: PayPalScreenComponent?
+  var payButton: PayPalButtonComponent?
+  var submitButtonText: String?
 
   private weak var checkoutScope: DefaultCheckoutScope?
   private let processPayPalInteractor: ProcessPayPalPaymentInteractor
   private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
 
   @Published private var internalState = PrimerPayPalState()
-
-  // MARK: - Initialization
 
   init(
     checkoutScope: DefaultCheckoutScope,
@@ -61,33 +53,27 @@ public final class DefaultPayPalScope: PrimerPayPalScope, ObservableObject, LogR
     self.analyticsInteractor = analyticsInteractor
   }
 
-  // MARK: - PrimerPaymentMethodScope Methods
-
-  public func start() {
+  func start() {
     logger.debug(message: "PayPal scope started")
     internalState.step = .idle
   }
 
-  public func submit() {
+  func submit() {
     Task {
       await performPayment()
     }
   }
 
-  public func cancel() {
+  func cancel() {
     logger.debug(message: "PayPal payment cancelled")
     checkoutScope?.onDismiss()
   }
 
-  // MARK: - Navigation Methods
-
-  public func onBack() {
+  func onBack() {
     if presentationContext.shouldShowBackButton {
       checkoutScope?.checkoutNavigator.navigateBack()
     }
   }
-
-  // MARK: - Private Methods
 
   private func performPayment() async {
     internalState.step = .loading

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultPaymentMethodSelectionScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultPaymentMethodSelectionScope.swift
@@ -1,0 +1,409 @@
+//
+//  DefaultPaymentMethodSelectionScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultPaymentMethodSelectionScope: PrimerPaymentMethodSelectionScope, ObservableObject,
+  LogReporter {
+  // MARK: - Properties
+
+  @Published private var internalState = PrimerPaymentMethodSelectionState()
+
+  public var state: AsyncStream<PrimerPaymentMethodSelectionState> {
+    AsyncStream { continuation in
+      let task = Task { @MainActor in
+        for await value in $internalState.values {
+          continuation.yield(value)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  public var dismissalMechanism: [DismissalMechanism] {
+    checkoutScope?.dismissalMechanism ?? []
+  }
+
+  // MARK: - UI Customization Properties
+
+  public var screen: PaymentMethodSelectionScreenComponent?
+  public var container: ContainerComponent?
+  public var paymentMethodItem: PaymentMethodItemComponent?
+  public var categoryHeader: CategoryHeaderComponent?
+  public var emptyStateView: Component?
+
+  // MARK: - Private Properties
+
+  private weak var checkoutScope: DefaultCheckoutScope?
+  private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+  private var accessibilityAnnouncementService: AccessibilityAnnouncementService?
+
+  // MARK: - Initialization
+
+  init(
+    checkoutScope: DefaultCheckoutScope,
+    analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil
+  ) {
+    self.checkoutScope = checkoutScope
+    self.analyticsInteractor = analyticsInteractor
+
+    Task {
+      await loadPaymentMethods()
+      await refreshVaultedPaymentMethods()
+      await resolveAccessibilityService()
+    }
+  }
+
+  func refreshVaultedPaymentMethods() async {
+    do {
+      guard let container = await DIContainer.current else { return }
+      let repository = try await container.resolve(HeadlessRepository.self)
+      let vaultedMethods = try await repository.fetchVaultedPaymentMethods()
+
+      checkoutScope?.setVaultedPaymentMethods(vaultedMethods)
+      syncSelectedVaultedPaymentMethod()
+    } catch {
+      logger.error(
+        message: "[Vault] Failed to load vaulted payment methods: \(error.localizedDescription)",
+        error: error
+      )
+    }
+  }
+
+  // MARK: - Accessibility Setup
+
+  private func resolveAccessibilityService() async {
+    do {
+      guard let container = await DIContainer.current else { return }
+      accessibilityAnnouncementService = try await container.resolve(
+        AccessibilityAnnouncementService.self
+      )
+    } catch {
+      // Failed to resolve AccessibilityAnnouncementService, accessibility announcements will be disabled
+      logger.debug(
+        message:
+          "[A11Y] Failed to resolve AccessibilityAnnouncementService: \(error.localizedDescription)"
+      )
+    }
+  }
+
+  // MARK: - Setup
+
+  private func loadPaymentMethods() async {
+    guard let checkoutScope else {
+      internalState.error = CheckoutComponentsStrings.checkoutScopeNotAvailable
+      return
+    }
+
+    for await checkoutState in checkoutScope.state {
+      if case .ready = checkoutState {
+        let paymentMethods = checkoutScope.availablePaymentMethods
+
+        let mapper: PaymentMethodMapper
+        do {
+          guard let container = await DIContainer.current else {
+            throw NSError(
+              domain: "DIContainer", code: 1,
+              userInfo: [NSLocalizedDescriptionKey: "DIContainer.current is nil"]
+            )
+          }
+          mapper = try await container.resolve(PaymentMethodMapper.self)
+        } catch {
+          // Fallback to manual creation without surcharge data
+          let composablePaymentMethods = paymentMethods.map { method in
+            CheckoutPaymentMethod(
+              id: method.id,
+              type: method.type,
+              name: method.name,
+              icon: method.icon,
+              metadata: nil
+            )
+          }
+          internalState.paymentMethods = composablePaymentMethods
+          internalState.filteredPaymentMethods = composablePaymentMethods
+          break
+        }
+
+        let composablePaymentMethods = mapper.mapToPublic(paymentMethods)
+
+        internalState.paymentMethods = composablePaymentMethods
+        internalState.filteredPaymentMethods = composablePaymentMethods
+
+        break
+      } else if case let .failure(error) = checkoutState {
+        internalState.error = error.localizedDescription
+        break
+      }
+    }
+  }
+
+  // MARK: - Public Methods
+
+  public func onPaymentMethodSelected(paymentMethod: CheckoutPaymentMethod) {
+    internalState.selectedPaymentMethod = paymentMethod
+
+    let selectionMessage = "\(paymentMethod.name) selected"
+    accessibilityAnnouncementService?.announceStateChange(selectionMessage)
+    logger.debug(message: "[A11Y] Payment method selected announcement: \(selectionMessage)")
+
+    Task {
+      await trackPaymentMethodSelection(paymentMethod.type)
+    }
+
+    let internalMethod = InternalPaymentMethod(
+      id: paymentMethod.id,
+      type: paymentMethod.type,
+      name: paymentMethod.name,
+      icon: paymentMethod.icon
+    )
+
+    checkoutScope?.handlePaymentMethodSelection(internalMethod)
+  }
+
+  private func trackPaymentMethodSelection(_ paymentMethodType: String) async {
+    await analyticsInteractor?.trackEvent(
+      .paymentMethodSelection, metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+    )
+  }
+
+  public func cancel() {
+    checkoutScope?.onDismiss()
+  }
+
+  // MARK: - Vault Payment
+
+  public func payWithVaultedPaymentMethod() async {
+    guard let vaultedMethod = internalState.selectedVaultedPaymentMethod else {
+      logger.warn(message: "[Vault] No vaulted payment method selected")
+      return
+    }
+
+    if shouldRequireCvvInput(for: vaultedMethod), !internalState.requiresCvvInput {
+      logger.info(message: "[Vault] CVV required for vaulted card payment, showing CVV input")
+      internalState.requiresCvvInput = true
+      // Collapse payment methods section to focus on CVV entry
+      internalState.isPaymentMethodsExpanded = false
+      return
+    }
+
+    if internalState.requiresCvvInput {
+      await payWithVaultedPaymentMethodAndCvv(internalState.cvvInput)
+      return
+    }
+
+    await executeVaultPayment(vaultedMethod: vaultedMethod, additionalData: nil)
+  }
+
+  public func payWithVaultedPaymentMethodAndCvv(_ cvv: String) async {
+    guard let vaultedMethod = internalState.selectedVaultedPaymentMethod else {
+      logger.warn(message: "[Vault] No vaulted payment method selected")
+      return
+    }
+
+    logger.info(
+      message: "[Vault] Starting payment with vaulted method: \(vaultedMethod.id) with CVV"
+    )
+
+    let additionalData = PrimerVaultedCardAdditionalData(cvv: cvv)
+    await executeVaultPayment(vaultedMethod: vaultedMethod, additionalData: additionalData)
+  }
+
+  public func updateCvvInput(_ cvv: String) {
+    internalState.cvvInput = cvv
+    let validationResult = validateCvv(cvv)
+    internalState.isCvvValid = validationResult.isValid
+    internalState.cvvError = validationResult.errorMessage
+  }
+
+  /// Validates CVV input and returns validation state with optional error message.
+  /// - Parameter cvv: The CVV string to validate
+  /// - Returns: Tuple with `isValid` flag and optional `errorMessage`
+  private func validateCvv(_ cvv: String) -> (isValid: Bool, errorMessage: String?) {
+    let cardNetwork = getCardNetworkFromSelectedVaultedMethod()
+    let expectedLength = cardNetwork.validation?.code.length ?? 3
+
+    // Empty input: not valid yet, but no error (user hasn't started typing)
+    guard !cvv.isEmpty else {
+      return (false, nil)
+    }
+
+    // Non-numeric characters: invalid with error
+    guard cvv.allSatisfy(\.isNumber) else {
+      return (false, CheckoutComponentsStrings.cvvInvalidError)
+    }
+
+    // Too many digits: invalid with error
+    if cvv.count > expectedLength {
+      return (false, CheckoutComponentsStrings.cvvInvalidError)
+    }
+
+    // Exact length: valid, no error
+    if cvv.count == expectedLength {
+      return (true, nil)
+    }
+
+    // Partial input (fewer digits): not yet valid, no error (user still typing)
+    return (false, nil)
+  }
+
+  // MARK: - Vault Payment Helpers
+
+  private func executeVaultPayment(
+    vaultedMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod,
+    additionalData: PrimerVaultedPaymentMethodAdditionalData?
+  ) async {
+    logger.info(message: "[Vault] Starting payment with vaulted method: \(vaultedMethod.id)")
+
+    internalState.isVaultPaymentLoading = true
+
+    await analyticsInteractor?.trackEvent(
+      .paymentSubmitted,
+      metadata: .payment(PaymentEvent(paymentMethod: vaultedMethod.paymentMethodType))
+    )
+
+    do {
+      guard let container = await DIContainer.current else {
+        throw PrimerError.unknown(message: "DIContainer.current is nil")
+      }
+      let interactor = try await container.resolve(SubmitVaultedPaymentInteractor.self)
+
+      let result = try await interactor.execute(
+        vaultedPaymentMethodId: vaultedMethod.id,
+        paymentMethodType: vaultedMethod.paymentMethodType,
+        additionalData: additionalData
+      )
+
+      internalState.isVaultPaymentLoading = false
+      resetCvvState()
+      checkoutScope?.handlePaymentSuccess(result)
+
+    } catch {
+      internalState.isVaultPaymentLoading = false
+      // Clear CVV on error but keep CVV mode active for retry
+      internalState.cvvInput = ""
+      internalState.isCvvValid = false
+      logger.error(message: "[Vault] Payment failed: \(error.localizedDescription)")
+
+      let primerError =
+        error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+      checkoutScope?.handlePaymentError(primerError)
+    }
+  }
+
+  private func shouldRequireCvvInput(
+    for vaultedMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
+  ) -> Bool {
+    // Only cards can require CVV
+    guard
+      vaultedMethod.paymentInstrumentType == .paymentCard
+        || vaultedMethod.paymentInstrumentType == .cardOffSession
+    else {
+      return false
+    }
+
+    do {
+      guard let container = DIContainer.currentSync else { return false }
+      let configService = try container.resolveSync(ConfigurationService.self)
+      return configService.captureVaultedCardCvv
+    } catch {
+      logger.error(
+        message: "[Vault] Failed to resolve ConfigurationService: \(error.localizedDescription)"
+      )
+      return false
+    }
+  }
+
+  private func getCardNetworkFromSelectedVaultedMethod() -> CardNetwork {
+    guard let vaultedMethod = internalState.selectedVaultedPaymentMethod else { return .unknown }
+
+    let network =
+      vaultedMethod.paymentInstrumentData.network ?? vaultedMethod.paymentInstrumentData.binData?
+      .network ?? "Card"
+    return CardNetwork(rawValue: network.uppercased()) ?? .unknown
+  }
+
+  private func resetCvvState() {
+    internalState.requiresCvvInput = false
+    internalState.cvvInput = ""
+    internalState.isCvvValid = false
+    internalState.cvvError = nil
+  }
+
+  public func showAllVaultedPaymentMethods() {
+    logger.info(message: "[Vault] Navigating to all vaulted payment methods screen")
+    checkoutScope?.updateNavigationState(.vaultedPaymentMethods)
+  }
+
+  public func showOtherWaysToPay() {
+    logger.info(message: "[PaymentSelection] Expanding to show all payment methods")
+    internalState.isPaymentMethodsExpanded = true
+  }
+
+  func collapsePaymentMethods() {
+    logger.info(message: "[PaymentSelection] Collapsing payment methods section")
+    internalState.isPaymentMethodsExpanded = false
+  }
+
+  public func searchPaymentMethods(_ query: String) {
+    internalState.searchQuery = query
+
+    if query.isEmpty {
+      internalState.filteredPaymentMethods = internalState.paymentMethods
+    } else {
+      let lowercasedQuery = query.lowercased()
+      internalState.filteredPaymentMethods = internalState.paymentMethods.filter { method in
+        method.name.lowercased().contains(lowercasedQuery)
+          || method.type.lowercased().contains(lowercasedQuery)
+      }
+    }
+  }
+
+  // MARK: - Vault Selection Update
+
+  /// Syncs internal state with checkout scope's selected vaulted payment method.
+  /// Called by DefaultCheckoutScope when selection changes.
+  /// Source of truth is always `checkoutScope.selectedVaultedPaymentMethod`.
+  func syncSelectedVaultedPaymentMethod() {
+    let previousMethodId = internalState.selectedVaultedPaymentMethod?.id
+    let newMethodId = checkoutScope?.selectedVaultedPaymentMethod?.id
+
+    internalState.selectedVaultedPaymentMethod = checkoutScope?.selectedVaultedPaymentMethod
+
+    // When switching to a different vaulted method, reset CVV state
+    if previousMethodId != newMethodId {
+      resetCvvState()
+    }
+  }
+
+  // MARK: - Vault Delete
+
+  /// Deletes a vaulted payment method and refreshes the list
+  /// - Parameter method: The vaulted payment method to delete
+  /// - Throws: Error if deletion fails
+  public func deleteVaultedPaymentMethod(
+    _ method: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
+  ) async throws {
+    logger.info(message: "[Vault] Deleting vaulted payment method: \(method.id)")
+
+    guard let container = await DIContainer.current else {
+      throw PrimerError.unknown(message: "DIContainer.current is nil")
+    }
+
+    let repository = try await container.resolve(HeadlessRepository.self)
+    try await repository.deleteVaultedPaymentMethod(method.id)
+
+    logger.info(message: "[Vault] Successfully deleted payment method: \(method.id)")
+
+    await refreshVaultedPaymentMethods()
+  }
+
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultQRCodeScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultQRCodeScope.swift
@@ -1,0 +1,123 @@
+//
+//  DefaultQRCodeScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+public final class DefaultQRCodeScope: PrimerQRCodeScope, ObservableObject, LogReporter {
+
+  // MARK: - Public Properties
+
+  public private(set) var presentationContext: PresentationContext
+  public var screen: QRCodeScreenComponent?
+
+  public var dismissalMechanism: [DismissalMechanism] {
+    checkoutScope?.dismissalMechanism ?? []
+  }
+
+  public var state: AsyncStream<PrimerQRCodeState> {
+    AsyncStream { continuation in
+      let task = Task { @MainActor in
+        for await _ in $internalState.values {
+          continuation.yield(internalState)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  // MARK: - Private Properties
+
+  private weak var checkoutScope: DefaultCheckoutScope?
+  private let interactor: ProcessQRCodePaymentInteractor
+  private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+  private let paymentMethodType: String
+
+  @Published private var internalState = PrimerQRCodeState()
+
+  // MARK: - Initialization
+
+  init(
+    checkoutScope: DefaultCheckoutScope,
+    presentationContext: PresentationContext = .fromPaymentSelection,
+    interactor: ProcessQRCodePaymentInteractor,
+    analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil,
+    paymentMethodType: String
+  ) {
+    self.checkoutScope = checkoutScope
+    self.presentationContext = presentationContext
+    self.interactor = interactor
+    self.analyticsInteractor = analyticsInteractor
+    self.paymentMethodType = paymentMethodType
+  }
+
+  // MARK: - PrimerPaymentMethodScope Methods
+
+  public func start() {
+    logger.debug(message: "QR code scope started")
+    Task { [self] in
+      await performPayment()
+    }
+  }
+
+  // No-op: QR code payments auto-submit via start()
+  public func submit() {}
+
+  public func cancel() {
+    logger.debug(message: "QR code payment cancelled")
+    interactor.cancelPolling()
+    checkoutScope?.onDismiss()
+  }
+
+  // MARK: - Navigation Methods
+
+  public func onBack() {
+    if presentationContext.shouldShowBackButton {
+      interactor.cancelPolling()
+      checkoutScope?.checkoutNavigator.navigateBack()
+    }
+  }
+
+  // MARK: - Private Methods
+
+  private func performPayment() async {
+    internalState.status = .loading
+
+    let metadata: AnalyticsEventMetadata = .payment(PaymentEvent(paymentMethod: paymentMethodType))
+    await analyticsInteractor?.trackEvent(.paymentSubmitted, metadata: metadata)
+    await analyticsInteractor?.trackEvent(.paymentProcessingStarted, metadata: metadata)
+
+    do {
+      try await checkoutScope?.invokeBeforePaymentCreate(
+        paymentMethodType: paymentMethodType
+      )
+
+      let paymentData = try await interactor.startPayment()
+      internalState.qrCodeImageData = paymentData.qrCodeImageData
+      internalState.status = .displaying
+
+      let result = try await interactor.pollAndComplete(
+        statusUrl: paymentData.statusUrl,
+        paymentId: paymentData.paymentId
+      )
+
+      internalState.status = .success
+      checkoutScope?.handlePaymentSuccess(result)
+    } catch {
+      logger.error(message: "QR code payment failed: \(error.localizedDescription)")
+      internalState.status = .failure(error.localizedDescription)
+
+      let primerError =
+        error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+      checkoutScope?.handlePaymentError(primerError)
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultSelectCountryScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultSelectCountryScope.swift
@@ -1,0 +1,128 @@
+//
+//  DefaultSelectCountryScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// NOTE: Currently card-specific - holds reference to DefaultCardFormScope for billing address.
+/// If other payment methods require country selection in the future, this should be refactored
+/// to accept a generic payment method context instead of being tied to card payments.
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultSelectCountryScope: PrimerSelectCountryScope, LogReporter {
+
+  // MARK: - Properties
+
+  public var state: AsyncStream<PrimerSelectCountryState> {
+    AsyncStream { continuation in
+      let task = Task { @MainActor in
+        for await value in $internalState.values {
+          continuation.yield(value)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  // MARK: - UI Customization Properties
+
+  public var screen: ((_ scope: PrimerSelectCountryScope) -> AnyView)?
+  public var searchBar:
+    (
+      (_ query: String, _ onQueryChange: @escaping (String) -> Void, _ placeholder: String) ->
+        AnyView
+    )?
+  public var countryItem: CountryItemComponent?
+
+  // MARK: - Private Properties
+
+  @Published private var internalState = PrimerSelectCountryState()
+  private weak var cardFormScope: DefaultCardFormScope?
+  private weak var checkoutScope: DefaultCheckoutScope?
+
+  // MARK: - Initialization
+
+  init(cardFormScope: DefaultCardFormScope?, checkoutScope: DefaultCheckoutScope?) {
+    self.cardFormScope = cardFormScope
+    self.checkoutScope = checkoutScope
+    loadAvailableCountries()
+  }
+
+  // MARK: - Selection Methods
+
+  public func onCountrySelected(countryCode: String, countryName: String) {
+    // Update the card form with the selected country code
+    // Navigation is handled by the local sheet in CountryInputField
+    cardFormScope?.updateCountryCode(countryCode)
+  }
+
+  public func cancel() {
+    // No-op: Navigation is handled by the local sheet dismissal in CountryInputField
+  }
+
+  public func onSearch(query: String) {
+    internalState.searchQuery = query
+    filterCountries(with: query)
+  }
+
+  // MARK: - Private Methods
+
+  private func loadAvailableCountries() {
+    let allCountries = CountryCode.allCases.compactMap { countryCode in
+      convertCountryCodeToPrimerCountry(countryCode)
+    }.sorted { $0.name < $1.name }
+
+    internalState.countries = allCountries
+    internalState.filteredCountries = allCountries
+  }
+
+  private func convertCountryCodeToPrimerCountry(_ countryCode: CountryCode) -> PrimerCountry? {
+    let code = countryCode.rawValue
+    let localizedName = countryCode.country
+    let flagEmoji = countryCode.flag
+
+    let dialCode = CountryCode.phoneNumberCountryCodes
+      .first { $0.code.uppercased() == code.uppercased() }?
+      .dialCode
+
+    guard localizedName != "N/A", !localizedName.isEmpty else {
+      return nil
+    }
+
+    return PrimerCountry(
+      code: code,
+      name: localizedName,
+      flag: flagEmoji,
+      dialCode: dialCode
+    )
+  }
+
+  private func filterCountries(with query: String) {
+    if query.isEmpty {
+      internalState.filteredCountries = internalState.countries
+    } else {
+      let normalizedQuery = query.folding(
+        options: [.diacriticInsensitive, .caseInsensitive], locale: nil
+      )
+
+      internalState.filteredCountries = internalState.countries.filter { country in
+        let normalizedCountryName = country.name.folding(
+          options: [.diacriticInsensitive, .caseInsensitive], locale: nil
+        )
+        let normalizedCountryCode = country.code.folding(
+          options: [.diacriticInsensitive, .caseInsensitive], locale: nil
+        )
+
+        return normalizedCountryName.contains(normalizedQuery)
+          || normalizedCountryCode.contains(normalizedQuery)
+          || (country.dialCode?.contains(query) ?? false)
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultSelectCountryScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultSelectCountryScope.swift
@@ -32,25 +32,19 @@ final class DefaultSelectCountryScope: PrimerSelectCountryScope, LogReporter {
 
   // MARK: - UI Customization Properties
 
-  public var screen: ((_ scope: PrimerSelectCountryScope) -> AnyView)?
-  public var searchBar:
-    (
-      (_ query: String, _ onQueryChange: @escaping (String) -> Void, _ placeholder: String) ->
-        AnyView
-    )?
+  public var screen: SelectCountryScreenComponent?
+  public var searchBar: SearchBarComponent?
   public var countryItem: CountryItemComponent?
 
   // MARK: - Private Properties
 
   @Published private var internalState = PrimerSelectCountryState()
   private weak var cardFormScope: DefaultCardFormScope?
-  private weak var checkoutScope: DefaultCheckoutScope?
 
   // MARK: - Initialization
 
-  init(cardFormScope: DefaultCardFormScope?, checkoutScope: DefaultCheckoutScope?) {
+  init(cardFormScope: DefaultCardFormScope?) {
     self.cardFormScope = cardFormScope
-    self.checkoutScope = checkoutScope
     loadAvailableCountries()
   }
 
@@ -108,16 +102,13 @@ final class DefaultSelectCountryScope: PrimerSelectCountryScope, LogReporter {
       internalState.filteredCountries = internalState.countries
     } else {
       let normalizedQuery = query.folding(
-        options: [.diacriticInsensitive, .caseInsensitive], locale: nil
-      )
+        options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
 
       internalState.filteredCountries = internalState.countries.filter { country in
         let normalizedCountryName = country.name.folding(
-          options: [.diacriticInsensitive, .caseInsensitive], locale: nil
-        )
+          options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
         let normalizedCountryCode = country.code.folding(
-          options: [.diacriticInsensitive, .caseInsensitive], locale: nil
-        )
+          options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
 
         return normalizedCountryName.contains(normalizedQuery)
           || normalizedCountryCode.contains(normalizedQuery)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultWebRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultWebRedirectScope.swift
@@ -1,0 +1,175 @@
+//
+//  DefaultWebRedirectScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+public final class DefaultWebRedirectScope: PrimerWebRedirectScope, ObservableObject, LogReporter {
+
+    // MARK: - Public Properties
+
+    public let paymentMethodType: String
+
+    public private(set) var presentationContext: PresentationContext
+
+    public var dismissalMechanism: [DismissalMechanism] {
+        checkoutScope?.dismissalMechanism ?? []
+    }
+
+    public var state: AsyncStream<PrimerWebRedirectState> {
+        AsyncStream { continuation in
+            let task = Task { @MainActor in
+                for await _ in $internalState.values {
+                    continuation.yield(internalState)
+                }
+                continuation.finish()
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    // MARK: - UI Customization Properties
+
+    public var screen: WebRedirectScreenComponent?
+    public var payButton: WebRedirectButtonComponent?
+    public var submitButtonText: String?
+
+    // MARK: - Private Properties
+
+    private weak var checkoutScope: DefaultCheckoutScope?
+    private let processWebRedirectInteractor: ProcessWebRedirectPaymentInteractor
+    private let accessibilityService: AccessibilityAnnouncementService?
+    private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+    private let repository: WebRedirectRepository?
+
+    @Published private var internalState: PrimerWebRedirectState
+
+    // MARK: - Initialization
+
+    init(
+        paymentMethodType: String,
+        checkoutScope: DefaultCheckoutScope,
+        presentationContext: PresentationContext = .fromPaymentSelection,
+        processWebRedirectInteractor: ProcessWebRedirectPaymentInteractor,
+        accessibilityService: AccessibilityAnnouncementService? = nil,
+        analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil,
+        repository: WebRedirectRepository? = nil,
+        paymentMethod: CheckoutPaymentMethod? = nil,
+        surchargeAmount: String? = nil
+    ) {
+        self.paymentMethodType = paymentMethodType
+        self.checkoutScope = checkoutScope
+        self.presentationContext = presentationContext
+        self.processWebRedirectInteractor = processWebRedirectInteractor
+        self.accessibilityService = accessibilityService
+        self.analyticsInteractor = analyticsInteractor
+        self.repository = repository
+        internalState = PrimerWebRedirectState(
+            status: .idle,
+            paymentMethod: paymentMethod,
+            surchargeAmount: surchargeAmount
+        )
+    }
+
+    // MARK: - PrimerPaymentMethodScope Methods
+
+    public func start() {
+        internalState.status = .idle
+    }
+
+    public func submit() {
+        Task {
+            await performPayment()
+        }
+    }
+
+    public func cancel() {
+        // Cancel any in-flight polling before resetting state
+        repository?.cancelPolling(paymentMethodType: paymentMethodType)
+        internalState.status = .idle
+        checkoutScope?.onDismiss()
+    }
+
+    // MARK: - Navigation Methods
+
+    public func onBack() {
+        if presentationContext.shouldShowBackButton {
+            checkoutScope?.checkoutNavigator.navigateBack()
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func performPayment() async {
+        // Capture strong reference to checkoutScope before Safari opens
+        // Safari redirect causes SwiftUI views to go off-screen, releasing weak references
+        guard let checkoutScope else { return }
+
+        internalState.status = .loading
+        checkoutScope.startProcessing()
+
+        accessibilityService?.announceStateChange(CheckoutComponentsStrings.a11yWebRedirectLoading)
+
+        await analyticsInteractor?.trackEvent(
+            .paymentSubmitted,
+            metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+        )
+
+        do {
+            try await checkoutScope.invokeBeforePaymentCreate(
+                paymentMethodType: paymentMethodType
+            )
+
+            await analyticsInteractor?.trackEvent(
+                .paymentProcessingStarted,
+                metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+            )
+
+            internalState.status = .redirecting
+            accessibilityService?.announceStateChange(CheckoutComponentsStrings.a11yWebRedirectRedirecting)
+
+            let result = try await processWebRedirectInteractor.execute(paymentMethodType: paymentMethodType)
+
+            // Show checkout processing screen to avoid WebRedirectScreen flash when returning from Safari
+            checkoutScope.startProcessing()
+
+            internalState.status = .polling
+            accessibilityService?.announceStateChange(CheckoutComponentsStrings.a11yWebRedirectPolling)
+
+            await analyticsInteractor?.trackEvent(
+                .paymentRedirectToThirdParty,
+                metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+            )
+
+            internalState.status = .success
+            accessibilityService?.announceStateChange(CheckoutComponentsStrings.a11yWebRedirectSuccess)
+
+            checkoutScope.handlePaymentSuccess(result)
+
+        } catch {
+            // Show checkout processing screen to avoid WebRedirectScreen flash when returning from Safari
+            checkoutScope.startProcessing()
+
+            let errorMessage = extractUserFriendlyErrorMessage(from: error)
+            internalState.status = .failure(errorMessage)
+            accessibilityService?.announceError(CheckoutComponentsStrings.a11yWebRedirectFailure(errorMessage))
+
+            let primerError = error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+            checkoutScope.handlePaymentError(primerError)
+        }
+    }
+
+    private func extractUserFriendlyErrorMessage(from error: Error) -> String {
+        if let primerError = error as? PrimerError {
+            return primerError.localizedDescription
+        }
+        return error.localizedDescription
+    }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultWebRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultWebRedirectScope.swift
@@ -8,19 +8,17 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 @MainActor
-public final class DefaultWebRedirectScope: PrimerWebRedirectScope, ObservableObject, LogReporter {
+final class DefaultWebRedirectScope: PrimerWebRedirectScope, ObservableObject, LogReporter {
 
-    // MARK: - Public Properties
+    let paymentMethodType: String
 
-    public let paymentMethodType: String
+    private(set) var presentationContext: PresentationContext
 
-    public private(set) var presentationContext: PresentationContext
-
-    public var dismissalMechanism: [DismissalMechanism] {
+    var dismissalMechanism: [DismissalMechanism] {
         checkoutScope?.dismissalMechanism ?? []
     }
 
-    public var state: AsyncStream<PrimerWebRedirectState> {
+    var state: AsyncStream<PrimerWebRedirectState> {
         AsyncStream { continuation in
             let task = Task { @MainActor in
                 for await _ in $internalState.values {
@@ -35,13 +33,9 @@ public final class DefaultWebRedirectScope: PrimerWebRedirectScope, ObservableOb
         }
     }
 
-    // MARK: - UI Customization Properties
-
-    public var screen: WebRedirectScreenComponent?
-    public var payButton: WebRedirectButtonComponent?
-    public var submitButtonText: String?
-
-    // MARK: - Private Properties
+    var screen: WebRedirectScreenComponent?
+    var payButton: WebRedirectButtonComponent?
+    var submitButtonText: String?
 
     private weak var checkoutScope: DefaultCheckoutScope?
     private let processWebRedirectInteractor: ProcessWebRedirectPaymentInteractor
@@ -50,8 +44,6 @@ public final class DefaultWebRedirectScope: PrimerWebRedirectScope, ObservableOb
     private let repository: WebRedirectRepository?
 
     @Published private var internalState: PrimerWebRedirectState
-
-    // MARK: - Initialization
 
     init(
         paymentMethodType: String,
@@ -78,34 +70,28 @@ public final class DefaultWebRedirectScope: PrimerWebRedirectScope, ObservableOb
         )
     }
 
-    // MARK: - PrimerPaymentMethodScope Methods
-
-    public func start() {
+    func start() {
         internalState.status = .idle
     }
 
-    public func submit() {
+    func submit() {
         Task {
             await performPayment()
         }
     }
 
-    public func cancel() {
+    func cancel() {
         // Cancel any in-flight polling before resetting state
         repository?.cancelPolling(paymentMethodType: paymentMethodType)
         internalState.status = .idle
         checkoutScope?.onDismiss()
     }
 
-    // MARK: - Navigation Methods
-
-    public func onBack() {
+    func onBack() {
         if presentationContext.shouldShowBackButton {
             checkoutScope?.checkoutNavigator.navigateBack()
         }
     }
-
-    // MARK: - Private Methods
 
     private func performPayment() async {
         // Capture strong reference to checkoutScope before Safari opens

--- a/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
@@ -1,0 +1,982 @@
+//
+//  DefaultCheckoutScopeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class NavigationStateEqualityTests: XCTestCase {
+
+    private func createMockVaultedPaymentMethod(id: String) -> PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+        let data = try! JSONSerialization.data(withJSONObject: ["last4Digits": "4242"]) // swiftlint:disable:this force_try
+        let instrumentData = try! JSONDecoder().decode( // swiftlint:disable:this force_try
+            Response.Body.Tokenization.PaymentInstrumentData.self,
+            from: data
+        )
+
+        return PrimerHeadlessUniversalCheckout.VaultedPaymentMethod(
+            id: id,
+            paymentMethodType: PrimerPaymentMethodType.paymentCard.rawValue,
+            paymentInstrumentType: .paymentCard,
+            paymentInstrumentData: instrumentData,
+            analyticsId: "analytics_\(id)"
+        )
+    }
+
+    private func createMockPaymentResult(paymentId: String) -> PaymentResult {
+        PaymentResult(paymentId: paymentId, status: .success)
+    }
+
+    private func createMockError(message: String) -> PrimerError {
+        PrimerError.unknown(
+            message: message,
+            diagnosticsId: "test_diagnostics"
+        )
+    }
+
+    // MARK: - Simple State Equality
+
+    func test_navigationState_loading_equalsLoading() {
+        XCTAssertEqual(
+            DefaultCheckoutScope.NavigationState.loading,
+            DefaultCheckoutScope.NavigationState.loading
+        )
+    }
+
+    func test_navigationState_paymentMethodSelection_equalsPaymentMethodSelection() {
+        XCTAssertEqual(
+            DefaultCheckoutScope.NavigationState.paymentMethodSelection,
+            DefaultCheckoutScope.NavigationState.paymentMethodSelection
+        )
+    }
+
+    func test_navigationState_vaultedPaymentMethods_equalsVaultedPaymentMethods() {
+        XCTAssertEqual(
+            DefaultCheckoutScope.NavigationState.vaultedPaymentMethods,
+            DefaultCheckoutScope.NavigationState.vaultedPaymentMethods
+        )
+    }
+
+    func test_navigationState_processing_equalsProcessing() {
+        XCTAssertEqual(
+            DefaultCheckoutScope.NavigationState.processing,
+            DefaultCheckoutScope.NavigationState.processing
+        )
+    }
+
+    func test_navigationState_dismissed_equalsDismissed() {
+        XCTAssertEqual(
+            DefaultCheckoutScope.NavigationState.dismissed,
+            DefaultCheckoutScope.NavigationState.dismissed
+        )
+    }
+
+    // MARK: - Payment Method State Equality
+
+    func test_navigationState_paymentMethod_sameType_areEqual() {
+        XCTAssertEqual(
+            DefaultCheckoutScope.NavigationState.paymentMethod("PAYMENT_CARD"),
+            DefaultCheckoutScope.NavigationState.paymentMethod("PAYMENT_CARD")
+        )
+    }
+
+    func test_navigationState_paymentMethod_differentType_areNotEqual() {
+        XCTAssertNotEqual(
+            DefaultCheckoutScope.NavigationState.paymentMethod("PAYMENT_CARD"),
+            DefaultCheckoutScope.NavigationState.paymentMethod("PAYPAL")
+        )
+    }
+
+    // MARK: - Success State Equality
+
+    func test_navigationState_success_samePaymentId_areEqual() {
+        let state1 = DefaultCheckoutScope.NavigationState.success(createMockPaymentResult(paymentId: "pay_123"))
+        let state2 = DefaultCheckoutScope.NavigationState.success(createMockPaymentResult(paymentId: "pay_123"))
+        XCTAssertEqual(state1, state2)
+    }
+
+    func test_navigationState_success_differentPaymentId_areNotEqual() {
+        let state1 = DefaultCheckoutScope.NavigationState.success(createMockPaymentResult(paymentId: "pay_123"))
+        let state2 = DefaultCheckoutScope.NavigationState.success(createMockPaymentResult(paymentId: "pay_456"))
+        XCTAssertNotEqual(state1, state2)
+    }
+
+    // MARK: - Failure State Equality
+
+    func test_navigationState_failure_sameError_areEqual() {
+        let state1 = DefaultCheckoutScope.NavigationState.failure(createMockError(message: "Payment failed"))
+        let state2 = DefaultCheckoutScope.NavigationState.failure(createMockError(message: "Payment failed"))
+        XCTAssertEqual(state1, state2)
+    }
+
+    func test_navigationState_failure_differentError_areNotEqual() {
+        let state1 = DefaultCheckoutScope.NavigationState.failure(createMockError(message: "Payment failed"))
+        let state2 = DefaultCheckoutScope.NavigationState.failure(createMockError(message: "Network error"))
+        XCTAssertNotEqual(state1, state2)
+    }
+
+    // MARK: - Delete Confirmation State Equality
+
+    func test_navigationState_deleteConfirmation_sameMethod_areEqual() {
+        let state1 = DefaultCheckoutScope.NavigationState.deleteVaultedPaymentMethodConfirmation(createMockVaultedPaymentMethod(id: "vault_123"))
+        let state2 = DefaultCheckoutScope.NavigationState.deleteVaultedPaymentMethodConfirmation(createMockVaultedPaymentMethod(id: "vault_123"))
+        XCTAssertEqual(state1, state2)
+    }
+
+    func test_navigationState_deleteConfirmation_differentMethod_areNotEqual() {
+        let state1 = DefaultCheckoutScope.NavigationState.deleteVaultedPaymentMethodConfirmation(createMockVaultedPaymentMethod(id: "vault_123"))
+        let state2 = DefaultCheckoutScope.NavigationState.deleteVaultedPaymentMethodConfirmation(createMockVaultedPaymentMethod(id: "vault_456"))
+        XCTAssertNotEqual(state1, state2)
+    }
+
+    // MARK: - Cross-Type Inequality
+
+    func test_navigationState_differentTypes_areNotEqual() {
+        let loading = DefaultCheckoutScope.NavigationState.loading
+        let selection = DefaultCheckoutScope.NavigationState.paymentMethodSelection
+        let vaulted = DefaultCheckoutScope.NavigationState.vaultedPaymentMethods
+        let processing = DefaultCheckoutScope.NavigationState.processing
+        let dismissed = DefaultCheckoutScope.NavigationState.dismissed
+
+        XCTAssertNotEqual(loading, selection)
+        XCTAssertNotEqual(loading, vaulted)
+        XCTAssertNotEqual(loading, processing)
+        XCTAssertNotEqual(loading, dismissed)
+        XCTAssertNotEqual(selection, vaulted)
+        XCTAssertNotEqual(selection, processing)
+        XCTAssertNotEqual(selection, dismissed)
+        XCTAssertNotEqual(vaulted, processing)
+        XCTAssertNotEqual(vaulted, dismissed)
+        XCTAssertNotEqual(processing, dismissed)
+    }
+
+    func test_navigationState_paymentMethod_notEqual_toOtherTypes() {
+        XCTAssertNotEqual(
+            DefaultCheckoutScope.NavigationState.paymentMethod("PAYMENT_CARD"),
+            DefaultCheckoutScope.NavigationState.loading
+        )
+    }
+
+    func test_navigationState_success_notEqual_toOtherTypes() {
+        XCTAssertNotEqual(
+            DefaultCheckoutScope.NavigationState.success(createMockPaymentResult(paymentId: "pay_123")),
+            DefaultCheckoutScope.NavigationState.processing
+        )
+    }
+
+    func test_navigationState_failure_notEqual_toOtherTypes() {
+        XCTAssertNotEqual(
+            DefaultCheckoutScope.NavigationState.failure(createMockError(message: "Error")),
+            DefaultCheckoutScope.NavigationState.loading
+        )
+    }
+}
+
+// MARK: - Vaulted Payment Methods Management Tests
+
+@available(iOS 15.0, *)
+final class VaultedPaymentMethodsStateTests: XCTestCase {
+
+    private func createMockVaultedPaymentMethod(
+        id: String,
+        type: String = PrimerPaymentMethodType.paymentCard.rawValue
+    ) -> PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+        let data = try! JSONSerialization.data(withJSONObject: ["last4Digits": "4242"]) // swiftlint:disable:this force_try
+        let instrumentData = try! JSONDecoder().decode( // swiftlint:disable:this force_try
+            Response.Body.Tokenization.PaymentInstrumentData.self,
+            from: data
+        )
+
+        return PrimerHeadlessUniversalCheckout.VaultedPaymentMethod(
+            id: id,
+            paymentMethodType: type,
+            paymentInstrumentType: .paymentCard,
+            paymentInstrumentData: instrumentData,
+            analyticsId: "analytics_\(id)"
+        )
+    }
+
+    func test_vaultedPaymentMethods_emptyList_clearsSelection() {
+        // Given
+        var vaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
+        var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod? = createMockVaultedPaymentMethod(id: "vault_1")
+        let methods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
+
+        // When
+        vaultedPaymentMethods = methods
+
+        if let selectedId = selectedVaultedPaymentMethod?.id,
+           !methods.contains(where: { $0.id == selectedId }) {
+            selectedVaultedPaymentMethod = nil
+        }
+
+        if selectedVaultedPaymentMethod == nil, let first = methods.first {
+            selectedVaultedPaymentMethod = first
+        }
+
+        // Then
+        XCTAssertTrue(vaultedPaymentMethods.isEmpty)
+        XCTAssertNil(selectedVaultedPaymentMethod)
+    }
+
+    func test_vaultedPaymentMethods_withMethods_setsMethodsArray() {
+        // Given
+        var vaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
+        var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod?
+        let methods = [createMockVaultedPaymentMethod(id: "vault_1"), createMockVaultedPaymentMethod(id: "vault_2")]
+
+        // When
+        vaultedPaymentMethods = methods
+
+        if let selectedId = selectedVaultedPaymentMethod?.id,
+           !methods.contains(where: { $0.id == selectedId }) {
+            selectedVaultedPaymentMethod = nil
+        }
+
+        if selectedVaultedPaymentMethod == nil, let first = methods.first {
+            selectedVaultedPaymentMethod = first
+        }
+
+        // Then
+        XCTAssertEqual(vaultedPaymentMethods.count, 2)
+        XCTAssertEqual(selectedVaultedPaymentMethod?.id, "vault_1")
+    }
+
+    func test_vaultedPaymentMethods_selectsFirstAsDefault() {
+        // Given
+        var vaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
+        var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod?
+        let methods = [createMockVaultedPaymentMethod(id: "first_method"), createMockVaultedPaymentMethod(id: "second_method")]
+
+        // When
+        vaultedPaymentMethods = methods
+
+        if selectedVaultedPaymentMethod == nil, let first = methods.first {
+            selectedVaultedPaymentMethod = first
+        }
+
+        // Then
+        XCTAssertEqual(vaultedPaymentMethods.count, 2)
+        XCTAssertEqual(selectedVaultedPaymentMethod?.id, "first_method")
+    }
+
+    func test_vaultedPaymentMethods_clearsSelectionIfDeleted() {
+        // Given
+        var vaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
+        var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod? = createMockVaultedPaymentMethod(id: "deleted_method")
+        let methods = [createMockVaultedPaymentMethod(id: "vault_1"), createMockVaultedPaymentMethod(id: "vault_2")]
+
+        // When
+        vaultedPaymentMethods = methods
+
+        if let selectedId = selectedVaultedPaymentMethod?.id,
+           !methods.contains(where: { $0.id == selectedId }) {
+            selectedVaultedPaymentMethod = nil
+        }
+
+        if selectedVaultedPaymentMethod == nil, let first = methods.first {
+            selectedVaultedPaymentMethod = first
+        }
+
+        // Then
+        XCTAssertEqual(vaultedPaymentMethods.count, 2)
+        XCTAssertEqual(selectedVaultedPaymentMethod?.id, "vault_1")
+    }
+
+    func test_vaultedPaymentMethods_retainsSelectionIfPresent() {
+        // Given
+        var vaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] = []
+        var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod? = createMockVaultedPaymentMethod(id: "vault_2")
+        let methods = [
+            createMockVaultedPaymentMethod(id: "vault_1"),
+            createMockVaultedPaymentMethod(id: "vault_2"),
+            createMockVaultedPaymentMethod(id: "vault_3")
+        ]
+
+        // When
+        vaultedPaymentMethods = methods
+
+        if let selectedId = selectedVaultedPaymentMethod?.id,
+           !methods.contains(where: { $0.id == selectedId }) {
+            selectedVaultedPaymentMethod = nil
+        }
+
+        if selectedVaultedPaymentMethod == nil, let first = methods.first {
+            selectedVaultedPaymentMethod = first
+        }
+
+        // Then
+        XCTAssertEqual(vaultedPaymentMethods.count, 3)
+        XCTAssertEqual(selectedVaultedPaymentMethod?.id, "vault_2")
+    }
+
+    func test_setSelectedVaultedPaymentMethod_validMethod_setsSelection() {
+        // Given / When
+        let selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod? = createMockVaultedPaymentMethod(id: "selected_method")
+
+        // Then
+        XCTAssertEqual(selectedVaultedPaymentMethod?.id, "selected_method")
+    }
+
+    func test_setSelectedVaultedPaymentMethod_nil_clearsSelection() {
+        // Given
+        var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod? = createMockVaultedPaymentMethod(id: "existing")
+
+        // When
+        selectedVaultedPaymentMethod = nil
+
+        // Then
+        XCTAssertNil(selectedVaultedPaymentMethod)
+    }
+
+    func test_setSelectedVaultedPaymentMethod_changeSelection_updatesCorrectly() {
+        // Given
+        var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod? = createMockVaultedPaymentMethod(id: "original")
+
+        // When
+        selectedVaultedPaymentMethod = createMockVaultedPaymentMethod(id: "new_selection")
+
+        // Then
+        XCTAssertEqual(selectedVaultedPaymentMethod?.id, "new_selection")
+    }
+}
+
+// MARK: - DefaultCheckoutScope Behavior Tests
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultCheckoutScopeBehaviorTests: XCTestCase {
+
+    private var sut: DefaultCheckoutScope!
+    private var navigator: CheckoutNavigator!
+
+    override func setUp() {
+        super.setUp()
+        navigator = CheckoutNavigator(coordinator: CheckoutCoordinator())
+    }
+
+    override func tearDown() {
+        sut = nil
+        navigator = nil
+        super.tearDown()
+    }
+
+    private func makeSut(
+        settings: PrimerSettings = PrimerSettings()
+    ) -> DefaultCheckoutScope {
+        DefaultCheckoutScope(
+            clientToken: TestData.Tokens.valid,
+            settings: settings,
+            diContainer: DIContainer.shared,
+            navigator: navigator
+        )
+    }
+
+    private func makePaymentResult(
+        paymentId: String = TestData.PaymentIds.success,
+        paymentMethodType: String? = nil
+    ) -> PaymentResult {
+        PaymentResult(
+            paymentId: paymentId,
+            status: .success,
+            paymentMethodType: paymentMethodType
+        )
+    }
+
+    private func makeVaultedPaymentMethod(
+        id: String = "vault_1"
+    ) -> PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+        let data = try! JSONSerialization.data(withJSONObject: ["last4Digits": "4242"]) // swiftlint:disable:this force_try
+        let instrumentData = try! JSONDecoder().decode( // swiftlint:disable:this force_try
+            Response.Body.Tokenization.PaymentInstrumentData.self,
+            from: data
+        )
+        return PrimerHeadlessUniversalCheckout.VaultedPaymentMethod(
+            id: id,
+            paymentMethodType: PrimerPaymentMethodType.paymentCard.rawValue,
+            paymentInstrumentType: .paymentCard,
+            paymentInstrumentData: instrumentData,
+            analyticsId: "analytics_\(id)"
+        )
+    }
+
+    // MARK: - handlePaymentSuccess Tests
+
+    func test_handlePaymentSuccess_updatesStateToSuccess() async throws {
+        // Given
+        sut = makeSut()
+        let result = makePaymentResult()
+
+        // When
+        sut.handlePaymentSuccess(result)
+
+        // Then
+        let state = try await awaitValue(sut.state) {
+            if case .success = $0 { return true }
+            return false
+        }
+        if case let .success(paymentResult) = state {
+            XCTAssertEqual(paymentResult.paymentId, TestData.PaymentIds.success)
+        } else {
+            XCTFail("Expected success state")
+        }
+    }
+
+    func test_handlePaymentSuccess_updatesNavigationStateToSuccess() {
+        // Given
+        sut = makeSut()
+        let result = makePaymentResult()
+
+        // When
+        sut.handlePaymentSuccess(result)
+
+        // Then
+        if case let .success(navResult) = sut.navigationState {
+            XCTAssertEqual(navResult.paymentId, TestData.PaymentIds.success)
+        } else {
+            XCTFail("Expected navigation state to be success")
+        }
+    }
+
+    // MARK: - handlePaymentError Tests
+
+    func test_handlePaymentError_updatesStateToFailure() async throws {
+        // Given
+        sut = makeSut()
+        let error = PrimerError.unknown(message: "Test error")
+
+        // When
+        sut.handlePaymentError(error)
+
+        // Then
+        let state = try await awaitValue(sut.state) {
+            if case .failure = $0 { return true }
+            return false
+        }
+        if case .failure = state {
+            // Expected
+        } else {
+            XCTFail("Expected failure state")
+        }
+    }
+
+    func test_handlePaymentError_updatesNavigationStateToFailure() {
+        // Given
+        sut = makeSut()
+        let error = PrimerError.unknown(message: "Payment error")
+
+        // When
+        sut.handlePaymentError(error)
+
+        // Then
+        if case .failure = sut.navigationState {
+            // Expected
+        } else {
+            XCTFail("Expected navigation state to be failure")
+        }
+    }
+
+    // MARK: - startProcessing Tests
+
+    func test_startProcessing_setsNavigationStateToProcessing() {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.startProcessing()
+
+        // Then
+        XCTAssertEqual(sut.navigationState, .processing)
+    }
+
+    // MARK: - handleAutoDismiss Tests
+
+    func test_handleAutoDismiss_updatesStateToDismissed() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.handleAutoDismiss()
+
+        // Then
+        let state = try await awaitValue(sut.state) {
+            if case .dismissed = $0 { return true }
+            return false
+        }
+        if case .dismissed = state {
+            // Expected
+        } else {
+            XCTFail("Expected dismissed state")
+        }
+    }
+
+    // MARK: - onDismiss Tests
+
+    func test_onDismiss_setsStateToDismissed() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.onDismiss()
+
+        // Then
+        let state = try await awaitValue(sut.state) {
+            if case .dismissed = $0 { return true }
+            return false
+        }
+        if case .dismissed = state {
+            // Expected
+        } else {
+            XCTFail("Expected dismissed state")
+        }
+    }
+
+    func test_onDismiss_setsNavigationStateToDismissed() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.onDismiss()
+
+        // Wait for the Task to execute
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        // Then — onDismiss may set dismissed on state stream but not always on navigationState directly
+        let navState = sut.navigationState
+        XCTAssertTrue(navState == .dismissed || navState == .loading)
+    }
+
+    // MARK: - updateNavigationState Tests
+
+    func test_updateNavigationState_loading_navigatesToLoading() {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateNavigationState(.loading)
+
+        // Then
+        XCTAssertEqual(sut.navigationState, .loading)
+    }
+
+    func test_updateNavigationState_paymentMethodSelection_navigatesToSelection() {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateNavigationState(.paymentMethodSelection)
+
+        // Then
+        XCTAssertEqual(sut.navigationState, .paymentMethodSelection)
+    }
+
+    func test_updateNavigationState_vaultedPaymentMethods_navigatesToVaulted() {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateNavigationState(.vaultedPaymentMethods)
+
+        // Then
+        XCTAssertEqual(sut.navigationState, .vaultedPaymentMethods)
+    }
+
+    func test_updateNavigationState_deleteVaultedConfirmation_navigatesToConfirmation() {
+        // Given
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod()
+
+        // When
+        sut.updateNavigationState(.deleteVaultedPaymentMethodConfirmation(method))
+
+        // Then
+        if case let .deleteVaultedPaymentMethodConfirmation(navMethod) = sut.navigationState {
+            XCTAssertEqual(navMethod.id, "vault_1")
+        } else {
+            XCTFail("Expected deleteVaultedPaymentMethodConfirmation state")
+        }
+    }
+
+    func test_updateNavigationState_paymentMethod_navigatesToPaymentMethod() {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateNavigationState(.paymentMethod(TestData.PaymentMethodTypes.card))
+
+        // Then
+        XCTAssertEqual(sut.navigationState, .paymentMethod(TestData.PaymentMethodTypes.card))
+    }
+
+    func test_updateNavigationState_processing_navigatesToProcessing() {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateNavigationState(.processing)
+
+        // Then
+        XCTAssertEqual(sut.navigationState, .processing)
+    }
+
+    func test_updateNavigationState_failure_navigatesToError() {
+        // Given
+        sut = makeSut()
+        let error = PrimerError.unknown(message: "Navigation error")
+
+        // When
+        sut.updateNavigationState(.failure(error))
+
+        // Then
+        if case .failure = sut.navigationState {
+            // Expected
+        } else {
+            XCTFail("Expected failure navigation state")
+        }
+    }
+
+    func test_updateNavigationState_success_doesNotCallNavigator() {
+        // Given
+        sut = makeSut()
+        let result = makePaymentResult()
+
+        // When / Then — should not crash; success doesn't navigate
+        sut.updateNavigationState(.success(result))
+        if case .success = sut.navigationState {
+            // Expected
+        } else {
+            XCTFail("Expected success navigation state")
+        }
+    }
+
+    func test_updateNavigationState_dismissed_doesNotCallNavigator() {
+        // Given
+        sut = makeSut()
+
+        // When / Then — should not crash; dismissed doesn't navigate
+        sut.updateNavigationState(.dismissed)
+        XCTAssertEqual(sut.navigationState, .dismissed)
+    }
+
+    func test_updateNavigationState_syncToNavigatorFalse_doesNotSyncToNavigator() {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateNavigationState(.processing, syncToNavigator: false)
+
+        // Then
+        XCTAssertEqual(sut.navigationState, .processing)
+    }
+
+    // MARK: - paymentMethodSelection Tests
+
+    func test_paymentMethodSelection_returnsCachedScope() {
+        // Given
+        sut = makeSut()
+
+        // When
+        let scope1 = sut.paymentMethodSelection
+        let scope2 = sut.paymentMethodSelection
+
+        // Then
+        XCTAssertTrue(scope1 === scope2)
+    }
+
+    // MARK: - Properties Tests
+
+    func test_paymentHandling_delegatesToSettings() {
+        // Given
+        let settings = PrimerSettings(paymentHandling: .manual)
+        sut = makeSut(settings: settings)
+
+        // Then
+        XCTAssertEqual(sut.paymentHandling, .manual)
+    }
+
+    func test_isInitScreenEnabled_delegatesToSettings() {
+        // Given
+        sut = makeSut()
+
+        // Then — default PrimerSettings
+        XCTAssertNotNil(sut.isInitScreenEnabled)
+    }
+
+    func test_isSuccessScreenEnabled_delegatesToSettings() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertNotNil(sut.isSuccessScreenEnabled)
+    }
+
+    func test_isErrorScreenEnabled_delegatesToSettings() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertNotNil(sut.isErrorScreenEnabled)
+    }
+
+    func test_dismissalMechanism_delegatesToSettings() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertNotNil(sut.dismissalMechanism)
+    }
+
+    func test_is3DSSanityCheckEnabled_delegatesToSettings() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertNotNil(sut.is3DSSanityCheckEnabled)
+    }
+
+    func test_presentationContext_defaultsToFromPaymentSelection() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertEqual(sut.presentationContext, .fromPaymentSelection)
+    }
+
+    func test_currentState_reflectsInternalState() {
+        // Given
+        sut = makeSut()
+
+        // Then — initial state is .initializing
+        if case .initializing = sut.currentState {
+            // Expected
+        } else {
+            XCTFail("Expected initializing state")
+        }
+    }
+
+    func test_checkoutNavigator_returnsNavigator() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertNotNil(sut.checkoutNavigator)
+    }
+
+    func test_availablePaymentMethods_defaultsToEmpty() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertTrue(sut.availablePaymentMethods.isEmpty)
+    }
+
+    // MARK: - UI Customization Properties Tests
+
+    func test_uiCustomizationProperties_defaultToNil() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertNil(sut.onBeforePaymentCreate)
+        XCTAssertNil(sut.container)
+        XCTAssertNil(sut.splashScreen)
+        XCTAssertNil(sut.loadingScreen)
+        XCTAssertNil(sut.successScreen)
+        XCTAssertNil(sut.errorScreen)
+        XCTAssertNil(sut.paymentMethodSelectionScreen)
+    }
+
+    // MARK: - retryPayment Tests
+
+    func test_retryPayment_doesNotCrash_withNoCurrentScope() {
+        // Given
+        sut = makeSut()
+
+        // When / Then — should not crash when no payment method scope is set
+        sut.retryPayment()
+    }
+
+    // MARK: - handlePaymentMethodSelection Tests
+
+    func test_handlePaymentMethodSelection_withoutContainer_navigatesToFailure() {
+        // Given
+        sut = makeSut()
+        let method = InternalPaymentMethod(
+            id: "pm_1",
+            type: TestData.PaymentMethodTypes.card,
+            name: TestData.PaymentMethodNames.cardName
+        )
+
+        // When
+        sut.handlePaymentMethodSelection(method)
+
+        // Then — without a container, should navigate to failure or payment method
+        // The method either succeeds or shows a failure state
+        XCTAssertNotEqual(sut.navigationState, .loading)
+    }
+
+    // MARK: - getPaymentMethodScope Tests
+
+    func test_getPaymentMethodScope_forString_withoutContainer_returnsNil() {
+        // Given
+        sut = makeSut()
+
+        // When
+        let scope: DefaultCardFormScope? = sut.getPaymentMethodScope(for: "PAYMENT_CARD")
+
+        // Then
+        XCTAssertNil(scope)
+    }
+
+    func test_getPaymentMethodScope_byType_withoutContainer_returnsNil() {
+        // Given
+        sut = makeSut()
+
+        // When
+        let scope: DefaultCardFormScope? = sut.getPaymentMethodScope(DefaultCardFormScope.self)
+
+        // Then
+        XCTAssertNil(scope)
+    }
+
+    func test_getPaymentMethodScope_forEnum_delegatesToStringVersion() {
+        // Given
+        sut = makeSut()
+        PaymentMethodRegistry.shared.reset()
+
+        // When
+        let scope: DefaultApplePayScope? = sut.getPaymentMethodScope(for: .applePay)
+
+        // Then
+        XCTAssertNil(scope)
+    }
+
+    // MARK: - setVaultedPaymentMethods Tests (on real scope)
+
+    func test_setVaultedPaymentMethods_setsMethodsAndDefaultSelection() {
+        // Given
+        sut = makeSut()
+        let methods = [makeVaultedPaymentMethod(id: "v1"), makeVaultedPaymentMethod(id: "v2")]
+
+        // When
+        sut.setVaultedPaymentMethods(methods)
+
+        // Then
+        XCTAssertEqual(sut.vaultedPaymentMethods.count, 2)
+        XCTAssertEqual(sut.selectedVaultedPaymentMethod?.id, "v1")
+    }
+
+    func test_setVaultedPaymentMethods_emptyList_clearsSelection() {
+        // Given
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod()
+        sut.setVaultedPaymentMethods([method])
+
+        // When
+        sut.setVaultedPaymentMethods([])
+
+        // Then
+        XCTAssertTrue(sut.vaultedPaymentMethods.isEmpty)
+        XCTAssertNil(sut.selectedVaultedPaymentMethod)
+    }
+
+    func test_setVaultedPaymentMethods_deletedSelection_fallsBackToFirst() {
+        // Given
+        sut = makeSut()
+        let method1 = makeVaultedPaymentMethod(id: "v1")
+        let method2 = makeVaultedPaymentMethod(id: "v2")
+        sut.setVaultedPaymentMethods([method1, method2])
+        sut.setSelectedVaultedPaymentMethod(method2)
+
+        // When — remove method2
+        sut.setVaultedPaymentMethods([method1])
+
+        // Then
+        XCTAssertEqual(sut.selectedVaultedPaymentMethod?.id, "v1")
+    }
+
+    func test_setSelectedVaultedPaymentMethod_setsSelection() {
+        // Given
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod()
+        sut.setVaultedPaymentMethods([method])
+
+        // When
+        sut.setSelectedVaultedPaymentMethod(method)
+
+        // Then
+        XCTAssertEqual(sut.selectedVaultedPaymentMethod?.id, "vault_1")
+    }
+
+    func test_setSelectedVaultedPaymentMethod_nil_clearsSelection() {
+        // Given
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod()
+        sut.setVaultedPaymentMethods([method])
+        sut.setSelectedVaultedPaymentMethod(method)
+
+        // When
+        sut.setSelectedVaultedPaymentMethod(nil)
+
+        // Then
+        XCTAssertNil(sut.selectedVaultedPaymentMethod)
+    }
+
+    // MARK: - state AsyncStream Tests
+
+    func test_state_emitsInitialState() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        if case .initializing = state {
+            // Expected
+        } else {
+            XCTFail("Expected initializing state, got \(state)")
+        }
+    }
+
+    // MARK: - invokeBeforePaymentCreate Tests
+
+    func test_invokeBeforePaymentCreate_noCallback_returnsImmediately() async throws {
+        // Given
+        sut = makeSut()
+        sut.onBeforePaymentCreate = nil
+
+        // When / Then — should not throw
+        try await sut.invokeBeforePaymentCreate(paymentMethodType: TestData.PaymentMethodTypes.card)
+    }
+
+    func test_invokeBeforePaymentCreate_abortDecision_throwsMerchantError() async throws {
+        // Given
+        sut = makeSut()
+        sut.onBeforePaymentCreate = { _, handler in
+            handler(PrimerPaymentCreationDecision.abortPaymentCreation(withErrorMessage: "Aborted by merchant"))
+        }
+
+        // When / Then
+        do {
+            try await sut.invokeBeforePaymentCreate(paymentMethodType: TestData.PaymentMethodTypes.card)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            // Expected
+        }
+    }
+
+    func test_invokeBeforePaymentCreate_continueDecision_succeeds() async throws {
+        // Given
+        sut = makeSut()
+        sut.onBeforePaymentCreate = { _, handler in
+            handler(PrimerPaymentCreationDecision.continuePaymentCreation())
+        }
+
+        // When / Then — should not throw
+        try await sut.invokeBeforePaymentCreate(paymentMethodType: TestData.PaymentMethodTypes.card)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/DefaultPaymentMethodSelectionScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultPaymentMethodSelectionScopeTests.swift
@@ -529,7 +529,7 @@ final class DefaultPaymentMethodSelectionScopeTests: XCTestCase {
 
     func test_refreshVaultedPaymentMethods_withContainer_callsRepository() async throws {
         // Given
-        let container = await ContainerTestHelpers.createTestContainer()
+        let container = try await ContainerTestHelpers.createTestContainer()
         let mockRepo = MockHeadlessRepository()
         mockRepo.vaultedPaymentMethodsToReturn = [makeVaultedPaymentMethod()]
         _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
@@ -546,7 +546,7 @@ final class DefaultPaymentMethodSelectionScopeTests: XCTestCase {
 
     func test_refreshVaultedPaymentMethods_repositoryThrows_doesNotCrash() async throws {
         // Given
-        let container = await ContainerTestHelpers.createTestContainer()
+        let container = try await ContainerTestHelpers.createTestContainer()
         let mockRepo = MockHeadlessRepository()
         mockRepo.fetchVaultedPaymentMethodsError = TestError.networkFailure
         _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
@@ -563,7 +563,7 @@ final class DefaultPaymentMethodSelectionScopeTests: XCTestCase {
 
     func test_deleteVaultedPaymentMethod_success_callsRepositoryAndRefreshes() async throws {
         // Given
-        let container = await ContainerTestHelpers.createTestContainer()
+        let container = try await ContainerTestHelpers.createTestContainer()
         let mockRepo = MockHeadlessRepository()
         mockRepo.vaultedPaymentMethodsToReturn = []
         _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
@@ -584,7 +584,7 @@ final class DefaultPaymentMethodSelectionScopeTests: XCTestCase {
 
     func test_deleteVaultedPaymentMethod_repositoryThrows_propagatesError() async throws {
         // Given
-        let container = await ContainerTestHelpers.createTestContainer()
+        let container = try await ContainerTestHelpers.createTestContainer()
         let mockRepo = MockHeadlessRepository()
         mockRepo.deleteVaultedPaymentMethodError = TestError.networkFailure
         _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
@@ -878,7 +878,7 @@ final class DefaultPaymentMethodSelectionScopeVaultTests: XCTestCase {
 
     func test_deleteVaultedPaymentMethod_success_refreshesAfterDelete() async throws {
         // Given
-        let container = await ContainerTestHelpers.createTestContainer()
+        let container = try await ContainerTestHelpers.createTestContainer()
         let mockRepo = MockHeadlessRepository()
         let remainingMethod = makeVaultedPaymentMethod(id: "vault_remaining")
         mockRepo.vaultedPaymentMethodsToReturn = [remainingMethod]
@@ -899,9 +899,9 @@ final class DefaultPaymentMethodSelectionScopeVaultTests: XCTestCase {
 
     // MARK: - deleteVaultedPaymentMethod: repository delete throws
 
-    func test_deleteVaultedPaymentMethod_whenDeleteThrows_propagatesErrorWithoutRefresh() async {
+    func test_deleteVaultedPaymentMethod_whenDeleteThrows_propagatesErrorWithoutRefresh() async throws {
         // Given
-        let container = await ContainerTestHelpers.createTestContainer()
+        let container = try await ContainerTestHelpers.createTestContainer()
         let mockRepo = MockHeadlessRepository()
         mockRepo.deleteVaultedPaymentMethodError = TestError.networkFailure
         _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
@@ -927,7 +927,7 @@ final class DefaultPaymentMethodSelectionScopeVaultTests: XCTestCase {
 
     func test_refreshVaultedPaymentMethods_success_syncesCheckoutScope() async throws {
         // Given
-        let container = await ContainerTestHelpers.createTestContainer()
+        let container = try await ContainerTestHelpers.createTestContainer()
         let mockRepo = MockHeadlessRepository()
         let vaultedMethod = makeVaultedPaymentMethod(id: "vault_synced")
         mockRepo.vaultedPaymentMethodsToReturn = [vaultedMethod]
@@ -945,9 +945,9 @@ final class DefaultPaymentMethodSelectionScopeVaultTests: XCTestCase {
 
     // MARK: - refreshVaultedPaymentMethods: repository throws logs error
 
-    func test_refreshVaultedPaymentMethods_whenRepositoryThrows_handlesGracefully() async {
+    func test_refreshVaultedPaymentMethods_whenRepositoryThrows_handlesGracefully() async throws {
         // Given
-        let container = await ContainerTestHelpers.createTestContainer()
+        let container = try await ContainerTestHelpers.createTestContainer()
         let mockRepo = MockHeadlessRepository()
         mockRepo.fetchVaultedPaymentMethodsError = TestError.networkFailure
         _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }

--- a/Tests/Primer/CheckoutComponents/DefaultPaymentMethodSelectionScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultPaymentMethodSelectionScopeTests.swift
@@ -1,0 +1,1580 @@
+//
+//  DefaultPaymentMethodSelectionScopeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+// MARK: - DefaultPaymentMethodSelectionScope Tests
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultPaymentMethodSelectionScopeTests: XCTestCase {
+
+    private var mockCheckoutScope: DefaultCheckoutScope!
+    private var mockAnalytics: MockTrackingAnalyticsInteractor!
+    private var sut: DefaultPaymentMethodSelectionScope!
+
+    override func setUp() {
+        super.setUp()
+        mockCheckoutScope = createCheckoutScope()
+        mockAnalytics = MockTrackingAnalyticsInteractor()
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockAnalytics = nil
+        mockCheckoutScope = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func createCheckoutScope() -> DefaultCheckoutScope {
+        DefaultCheckoutScope(
+            clientToken: TestData.Tokens.valid,
+            settings: PrimerSettings(),
+            diContainer: DIContainer.shared,
+            navigator: CheckoutNavigator()
+        )
+    }
+
+    private func makeSut() -> DefaultPaymentMethodSelectionScope {
+        DefaultPaymentMethodSelectionScope(
+            checkoutScope: mockCheckoutScope,
+            analyticsInteractor: mockAnalytics
+        )
+    }
+
+    private func makePaymentMethod(
+        id: String = "pm_1",
+        type: String = TestData.PaymentMethodTypes.card,
+        name: String = TestData.PaymentMethodNames.cardName
+    ) -> CheckoutPaymentMethod {
+        CheckoutPaymentMethod(id: id, type: type, name: name)
+    }
+
+    private func makeVaultedPaymentMethod(
+        id: String = "vault_1",
+        paymentMethodType: String = PrimerPaymentMethodType.paymentCard.rawValue,
+        instrumentType: PaymentInstrumentType = .paymentCard,
+        network: String? = nil
+    ) -> PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+        var json: [String: Any] = ["last4Digits": "4242"]
+        if let network {
+            json["network"] = network
+        }
+        let data = try! JSONSerialization.data(withJSONObject: json) // swiftlint:disable:this force_try
+        let instrumentData = try! JSONDecoder().decode( // swiftlint:disable:this force_try
+            Response.Body.Tokenization.PaymentInstrumentData.self,
+            from: data
+        )
+        return PrimerHeadlessUniversalCheckout.VaultedPaymentMethod(
+            id: id,
+            paymentMethodType: paymentMethodType,
+            paymentInstrumentType: instrumentType,
+            paymentInstrumentData: instrumentData,
+            analyticsId: "analytics_\(id)"
+        )
+    }
+
+    // MARK: - State Stream Tests
+
+    func test_state_emitsInitialState() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        let state = try await awaitFirst(sut.state)
+
+        // Then
+        XCTAssertTrue(state.paymentMethods.isEmpty)
+        XCTAssertTrue(state.filteredPaymentMethods.isEmpty)
+        XCTAssertNil(state.selectedPaymentMethod)
+        XCTAssertTrue(state.isPaymentMethodsExpanded)
+    }
+
+    // MARK: - onPaymentMethodSelected Tests
+
+    func test_onPaymentMethodSelected_setsSelectedPaymentMethod() async throws {
+        // Given
+        sut = makeSut()
+        let method = makePaymentMethod()
+
+        // When
+        sut.onPaymentMethodSelected(paymentMethod: method)
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.selectedPaymentMethod != nil }
+        XCTAssertEqual(state.selectedPaymentMethod?.id, "pm_1")
+    }
+
+    func test_onPaymentMethodSelected_tracksAnalyticsEvent() async throws {
+        // Given
+        sut = makeSut()
+        let method = makePaymentMethod(type: TestData.PaymentMethodTypes.paypal)
+
+        // When
+        sut.onPaymentMethodSelected(paymentMethod: method)
+
+        // Then — allow async task to complete
+        try await Task.sleep(nanoseconds: 200_000_000)
+        let hasTracked = await mockAnalytics.hasTracked(.paymentMethodSelection)
+        XCTAssertTrue(hasTracked)
+    }
+
+    func test_onPaymentMethodSelected_multipleSelections_updatesState() async throws {
+        // Given
+        sut = makeSut()
+        let card = makePaymentMethod(id: "pm_card", type: TestData.PaymentMethodTypes.card, name: "Card")
+        let paypal = makePaymentMethod(id: "pm_paypal", type: TestData.PaymentMethodTypes.paypal, name: "PayPal")
+
+        // When
+        sut.onPaymentMethodSelected(paymentMethod: card)
+        sut.onPaymentMethodSelected(paymentMethod: paypal)
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.selectedPaymentMethod?.id == "pm_paypal" }
+        XCTAssertEqual(state.selectedPaymentMethod?.id, "pm_paypal")
+    }
+
+    // MARK: - cancel Tests
+
+    func test_cancel_callsCheckoutScopeOnDismiss() {
+        // Given
+        sut = makeSut()
+
+        // When / Then — should not crash; delegates to checkoutScope.onDismiss()
+        sut.cancel()
+    }
+
+    // MARK: - searchPaymentMethods Tests
+
+    func test_searchPaymentMethods_emptyQuery_resetsToAllMethods() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.searchPaymentMethods("")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertTrue(state.searchQuery.isEmpty)
+    }
+
+    func test_searchPaymentMethods_withQuery_updatesSearchQueryAndFilters() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.searchPaymentMethods("Card")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.searchQuery == "Card" }
+        XCTAssertEqual(state.searchQuery, "Card")
+    }
+
+    func test_searchPaymentMethods_caseInsensitive_matchesByNameOrType() async throws {
+        // Given
+        sut = makeSut()
+
+        // When — search should set query regardless of payment methods loaded
+        sut.searchPaymentMethods("paypal")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.searchQuery == "paypal" }
+        XCTAssertEqual(state.searchQuery, "paypal")
+    }
+
+    // MARK: - showOtherWaysToPay Tests
+
+    func test_showOtherWaysToPay_setsExpansionToTrue() async throws {
+        // Given
+        sut = makeSut()
+        sut.collapsePaymentMethods()
+
+        // When
+        sut.showOtherWaysToPay()
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.isPaymentMethodsExpanded }
+        XCTAssertTrue(state.isPaymentMethodsExpanded)
+    }
+
+    // MARK: - collapsePaymentMethods Tests
+
+    func test_collapsePaymentMethods_setsExpansionToFalse() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.collapsePaymentMethods()
+
+        // Then
+        let state = try await awaitValue(sut.state) { !$0.isPaymentMethodsExpanded }
+        XCTAssertFalse(state.isPaymentMethodsExpanded)
+    }
+
+    // MARK: - showAllVaultedPaymentMethods Tests
+
+    func test_showAllVaultedPaymentMethods_updatesCheckoutScopeNavigation() {
+        // Given
+        sut = makeSut()
+
+        // When / Then — should not crash; delegates to checkoutScope.updateNavigationState
+        sut.showAllVaultedPaymentMethods()
+        XCTAssertEqual(mockCheckoutScope.navigationState, .vaultedPaymentMethods)
+    }
+
+    // MARK: - updateCvvInput Tests
+
+    func test_updateCvvInput_emptyString_notValidNoError() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateCvvInput("")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.cvvInput == "" }
+        XCTAssertFalse(state.isCvvValid)
+        XCTAssertNil(state.cvvError)
+    }
+
+    func test_updateCvvInput_validThreeDigits_isValid() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateCvvInput("123")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.cvvInput == "123" }
+        XCTAssertTrue(state.isCvvValid)
+        XCTAssertNil(state.cvvError)
+    }
+
+    func test_updateCvvInput_nonNumeric_showsError() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateCvvInput("abc")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.cvvInput == "abc" }
+        XCTAssertFalse(state.isCvvValid)
+        XCTAssertNotNil(state.cvvError)
+    }
+
+    func test_updateCvvInput_tooManyDigits_showsError() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateCvvInput("12345")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.cvvInput == "12345" }
+        XCTAssertFalse(state.isCvvValid)
+        XCTAssertNotNil(state.cvvError)
+    }
+
+    func test_updateCvvInput_partialInput_notValidNoError() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateCvvInput("12")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.cvvInput == "12" }
+        XCTAssertFalse(state.isCvvValid)
+        XCTAssertNil(state.cvvError)
+    }
+
+    func test_updateCvvInput_specialCharacters_showsError() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateCvvInput("1!2")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.cvvInput == "1!2" }
+        XCTAssertFalse(state.isCvvValid)
+        XCTAssertNotNil(state.cvvError)
+    }
+
+    // MARK: - payWithVaultedPaymentMethod Tests
+
+    func test_payWithVaultedPaymentMethod_noMethodSelected_returnsEarly() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        await sut.payWithVaultedPaymentMethod()
+
+        // Then — state should remain unchanged
+        let state = try await awaitFirst(sut.state)
+        XCTAssertFalse(state.isVaultPaymentLoading)
+        XCTAssertFalse(state.requiresCvvInput)
+    }
+
+    // MARK: - payWithVaultedPaymentMethodAndCvv Tests
+
+    func test_payWithVaultedPaymentMethodAndCvv_noMethodSelected_returnsEarly() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        await sut.payWithVaultedPaymentMethodAndCvv("123")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertFalse(state.isVaultPaymentLoading)
+    }
+
+    // MARK: - syncSelectedVaultedPaymentMethod Tests
+
+    func test_syncSelectedVaultedPaymentMethod_updatesFromCheckoutScope() async throws {
+        // Given
+        sut = makeSut()
+        let vaultedMethod = makeVaultedPaymentMethod()
+        mockCheckoutScope.setVaultedPaymentMethods([vaultedMethod])
+        mockCheckoutScope.setSelectedVaultedPaymentMethod(vaultedMethod)
+
+        // When
+        sut.syncSelectedVaultedPaymentMethod()
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.selectedVaultedPaymentMethod != nil }
+        XCTAssertEqual(state.selectedVaultedPaymentMethod?.id, "vault_1")
+    }
+
+    func test_syncSelectedVaultedPaymentMethod_differentMethod_resetsCvvState() async throws {
+        // Given
+        sut = makeSut()
+        let method1 = makeVaultedPaymentMethod(id: "vault_1")
+        let method2 = makeVaultedPaymentMethod(id: "vault_2")
+
+        mockCheckoutScope.setVaultedPaymentMethods([method1, method2])
+        mockCheckoutScope.setSelectedVaultedPaymentMethod(method1)
+        sut.syncSelectedVaultedPaymentMethod()
+
+        // Simulate CVV entry
+        sut.updateCvvInput("123")
+
+        // When — switch to different method
+        mockCheckoutScope.setSelectedVaultedPaymentMethod(method2)
+        sut.syncSelectedVaultedPaymentMethod()
+
+        // Then — CVV should be reset
+        let state = try await awaitValue(sut.state) { $0.selectedVaultedPaymentMethod?.id == "vault_2" }
+        XCTAssertEqual(state.cvvInput, "")
+        XCTAssertFalse(state.isCvvValid)
+        XCTAssertFalse(state.requiresCvvInput)
+        XCTAssertNil(state.cvvError)
+    }
+
+    func test_syncSelectedVaultedPaymentMethod_sameMethod_preservesCvvState() async throws {
+        // Given
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod(id: "vault_1")
+
+        mockCheckoutScope.setVaultedPaymentMethods([method])
+        mockCheckoutScope.setSelectedVaultedPaymentMethod(method)
+        sut.syncSelectedVaultedPaymentMethod()
+
+        sut.updateCvvInput("123")
+
+        // When — sync same method again
+        sut.syncSelectedVaultedPaymentMethod()
+
+        // Then — CVV should remain
+        let state = try await awaitValue(sut.state) { $0.cvvInput == "123" }
+        XCTAssertEqual(state.cvvInput, "123")
+    }
+
+    func test_syncSelectedVaultedPaymentMethod_nilSelection_clearsState() async throws {
+        // Given
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod()
+        mockCheckoutScope.setVaultedPaymentMethods([method])
+        mockCheckoutScope.setSelectedVaultedPaymentMethod(method)
+        sut.syncSelectedVaultedPaymentMethod()
+
+        // When — deselect
+        mockCheckoutScope.setSelectedVaultedPaymentMethod(nil)
+        sut.syncSelectedVaultedPaymentMethod()
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.selectedVaultedPaymentMethod == nil }
+        XCTAssertNil(state.selectedVaultedPaymentMethod)
+    }
+
+    // MARK: - deleteVaultedPaymentMethod Tests
+
+    func test_deleteVaultedPaymentMethod_withoutContainer_throwsError() async {
+        // Given
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod()
+
+        // When / Then
+        await DIContainer.clearContainer()
+        do {
+            try await sut.deleteVaultedPaymentMethod(method)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            // Expected — container is nil
+        }
+
+        // Restore container
+        let container = Container()
+        await DIContainer.setContainer(container)
+    }
+
+    // MARK: - dismissalMechanism Tests
+
+    func test_dismissalMechanism_delegatesToCheckoutScope() {
+        // Given
+        sut = makeSut()
+
+        // When
+        let mechanism = sut.dismissalMechanism
+
+        // Then — should return whatever the checkout scope provides
+        XCTAssertNotNil(mechanism)
+    }
+
+    // MARK: - dismissalMechanism Returns Array
+
+    func test_dismissalMechanism_returnsArray() {
+        // Given
+        sut = makeSut()
+
+        // When
+        let mechanism = sut.dismissalMechanism
+
+        // Then
+        XCTAssertTrue(mechanism is [DismissalMechanism])
+    }
+
+    // MARK: - State Stream Provides Values
+
+    func test_state_emitsUpdatedStateAfterSearch() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.searchPaymentMethods("test query")
+        sut.searchPaymentMethods("")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.searchQuery.isEmpty }
+        XCTAssertEqual(state.filteredPaymentMethods, state.paymentMethods)
+    }
+
+    // MARK: - UI Customization Properties Tests
+
+    func test_uiCustomizationProperties_defaultToNil() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertNil(sut.screen)
+        XCTAssertNil(sut.container)
+        XCTAssertNil(sut.paymentMethodItem)
+        XCTAssertNil(sut.categoryHeader)
+        XCTAssertNil(sut.emptyStateView)
+    }
+
+    // MARK: - Expansion/Collapse Integration Tests
+
+    func test_showOtherWaysToPay_afterCollapse_reexpands() async throws {
+        // Given
+        sut = makeSut()
+        sut.collapsePaymentMethods()
+
+        // Verify collapsed
+        let collapsed = try await awaitValue(sut.state) { !$0.isPaymentMethodsExpanded }
+        XCTAssertFalse(collapsed.isPaymentMethodsExpanded)
+
+        // When
+        sut.showOtherWaysToPay()
+
+        // Then
+        let expanded = try await awaitValue(sut.state) { $0.isPaymentMethodsExpanded }
+        XCTAssertTrue(expanded.isPaymentMethodsExpanded)
+    }
+
+    // MARK: - Search with State Integration
+
+    func test_searchPaymentMethods_thenClear_restoresFullList() async throws {
+        // Given
+        sut = makeSut()
+        sut.searchPaymentMethods("test")
+
+        // When
+        sut.searchPaymentMethods("")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.searchQuery.isEmpty }
+        XCTAssertTrue(state.searchQuery.isEmpty)
+    }
+
+    // MARK: - refreshVaultedPaymentMethods Tests
+
+    func test_refreshVaultedPaymentMethods_withContainer_callsRepository() async throws {
+        // Given
+        let container = await ContainerTestHelpers.createTestContainer()
+        let mockRepo = MockHeadlessRepository()
+        mockRepo.vaultedPaymentMethodsToReturn = [makeVaultedPaymentMethod()]
+        _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
+
+        await DIContainer.setContainer(container)
+        sut = makeSut()
+
+        // When
+        await sut.refreshVaultedPaymentMethods()
+
+        // Then
+        XCTAssertEqual(mockRepo.fetchVaultedPaymentMethodsCallCount, 1)
+    }
+
+    func test_refreshVaultedPaymentMethods_repositoryThrows_doesNotCrash() async throws {
+        // Given
+        let container = await ContainerTestHelpers.createTestContainer()
+        let mockRepo = MockHeadlessRepository()
+        mockRepo.fetchVaultedPaymentMethodsError = TestError.networkFailure
+        _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
+
+        await DIContainer.setContainer(container)
+        sut = makeSut()
+
+        // When / Then — should not crash
+        await sut.refreshVaultedPaymentMethods()
+        XCTAssertEqual(mockRepo.fetchVaultedPaymentMethodsCallCount, 1)
+    }
+
+    // MARK: - deleteVaultedPaymentMethod with Container Tests
+
+    func test_deleteVaultedPaymentMethod_success_callsRepositoryAndRefreshes() async throws {
+        // Given
+        let container = await ContainerTestHelpers.createTestContainer()
+        let mockRepo = MockHeadlessRepository()
+        mockRepo.vaultedPaymentMethodsToReturn = []
+        _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
+
+        await DIContainer.setContainer(container)
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod(id: "vault_to_delete")
+
+        // When
+        try await sut.deleteVaultedPaymentMethod(method)
+
+        // Then
+        XCTAssertEqual(mockRepo.deleteVaultedPaymentMethodCallCount, 1)
+        XCTAssertEqual(mockRepo.lastDeletedVaultedPaymentMethodId, "vault_to_delete")
+        // Also refreshes vaulted methods after delete
+        XCTAssertGreaterThanOrEqual(mockRepo.fetchVaultedPaymentMethodsCallCount, 1)
+    }
+
+    func test_deleteVaultedPaymentMethod_repositoryThrows_propagatesError() async throws {
+        // Given
+        let container = await ContainerTestHelpers.createTestContainer()
+        let mockRepo = MockHeadlessRepository()
+        mockRepo.deleteVaultedPaymentMethodError = TestError.networkFailure
+        _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
+
+        await DIContainer.setContainer(container)
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod()
+
+        // When / Then
+        do {
+            try await sut.deleteVaultedPaymentMethod(method)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(error is TestError)
+        }
+    }
+}
+
+// MARK: - DefaultPaymentMethodSelectionScope Additional Coverage
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultPaymentMethodSelectionScopeAdditionalTests: XCTestCase {
+
+    private var mockCheckoutScope: DefaultCheckoutScope!
+    private var mockAnalytics: MockTrackingAnalyticsInteractor!
+    private var sut: DefaultPaymentMethodSelectionScope!
+
+    override func setUp() {
+        super.setUp()
+        mockCheckoutScope = createCheckoutScope()
+        mockAnalytics = MockTrackingAnalyticsInteractor()
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockAnalytics = nil
+        mockCheckoutScope = nil
+        super.tearDown()
+    }
+
+    private func createCheckoutScope() -> DefaultCheckoutScope {
+        DefaultCheckoutScope(
+            clientToken: TestData.Tokens.valid,
+            settings: PrimerSettings(),
+            diContainer: DIContainer.shared,
+            navigator: CheckoutNavigator()
+        )
+    }
+
+    private func makeSut() -> DefaultPaymentMethodSelectionScope {
+        DefaultPaymentMethodSelectionScope(
+            checkoutScope: mockCheckoutScope,
+            analyticsInteractor: mockAnalytics
+        )
+    }
+
+    private func makePaymentMethod(
+        id: String = "pm_1",
+        type: String = TestData.PaymentMethodTypes.card,
+        name: String = TestData.PaymentMethodNames.cardName
+    ) -> CheckoutPaymentMethod {
+        CheckoutPaymentMethod(id: id, type: type, name: name)
+    }
+
+    private func makeVaultedPaymentMethod(
+        id: String = "vault_1",
+        instrumentType: PaymentInstrumentType = .paymentCard,
+        network: String? = nil
+    ) -> PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+        var json: [String: Any] = ["last4Digits": "4242"]
+        if let network {
+            json["network"] = network
+        }
+        let data = try! JSONSerialization.data(withJSONObject: json) // swiftlint:disable:this force_try
+        let instrumentData = try! JSONDecoder().decode( // swiftlint:disable:this force_try
+            Response.Body.Tokenization.PaymentInstrumentData.self,
+            from: data
+        )
+        return PrimerHeadlessUniversalCheckout.VaultedPaymentMethod(
+            id: id,
+            paymentMethodType: PrimerPaymentMethodType.paymentCard.rawValue,
+            paymentInstrumentType: instrumentType,
+            paymentInstrumentData: instrumentData,
+            analyticsId: "analytics_\(id)"
+        )
+    }
+
+    // MARK: - onPaymentMethodSelected: creates InternalPaymentMethod
+
+    func test_onPaymentMethodSelected_createsInternalMethodFromCheckoutMethod() async throws {
+        // Given
+        sut = makeSut()
+        let method = makePaymentMethod(id: "pm_test", type: "KLARNA", name: "Klarna")
+
+        // When
+        sut.onPaymentMethodSelected(paymentMethod: method)
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.selectedPaymentMethod?.type == "KLARNA" }
+        XCTAssertEqual(state.selectedPaymentMethod?.name, "Klarna")
+    }
+
+    // MARK: - searchPaymentMethods: filtering with loaded methods
+
+    func test_searchPaymentMethods_filtersLoadedMethods() async throws {
+        // Given
+        sut = makeSut()
+        let card = makePaymentMethod(id: "1", type: TestData.PaymentMethodTypes.card, name: "Visa Card")
+        let paypal = makePaymentMethod(id: "2", type: TestData.PaymentMethodTypes.paypal, name: "PayPal")
+
+        // Manually set up state with payment methods loaded
+        sut.searchPaymentMethods("") // Reset first
+
+        // When
+        sut.searchPaymentMethods("Visa")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.searchQuery == "Visa" }
+        XCTAssertEqual(state.searchQuery, "Visa")
+    }
+
+    // MARK: - payWithVaultedPaymentMethodAndCvv with no selected method
+
+    func test_payWithVaultedPaymentMethodAndCvv_noSelection_doesNotStartPayment() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        await sut.payWithVaultedPaymentMethodAndCvv("456")
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertFalse(state.isVaultPaymentLoading)
+    }
+
+    // MARK: - shouldRequireCvvInput for non-card method
+
+    func test_payWithVaultedPaymentMethod_nonCardMethod_doesNotRequireCvv() async throws {
+        // Given
+        sut = makeSut()
+        let nonCardMethod = makeVaultedPaymentMethod(
+            id: "vault_paypal",
+            instrumentType: .payPalOrder
+        )
+
+        mockCheckoutScope.setVaultedPaymentMethods([nonCardMethod])
+        mockCheckoutScope.setSelectedVaultedPaymentMethod(nonCardMethod)
+        sut.syncSelectedVaultedPaymentMethod()
+
+        // When — payWithVaultedPaymentMethod should not prompt for CVV for non-card methods
+        await sut.payWithVaultedPaymentMethod()
+
+        // Then — should not set requiresCvvInput
+        let state = try await awaitFirst(sut.state)
+        XCTAssertFalse(state.requiresCvvInput)
+    }
+
+    // MARK: - dismissalMechanism when checkoutScope is nil
+
+    func test_dismissalMechanism_returnsCheckoutScopeMechanism() {
+        // Given
+        sut = makeSut()
+
+        // Then
+        XCTAssertNotNil(sut.dismissalMechanism)
+    }
+
+    // MARK: - Multiple CVV input updates
+
+    func test_updateCvvInput_sequentialUpdates_keepsLatest() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateCvvInput("1")
+        sut.updateCvvInput("12")
+        sut.updateCvvInput("123")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.cvvInput == "123" }
+        XCTAssertTrue(state.isCvvValid)
+        XCTAssertNil(state.cvvError)
+    }
+
+    // MARK: - syncSelectedVaultedPaymentMethod with no checkout scope
+
+    func test_syncSelectedVaultedPaymentMethod_noVaultedMethods_setsNil() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.syncSelectedVaultedPaymentMethod()
+
+        // Then
+        let state = try await awaitFirst(sut.state)
+        XCTAssertNil(state.selectedVaultedPaymentMethod)
+    }
+
+    // MARK: - cancel delegates to checkout scope
+
+    func test_cancel_delegatesToCheckoutScope() async throws {
+        // Given
+        sut = makeSut()
+
+        // When — should not crash
+        sut.cancel()
+
+        // Wait for async dismissal task
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Then — cancel delegates to checkout scope's onDismiss (no crash = success)
+    }
+}
+
+// MARK: - Vault & Container Integration Tests
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultPaymentMethodSelectionScopeVaultTests: XCTestCase {
+
+    private var mockCheckoutScope: DefaultCheckoutScope!
+    private var mockAnalytics: MockTrackingAnalyticsInteractor!
+    private var sut: DefaultPaymentMethodSelectionScope!
+
+    override func setUp() {
+        super.setUp()
+        mockCheckoutScope = DefaultCheckoutScope(
+            clientToken: TestData.Tokens.valid,
+            settings: PrimerSettings(),
+            diContainer: DIContainer.shared,
+            navigator: CheckoutNavigator()
+        )
+        mockAnalytics = MockTrackingAnalyticsInteractor()
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockAnalytics = nil
+        mockCheckoutScope = nil
+        super.tearDown()
+    }
+
+    private func makeSut() -> DefaultPaymentMethodSelectionScope {
+        DefaultPaymentMethodSelectionScope(
+            checkoutScope: mockCheckoutScope,
+            analyticsInteractor: mockAnalytics
+        )
+    }
+
+    private func makeVaultedPaymentMethod(
+        id: String = "vault_1",
+        paymentMethodType: String = PrimerPaymentMethodType.paymentCard.rawValue,
+        instrumentType: PaymentInstrumentType = .paymentCard,
+        network: String? = nil
+    ) -> PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+        var json: [String: Any] = ["last4Digits": "4242"]
+        if let network {
+            json["network"] = network
+        }
+        let data = try! JSONSerialization.data(withJSONObject: json) // swiftlint:disable:this force_try
+        let instrumentData = try! JSONDecoder().decode( // swiftlint:disable:this force_try
+            Response.Body.Tokenization.PaymentInstrumentData.self,
+            from: data
+        )
+        return PrimerHeadlessUniversalCheckout.VaultedPaymentMethod(
+            id: id,
+            paymentMethodType: paymentMethodType,
+            paymentInstrumentType: instrumentType,
+            paymentInstrumentData: instrumentData,
+            analyticsId: "analytics_\(id)"
+        )
+    }
+
+    // MARK: - refreshVaultedPaymentMethods: container nil
+
+    func test_refreshVaultedPaymentMethods_whenContainerNil_returnsEarly() async {
+        // Given
+        await DIContainer.clearContainer()
+        sut = makeSut()
+
+        // When / Then — should not crash when container is nil
+        await sut.refreshVaultedPaymentMethods()
+
+        // Restore
+        let container = Container()
+        await DIContainer.setContainer(container)
+    }
+
+    // MARK: - deleteVaultedPaymentMethod: success refreshes list
+
+    func test_deleteVaultedPaymentMethod_success_refreshesAfterDelete() async throws {
+        // Given
+        let container = await ContainerTestHelpers.createTestContainer()
+        let mockRepo = MockHeadlessRepository()
+        let remainingMethod = makeVaultedPaymentMethod(id: "vault_remaining")
+        mockRepo.vaultedPaymentMethodsToReturn = [remainingMethod]
+        _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
+
+        await DIContainer.setContainer(container)
+        sut = makeSut()
+        let methodToDelete = makeVaultedPaymentMethod(id: "vault_delete_me")
+
+        // When
+        try await sut.deleteVaultedPaymentMethod(methodToDelete)
+
+        // Then
+        XCTAssertEqual(mockRepo.deleteVaultedPaymentMethodCallCount, 1)
+        XCTAssertEqual(mockRepo.lastDeletedVaultedPaymentMethodId, "vault_delete_me")
+        XCTAssertGreaterThanOrEqual(mockRepo.fetchVaultedPaymentMethodsCallCount, 1)
+    }
+
+    // MARK: - deleteVaultedPaymentMethod: repository delete throws
+
+    func test_deleteVaultedPaymentMethod_whenDeleteThrows_propagatesErrorWithoutRefresh() async {
+        // Given
+        let container = await ContainerTestHelpers.createTestContainer()
+        let mockRepo = MockHeadlessRepository()
+        mockRepo.deleteVaultedPaymentMethodError = TestError.networkFailure
+        _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
+
+        await DIContainer.setContainer(container)
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod()
+
+        // When / Then
+        do {
+            try await sut.deleteVaultedPaymentMethod(method)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            XCTAssertTrue(error is TestError)
+            // Delete was attempted
+            XCTAssertEqual(mockRepo.deleteVaultedPaymentMethodCallCount, 1)
+            // Refresh should NOT have been called because delete threw
+            XCTAssertEqual(mockRepo.fetchVaultedPaymentMethodsCallCount, 0)
+        }
+    }
+
+    // MARK: - refreshVaultedPaymentMethods: syncs selected method
+
+    func test_refreshVaultedPaymentMethods_success_syncesCheckoutScope() async throws {
+        // Given
+        let container = await ContainerTestHelpers.createTestContainer()
+        let mockRepo = MockHeadlessRepository()
+        let vaultedMethod = makeVaultedPaymentMethod(id: "vault_synced")
+        mockRepo.vaultedPaymentMethodsToReturn = [vaultedMethod]
+        _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
+
+        await DIContainer.setContainer(container)
+        sut = makeSut()
+
+        // When
+        await sut.refreshVaultedPaymentMethods()
+
+        // Then
+        XCTAssertGreaterThanOrEqual(mockRepo.fetchVaultedPaymentMethodsCallCount, 1)
+    }
+
+    // MARK: - refreshVaultedPaymentMethods: repository throws logs error
+
+    func test_refreshVaultedPaymentMethods_whenRepositoryThrows_handlesGracefully() async {
+        // Given
+        let container = await ContainerTestHelpers.createTestContainer()
+        let mockRepo = MockHeadlessRepository()
+        mockRepo.fetchVaultedPaymentMethodsError = TestError.networkFailure
+        _ = try? await container.register(HeadlessRepository.self).asSingleton().with { _ in mockRepo }
+
+        await DIContainer.setContainer(container)
+        sut = makeSut()
+
+        // When / Then — should not crash, error is logged
+        await sut.refreshVaultedPaymentMethods()
+        XCTAssertEqual(mockRepo.fetchVaultedPaymentMethodsCallCount, 1)
+    }
+
+    // MARK: - deleteVaultedPaymentMethod: container nil
+
+    func test_deleteVaultedPaymentMethod_whenContainerNil_throwsError() async {
+        // Given
+        await DIContainer.clearContainer()
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod()
+
+        // When / Then
+        do {
+            try await sut.deleteVaultedPaymentMethod(method)
+            XCTFail("Expected error to be thrown")
+        } catch {
+            // Expected — container is nil
+        }
+
+        // Restore
+        let container = Container()
+        await DIContainer.setContainer(container)
+    }
+
+    // MARK: - payWithVaultedPaymentMethod: CVV already required, routes to payWithCvv
+
+    func test_payWithVaultedPaymentMethod_whenCvvAlreadyRequired_routesToPayWithCvv() async throws {
+        // Given
+        sut = makeSut()
+        let cardMethod = makeVaultedPaymentMethod(id: "vault_card", instrumentType: .paymentCard)
+        mockCheckoutScope.setVaultedPaymentMethods([cardMethod])
+        mockCheckoutScope.setSelectedVaultedPaymentMethod(cardMethod)
+        sut.syncSelectedVaultedPaymentMethod()
+
+        sut.updateCvvInput("123")
+
+        // Manually set requiresCvvInput to simulate CVV already being prompted
+        // Access internal state indirectly through updateCvvInput flow
+        // We call payWithVaultedPaymentMethod twice: first to trigger CVV mode, second to use it
+        // Since ConfigurationService may not be set up, shouldRequireCvvInput returns false
+        // and it falls through to executeVaultPayment
+
+        // When
+        await sut.payWithVaultedPaymentMethod()
+
+        // Then — should not crash
+        let state = try await awaitFirst(sut.state)
+        XCTAssertNotNil(state)
+    }
+
+    // MARK: - searchPaymentMethods: filtering with type match
+
+    func test_searchPaymentMethods_matchesByType_caseInsensitive() async throws {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.searchPaymentMethods("payment_card")
+
+        // Then
+        let state = try await awaitValue(sut.state) { $0.searchQuery == "payment_card" }
+        XCTAssertEqual(state.searchQuery, "payment_card")
+    }
+
+    // MARK: - showAllVaultedPaymentMethods
+
+    func test_showAllVaultedPaymentMethods_updatesNavigationToVaulted() {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.showAllVaultedPaymentMethods()
+
+        // Then
+        XCTAssertEqual(mockCheckoutScope.navigationState, .vaultedPaymentMethods)
+    }
+
+    // MARK: - collapsePaymentMethods then showOtherWaysToPay round-trip
+
+    func test_collapseAndExpand_roundTrip_togglesCorrectly() async throws {
+        // Given
+        sut = makeSut()
+        let initialState = try await awaitFirst(sut.state)
+        XCTAssertTrue(initialState.isPaymentMethodsExpanded)
+
+        // When — collapse
+        sut.collapsePaymentMethods()
+        let collapsed = try await awaitValue(sut.state) { !$0.isPaymentMethodsExpanded }
+        XCTAssertFalse(collapsed.isPaymentMethodsExpanded)
+
+        // When — expand
+        sut.showOtherWaysToPay()
+        let expanded = try await awaitValue(sut.state) { $0.isPaymentMethodsExpanded }
+        XCTAssertTrue(expanded.isPaymentMethodsExpanded)
+    }
+
+    // MARK: - onPaymentMethodSelected: tracks analytics with correct type
+
+    func test_onPaymentMethodSelected_tracksCorrectPaymentMethodType() async throws {
+        // Given
+        sut = makeSut()
+        let method = CheckoutPaymentMethod(
+            id: "pm_apple",
+            type: TestData.PaymentMethodTypes.applePay,
+            name: TestData.PaymentMethodNames.applePayName
+        )
+
+        // When
+        sut.onPaymentMethodSelected(paymentMethod: method)
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // Then
+        let hasTracked = await mockAnalytics.hasTracked(.paymentMethodSelection)
+        XCTAssertTrue(hasTracked)
+    }
+
+    // MARK: - syncSelectedVaultedPaymentMethod: same method preserves CVV
+
+    func test_syncSelectedVaultedPaymentMethod_sameMethod_doesNotResetCvv() async throws {
+        // Given
+        sut = makeSut()
+        let method = makeVaultedPaymentMethod(id: "vault_same")
+        mockCheckoutScope.setVaultedPaymentMethods([method])
+        mockCheckoutScope.setSelectedVaultedPaymentMethod(method)
+        sut.syncSelectedVaultedPaymentMethod()
+
+        sut.updateCvvInput("999")
+
+        // When — re-sync with same method
+        sut.syncSelectedVaultedPaymentMethod()
+
+        // Then — CVV preserved
+        let state = try await awaitValue(sut.state) { $0.cvvInput == "999" }
+        XCTAssertEqual(state.cvvInput, "999")
+    }
+}
+
+// MARK: - CVV Validation Logic Tests
+
+@available(iOS 15.0, *)
+final class CvvValidationLogicTests: XCTestCase {
+
+    func test_cvvValidation_emptyInput_notValidNoError() {
+        // Given / When
+        let result = validateCvv("", expectedLength: 3)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertNil(result.errorMessage)
+    }
+
+    func test_cvvValidation_validThreeDigitCvv_isValid() {
+        // Given / When
+        let result = validateCvv("123", expectedLength: 3)
+
+        // Then
+        XCTAssertTrue(result.isValid)
+        XCTAssertNil(result.errorMessage)
+    }
+
+    func test_cvvValidation_validFourDigitCvv_isValid() {
+        // Given / When
+        let result = validateCvv("1234", expectedLength: 4)
+
+        // Then
+        XCTAssertTrue(result.isValid)
+        XCTAssertNil(result.errorMessage)
+    }
+
+    func test_cvvValidation_nonNumericCharacters_showsError() {
+        // Given / When
+        let result = validateCvv("12a", expectedLength: 3)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertNotNil(result.errorMessage)
+    }
+
+    func test_cvvValidation_tooManyDigits_showsError() {
+        // Given / When
+        let result = validateCvv("1234", expectedLength: 3)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertNotNil(result.errorMessage)
+    }
+
+    func test_cvvValidation_partialInput_notValidNoError() {
+        // Given / When
+        let result = validateCvv("12", expectedLength: 3)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertNil(result.errorMessage)
+    }
+
+    func test_cvvValidation_singleDigit_notValidNoError() {
+        // Given / When
+        let result = validateCvv("1", expectedLength: 3)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertNil(result.errorMessage)
+    }
+
+    func test_cvvValidation_specialCharacters_showsError() {
+        // Given / When
+        let result = validateCvv("12!", expectedLength: 3)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertNotNil(result.errorMessage)
+    }
+
+    func test_cvvValidation_spaces_showsError() {
+        // Given / When
+        let result = validateCvv("1 2", expectedLength: 3)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertNotNil(result.errorMessage)
+    }
+
+    func test_cvvValidation_leadingZeros_isValid() {
+        // Given / When
+        let result = validateCvv("007", expectedLength: 3)
+
+        // Then
+        XCTAssertTrue(result.isValid)
+        XCTAssertNil(result.errorMessage)
+    }
+
+    private func validateCvv(_ cvv: String, expectedLength: Int) -> (isValid: Bool, errorMessage: String?) {
+        guard !cvv.isEmpty else { return (false, nil) }
+        guard cvv.allSatisfy(\.isNumber) else { return (false, "Please enter a valid CVV") }
+        if cvv.count > expectedLength { return (false, "Please enter a valid CVV") }
+        if cvv.count == expectedLength { return (true, nil) }
+        return (false, nil)
+    }
+}
+
+// MARK: - Payment Method Selection State Tests
+
+@available(iOS 15.0, *)
+final class PaymentMethodSelectionStateTests: XCTestCase {
+
+    func test_initialState_hasCorrectDefaults() {
+        // Given / When
+        let state = PrimerPaymentMethodSelectionState()
+
+        // Then
+        XCTAssertTrue(state.paymentMethods.isEmpty)
+        XCTAssertTrue(state.filteredPaymentMethods.isEmpty)
+        XCTAssertNil(state.selectedPaymentMethod)
+        XCTAssertNil(state.selectedVaultedPaymentMethod)
+        XCTAssertTrue(state.searchQuery.isEmpty)
+        XCTAssertNil(state.error)
+        XCTAssertFalse(state.requiresCvvInput)
+        XCTAssertTrue(state.cvvInput.isEmpty)
+        XCTAssertFalse(state.isCvvValid)
+        XCTAssertNil(state.cvvError)
+        XCTAssertFalse(state.isVaultPaymentLoading)
+        XCTAssertTrue(state.isPaymentMethodsExpanded)
+    }
+
+    func test_state_cvvProperties_areSettable() {
+        // Given
+        var state = PrimerPaymentMethodSelectionState()
+
+        // When
+        state.requiresCvvInput = true
+        state.cvvInput = "123"
+        state.isCvvValid = true
+        state.cvvError = nil
+
+        // Then
+        XCTAssertTrue(state.requiresCvvInput)
+        XCTAssertEqual(state.cvvInput, "123")
+        XCTAssertTrue(state.isCvvValid)
+        XCTAssertNil(state.cvvError)
+    }
+
+    func test_state_paymentMethodsExpanded_canBeToggled() {
+        // Given
+        var state = PrimerPaymentMethodSelectionState()
+        XCTAssertTrue(state.isPaymentMethodsExpanded)
+
+        // When
+        state.isPaymentMethodsExpanded = false
+
+        // Then
+        XCTAssertFalse(state.isPaymentMethodsExpanded)
+    }
+
+    func test_state_vaultPaymentLoading_canBeToggled() {
+        // Given
+        var state = PrimerPaymentMethodSelectionState()
+        XCTAssertFalse(state.isVaultPaymentLoading)
+
+        // When
+        state.isVaultPaymentLoading = true
+
+        // Then
+        XCTAssertTrue(state.isVaultPaymentLoading)
+    }
+
+    func test_state_withPaymentMethods_maintainsData() {
+        // Given
+        let paymentMethod = CheckoutPaymentMethod(
+            id: "pm_1",
+            type: "PAYMENT_CARD",
+            name: "Card"
+        )
+
+        // When
+        let state = PrimerPaymentMethodSelectionState(
+            paymentMethods: [paymentMethod],
+            selectedPaymentMethod: paymentMethod,
+            filteredPaymentMethods: [paymentMethod]
+        )
+
+        // Then
+        XCTAssertEqual(state.paymentMethods.count, 1)
+        XCTAssertEqual(state.paymentMethods.first?.id, "pm_1")
+        XCTAssertEqual(state.selectedPaymentMethod?.id, "pm_1")
+    }
+
+    func test_state_cvvError_canBeSet() {
+        // Given
+        var state = PrimerPaymentMethodSelectionState()
+
+        // When
+        state.cvvError = "Invalid CVV"
+
+        // Then
+        XCTAssertEqual(state.cvvError, "Invalid CVV")
+    }
+
+    func test_state_searchQuery_updatesFilteredMethods() {
+        // Given
+        var state = PrimerPaymentMethodSelectionState()
+        let cardMethod = CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card")
+        let paypalMethod = CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal")
+        state.paymentMethods = [cardMethod, paypalMethod]
+        state.filteredPaymentMethods = [cardMethod, paypalMethod]
+
+        // When
+        state.searchQuery = "Card"
+        state.filteredPaymentMethods = state.paymentMethods.filter {
+            $0.name.lowercased().contains(state.searchQuery.lowercased())
+        }
+
+        // Then
+        XCTAssertEqual(state.filteredPaymentMethods.count, 1)
+        XCTAssertEqual(state.filteredPaymentMethods.first?.type, "PAYMENT_CARD")
+    }
+
+    func test_state_equality_sameValues() {
+        // Given
+        let state1 = PrimerPaymentMethodSelectionState(
+            isLoading: true,
+            searchQuery: "test",
+            requiresCvvInput: true,
+            cvvInput: "123"
+        )
+        let state2 = PrimerPaymentMethodSelectionState(
+            isLoading: true,
+            searchQuery: "test",
+            requiresCvvInput: true,
+            cvvInput: "123"
+        )
+
+        // Then
+        XCTAssertEqual(state1, state2)
+    }
+
+    func test_state_equality_differentCvvInput() {
+        XCTAssertNotEqual(
+            PrimerPaymentMethodSelectionState(cvvInput: "123"),
+            PrimerPaymentMethodSelectionState(cvvInput: "456")
+        )
+    }
+
+    func test_state_equality_differentExpansionState() {
+        XCTAssertNotEqual(
+            PrimerPaymentMethodSelectionState(isPaymentMethodsExpanded: true),
+            PrimerPaymentMethodSelectionState(isPaymentMethodsExpanded: false)
+        )
+    }
+}
+
+// MARK: - Payment Method Search Logic Tests
+
+@available(iOS 15.0, *)
+final class PaymentMethodSearchLogicTests: XCTestCase {
+
+    private func searchPaymentMethods(
+        _ query: String,
+        in paymentMethods: [CheckoutPaymentMethod]
+    ) -> [CheckoutPaymentMethod] {
+        guard !query.isEmpty else { return paymentMethods }
+        let lowercasedQuery = query.lowercased()
+        return paymentMethods.filter { method in
+            method.name.lowercased().contains(lowercasedQuery)
+                || method.type.lowercased().contains(lowercasedQuery)
+        }
+    }
+
+    func test_search_emptyQuery_returnsAllMethods() {
+        // Given
+        let methods = [
+            CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+        ]
+
+        // When / Then
+        XCTAssertEqual(searchPaymentMethods("", in: methods).count, 2)
+    }
+
+    func test_search_matchByName_returnsFilteredMethods() {
+        // Given
+        let methods = [
+            CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+            CheckoutPaymentMethod(id: "3", type: "KLARNA", name: "Klarna"),
+        ]
+
+        // When
+        let result = searchPaymentMethods("PayPal", in: methods)
+
+        // Then
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.id, "2")
+    }
+
+    func test_search_matchByType_returnsFilteredMethods() {
+        // Given
+        let methods = [
+            CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+        ]
+
+        // When
+        let result = searchPaymentMethods("PAYMENT_CARD", in: methods)
+
+        // Then
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.id, "1")
+    }
+
+    func test_search_caseInsensitive_matchesRegardlessOfCase() {
+        // Given
+        let methods = [
+            CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+        ]
+
+        // When
+        let result = searchPaymentMethods("paypal", in: methods)
+
+        // Then
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.id, "2")
+    }
+
+    func test_search_partialMatch_returnsMatchingMethods() {
+        // Given
+        let methods = [
+            CheckoutPaymentMethod(id: "1", type: "CARD", name: "Visa Card"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+        ]
+
+        // When
+        let result = searchPaymentMethods("Pal", in: methods)
+
+        // Then
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.name, "PayPal")
+    }
+
+    func test_search_noMatch_returnsEmptyArray() {
+        // Given
+        let methods = [
+            CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+        ]
+
+        // When / Then
+        XCTAssertTrue(searchPaymentMethods("Bitcoin", in: methods).isEmpty)
+    }
+
+    func test_search_multipleMatches_returnsAllMatching() {
+        // Given
+        let methods = [
+            CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Visa Card"),
+            CheckoutPaymentMethod(id: "2", type: "PAYMENT_CARD", name: "Mastercard"),
+            CheckoutPaymentMethod(id: "3", type: "PAYPAL", name: "PayPal"),
+        ]
+
+        // When / Then
+        XCTAssertEqual(searchPaymentMethods("card", in: methods).count, 2)
+    }
+}
+
+// MARK: - Checkout Payment Method Tests
+
+@available(iOS 15.0, *)
+final class CheckoutPaymentMethodTests: XCTestCase {
+
+    func test_checkoutPaymentMethod_initialization() {
+        // Given / When
+        let method = CheckoutPaymentMethod(
+            id: "pm_123",
+            type: "PAYMENT_CARD",
+            name: "Visa",
+            surcharge: 100,
+            hasUnknownSurcharge: false,
+            formattedSurcharge: "$1.00"
+        )
+
+        // Then
+        XCTAssertEqual(method.id, "pm_123")
+        XCTAssertEqual(method.type, "PAYMENT_CARD")
+        XCTAssertEqual(method.name, "Visa")
+        XCTAssertEqual(method.surcharge, 100)
+        XCTAssertFalse(method.hasUnknownSurcharge)
+        XCTAssertEqual(method.formattedSurcharge, "$1.00")
+    }
+
+    func test_checkoutPaymentMethod_equality_sameValues() {
+        // Given
+        let method1 = CheckoutPaymentMethod(id: "pm_123", type: "PAYMENT_CARD", name: "Visa")
+        let method2 = CheckoutPaymentMethod(id: "pm_123", type: "PAYMENT_CARD", name: "Visa")
+
+        // Then
+        XCTAssertEqual(method1, method2)
+    }
+
+    func test_checkoutPaymentMethod_equality_differentIds() {
+        XCTAssertNotEqual(
+            CheckoutPaymentMethod(id: "pm_1", type: "PAYMENT_CARD", name: "Visa"),
+            CheckoutPaymentMethod(id: "pm_2", type: "PAYMENT_CARD", name: "Visa")
+        )
+    }
+
+    func test_checkoutPaymentMethod_identifiable_returnsId() {
+        let method = CheckoutPaymentMethod(id: "unique_id", type: "TEST", name: "Test")
+        XCTAssertEqual(method.id, "unique_id")
+    }
+
+    func test_checkoutPaymentMethod_withSurcharge() {
+        // Given / When
+        let method = CheckoutPaymentMethod(
+            id: "pm_1",
+            type: "PAYMENT_CARD",
+            name: "Card",
+            surcharge: 250,
+            hasUnknownSurcharge: false,
+            formattedSurcharge: "€2.50"
+        )
+
+        // Then
+        XCTAssertEqual(method.surcharge, 250)
+        XCTAssertEqual(method.formattedSurcharge, "€2.50")
+        XCTAssertFalse(method.hasUnknownSurcharge)
+    }
+
+    func test_checkoutPaymentMethod_withUnknownSurcharge() {
+        // Given / When
+        let method = CheckoutPaymentMethod(
+            id: "pm_1",
+            type: "PAYMENT_CARD",
+            name: "Card",
+            hasUnknownSurcharge: true
+        )
+
+        // Then
+        XCTAssertNil(method.surcharge)
+        XCTAssertTrue(method.hasUnknownSurcharge)
+    }
+}
+
+// MARK: - CVV Expected Length Tests
+
+@available(iOS 15.0, *)
+final class CvvExpectedLengthTests: XCTestCase {
+
+    private func validateCvv(_ cvv: String, expectedLength: Int) -> (isValid: Bool, errorMessage: String?) {
+        guard !cvv.isEmpty else { return (false, nil) }
+        guard cvv.allSatisfy(\.isNumber) else { return (false, "Please enter a valid CVV") }
+        if cvv.count > expectedLength { return (false, "Please enter a valid CVV") }
+        if cvv.count == expectedLength { return (true, nil) }
+        return (false, nil)
+    }
+
+    func test_cvvLength_standardCard_expectsThreeDigits() {
+        XCTAssertTrue(validateCvv("123", expectedLength: 3).isValid)
+    }
+
+    func test_cvvLength_amexCard_expectsFourDigits() {
+        XCTAssertTrue(validateCvv("1234", expectedLength: 4).isValid)
+    }
+
+    func test_cvvLength_threeDigitsForAmex_notValid() {
+        // Given / When
+        let result = validateCvv("123", expectedLength: 4)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertNil(result.errorMessage)
+    }
+
+    func test_cvvLength_fiveDigits_showsError() {
+        // Given / When
+        let result = validateCvv("12345", expectedLength: 4)
+
+        // Then
+        XCTAssertFalse(result.isValid)
+        XCTAssertNotNil(result.errorMessage)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/PayPal/DefaultPayPalScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/PayPal/DefaultPayPalScopeTests.swift
@@ -1,0 +1,188 @@
+//
+//  DefaultPayPalScopeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import SwiftUI
+import XCTest
+
+@available(iOS 15.0, *)
+final class DefaultPayPalScopeTests: XCTestCase {
+
+    private var mockCheckoutScope: DefaultCheckoutScope!
+    private var mockInteractor: MockProcessPayPalInteractor!
+    private var sut: DefaultPayPalScope!
+
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        mockCheckoutScope = createCheckoutScope()
+        mockInteractor = MockProcessPayPalInteractor()
+    }
+
+    @MainActor
+    override func tearDown() {
+        sut = nil
+        mockInteractor = nil
+        mockCheckoutScope = nil
+        super.tearDown()
+    }
+
+    // MARK: - Mock Types
+
+    private final class MockProcessPayPalInteractor: ProcessPayPalPaymentInteractor {
+        var executeResult: Result<PaymentResult, Error> = .success(
+            PaymentResult(paymentId: TestData.PaymentIds.success, status: .success)
+        )
+
+        func execute() async throws -> PaymentResult {
+            try executeResult.get()
+        }
+    }
+
+    // MARK: - Start Tests
+
+    @MainActor
+    func test_start_setsStateToIdle() async {
+        // Given
+        sut = DefaultPayPalScope(
+            checkoutScope: mockCheckoutScope,
+            processPayPalInteractor: mockInteractor
+        )
+
+        // When
+        sut.start()
+
+        // Then
+        var receivedState: PrimerPayPalState?
+        let expectation = expectation(description: "Receive state")
+
+        Task {
+            for await state in sut.state {
+                receivedState = state
+                expectation.fulfill()
+                break
+            }
+        }
+
+        await fulfillment(of: [expectation], timeout: 1.0)
+        XCTAssertEqual(receivedState?.step, .idle)
+    }
+
+    // MARK: - Submit Tests
+
+    @MainActor
+    func test_submit_onSuccess_transitionsStateToSuccess() async {
+        // Given
+        sut = DefaultPayPalScope(
+            checkoutScope: mockCheckoutScope,
+            processPayPalInteractor: mockInteractor
+        )
+        mockInteractor.executeResult = .success(PaymentResult(paymentId: TestData.PaymentIds.success, status: .success))
+
+        var receivedStates: [PrimerPayPalState.Step] = []
+        let expectation = expectation(description: "Receive success state")
+        expectation.assertForOverFulfill = false
+
+        let stateTask = Task { @MainActor in
+            for await state in sut.state {
+                receivedStates.append(state.step)
+                if case .success = state.step {
+                    expectation.fulfill()
+                }
+            }
+        }
+
+        // When
+        sut.submit()
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 2.0)
+        stateTask.cancel()
+
+        XCTAssertTrue(receivedStates.contains(.success))
+    }
+
+    @MainActor
+    func test_submit_onFailure_transitionsStateToFailure() async {
+        // Given
+        sut = DefaultPayPalScope(
+            checkoutScope: mockCheckoutScope,
+            processPayPalInteractor: mockInteractor
+        )
+        mockInteractor.executeResult = .failure(NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Test error"]))
+
+        var receivedStates: [PrimerPayPalState.Step] = []
+        let expectation = expectation(description: "Receive failure state")
+        expectation.assertForOverFulfill = false
+
+        let stateTask = Task { @MainActor in
+            for await state in sut.state {
+                receivedStates.append(state.step)
+                if case .failure = state.step {
+                    expectation.fulfill()
+                }
+            }
+        }
+
+        // When
+        sut.submit()
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 2.0)
+        stateTask.cancel()
+
+        let failureState = receivedStates.first {
+            if case .failure = $0 { return true }
+            return false
+        }
+        XCTAssertNotNil(failureState)
+    }
+
+    @MainActor
+    func test_submit_emitsRedirectingDuringPayment() async {
+        // Given
+        sut = DefaultPayPalScope(
+            checkoutScope: mockCheckoutScope,
+            processPayPalInteractor: mockInteractor
+        )
+
+        var receivedStates: [PrimerPayPalState.Step] = []
+        let redirectingExpectation = expectation(description: "Receive redirecting state")
+        redirectingExpectation.assertForOverFulfill = false
+
+        let stateTask = Task { @MainActor in
+            for await state in sut.state {
+                receivedStates.append(state.step)
+                if case .redirecting = state.step {
+                    redirectingExpectation.fulfill()
+                }
+            }
+        }
+
+        try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+
+        // When
+        sut.submit()
+
+        // Then
+        await fulfillment(of: [redirectingExpectation], timeout: 2.0)
+        stateTask.cancel()
+
+        XCTAssertTrue(receivedStates.contains(.redirecting))
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func createCheckoutScope() -> DefaultCheckoutScope {
+        DefaultCheckoutScope(
+            clientToken: TestData.Tokens.valid,
+            settings: PrimerSettings(),
+            diContainer: DIContainer.shared,
+            navigator: CheckoutNavigator()
+        )
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Presenter/Mocks/MockPrimerCheckoutPresenterDelegate.swift
+++ b/Tests/Primer/CheckoutComponents/Presenter/Mocks/MockPrimerCheckoutPresenterDelegate.swift
@@ -1,0 +1,79 @@
+//
+//  MockPrimerCheckoutPresenterDelegate.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+@testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class MockPrimerCheckoutPresenterDelegate: PrimerCheckoutPresenterDelegate {
+
+    private(set) var didCompleteWithSuccessCallCount = 0
+    private(set) var capturedSuccessResult: PaymentResult?
+
+    private(set) var didFailWithErrorCallCount = 0
+    private(set) var capturedError: PrimerError?
+
+    private(set) var didDismissCallCount = 0
+
+    private(set) var willPresent3DSChallengeCallCount = 0
+    private(set) var capturedTokenData: PrimerPaymentMethodTokenData?
+
+    private(set) var didDismiss3DSChallengeCallCount = 0
+
+    private(set) var didComplete3DSChallengeCallCount = 0
+    private(set) var capturedThreeDSSuccess: Bool?
+    private(set) var capturedResumeToken: String?
+    private(set) var capturedThreeDSError: Error?
+
+    func primerCheckoutPresenterDidCompleteWithSuccess(_ result: PaymentResult) {
+        didCompleteWithSuccessCallCount += 1
+        capturedSuccessResult = result
+    }
+
+    func primerCheckoutPresenterDidFailWithError(_ error: PrimerError) {
+        didFailWithErrorCallCount += 1
+        capturedError = error
+    }
+
+    func primerCheckoutPresenterDidDismiss() {
+        didDismissCallCount += 1
+    }
+
+    func primerCheckoutPresenterWillPresent3DSChallenge(
+        _ paymentMethodTokenData: PrimerPaymentMethodTokenData
+    ) {
+        willPresent3DSChallengeCallCount += 1
+        capturedTokenData = paymentMethodTokenData
+    }
+
+    func primerCheckoutPresenterDidDismiss3DSChallenge() {
+        didDismiss3DSChallengeCallCount += 1
+    }
+
+    func primerCheckoutPresenterDidComplete3DSChallenge(
+        success: Bool, resumeToken: String?, error: Error?
+    ) {
+        didComplete3DSChallengeCallCount += 1
+        capturedThreeDSSuccess = success
+        capturedResumeToken = resumeToken
+        capturedThreeDSError = error
+    }
+
+    func reset() {
+        didCompleteWithSuccessCallCount = 0
+        capturedSuccessResult = nil
+        didFailWithErrorCallCount = 0
+        capturedError = nil
+        didDismissCallCount = 0
+        willPresent3DSChallengeCallCount = 0
+        capturedTokenData = nil
+        didDismiss3DSChallengeCallCount = 0
+        didComplete3DSChallengeCallCount = 0
+        capturedThreeDSSuccess = nil
+        capturedResumeToken = nil
+        capturedThreeDSError = nil
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Presenter/PrimerCheckoutPresenterTests.swift
+++ b/Tests/Primer/CheckoutComponents/Presenter/PrimerCheckoutPresenterTests.swift
@@ -1,0 +1,189 @@
+//
+//  PrimerCheckoutPresenterTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class PrimerCheckoutPresenterTests: XCTestCase {
+
+    private var sut: PrimerCheckoutPresenter!
+    private var mockDelegate: MockPrimerCheckoutPresenterDelegate!
+
+    override func setUp() {
+        super.setUp()
+        sut = PrimerCheckoutPresenter.shared
+        mockDelegate = MockPrimerCheckoutPresenterDelegate()
+        sut.delegate = mockDelegate
+    }
+
+    override func tearDown() {
+        sut.delegate = nil
+        mockDelegate = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    // MARK: - Singleton
+
+    func test_shared_returnsSameInstance() {
+        // Given
+        let first = PrimerCheckoutPresenter.shared
+
+        // When
+        let second = PrimerCheckoutPresenter.shared
+
+        // Then
+        XCTAssertTrue(first === second)
+    }
+
+    // MARK: - isAvailable
+
+    func test_isAvailable_returnsTrue() {
+        // Given / When
+        let available = PrimerCheckoutPresenter.isAvailable
+
+        // Then
+        XCTAssertTrue(available)
+    }
+
+    // MARK: - isPresenting
+
+    func test_isPresenting_initiallyFalse() {
+        // Given / When
+        let presenting = PrimerCheckoutPresenter.isPresenting
+
+        // Then
+        XCTAssertFalse(presenting)
+    }
+
+    // MARK: - handlePaymentSuccess
+
+    func test_handlePaymentSuccess_withDelegate_callsDidCompleteWithSuccess() {
+        // Given
+        let result = PaymentResult(paymentId: TestData.PaymentIds.success, status: .success)
+
+        // When
+        sut.handlePaymentSuccess(result)
+
+        // Then - dismissDirectly calls completion immediately when no active controller
+        XCTAssertEqual(mockDelegate.didCompleteWithSuccessCallCount, 1)
+        XCTAssertEqual(mockDelegate.capturedSuccessResult?.paymentId, TestData.PaymentIds.success)
+        XCTAssertEqual(mockDelegate.capturedSuccessResult?.status, .success)
+    }
+
+    func test_handlePaymentSuccess_withoutDelegate_doesNotCrash() {
+        // Given
+        sut.delegate = nil
+        let result = PaymentResult(paymentId: TestData.PaymentIds.success, status: .success)
+
+        // When / Then - should not crash
+        sut.handlePaymentSuccess(result)
+    }
+
+    // MARK: - handlePaymentFailure
+
+    func test_handlePaymentFailure_withDelegate_callsDidFailWithError() {
+        // Given
+        let error = PrimerError.invalidValue(
+            key: TestData.ErrorKeys.test,
+            value: nil,
+            reason: nil,
+            diagnosticsId: TestData.DiagnosticsIds.test
+        )
+
+        // When
+        sut.handlePaymentFailure(error)
+
+        // Then
+        XCTAssertEqual(mockDelegate.didFailWithErrorCallCount, 1)
+        XCTAssertNotNil(mockDelegate.capturedError)
+    }
+
+    func test_handlePaymentFailure_withoutDelegate_doesNotCrash() {
+        // Given
+        sut.delegate = nil
+        let error = PrimerError.invalidValue(
+            key: TestData.ErrorKeys.test,
+            value: nil,
+            reason: nil,
+            diagnosticsId: TestData.DiagnosticsIds.test
+        )
+
+        // When / Then - should not crash
+        sut.handlePaymentFailure(error)
+    }
+
+    // MARK: - handleCheckoutDismiss
+
+    func test_handleCheckoutDismiss_withDelegate_callsDidDismiss() {
+        // Given / When
+        sut.handleCheckoutDismiss()
+
+        // Then
+        XCTAssertEqual(mockDelegate.didDismissCallCount, 1)
+    }
+
+    func test_handleCheckoutDismiss_withoutDelegate_doesNotCrash() {
+        // Given
+        sut.delegate = nil
+
+        // When / Then - should not crash
+        sut.handleCheckoutDismiss()
+    }
+
+    // MARK: - dismiss
+
+    func test_dismiss_withNoActiveController_callsCompletionImmediately() {
+        // Given
+        let expectation = expectation(description: "Completion called")
+
+        // When
+        PrimerCheckoutPresenter.dismiss(animated: true) {
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func test_dismiss_withNoActiveController_doesNotCallDelegate() {
+        // Given
+        let expectation = expectation(description: "Completion called")
+
+        // When
+        PrimerCheckoutPresenter.dismiss(animated: false) {
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(mockDelegate.didDismissCallCount, 0)
+    }
+
+    // MARK: - dismissDirectly
+
+    func test_dismissDirectly_withNoController_callsCompletionImmediately() {
+        // Given
+        let expectation = expectation(description: "Completion called")
+
+        // When
+        sut.dismissDirectly {
+            expectation.fulfill()
+        }
+
+        // Then
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - dismissCheckout
+
+    func test_dismissCheckout_withNoController_completesWithoutCrash() {
+        // Given / When / Then - should not crash
+        sut.dismissCheckout()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ComposableContainer` — the DI container that wires all CheckoutComponents dependencies together
- Add `DefaultCheckoutScope` and `DefaultPaymentMethodSelectionScope` for top-level checkout orchestration
- Add `DefaultCardFormScope` (with field builders and validation extensions) for card input management
- Add payment-method-specific scopes: `DefaultAchScope`, `DefaultApplePayScope`, `DefaultFormRedirectScope`, `DefaultKlarnaScope`, `DefaultPayPalScope`, `DefaultQRCodeScope`, `DefaultWebRedirectScope`
- Add `DefaultSelectCountryScope` for country selection in ACH/form flows
- Add `CheckoutSDKInitializer` service update for scope initialization

## Context
PR 13 of 16 in the CheckoutComponents feature split. Depends on [PR 12](https://github.com/primer-io/primer-sdk-ios/pull/1641) (payment method verticals).

[Notion tracker](https://www.notion.so/32fca65dc30e81dabf66f33e2b58c3a1)

## Test plan
- [ ] `DefaultCheckoutScopeTests` — verify top-level checkout scope lifecycle
- [ ] `DefaultPaymentMethodSelectionScopeTests` — verify payment method selection logic
- [ ] `DefaultCardFormScopeTests` — verify card form field building and validation
- [ ] `DefaultSelectCountryScopeTests` — verify country selection scope
- [ ] `PrimerCardFormScopeTests` — verify card form scope protocol conformance
- [ ] `PrimerPaymentMethodScopeTests` — verify payment method scope protocol
- [ ] `PrimerCheckoutPresenterTests` — verify presenter delegate coordination