### PR TITLE
feat: Add UI layer (screens, components, views)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/ApplePayButtonView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/ApplePayButtonView.swift
@@ -1,0 +1,104 @@
+//
+//  ApplePayButtonView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PassKit
+import SwiftUI
+
+@available(iOS 15.0, *)
+public struct ApplePayButtonView: View {
+  private let style: PKPaymentButtonStyle
+  private let type: PKPaymentButtonType
+  private let cornerRadius: CGFloat
+  private let action: () -> Void
+
+  public init(
+    style: PKPaymentButtonStyle = .black,
+    type: PKPaymentButtonType = .plain,
+    cornerRadius: CGFloat = 8.0,
+    action: @escaping () -> Void
+  ) {
+    self.style = style
+    self.type = type
+    self.cornerRadius = cornerRadius
+    self.action = action
+  }
+
+  public var body: some View {
+    ApplePayButtonRepresentable(
+      style: style,
+      type: type,
+      cornerRadius: cornerRadius,
+      action: action
+    )
+    .frame(height: 50)
+    .accessibilityLabel("Pay with Apple Pay")
+    .accessibilityAddTraits(.isButton)
+  }
+}
+
+@available(iOS 15.0, *)
+private struct ApplePayButtonRepresentable: UIViewRepresentable {
+  let style: PKPaymentButtonStyle
+  let type: PKPaymentButtonType
+  let cornerRadius: CGFloat
+  let action: () -> Void
+
+  func makeUIView(context: Context) -> PKPaymentButton {
+    let button = PKPaymentButton(paymentButtonType: type, paymentButtonStyle: style)
+    button.cornerRadius = cornerRadius
+    button.addTarget(
+      context.coordinator, action: #selector(Coordinator.buttonTapped), for: .touchUpInside
+    )
+    return button
+  }
+
+  func updateUIView(_ uiView: PKPaymentButton, context: Context) {
+    uiView.cornerRadius = cornerRadius
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(action: action)
+  }
+
+  final class Coordinator: NSObject {
+    let action: () -> Void
+
+    init(action: @escaping () -> Void) {
+      self.action = action
+    }
+
+    @objc func buttonTapped() {
+      action()
+    }
+  }
+}
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  struct ApplePayButtonView_Previews: PreviewProvider {
+    static var previews: some View {
+      VStack(spacing: 16) {
+        ApplePayButtonView(style: .black, type: .plain) {
+          print("Apple Pay tapped")
+        }
+
+        ApplePayButtonView(style: .white, type: .buy) {
+          print("Apple Pay tapped")
+        }
+
+        ApplePayButtonView(style: .whiteOutline, type: .checkout) {
+          print("Apple Pay tapped")
+        }
+
+        ApplePayButtonView(style: .automatic, type: .inStore, cornerRadius: 16) {
+          print("Apple Pay tapped")
+        }
+      }
+      .padding()
+      .background(Color.gray.opacity(0.2))
+    }
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CardNetworkBadge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CardNetworkBadge.swift
@@ -1,0 +1,84 @@
+//
+//  CardNetworkBadge.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CardNetworkBadge: View, LogReporter {
+  let network: CardNetwork
+
+  @Environment(\.designTokens) private var tokens
+
+  @ViewBuilder
+  var body: some View {
+    if let icon = network.icon {
+      Image(uiImage: icon)
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+        .frame(
+          width: PrimerCardNetworkSelector.badgeWidth, height: PrimerCardNetworkSelector.badgeHeight
+        )
+        .cornerRadius(PrimerRadius.xsmall(tokens: tokens))
+    } else {
+      Text(network.displayName.prefix(2).uppercased())
+        .font(PrimerFont.smallBadge(tokens: tokens))
+        .foregroundColor(CheckoutColors.primary(tokens: tokens))
+        .frame(
+          width: PrimerCardNetworkSelector.badgeWidth, height: PrimerCardNetworkSelector.badgeHeight
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: PrimerRadius.xsmall(tokens: tokens))
+            .stroke(CheckoutColors.borderDefault(tokens: tokens), lineWidth: PrimerBorderWidth.thin)
+        )
+    }
+  }
+}
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    VStack(spacing: 16) {
+      HStack(spacing: 8) {
+        CardNetworkBadge(network: .visa)
+        CardNetworkBadge(network: .masterCard)
+        CardNetworkBadge(network: .amex)
+        CardNetworkBadge(network: .discover)
+      }
+
+      HStack(spacing: 8) {
+        CardNetworkBadge(network: .cartesBancaires)
+        CardNetworkBadge(network: .diners)
+        CardNetworkBadge(network: .jcb)
+        CardNetworkBadge(network: .unknown)
+      }
+    }
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    VStack(spacing: 16) {
+      HStack(spacing: 8) {
+        CardNetworkBadge(network: .visa)
+        CardNetworkBadge(network: .masterCard)
+        CardNetworkBadge(network: .amex)
+        CardNetworkBadge(network: .discover)
+      }
+
+      HStack(spacing: 8) {
+        CardNetworkBadge(network: .cartesBancaires)
+        CardNetworkBadge(network: .diners)
+        CardNetworkBadge(network: .jcb)
+        CardNetworkBadge(network: .unknown)
+      }
+    }
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutHeaderView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutHeaderView.swift
@@ -1,0 +1,119 @@
+//
+//  CheckoutHeaderView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CheckoutHeaderView: View {
+  let showBackButton: Bool
+  let onBack: () -> Void
+  let rightButton: RightButtonConfig?
+
+  @Environment(\.designTokens) private var tokens
+
+  struct RightButtonConfig {
+    let title: String
+    let icon: String?
+    let action: () -> Void
+    let accessibilityIdentifier: String
+    let accessibilityLabel: String
+
+    static func closeButton(action: @escaping () -> Void) -> RightButtonConfig {
+      RightButtonConfig(
+        title: CheckoutComponentsStrings.cancelButton,
+        icon: nil,
+        action: action,
+        accessibilityIdentifier: AccessibilityIdentifiers.Common.closeButton,
+        accessibilityLabel: CheckoutComponentsStrings.a11yCancel
+      )
+    }
+
+    static func editButton(action: @escaping () -> Void) -> RightButtonConfig {
+      RightButtonConfig(
+        title: CheckoutComponentsStrings.editButton,
+        icon: "pencil",
+        action: action,
+        accessibilityIdentifier: AccessibilityIdentifiers.Common.editButton,
+        accessibilityLabel: CheckoutComponentsStrings.a11yEdit
+      )
+    }
+
+    static func doneButton(action: @escaping () -> Void) -> RightButtonConfig {
+      RightButtonConfig(
+        title: CheckoutComponentsStrings.doneButton,
+        icon: "checkmark",
+        action: action,
+        accessibilityIdentifier: AccessibilityIdentifiers.Common.doneButton,
+        accessibilityLabel: CheckoutComponentsStrings.a11yDone
+      )
+    }
+  }
+
+  init(
+    showBackButton: Bool = true,
+    onBack: @escaping () -> Void,
+    rightButton: RightButtonConfig? = nil
+  ) {
+    self.showBackButton = showBackButton
+    self.onBack = onBack
+    self.rightButton = rightButton
+  }
+
+  var body: some View {
+    HStack {
+      if showBackButton {
+        makeBackButtonView()
+      }
+
+      Spacer()
+
+      if let rightButton {
+        makeRightButtonView(config: rightButton)
+      }
+    }
+    .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+    .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+  }
+
+  private func makeBackButtonView() -> some View {
+    Button(action: onBack) {
+      HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+        Image(systemName: RTLIcon.backChevron)
+        Text(CheckoutComponentsStrings.backButton)
+      }
+      .font(PrimerFont.bodyMedium(tokens: tokens))
+      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.Common.backButton,
+        label: CheckoutComponentsStrings.a11yBack,
+        traits: [.isButton]
+      )
+    )
+  }
+
+  private func makeRightButtonView(config: RightButtonConfig) -> some View {
+    Button(action: config.action) {
+      HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+        if let icon = config.icon {
+          Image(systemName: icon)
+            .font(PrimerFont.caption(tokens: tokens))
+        }
+        Text(config.title)
+          .font(PrimerFont.titleLarge(tokens: tokens))
+      }
+      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: config.accessibilityIdentifier,
+        label: config.accessibilityLabel,
+        traits: [.isButton]
+      )
+    )
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
@@ -95,7 +95,7 @@ struct CheckoutScopeObserver: View, LogReporter {
       }
     } else {
       EmptyView().onAppear {
-        logger.debug(message: "⏭️ [CheckoutComponents] Init screen disabled - skipping loading view")
+        logger.debug(message: "[CheckoutComponents] Init screen disabled - skipping loading view")
       }
     }
   }
@@ -148,8 +148,7 @@ struct CheckoutScopeObserver: View, LogReporter {
     } else {
       EmptyView().onAppear {
         logger.error(
-          message: "Cannot cast paymentMethodSelection to DefaultPaymentMethodSelectionScope"
-        )
+          message: "Cannot cast paymentMethodSelection to DefaultPaymentMethodSelectionScope")
         scope.checkoutNavigator.navigateBack()
       }
     }
@@ -185,7 +184,7 @@ struct CheckoutScopeObserver: View, LogReporter {
       }
     } else {
       EmptyView().onAppear {
-        logger.debug(message: "⏭️ [CheckoutComponents] Success screen disabled - auto-dismissing")
+        logger.debug(message: "[CheckoutComponents] Success screen disabled - auto-dismissing")
         DispatchQueue.main.async {
           onCompletion?(scope.currentState)
         }
@@ -213,7 +212,7 @@ struct CheckoutScopeObserver: View, LogReporter {
       }
     } else {
       EmptyView().onAppear {
-        logger.debug(message: "⏭️ [CheckoutComponents] Error screen disabled - auto-dismissing")
+        logger.debug(message: "[CheckoutComponents] Error screen disabled - auto-dismissing")
         DispatchQueue.main.async {
           onCompletion?(scope.currentState)
         }
@@ -247,8 +246,7 @@ struct CheckoutScopeObserver: View, LogReporter {
 
   private func loadDesignTokens(for colorScheme: ColorScheme) async {
     logger.info(
-      message: "Loading design tokens for color scheme: \(colorScheme == .dark ? "dark" : "light")"
-    )
+      message: "Loading design tokens for color scheme: \(colorScheme == .dark ? "dark" : "light")")
     do {
       try await designTokensManager.fetchTokens(for: colorScheme)
       logger.info(message: "Design tokens loaded successfully")

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
@@ -1,0 +1,259 @@
+//
+//  CheckoutScopeObserver.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CheckoutScopeObserver: View, LogReporter {
+  private let scope: DefaultCheckoutScope
+  private let theme: PrimerCheckoutTheme
+  private let onCompletion: ((PrimerCheckoutState) -> Void)?
+  @State private var navigationState: DefaultCheckoutScope.NavigationState = .loading
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.bridgeController) private var bridgeController
+  @StateObject private var designTokensManager = DesignTokensManager()
+
+  init(
+    scope: DefaultCheckoutScope,
+    theme: PrimerCheckoutTheme = PrimerCheckoutTheme(),
+    onCompletion: ((PrimerCheckoutState) -> Void)?
+  ) {
+    self.scope = scope
+    self.theme = theme
+    self.onCompletion = onCompletion
+  }
+
+  var body: some View {
+    if bridgeController != nil {
+      makeContentView()
+        .background(CheckoutColors.background(tokens: designTokensManager.tokens))
+    } else {
+      BackportedNavigationStack(content: makeContentView)
+      .background(CheckoutColors.background(tokens: designTokensManager.tokens))
+    }
+  }
+
+  private func makeContentView() -> some View {
+    VStack(spacing: 0) {
+      getCurrentView()
+        .animation(.easeInOut(duration: 0.3), value: navigationState)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    .environmentObject(scope)
+    .environment(\.diContainer, DIContainer.currentSync)
+    .environment(\.designTokens, designTokensManager.tokens)
+    .environment(\.primerCheckoutScope, scope)
+    .onReceive(scope.$navigationState) { newState in
+      navigationState = newState
+    }
+    .onAppear {
+      Task {
+        await setupDesignTokens()
+      }
+    }
+    .onChange(of: colorScheme) { newColorScheme in
+      Task {
+        await loadDesignTokens(for: newColorScheme)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func getCurrentView() -> some View {
+    switch navigationState {
+    case .loading:
+      makeLoadingView()
+    case .paymentMethodSelection:
+      makePaymentMethodSelectionView()
+    case .vaultedPaymentMethods:
+      makeVaultedPaymentMethodsView()
+    case let .deleteVaultedPaymentMethodConfirmation(method):
+      makeDeleteConfirmationView(method: method)
+    case let .paymentMethod(paymentMethodType):
+      makePaymentMethodView(type: paymentMethodType)
+    case .processing:
+      makeProcessingView()
+    case let .success(result):
+      makeSuccessView(result: result)
+    case let .failure(error):
+      makeFailureView(error: error)
+    case .dismissed:
+      makeDismissedView()
+    }
+  }
+
+  @ViewBuilder
+  private func makeLoadingView() -> some View {
+    if scope.isInitScreenEnabled {
+      if let customSplash = scope.splashScreen {
+        AnyView(customSplash())
+      } else {
+        SplashScreen()
+      }
+    } else {
+      EmptyView().onAppear {
+        logger.debug(message: "⏭️ [CheckoutComponents] Init screen disabled - skipping loading view")
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func makePaymentMethodSelectionView() -> some View {
+    if let customPaymentMethodSelectionScreen = scope.paymentMethodSelection.screen {
+      AnyView(customPaymentMethodSelectionScreen(scope.paymentMethodSelection))
+    } else if let customPaymentSelection = scope.paymentMethodSelectionScreen {
+      AnyView(customPaymentSelection(scope.paymentMethodSelection))
+    } else {
+      PaymentMethodSelectionScreen(
+        scope: scope.paymentMethodSelection
+      )
+    }
+  }
+
+  @ViewBuilder
+  private func makeVaultedPaymentMethodsView() -> some View {
+    VaultedPaymentMethodsListScreen(
+      vaultedPaymentMethods: scope.vaultedPaymentMethods,
+      selectedVaultedPaymentMethod: scope.selectedVaultedPaymentMethod,
+      onSelect: { method in
+        scope.setSelectedVaultedPaymentMethod(method)
+        if let selectionScope = scope.paymentMethodSelection
+          as? DefaultPaymentMethodSelectionScope {
+          selectionScope.collapsePaymentMethods()
+        }
+        scope.checkoutNavigator.navigateBack()
+      },
+      onBack: {
+        scope.checkoutNavigator.navigateBack()
+      },
+      onDeleteTapped: { method in
+        scope.updateNavigationState(.deleteVaultedPaymentMethodConfirmation(method))
+      }
+    )
+  }
+
+  @ViewBuilder
+  private func makeDeleteConfirmationView(
+    method: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
+  ) -> some View {
+    if let selectionScope = scope.paymentMethodSelection as? DefaultPaymentMethodSelectionScope {
+      DeleteVaultedPaymentMethodConfirmationScreen(
+        vaultedPaymentMethod: method,
+        navigator: scope.checkoutNavigator,
+        scope: selectionScope
+      )
+    } else {
+      EmptyView().onAppear {
+        logger.error(
+          message: "Cannot cast paymentMethodSelection to DefaultPaymentMethodSelectionScope"
+        )
+        scope.checkoutNavigator.navigateBack()
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func makePaymentMethodView(type: String) -> some View {
+    PaymentMethodScreen(
+      paymentMethodType: type,
+      checkoutScope: scope
+    )
+  }
+
+  @ViewBuilder
+  private func makeProcessingView() -> some View {
+    if let customLoading = scope.loadingScreen {
+      AnyView(customLoading())
+    } else {
+      DefaultLoadingScreen()
+    }
+  }
+
+  @ViewBuilder
+  private func makeSuccessView(result: PaymentResult) -> some View {
+    if scope.isSuccessScreenEnabled {
+      if let customSuccess = scope.successScreen {
+        AnyView(customSuccess(result))
+      } else {
+        SuccessScreen(result: result) {
+          logger.info(message: "Success screen auto-dismiss, calling completion callback")
+          onCompletion?(scope.currentState)
+        }
+      }
+    } else {
+      EmptyView().onAppear {
+        logger.debug(message: "⏭️ [CheckoutComponents] Success screen disabled - auto-dismissing")
+        DispatchQueue.main.async {
+          onCompletion?(scope.currentState)
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func makeFailureView(error: PrimerError) -> some View {
+    if scope.isErrorScreenEnabled {
+      if let customError = scope.errorScreen {
+        AnyView(customError(error.localizedDescription))
+      } else {
+        ErrorScreen(
+          error: error,
+          onRetry: {
+            logger.info(message: "Error screen retry tapped")
+            scope.retryPayment()
+          },
+          onChooseOtherPaymentMethods: {
+            logger.info(message: "Error screen choose other payment method tapped")
+            scope.checkoutNavigator.handleOtherPaymentMethods()
+          }
+        )
+      }
+    } else {
+      EmptyView().onAppear {
+        logger.debug(message: "⏭️ [CheckoutComponents] Error screen disabled - auto-dismissing")
+        DispatchQueue.main.async {
+          onCompletion?(scope.currentState)
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func makeDismissedView() -> some View {
+    VStack {
+      Text(CheckoutComponentsStrings.dismissingMessage)
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+    .onAppear {
+      logger.info(message: "Checkout dismissed, calling completion callback")
+      DispatchQueue.main.async {
+        onCompletion?(.dismissed)
+      }
+    }
+  }
+
+  private func setupDesignTokens() async {
+    logger.info(message: "Setting up design tokens...")
+
+    // Apply merchant theme overrides
+    designTokensManager.applyTheme(theme)
+
+    await loadDesignTokens(for: colorScheme)
+  }
+
+  private func loadDesignTokens(for colorScheme: ColorScheme) async {
+    logger.info(
+      message: "Loading design tokens for color scheme: \(colorScheme == .dark ? "dark" : "light")"
+    )
+    do {
+      try await designTokensManager.fetchTokens(for: colorScheme)
+      logger.info(message: "Design tokens loaded successfully")
+    } catch {
+      logger.error(message: "Failed to load design tokens: \(error)")
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Composite/BillingAddressView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Composite/BillingAddressView.swift
@@ -1,0 +1,185 @@
+//
+//  BillingAddressView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct BillingAddressConfiguration {
+  let showFirstName: Bool
+  let showLastName: Bool
+  let showEmail: Bool
+  let showPhoneNumber: Bool
+  let showAddressLine1: Bool
+  let showAddressLine2: Bool
+  let showCity: Bool
+  let showState: Bool
+  let showPostalCode: Bool
+  let showCountry: Bool
+}
+
+@available(iOS 15.0, *)
+struct BillingAddressView: View, LogReporter {
+  let cardFormScope: DefaultCardFormScope
+  let configuration: BillingAddressConfiguration
+  let styling: PrimerFieldStyling?
+
+  @Environment(\.designTokens) private var tokens
+
+  init(
+    cardFormScope: DefaultCardFormScope,
+    configuration: BillingAddressConfiguration,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.cardFormScope = cardFormScope
+    self.configuration = configuration
+    self.styling = styling
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      if configuration.showFirstName || configuration.showLastName {
+        HStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+          if configuration.showFirstName {
+            defaultFirstNameField()
+          }
+
+          if configuration.showLastName {
+            defaultLastNameField()
+          }
+        }
+      }
+
+      if configuration.showCountry {
+        defaultCountryField()
+      }
+
+      if configuration.showAddressLine1 {
+        defaultAddressLine1Field()
+      }
+
+      if configuration.showPostalCode {
+        defaultPostalCodeField()
+      }
+
+      if configuration.showState {
+        defaultStateField()
+      }
+
+      if configuration.showAddressLine2 {
+        defaultAddressLine2Field()
+      }
+
+      if configuration.showCity {
+        defaultCityField()
+      }
+
+      if configuration.showEmail {
+        defaultEmailField()
+      }
+
+      if configuration.showPhoneNumber {
+        defaultPhoneNumberField()
+      }
+    }
+  }
+
+  private func defaultFirstNameField() -> some View {
+    NameInputField(
+      label: CheckoutComponentsStrings.firstNameLabel,
+      placeholder: CheckoutComponentsStrings.firstNamePlaceholder,
+      inputType: .firstName,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+
+  private func defaultLastNameField() -> some View {
+    NameInputField(
+      label: CheckoutComponentsStrings.lastNameLabel,
+      placeholder: CheckoutComponentsStrings.lastNamePlaceholder,
+      inputType: .lastName,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+
+  private func defaultCountryField() -> some View {
+    CountryInputField(
+      label: CheckoutComponentsStrings.countryLabel,
+      placeholder: CheckoutComponentsStrings.countrySelectorPlaceholder,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+
+  private func defaultAddressLine1Field() -> some View {
+    AddressLineInputField(
+      label: CheckoutComponentsStrings.addressLine1Label,
+      placeholder: CheckoutComponentsStrings.addressLine1Placeholder,
+      isRequired: true,
+      inputType: .addressLine1,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+
+  private func defaultAddressLine2Field() -> some View {
+    AddressLineInputField(
+      label: CheckoutComponentsStrings.addressLine2Label,
+      placeholder: CheckoutComponentsStrings.addressLine2Placeholder,
+      isRequired: false,
+      inputType: .addressLine2,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+
+  private func defaultCityField() -> some View {
+    CityInputField(
+      label: CheckoutComponentsStrings.cityLabel,
+      placeholder: CheckoutComponentsStrings.cityPlaceholder,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+
+  private func defaultStateField() -> some View {
+    StateInputField(
+      label: CheckoutComponentsStrings.stateLabel,
+      placeholder: CheckoutComponentsStrings.statePlaceholder,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+
+  private func defaultPostalCodeField() -> some View {
+    PostalCodeInputField(
+      label: CheckoutComponentsStrings.postalCodeLabel,
+      placeholder: CheckoutComponentsStrings.postalCodePlaceholder,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+
+  private func defaultEmailField() -> some View {
+    EmailInputField(
+      label: CheckoutComponentsStrings.emailLabel,
+      placeholder: CheckoutComponentsStrings.emailPlaceholder,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+
+  private func defaultPhoneNumberField() -> some View {
+    NameInputField(
+      label: CheckoutComponentsStrings.phoneNumberLabel,
+      placeholder: CheckoutComponentsStrings.phoneNumberPlaceholder,
+      inputType: .phoneNumber,
+      scope: cardFormScope,
+      styling: styling
+    )
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Composite/CardDetailsView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Composite/CardDetailsView.swift
@@ -1,0 +1,48 @@
+//
+//  CardDetailsView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CardDetailsView: View {
+  let cardFormScope: any PrimerCardFormScope
+  @State private var cardNetwork: CardNetwork = .unknown
+
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      CardNumberInputField(
+        label: CheckoutComponentsStrings.cardNumberLabel,
+        placeholder: CheckoutComponentsStrings.cardNumberPlaceholder,
+        scope: cardFormScope
+      )
+
+      HStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+        ExpiryDateInputField(
+          label: CheckoutComponentsStrings.expiryDateLabel,
+          placeholder: CheckoutComponentsStrings.expiryDatePlaceholder,
+          scope: cardFormScope
+        )
+
+        CVVInputField(
+          label: CheckoutComponentsStrings.cvvLabel,
+          placeholder: cardNetwork.validation?.code.name
+            ?? CheckoutComponentsStrings.cvvPlaceholder,
+          scope: cardFormScope,
+          cardNetwork: cardNetwork
+        )
+        .frame(maxWidth: PrimerComponentWidth.cvvFieldMax)
+      }
+
+      CardholderNameInputField(
+        label: CheckoutComponentsStrings.cardholderNameLabel,
+        placeholder: CheckoutComponentsStrings.cardholderNamePlaceholder,
+        scope: cardFormScope
+      )
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/DropdownCardNetworkSelector/DropdownCardNetworkSelector.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/DropdownCardNetworkSelector/DropdownCardNetworkSelector.swift
@@ -1,0 +1,100 @@
+//
+//  DropdownCardNetworkSelector.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct DropdownCardNetworkSelector: View {
+  let availableNetworks: [CardNetwork]
+  @Binding var selectedNetwork: CardNetwork
+  let onNetworkSelected: ((CardNetwork) -> Void)?
+
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    Menu {
+      ForEach(availableNetworks, id: \.rawValue) { network in
+        Button {
+          selectedNetwork = network
+          onNetworkSelected?(network)
+        } label: {
+          Label {
+            Text(network.displayName)
+          } icon: {
+            if let icon = network.icon {
+              Image(uiImage: icon)
+            }
+          }
+        }
+      }
+    } label: {
+      HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+        CardNetworkBadge(network: selectedNetwork)
+
+        Image(systemName: "chevron.down")
+          .font(.system(size: PrimerCardNetworkSelector.chevronFontSize, weight: .medium))
+          .frame(
+            width: PrimerCardNetworkSelector.chevronSize,
+            height: PrimerCardNetworkSelector.chevronSize,
+            alignment: .center
+          )
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      }
+      .contentShape(Rectangle())
+    }
+    .accessibilityIdentifier(AccessibilityIdentifiers.CardForm.dropdownNetworkSelectorButton)
+    .accessibilityLabel(CheckoutComponentsStrings.a11yDropdownNetworkSelectorLabel)
+    .accessibilityHint(CheckoutComponentsStrings.a11yDropdownNetworkSelectorHint)
+  }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  private struct DropdownCardNetworkSelectorPreviewWrapper: View {
+    let networks: [CardNetwork]
+    @State private var selected: CardNetwork
+
+    init(networks: [CardNetwork]) {
+      self.networks = networks
+      _selected = State(initialValue: networks.first ?? .unknown)
+    }
+
+    var body: some View {
+      DropdownCardNetworkSelector(
+        availableNetworks: networks,
+        selectedNetwork: $selected,
+        onNetworkSelected: { network in
+          print("Selected: \(network.displayName)")
+        }
+      )
+    }
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Light Mode - Two Networks") {
+    DropdownCardNetworkSelectorPreviewWrapper(networks: [.visa, .masterCard])
+      .padding()
+      .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode - Two Networks") {
+    DropdownCardNetworkSelectorPreviewWrapper(networks: [.visa, .masterCard])
+      .padding()
+      .background(Color.black)
+      .environment(\.designTokens, MockDesignTokens.dark)
+      .preferredColorScheme(.dark)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Light Mode - Three Networks") {
+    DropdownCardNetworkSelectorPreviewWrapper(networks: [.visa, .masterCard, .cartesBancaires])
+      .padding()
+      .environment(\.designTokens, MockDesignTokens.light)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+PreviewHelpers.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+PreviewHelpers.swift
@@ -1,0 +1,94 @@
+//
+//  PrimerInputFieldContainer+PreviewHelpers.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  struct PreviewContainer: View {
+    let label: String?
+    let text: String
+    let errorMessage: String?
+
+    @State private var currentText: String
+    @State private var isValid = true
+    @State private var currentErrorMessage: String?
+    @State private var isFocused = false
+
+    init(label: String?, text: String, errorMessage: String?) {
+      self.label = label
+      self.text = text
+      self.errorMessage = errorMessage
+      _currentText = State(initialValue: text)
+      _currentErrorMessage = State(initialValue: errorMessage)
+    }
+
+    var body: some View {
+      PrimerInputFieldContainer(
+        label: label,
+        styling: nil,
+        text: $currentText,
+        isValid: $isValid,
+        errorMessage: $currentErrorMessage,
+        isFocused: $isFocused
+      ) {
+        TextField(
+          "Placeholder", text: $currentText,
+          onEditingChanged: { focused in
+            isFocused = focused
+          }
+        )
+        .textFieldStyle(.plain)
+      }
+    }
+  }
+
+  @available(iOS 15.0, *)
+  struct PreviewContainerWithRightComponent: View {
+    let label: String?
+    let text: String
+
+    @State private var currentText: String
+    @State private var isValid = true
+    @State private var errorMessage: String?
+    @State private var isFocused = false
+    @Environment(\.designTokens) private var tokens
+
+    init(label: String?, text: String) {
+      self.label = label
+      self.text = text
+      _currentText = State(initialValue: text)
+    }
+
+    var body: some View {
+      PrimerInputFieldContainer(
+        label: label,
+        styling: nil,
+        text: $currentText,
+        isValid: $isValid,
+        errorMessage: $errorMessage,
+        isFocused: $isFocused,
+        textFieldBuilder: {
+          TextField(
+            "Placeholder", text: $currentText,
+            onEditingChanged: { focused in
+              isFocused = focused
+            }
+          )
+          .textFieldStyle(.plain)
+        },
+        rightComponent: {
+          let iconSize = PrimerSize.medium(tokens: tokens)
+          Image(systemName: "info.circle")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: iconSize, height: iconSize)
+            .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        }
+      )
+    }
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Rendering.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Rendering.swift
@@ -1,0 +1,103 @@
+//
+//  PrimerInputFieldContainer+Rendering.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+extension PrimerInputFieldContainer {
+  func makeLabel(_ label: String) -> some View {
+    Text(label)
+      .font(labelFont)
+      .foregroundColor(labelForegroundColor)
+      .frame(minHeight: PrimerComponentHeight.label)
+  }
+}
+
+@available(iOS 15.0, *)
+extension PrimerInputFieldContainer {
+  func makeTextFieldContainer() -> some View {
+    HStack(spacing: PrimerSpacing.small(tokens: tokens), content: makeTextFieldContainerContent)
+      .padding(.leading, styling?.padding?.leading ?? PrimerSpacing.medium(tokens: tokens))
+      .padding(.trailing, styling?.padding?.trailing ?? PrimerSpacing.medium(tokens: tokens))
+      .frame(height: styling?.fieldHeight ?? PrimerSize.xxlarge(tokens: tokens))
+      .background(makeTextFieldContainerBackground())
+  }
+
+  func makeTextFieldContainerContent() -> some View {
+    Group {
+      textFieldBuilder()
+      Spacer()
+      rightComponent?()
+      if hasError { makeTextFieldContainerWarning() }
+    }
+  }
+
+  func makeTextFieldContainerBackground() -> some View {
+    RoundedRectangle(cornerRadius: fieldCornerRadius)
+      .strokeBorder(borderColor, lineWidth: textFieldContainerBackgroundLineWidth)
+      .background(makeTextFieldContainerBackgroundBackground())
+      .animation(AnimationConstants.focusAnimation, value: isFocused)
+  }
+
+  func makeTextFieldContainerBackgroundBackground() -> some View {
+    RoundedRectangle(cornerRadius: fieldCornerRadius)
+      .fill(styling?.backgroundColor ?? CheckoutColors.background(tokens: tokens))
+  }
+
+  func makeTextFieldContainerWarning() -> some View {
+    let iconSize = PrimerSize.medium(tokens: tokens)
+    return Image(systemName: "exclamationmark.triangle.fill")
+      .resizable()
+      .aspectRatio(contentMode: .fit)
+      .frame(width: iconSize, height: iconSize)
+      .foregroundColor(CheckoutColors.iconNegative(tokens: tokens))
+      .offset(x: hasError ? 0 : (RTLSupport.isRightToLeft ? 10 : -10))
+      .opacity(hasError ? 1.0 : 0.0)
+      .animation(.spring(response: 0.3, dampingFraction: 0.7), value: hasError)
+  }
+}
+
+@available(iOS 15.0, *)
+extension PrimerInputFieldContainer {
+  func makeErrorMessage(_ errorMessage: String) -> some View {
+    Text(errorMessage)
+      .font(errorMessageFont)
+      .foregroundColor(errorMessageForegroundColor)
+      .frame(height: errorMessageHeight)
+      .offset(y: hasError ? 0 : -10)
+      .opacity(hasError ? 1.0 : 0.0)
+      .padding(.top, errorMessageTopPadding)
+      .animation(.spring(response: 0.3, dampingFraction: 0.7), value: hasError)
+      .accessibility(
+        config: AccessibilityConfiguration(
+          identifier: AccessibilityIdentifiers.Error.messageContainer,
+          label: errorMessage,
+          traits: [.isStaticText]
+        )
+      )
+      .onAppear {
+        // Announce error to VoiceOver when error appears
+        if hasError {
+          announceError(errorMessage)
+        }
+      }
+      .onChange(of: errorMessage) { newError in
+        // Announce error when it changes
+        if hasError {
+          announceError(newError)
+        }
+      }
+  }
+
+  private func announceError(_ message: String) {
+    Task { @MainActor in
+      if let container = DIContainer.currentSync,
+        let announcementService = try? container.resolveSync(AccessibilityAnnouncementService.self) {
+        announcementService.announceError(message)
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
@@ -1,0 +1,56 @@
+//
+//  PrimerInputFieldContainer+Styling.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+extension PrimerInputFieldContainer {
+  var borderColor: Color {
+    if errorMessage?.isEmpty == false {
+      errorBorderColor
+    } else {
+      isFocused ? focusedBorderColor : defaultBorderColor
+    }
+  }
+
+  var labelForegroundColor: Color {
+    styling?.labelColor ?? CheckoutColors.textPrimary(tokens: tokens)
+  }
+
+  var errorMessageForegroundColor: Color {
+    CheckoutColors.textNegative(tokens: tokens)
+  }
+
+  var errorBorderColor: Color {
+    styling?.errorBorderColor ?? CheckoutColors.borderError(tokens: tokens)
+  }
+
+  var focusedBorderColor: Color {
+    styling?.focusedBorderColor ?? CheckoutColors.borderFocus(tokens: tokens)
+  }
+
+  var defaultBorderColor: Color {
+    styling?.borderColor ?? CheckoutColors.borderDefault(tokens: tokens)
+  }
+}
+
+@available(iOS 15.0, *)
+extension PrimerInputFieldContainer {
+  var errorMessageFont: Font { PrimerFont.bodySmall(tokens: tokens) }
+  var labelFont: Font {
+    styling?.resolvedLabelFont(tokens: tokens) ?? PrimerFont.bodySmall(tokens: tokens)
+  }
+}
+
+@available(iOS 15.0, *)
+extension PrimerInputFieldContainer {
+  var fieldCornerRadius: CGFloat { styling?.cornerRadius ?? PrimerRadius.small(tokens: tokens) }
+  var textFieldContainerBackgroundLineWidth: CGFloat {
+    styling?.borderWidth ?? PrimerBorderWidth.standard
+  }
+  var errorMessageHeight: CGFloat { hasError ? PrimerComponentHeight.errorMessage : 0 }
+  var errorMessageTopPadding: CGFloat { hasError ? PrimerSpacing.xsmall(tokens: tokens) : 0 }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer.swift
@@ -1,0 +1,160 @@
+//
+//  PrimerInputFieldContainer.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct PrimerInputFieldContainer<Content: View, RightContent: View>: View {
+  let label: String?
+  let styling: PrimerFieldStyling?
+  let textFieldBuilder: () -> Content
+  let rightComponent: (() -> RightContent)?
+
+  @Binding var text: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  @Environment(\.designTokens) var tokens
+  @Environment(\.sizeCategory) private var sizeCategory  // Observes Dynamic Type changes
+
+  var hasError: Bool { errorMessage?.isEmpty == false }
+
+  init(
+    label: String?,
+    styling: PrimerFieldStyling?,
+    text: Binding<String>,
+    isValid: Binding<Bool>,
+    errorMessage: Binding<String?>,
+    isFocused: Binding<Bool>,
+    @ViewBuilder textFieldBuilder: @escaping () -> Content,
+    @ViewBuilder rightComponent: @escaping () -> RightContent
+  ) {
+    self.label = label
+    self.styling = styling
+    _text = text
+    _isValid = isValid
+    _errorMessage = errorMessage
+    _isFocused = isFocused
+    self.textFieldBuilder = textFieldBuilder
+    self.rightComponent = rightComponent
+  }
+
+  var body: some View {
+    VStack(
+      alignment: .leading,
+      spacing: PrimerSpacing.xsmall(tokens: tokens),
+      content: makeContent
+    )
+    .padding(.bottom, PrimerSpacing.medium(tokens: tokens))
+  }
+
+  func makeContent() -> some View {
+    Group {
+      label.map(makeLabel)
+      makeTextFieldContainer()
+      errorMessage.map(makeErrorMessage)
+    }
+  }
+}
+
+// MARK: - Convenience Initializer
+@available(iOS 15.0, *)
+extension PrimerInputFieldContainer where RightContent == Never {
+  init(
+    label: String?,
+    styling: PrimerFieldStyling?,
+    text: Binding<String>,
+    isValid: Binding<Bool>,
+    errorMessage: Binding<String?>,
+    isFocused: Binding<Bool>,
+    @ViewBuilder textFieldBuilder: @escaping () -> Content
+  ) {
+    self.label = label
+    self.styling = styling
+    _text = text
+    _isValid = isValid
+    _errorMessage = errorMessage
+    _isFocused = isFocused
+    self.textFieldBuilder = textFieldBuilder
+    rightComponent = nil
+  }
+}
+
+// MARK: - Preview
+#if DEBUG
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    VStack(spacing: 16) {
+      PreviewContainer(
+        label: "Field Label",
+        text: "Sample text",
+        errorMessage: nil
+      )
+      .background(Color.gray.opacity(0.1))
+
+      PreviewContainer(
+        label: nil,
+        text: "",
+        errorMessage: nil
+      )
+      .background(Color.gray.opacity(0.1))
+
+      PreviewContainer(
+        label: "Field with Error",
+        text: "Invalid input",
+        errorMessage: "Please enter a valid value"
+      )
+      .background(Color.gray.opacity(0.1))
+
+      PreviewContainerWithRightComponent(
+        label: "Field with Right Component",
+        text: "With custom icon"
+      )
+      .background(Color.gray.opacity(0.1))
+    }
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    VStack(spacing: 16) {
+      PreviewContainer(
+        label: "Field Label",
+        text: "Sample text",
+        errorMessage: nil
+      )
+      .background(Color.gray.opacity(0.1))
+
+      PreviewContainer(
+        label: nil,
+        text: "",
+        errorMessage: nil
+      )
+      .background(Color.gray.opacity(0.1))
+
+      PreviewContainer(
+        label: "Field with Error",
+        text: "Invalid input",
+        errorMessage: "Please enter a valid value"
+      )
+      .background(Color.gray.opacity(0.1))
+
+      PreviewContainerWithRightComponent(
+        label: "Field with Right Component",
+        text: "With custom icon"
+      )
+      .background(Color.gray.opacity(0.1))
+    }
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/SecureTextField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/SecureTextField.swift
@@ -1,0 +1,22 @@
+//
+//  SecureTextField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+/// A UITextField subclass that masks the `.text` property to prevent sensitive data
+/// (card numbers, CVVs) from being exposed via debugger, logging, or view hierarchy dumps.
+/// Use `internalText` to access the actual value.
+final class SecureTextField: UITextField {
+  var internalText: String? {
+    get { super.text }
+    set { super.text = newValue }
+  }
+
+  override var text: String? {
+    get { "****" }
+    set { super.text = newValue }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/SecureTextField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/SecureTextField.swift
@@ -19,4 +19,9 @@ final class SecureTextField: UITextField {
     get { "****" }
     set { super.text = newValue }
   }
+
+  override var accessibilityValue: String? {
+    get { nil }
+    set { }
+  }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
@@ -1,0 +1,166 @@
+//
+//  PrimerTextFieldExtension.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+@available(iOS 15.0, *)
+struct PrimerTextFieldConfiguration {
+  let keyboardType: UIKeyboardType
+  let autocapitalizationType: UITextAutocapitalizationType
+  let autocorrectionType: UITextAutocorrectionType
+  let textContentType: UITextContentType?
+  let returnKeyType: UIReturnKeyType
+  let isSecureTextEntry: Bool
+
+  static let standard = PrimerTextFieldConfiguration(
+    keyboardType: .default,
+    autocapitalizationType: .words,
+    autocorrectionType: .no,
+    textContentType: nil,
+    returnKeyType: .done,
+    isSecureTextEntry: false
+  )
+
+  static let email = PrimerTextFieldConfiguration(
+    keyboardType: .emailAddress,
+    autocapitalizationType: .none,
+    autocorrectionType: .no,
+    textContentType: .emailAddress,
+    returnKeyType: .done,
+    isSecureTextEntry: false
+  )
+
+  static let numberPad = PrimerTextFieldConfiguration(
+    keyboardType: .numberPad,
+    autocapitalizationType: .none,
+    autocorrectionType: .no,
+    textContentType: nil,
+    returnKeyType: .done,
+    isSecureTextEntry: false
+  )
+
+  /// Secure entry with number pad and one-time code content type
+  static let cvv = PrimerTextFieldConfiguration(
+    keyboardType: .numberPad,
+    autocapitalizationType: .none,
+    autocorrectionType: .no,
+    textContentType: .oneTimeCode,
+    returnKeyType: .done,
+    isSecureTextEntry: true
+  )
+
+  /// Uses all caps auto-capitalization
+  static let postalCode = PrimerTextFieldConfiguration(
+    keyboardType: .default,
+    autocapitalizationType: .allCharacters,
+    autocorrectionType: .no,
+    textContentType: nil,
+    returnKeyType: .done,
+    isSecureTextEntry: false
+  )
+
+  /// Number pad with no autofill
+  static let expiryDate = PrimerTextFieldConfiguration(
+    keyboardType: .numberPad,
+    autocapitalizationType: .none,
+    autocorrectionType: .no,
+    textContentType: .none,
+    returnKeyType: .done,
+    isSecureTextEntry: false
+  )
+
+  init(
+    keyboardType: UIKeyboardType = .default,
+    autocapitalizationType: UITextAutocapitalizationType = .words,
+    autocorrectionType: UITextAutocorrectionType = .no,
+    textContentType: UITextContentType? = nil,
+    returnKeyType: UIReturnKeyType = .done,
+    isSecureTextEntry: Bool = false
+  ) {
+    self.keyboardType = keyboardType
+    self.autocapitalizationType = autocapitalizationType
+    self.autocorrectionType = autocorrectionType
+    self.textContentType = textContentType
+    self.returnKeyType = returnKeyType
+    self.isSecureTextEntry = isSecureTextEntry
+  }
+}
+
+@available(iOS 15.0, *)
+extension UITextField {
+  func configurePrimerStyle(
+    placeholder: String,
+    configuration: PrimerTextFieldConfiguration,
+    styling: PrimerFieldStyling?,
+    tokens: DesignTokens?,
+    doneButtonTarget: Any?,
+    doneButtonAction: Selector
+  ) {
+    self.placeholder = placeholder
+    borderStyle = .none
+    backgroundColor = .clear
+
+    // Apply keyboard configuration
+    keyboardType = configuration.keyboardType
+    autocapitalizationType = configuration.autocapitalizationType
+    autocorrectionType = configuration.autocorrectionType
+    textContentType = configuration.textContentType
+    returnKeyType = configuration.returnKeyType
+    isSecureTextEntry = configuration.isSecureTextEntry
+
+    // Text styling with design tokens
+    if let fontName = styling?.fontName {
+      font = PrimerFont.uiFont(
+        family: fontName,
+        weight: styling?.fontWeight,
+        size: styling?.fontSize
+      )
+    } else {
+      font = PrimerFont.uiFontBodyLarge(tokens: tokens)
+    }
+    textColor =
+      styling?.textColor.map(UIColor.init) ?? UIColor(CheckoutColors.textPrimary(tokens: tokens))
+
+    // Placeholder styling with design tokens
+    let placeholderColor =
+      styling?.placeholderColor.map(UIColor.init)
+      ?? UIColor(CheckoutColors.textPlaceholder(tokens: tokens))
+    attributedPlaceholder = NSAttributedString(
+      string: placeholder,
+      attributes: [.foregroundColor: placeholderColor, .font: font as Any]
+    )
+
+    // Add keyboard accessory view with "Done" button
+    let accessoryView = UIView(
+      frame: CGRect(
+        x: 0, y: 0, width: UIScreen.main.bounds.width,
+        height: PrimerComponentHeight.keyboardAccessory
+      )
+    )
+    accessoryView.backgroundColor = UIColor.systemGray6
+    // Hide container from accessibility - only the button should be accessible
+    accessoryView.isAccessibilityElement = false
+
+    let doneButton = UIButton(type: .system)
+    doneButton.setTitle("Done", for: .normal)
+    doneButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .medium)
+    doneButton.accessibilityLabel = "Done"
+    doneButton.accessibilityTraits = .button
+    if let target = doneButtonTarget {
+      doneButton.addTarget(target, action: doneButtonAction, for: .touchUpInside)
+    }
+
+    accessoryView.addSubview(doneButton)
+    doneButton.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      doneButton.trailingAnchor.constraint(equalTo: accessoryView.trailingAnchor, constant: -16),
+      doneButton.centerYAnchor.constraint(equalTo: accessoryView.centerYAnchor)
+    ])
+
+    inputAccessoryView = accessoryView
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
@@ -138,17 +138,15 @@ extension UITextField {
     let accessoryView = UIView(
       frame: CGRect(
         x: 0, y: 0, width: UIScreen.main.bounds.width,
-        height: PrimerComponentHeight.keyboardAccessory
-      )
-    )
+        height: PrimerComponentHeight.keyboardAccessory))
     accessoryView.backgroundColor = UIColor.systemGray6
     // Hide container from accessibility - only the button should be accessible
     accessoryView.isAccessibilityElement = false
 
     let doneButton = UIButton(type: .system)
-    doneButton.setTitle("Done", for: .normal)
+    doneButton.setTitle(CheckoutComponentsStrings.a11yDone, for: .normal)
     doneButton.titleLabel?.font = UIFont.systemFont(ofSize: 17, weight: .medium)
-    doneButton.accessibilityLabel = "Done"
+    doneButton.accessibilityLabel = CheckoutComponentsStrings.a11yDone
     doneButton.accessibilityTraits = .button
     if let target = doneButtonTarget {
       doneButton.addTarget(target, action: doneButtonAction, for: .touchUpInside)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector+Border.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector+Border.swift
@@ -1,0 +1,83 @@
+//
+//  InlineCardNetworkSelector+Border.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct RoundedCorners: InsettableShape {
+  private let topLeft: CGFloat
+  private let topRight: CGFloat
+  private let bottomLeft: CGFloat
+  private let bottomRight: CGFloat
+  private var insetAmount: CGFloat = 0
+
+  init(topLeft: CGFloat, topRight: CGFloat, bottomLeft: CGFloat, bottomRight: CGFloat) {
+    self.topLeft = topLeft
+    self.topRight = topRight
+    self.bottomLeft = bottomLeft
+    self.bottomRight = bottomRight
+  }
+
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    let rect = rect.insetBy(dx: insetAmount, dy: insetAmount)
+
+    path.move(to: CGPoint(x: rect.minX + topLeft, y: rect.minY))
+
+    path.addLine(to: CGPoint(x: rect.maxX - topRight, y: rect.minY))
+    if topRight > 0 {
+      path.addArc(
+        center: CGPoint(x: rect.maxX - topRight, y: rect.minY + topRight),
+        radius: topRight,
+        startAngle: .degrees(-90),
+        endAngle: .degrees(0),
+        clockwise: false
+      )
+    }
+
+    path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - bottomRight))
+    if bottomRight > 0 {
+      path.addArc(
+        center: CGPoint(x: rect.maxX - bottomRight, y: rect.maxY - bottomRight),
+        radius: bottomRight,
+        startAngle: .degrees(0),
+        endAngle: .degrees(90),
+        clockwise: false
+      )
+    }
+
+    path.addLine(to: CGPoint(x: rect.minX + bottomLeft, y: rect.maxY))
+    if bottomLeft > 0 {
+      path.addArc(
+        center: CGPoint(x: rect.minX + bottomLeft, y: rect.maxY - bottomLeft),
+        radius: bottomLeft,
+        startAngle: .degrees(90),
+        endAngle: .degrees(180),
+        clockwise: false
+      )
+    }
+
+    path.addLine(to: CGPoint(x: rect.minX, y: rect.minY + topLeft))
+    if topLeft > 0 {
+      path.addArc(
+        center: CGPoint(x: rect.minX + topLeft, y: rect.minY + topLeft),
+        radius: topLeft,
+        startAngle: .degrees(180),
+        endAngle: .degrees(270),
+        clockwise: false
+      )
+    }
+
+    path.closeSubpath()
+    return path
+  }
+
+  func inset(by amount: CGFloat) -> some InsettableShape {
+    var shape = self
+    shape.insetAmount += amount
+    return shape
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector+Button.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector+Button.swift
@@ -1,0 +1,101 @@
+//
+//  InlineCardNetworkSelector+Button.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct InlineCardNetworkButton: View {
+  let network: CardNetwork
+  let isSelected: Bool
+  let tokens: DesignTokens?
+  let onTap: () -> Void
+
+  var body: some View {
+    Button(action: onTap) {
+      CardNetworkBadge(network: network)
+        .frame(
+          width: PrimerCardNetworkSelector.buttonFrameWidth,
+          height: PrimerCardNetworkSelector.buttonFrameHeight,
+          alignment: .center
+        )
+        .background(backgroundColor)
+    }
+    .buttonStyle(PlainButtonStyle())
+    .accessibilityIdentifier(
+      AccessibilityIdentifiers.CardForm.inlineNetworkSelectorButton(forNetwork: network.rawValue)
+    )
+    .accessibilityLabel(network.displayName)
+    .accessibilityHint(isSelected ? "" : CheckoutComponentsStrings.a11yInlineNetworkButtonHint)
+    .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
+  }
+
+  private var backgroundColor: Color {
+    isSelected
+      ? CheckoutColors.gray100(tokens: tokens)
+      : CheckoutColors.background(tokens: tokens)
+  }
+}
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  #Preview("Selected Button") {
+    HStack(spacing: 0) {
+      InlineCardNetworkButton(
+        network: .visa,
+        isSelected: true,
+        tokens: MockDesignTokens.light,
+        onTap: {}
+      )
+    }
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Unselected Button") {
+    HStack(spacing: 0) {
+      InlineCardNetworkButton(
+        network: .masterCard,
+        isSelected: false,
+        tokens: MockDesignTokens.light,
+        onTap: {}
+      )
+    }
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("All Button States") {
+    VStack(spacing: 20) {
+      HStack(spacing: 0) {
+        InlineCardNetworkButton(
+          network: .visa, isSelected: true, tokens: MockDesignTokens.light, onTap: {}
+        )
+        InlineCardNetworkButton(
+          network: .masterCard, isSelected: false, tokens: MockDesignTokens.light, onTap: {}
+        )
+        InlineCardNetworkButton(
+          network: .amex, isSelected: false, tokens: MockDesignTokens.light, onTap: {}
+        )
+      }
+
+      HStack(spacing: 0) {
+        InlineCardNetworkButton(
+          network: .visa, isSelected: false, tokens: MockDesignTokens.light, onTap: {}
+        )
+        InlineCardNetworkButton(
+          network: .masterCard, isSelected: true, tokens: MockDesignTokens.light, onTap: {}
+        )
+        InlineCardNetworkButton(
+          network: .amex, isSelected: false, tokens: MockDesignTokens.light, onTap: {}
+        )
+      }
+    }
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector.swift
@@ -1,0 +1,175 @@
+//
+//  InlineCardNetworkSelector.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct InlineCardNetworkSelector: View {
+  // MARK: - Properties
+
+  let availableNetworks: [CardNetwork]
+  @Binding var selectedNetwork: CardNetwork
+  let onNetworkSelected: ((CardNetwork) -> Void)?
+
+  // MARK: - Private Properties
+
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Body
+
+  var body: some View {
+    HStack(spacing: 0) {
+      ForEach(Array(availableNetworks.enumerated()), id: \.element.rawValue) { index, network in
+        InlineCardNetworkButton(
+          network: network,
+          isSelected: selectedNetwork == network,
+          tokens: tokens
+        ) {
+          selectedNetwork = network
+          onNetworkSelected?(network)
+        }
+        .id(network.rawValue)
+
+        if index < availableNetworks.count - 1 {
+          Rectangle()
+            .fill(baseBorderColor)
+            .frame(
+              width: PrimerBorderWidth.standard, height: PrimerCardNetworkSelector.buttonFrameHeight
+            )
+        }
+      }
+    }
+
+    .padding(PrimerBorderWidth.standard)
+    .overlay(
+      RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+        .strokeBorder(baseBorderColor, lineWidth: PrimerBorderWidth.standard)
+    )
+    .accessibilityIdentifier(AccessibilityIdentifiers.CardForm.inlineNetworkSelectorContainer)
+    .overlay(
+      GeometryReader { _ in
+        if let selectedIndex = availableNetworks.firstIndex(of: selectedNetwork) {
+          let xOffset = getOffset(selectedIndex: selectedIndex)
+
+          RoundedCorners(
+            topLeft: selectedIndex == 0 ? PrimerRadius.small(tokens: tokens) : 0,
+            topRight: selectedIndex == availableNetworks.count - 1
+              ? PrimerRadius.small(tokens: tokens) : 0,
+            bottomLeft: selectedIndex == 0 ? PrimerRadius.small(tokens: tokens) : 0,
+            bottomRight: selectedIndex == availableNetworks.count - 1
+              ? PrimerRadius.small(tokens: tokens) : 0
+          )
+          .strokeBorder(selectedBorderColor, lineWidth: PrimerBorderWidth.standard)
+          .frame(width: buttonWidth, height: PrimerCardNetworkSelector.selectedBorderHeight)
+          .offset(x: xOffset)
+        }
+      }
+    )
+  }
+
+  private func getOffset(selectedIndex: Int) -> CGFloat {
+    guard selectedIndex > 0 else { return 0 }
+    let xOffset =
+      CGFloat(selectedIndex) * (PrimerCardNetworkSelector.buttonFrameWidth + borderWidth)
+    return RTLSupport.isRightToLeft ? -xOffset : xOffset
+  }
+
+  private var borderWidth: CGFloat {
+    PrimerBorderWidth.standard
+  }
+
+  private var buttonWidth: CGFloat {
+    PrimerCardNetworkSelector.buttonTotalWidth
+  }
+
+  private var selectedBorderColor: Color {
+    CheckoutColors.gray700(tokens: tokens)
+  }
+
+  private var baseBorderColor: Color {
+    CheckoutColors.gray300(tokens: tokens)
+  }
+}
+
+#if DEBUG
+
+  // MARK: - Preview
+
+  @available(iOS 15.0, *)
+  #Preview("Light Mode - 2 Networks") {
+    VStack(spacing: 20) {
+      Text("Co-badged Card Networks")
+        .font(.headline)
+
+      InlineCardNetworkSelector(
+        availableNetworks: [.visa, .cartesBancaires],
+        selectedNetwork: .constant(.visa),
+        onNetworkSelected: { network in
+          print("Selected: \(network.displayName)")
+        }
+      )
+      .padding()
+    }
+    .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode - 2 Networks") {
+    VStack(spacing: 20) {
+      Text("Co-badged Card Networks")
+        .font(.headline)
+        .foregroundColor(.white)
+
+      InlineCardNetworkSelector(
+        availableNetworks: [.visa, .cartesBancaires],
+        selectedNetwork: .constant(.cartesBancaires),
+        onNetworkSelected: { network in
+          print("Selected: \(network.displayName)")
+        }
+      )
+      .padding()
+    }
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .preferredColorScheme(.dark)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Light Mode - 3 Networks") {
+    VStack(spacing: 20) {
+      Text("Multiple Networks")
+        .font(.headline)
+
+      InlineCardNetworkSelector(
+        availableNetworks: [.visa, .masterCard, .cartesBancaires],
+        selectedNetwork: .constant(.masterCard),
+        onNetworkSelected: { network in
+          print("Selected: \(network.displayName)")
+        }
+      )
+      .padding()
+    }
+    .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Light Mode - 5 Networks") {
+    VStack(spacing: 20) {
+      Text("Five Networks")
+        .font(.headline)
+
+      InlineCardNetworkSelector(
+        availableNetworks: [.visa, .masterCard, .cartesBancaires, .amex, .discover],
+        selectedNetwork: .constant(.cartesBancaires),
+        onNetworkSelected: { network in
+          print("Selected: \(network.displayName)")
+        }
+      )
+      .padding()
+    }
+    .environment(\.designTokens, MockDesignTokens.light)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField+UIViewRepresentable.swift
@@ -1,0 +1,221 @@
+//
+//  AddressLineInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// UIViewRepresentable wrapper for address line input with focus-based validation
+@available(iOS 15.0, *)
+struct AddressLineTextField: UIViewRepresentable, LogReporter {
+  @Binding var addressLine: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  let placeholder: String
+  let isRequired: Bool
+  let inputType: PrimerInputElementType
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let scope: (any PrimerCardFormScope)?
+  let onAddressChange: ((String) -> Void)?
+  let onValidationChange: ((Bool) -> Void)?
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.delegate = context.coordinator
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: .standard,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    return textField
+  }
+
+  func updateUIView(_ textField: UITextField, context: Context) {
+    if textField.text != addressLine {
+      textField.text = addressLine
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      validationService: validationService,
+      addressLine: $addressLine,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      isRequired: isRequired,
+      inputType: inputType,
+      scope: scope,
+      onAddressChange: onAddressChange,
+      onValidationChange: onValidationChange
+    )
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    private let validationService: ValidationService
+    @Binding private var addressLine: String
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let isRequired: Bool
+    private let inputType: PrimerInputElementType
+    private let scope: (any PrimerCardFormScope)?
+    private let onAddressChange: ((String) -> Void)?
+    private let onValidationChange: ((Bool) -> Void)?
+
+    init(
+      validationService: ValidationService,
+      addressLine: Binding<String>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>,
+      isRequired: Bool,
+      inputType: PrimerInputElementType,
+      scope: (any PrimerCardFormScope)?,
+      onAddressChange: ((String) -> Void)?,
+      onValidationChange: ((Bool) -> Void)?
+    ) {
+      self.validationService = validationService
+      _addressLine = addressLine
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+      self.isRequired = isRequired
+      self.inputType = inputType
+      self.scope = scope
+      self.onAddressChange = onAddressChange
+      self.onValidationChange = onValidationChange
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.errorMessage = nil
+        self.scope?.clearFieldError(self.inputType)
+        // Don't set isValid = false immediately - let validation happen on text change or focus loss
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+      }
+      validateAddress()
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+      textField.resignFirstResponder()
+      return true
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let currentText = addressLine
+
+      guard let textRange = Range(range, in: currentText) else { return false }
+      let newText = currentText.replacingCharacters(in: textRange, with: string)
+
+      addressLine = newText
+
+      if let scope {
+        switch inputType {
+        case .addressLine1:
+          scope.updateAddressLine1(newText)
+        case .addressLine2:
+          scope.updateAddressLine2(newText)
+        default:
+          break
+        }
+      } else {
+        onAddressChange?(newText)
+      }
+
+      // Simple validation while typing (don't show errors until focus loss)
+      if isRequired {
+        isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      } else {
+        isValid = true  // Optional fields are always valid while typing
+      }
+
+      if let scope = scope as? DefaultCardFormScope {
+        scope.updateValidationStateIfNeeded(for: inputType, isValid: isValid)
+      }
+
+      return false
+    }
+
+    private func validateAddress() {
+      let trimmedAddress = addressLine.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // Empty field handling - don't show errors for empty fields
+      if trimmedAddress.isEmpty {
+        isValid = !isRequired
+        errorMessage = nil  // Never show error message for empty fields
+        onValidationChange?(isValid)
+
+        scope?.clearFieldError(inputType)
+
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationStateIfNeeded(for: inputType, isValid: isValid)
+        }
+        return
+      }
+
+      // Convert PrimerInputElementType to ValidationError.InputElementType
+      let elementType: ValidationError.InputElementType = {
+        switch inputType {
+        case .addressLine1:
+          .addressLine1
+        case .addressLine2:
+          .addressLine2
+        default:
+          .addressLine1
+        }
+      }()
+
+      let result = validationService.validate(
+        input: addressLine,
+        with: AddressRule(inputElementType: elementType, isRequired: isRequired)
+      )
+
+      isValid = result.isValid
+      errorMessage = result.errorMessage
+      onValidationChange?(result.isValid)
+
+      if let scope {
+        if result.isValid {
+          scope.clearFieldError(inputType)
+          if let scope = scope as? DefaultCardFormScope {
+            scope.updateValidationStateIfNeeded(for: inputType, isValid: true)
+          }
+        } else if let message = result.errorMessage {
+          scope.setFieldError(inputType, message: message, errorCode: result.errorCode)
+          if let scope = scope as? DefaultCardFormScope {
+            scope.updateValidationStateIfNeeded(for: inputType, isValid: false)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField.swift
@@ -1,0 +1,162 @@
+//
+//  AddressLineInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct AddressLineInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let isRequired: Bool
+  let inputType: PrimerInputElementType
+  let scope: (any PrimerCardFormScope)?
+  let onAddressChange: ((String) -> Void)?
+  let onValidationChange: ((Bool) -> Void)?
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var addressLine: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    isRequired: Bool,
+    inputType: PrimerInputElementType,
+    scope: any PrimerCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.isRequired = isRequired
+    self.inputType = inputType
+    self.scope = scope
+    self.styling = styling
+    onAddressChange = nil
+    onValidationChange = nil
+  }
+
+  init(
+    label: String?,
+    placeholder: String,
+    isRequired: Bool,
+    inputType: PrimerInputElementType,
+    styling: PrimerFieldStyling? = nil,
+    onAddressChange: ((String) -> Void)? = nil,
+    onValidationChange: ((Bool) -> Void)? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.isRequired = isRequired
+    self.inputType = inputType
+    scope = nil
+    self.styling = styling
+    self.onAddressChange = onAddressChange
+    self.onValidationChange = onValidationChange
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $addressLine,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      if let validationService {
+        AddressLineTextField(
+          addressLine: $addressLine,
+          isValid: $isValid,
+          errorMessage: $errorMessage,
+          isFocused: $isFocused,
+          placeholder: placeholder,
+          isRequired: isRequired,
+          inputType: inputType,
+          styling: styling,
+          validationService: validationService,
+          scope: scope,
+          onAddressChange: onAddressChange,
+          onValidationChange: onValidationChange,
+          tokens: tokens
+        )
+      } else {
+        // Fallback view while loading validation service
+        TextField(placeholder, text: $addressLine)
+          .autocapitalization(.words)
+          .disabled(true)
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.billingAddressField("\(inputType)"),
+        label: label ?? "Address",
+        hint: CheckoutComponentsStrings.a11yBillingAddressHint
+      ),
+      combinesChildren: false
+    )
+    .onAppear {
+      setupValidationService()
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for AddressLineInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    AddressLineInputField(
+      label: "Address Line 1",
+      placeholder: "Street address",
+      isRequired: true,
+      inputType: .addressLine1,
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    AddressLineInputField(
+      label: "Address Line 1",
+      placeholder: "Street address",
+      isRequired: true,
+      inputType: .addressLine1,
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField+UIViewRepresentable.swift
@@ -1,0 +1,183 @@
+//
+//  CVVInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+/// UIViewRepresentable wrapper for CVV text field
+@available(iOS 15.0, *)
+struct CVVTextField: UIViewRepresentable, LogReporter {
+  @Binding var cvv: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  let placeholder: String
+  let cardNetwork: CardNetwork
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let scope: any PrimerCardFormScope
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> SecureTextField {
+    let textField = SecureTextField()
+    textField.delegate = context.coordinator
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: .cvv,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    return textField
+  }
+
+  func updateUIView(_ textField: SecureTextField, context: Context) {
+    if textField.internalText != cvv {
+      textField.internalText = cvv
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      validationService: validationService,
+      cardNetwork: cardNetwork,
+      cvv: $cvv,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      scope: scope
+    )
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    private let validationService: ValidationService
+    private let cardNetwork: CardNetwork
+    @Binding private var cvv: String
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let scope: any PrimerCardFormScope
+
+    private var expectedCVVLength: Int {
+      cardNetwork.validation?.code.length ?? 3
+    }
+
+    init(
+      validationService: ValidationService,
+      cardNetwork: CardNetwork,
+      cvv: Binding<String>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>,
+      scope: any PrimerCardFormScope
+    ) {
+      self.validationService = validationService
+      self.cardNetwork = cardNetwork
+      _cvv = cvv
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+      self.scope = scope
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.errorMessage = nil
+        self.scope.clearFieldError(.cvv)
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+      }
+      validateCVV()
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let currentText = cvv
+
+      guard let textRange = Range(range, in: currentText) else { return false }
+      let newText = currentText.replacingCharacters(in: textRange, with: string)
+
+      // Only allow numbers
+      if !string.isEmpty,
+        !CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: string)) {
+        return false
+      }
+
+      if newText.count > expectedCVVLength {
+        return false
+      }
+
+      cvv = newText
+      scope.updateCvv(newText)
+
+      if newText.count == expectedCVVLength {
+        validateCVV()
+      } else {
+        isValid = false
+        errorMessage = nil
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.cvv, isValid: false)
+        }
+      }
+
+      return false
+    }
+
+    private func validateCVV() {
+      // Empty field handling - don't show errors for empty fields
+      let trimmedCVV = cvv.trimmingCharacters(in: .whitespacesAndNewlines)
+      if trimmedCVV.isEmpty {
+        isValid = false  // CVV is required
+        errorMessage = nil  // Never show error message for empty fields
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.cvv, isValid: false)
+        }
+        return
+      }
+
+      // Create CVVRule with the current card network for non-empty fields
+      let cvvRule = CVVRule(cardNetwork: cardNetwork)
+      let result = cvvRule.validate(cvv)
+
+      isValid = result.isValid
+      errorMessage = result.errorMessage
+
+      if result.isValid {
+        scope.clearFieldError(.cvv)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.cvv, isValid: true)
+        }
+      } else {
+        if let message = result.errorMessage {
+          scope.setFieldError(.cvv, message: message, errorCode: result.errorCode)
+        }
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.cvv, isValid: false)
+        }
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField.swift
@@ -78,7 +78,8 @@ struct CVVInputField: View, LogReporter {
         hint: CheckoutComponentsStrings.a11yCVCHint,
         value: errorMessage,
         traits: []
-      )
+      ),
+      combinesChildren: false
     )
     .onAppear {
       setupValidationService()

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField.swift
@@ -1,0 +1,131 @@
+//
+//  CVVInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CVVInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let scope: any PrimerCardFormScope
+  let cardNetwork: CardNetwork
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var cvv: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    scope: any PrimerCardFormScope,
+    cardNetwork: CardNetwork,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.scope = scope
+    self.cardNetwork = cardNetwork
+    self.styling = styling
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $cvv,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      if let validationService {
+        CVVTextField(
+          cvv: $cvv,
+          isValid: $isValid,
+          errorMessage: $errorMessage,
+          isFocused: $isFocused,
+          placeholder: placeholder,
+          cardNetwork: cardNetwork,
+          styling: styling,
+          validationService: validationService,
+          scope: scope,
+          tokens: tokens
+        )
+      } else {
+        // Fallback view while loading validation service
+        TextField(placeholder, text: $cvv)
+          .keyboardType(.numberPad)
+          .disabled(true)
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.cvcField,
+        label: CheckoutComponentsStrings.a11yCVCLabel,
+        hint: CheckoutComponentsStrings.a11yCVCHint,
+        value: errorMessage,
+        traits: []
+      )
+    )
+    .onAppear {
+      setupValidationService()
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for CVVInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    CVVInputField(
+      label: "CVV",
+      placeholder: "123",
+      scope: MockCardFormScope(),
+      cardNetwork: .visa
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    CVVInputField(
+      label: "CVV",
+      placeholder: "123",
+      scope: MockCardFormScope(),
+      cardNetwork: .visa
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField+UIViewRepresentable.swift
@@ -1,0 +1,469 @@
+//
+//  CardNumberInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+@available(iOS 15.0, *)
+struct CardNumberTextField: UIViewRepresentable, LogReporter {
+  @Binding var cardNumber: String
+  @Binding var isValid: Bool
+  @Binding var cardNetwork: CardNetwork
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+
+  let scope: any PrimerCardFormScope
+  let placeholder: String
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> SecureTextField {
+    let textField = SecureTextField()
+    textField.delegate = context.coordinator
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: .numberPad,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    return textField
+  }
+
+  func updateUIView(_ textField: SecureTextField, context: Context) {
+    if textField.internalText != formatCardNumber(cardNumber, for: cardNetwork) {
+      textField.internalText = formatCardNumber(cardNumber, for: cardNetwork)
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      scope: scope,
+      validationService: validationService,
+      cardNumber: $cardNumber,
+      cardNetwork: $cardNetwork,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    )
+  }
+  private func formatCardNumber(_ number: String, for network: CardNetwork) -> String {
+    let gaps = network.validation?.gaps ?? [4, 8, 12]
+    var formatted = ""
+    for (index, char) in number.enumerated() {
+      formatted.append(char)
+      if gaps.contains(index + 1), index + 1 < number.count {
+        formatted.append(" ")
+      }
+    }
+    return formatted
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    // MARK: - Properties
+
+    @Binding private var cardNumber: String
+    @Binding private var cardNetwork: CardNetwork
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let scope: any PrimerCardFormScope
+    private let validationService: ValidationService
+    private var savedCursorPosition: Int = 0
+    private var networkDetectionTimer: Timer?
+    private var validationTimer: Timer?
+
+    init(
+      scope: any PrimerCardFormScope,
+      validationService: ValidationService,
+      cardNumber: Binding<String>,
+      cardNetwork: Binding<CardNetwork>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>
+    ) {
+      self.scope = scope
+      self.validationService = validationService
+      _cardNumber = cardNumber
+      _cardNetwork = cardNetwork
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.scope.clearFieldError(.cardNumber)
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+        self.validateCardNumberFully(self.cardNumber)
+      }
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let secureTextField = textField as? SecureTextField
+      saveCursorPosition(textField)
+      let currentText = cardNumber
+      let isDeletion = string.isEmpty
+      let newCardNumber = processTextFieldChange(
+        currentText: currentText,
+        range: range,
+        replacementString: string,
+        formattedText: secureTextField?.internalText ?? "",
+        isDeletion: isDeletion
+      )
+      guard newCardNumber != currentText || isDeletion else {
+        return false
+      }
+      cardNumber = newCardNumber
+      scope.updateCardNumber(newCardNumber)
+      updateCardNetworkIfNeeded(newCardNumber)
+      let formattedText = formatCardNumber(newCardNumber, for: cardNetwork)
+      secureTextField?.internalText = formattedText
+      restoreCursorPosition(
+        textField: textField,
+        formattedText: formattedText,
+        originalCursorPos: savedCursorPosition,
+        isDeletion: isDeletion,
+        insertedLength: isDeletion ? 0 : string.count
+      )
+      updateValidationState(newCardNumber)
+      return false
+    }
+
+    private func processTextFieldChange(
+      currentText: String,
+      range: NSRange,
+      replacementString string: String,
+      formattedText: String,
+      isDeletion: Bool
+    ) -> String {
+      var newCardNumber: String
+      if isDeletion {
+        newCardNumber = processDeletion(
+          currentText: currentText,
+          range: range,
+          formattedText: formattedText
+        )
+      } else {
+        let filteredText = string.filter(\.isNumber)
+        if filteredText.isEmpty {
+          return currentText
+        }
+        newCardNumber = processInsertion(
+          currentText: currentText,
+          range: range,
+          formattedText: formattedText,
+          insertText: filteredText
+        )
+      }
+      if newCardNumber.count > 19 {
+        newCardNumber = String(newCardNumber.prefix(19))
+      }
+      return newCardNumber
+    }
+
+    private func processDeletion(
+      currentText: String,
+      range: NSRange,
+      formattedText: String
+    ) -> String {
+      if range.length > 0 {
+        let unformattedRange = getUnformattedRange(
+          formattedRange: range,
+          formattedText: formattedText,
+          unformattedText: currentText
+        )
+        return handleDeletion(currentText: currentText, unformattedRange: unformattedRange)
+      } else if range.location > 0 {
+        let unformattedPos = calculateUnformattedPosition(
+          upToIndex: range.location,
+          in: formattedText
+        )
+        if unformattedPos > 0, unformattedPos <= currentText.count {
+          let index = currentText.index(currentText.startIndex, offsetBy: unformattedPos - 1)
+          return currentText.removing(at: index)
+        }
+      }
+      return currentText
+    }
+
+    private func processInsertion(
+      currentText: String,
+      range: NSRange,
+      formattedText: String,
+      insertText: String
+    ) -> String {
+      let unformattedPos = calculateUnformattedPosition(
+        upToIndex: range.location,
+        in: formattedText
+      )
+      if unformattedPos <= currentText.count {
+        let index = currentText.index(currentText.startIndex, offsetBy: unformattedPos)
+        return currentText.inserting(contentsOf: insertText, at: index)
+      } else {
+        return currentText + insertText
+      }
+    }
+
+    private func calculateUnformattedPosition(upToIndex index: Int, in formattedText: String) -> Int {
+      var unformattedPos = 0
+      for i in 0..<index where i < formattedText.count {
+        let charIndex = formattedText.index(formattedText.startIndex, offsetBy: i)
+        if formattedText[charIndex].isNumber {
+          unformattedPos += 1
+        }
+      }
+      return unformattedPos
+    }
+
+    private func updateCardNetworkIfNeeded(_ newCardNumber: String) {
+      let newNetwork = CardNetwork(cardNumber: newCardNumber)
+      if newNetwork != cardNetwork {
+        cardNetwork = newNetwork
+        scope.updateSelectedCardNetwork(newNetwork.rawValue)
+      }
+    }
+
+    private func updateValidationState(_ newCardNumber: String) {
+      if newCardNumber.count >= 6 {
+        debouncedNetworkDetection(newCardNumber)
+      }
+      if newCardNumber.count >= 13 {
+        debouncedValidation(newCardNumber)
+      } else if newCardNumber.isEmpty {
+        isValid = false
+        errorMessage = nil
+        scope.clearFieldError(.cardNumber)
+        scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: false)
+      }
+    }
+
+    private func saveCursorPosition(_ textField: UITextField) {
+      if let selectedRange = textField.selectedTextRange {
+        savedCursorPosition = textField.offset(
+          from: textField.beginningOfDocument, to: selectedRange.start
+        )
+      }
+    }
+
+    private func restoreCursorPosition(
+      textField: UITextField, formattedText: String, originalCursorPos: Int, isDeletion: Bool,
+      insertedLength: Int
+    ) {
+      var newCursorPosition: Int
+      if isDeletion {
+        newCursorPosition = min(originalCursorPos, formattedText.count)
+      } else {
+        newCursorPosition = min(originalCursorPos + insertedLength, formattedText.count)
+        if originalCursorPos < formattedText.count {
+          let spacesAdded = formattedText.prefix(newCursorPosition).filter { $0 == " " }.count
+          newCursorPosition = min(
+            originalCursorPos + insertedLength + spacesAdded, formattedText.count
+          )
+        }
+      }
+      DispatchQueue.main.async {
+        if let newPosition = textField.position(
+          from: textField.beginningOfDocument, offset: newCursorPosition
+        ) {
+          textField.selectedTextRange = textField.textRange(from: newPosition, to: newPosition)
+        }
+      }
+    }
+
+    private func getUnformattedRange(
+      formattedRange: NSRange, formattedText: String, unformattedText: String
+    ) -> NSRange {
+      var digitCount = 0
+      for (index, char) in formattedText.enumerated() {
+        if index >= formattedRange.location {
+          break
+        }
+        if char.isNumber {
+          digitCount += 1
+        }
+      }
+      let unformattedLocation = digitCount
+      var unformattedLength = 0
+      if formattedRange.length > 0 {
+        let rangeEnd = min(formattedRange.location + formattedRange.length, formattedText.count)
+        for index in formattedRange.location..<rangeEnd where index < formattedText.count {
+          let charIndex = formattedText.index(formattedText.startIndex, offsetBy: index)
+          if formattedText[charIndex].isNumber {
+            unformattedLength += 1
+          }
+        }
+      }
+      return NSRange(location: unformattedLocation, length: unformattedLength)
+    }
+
+    private func handleDeletion(currentText: String, unformattedRange: NSRange) -> String {
+      if unformattedRange.length > 0 {
+        if unformattedRange.location >= currentText.count {
+          return currentText
+        }
+        let startIndex = currentText.index(
+          currentText.startIndex, offsetBy: unformattedRange.location
+        )
+        let endIndex = currentText.index(
+          startIndex,
+          offsetBy: min(unformattedRange.length, currentText.count - unformattedRange.location)
+        )
+        return currentText.replacingCharacters(in: startIndex..<endIndex, with: "")
+      }
+      if unformattedRange.location >= currentText.count, !currentText.isEmpty {
+        return String(currentText.dropLast())
+      }
+      if unformattedRange.location > 0, unformattedRange.location <= currentText.count {
+        let index = currentText.index(
+          currentText.startIndex, offsetBy: unformattedRange.location - 1
+        )
+        return currentText.removing(at: index)
+      }
+      return currentText
+    }
+
+    private func formatCardNumber(_ number: String, for network: CardNetwork) -> String {
+      let gaps = network.validation?.gaps ?? [4, 8, 12]
+      var formatted = ""
+      for (index, char) in number.enumerated() {
+        formatted.append(char)
+        if gaps.contains(index + 1), index + 1 < number.count {
+          formatted.append(" ")
+        }
+      }
+      return formatted
+    }
+
+    private func debouncedValidation(_ number: String) {
+      validationTimer?.invalidate()
+      validationTimer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: false) {
+        [weak self] _ in
+        guard let self else { return }
+        validateCardNumberWhileTyping(number)
+      }
+    }
+
+    private func debouncedNetworkDetection(_ number: String) {
+      networkDetectionTimer?.invalidate()
+      networkDetectionTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: false) {
+        [weak self] _ in
+        guard let self else { return }
+        detectNetworksForCardNumber(number)
+      }
+    }
+
+    private func detectNetworksForCardNumber(_ cardNumber: String) {
+      logger.debug(message: "Detecting card networks")
+    }
+
+    private func validateCardNumberWhileTyping(_ number: String) {
+      if number.count < 13 {
+        isValid = false
+        errorMessage = nil
+        scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: false)
+        return
+      }
+
+      let network = CardNetwork(cardNumber: number)
+      if network != .unknown, let validation = network.validation,
+        validation.lengths.contains(number.count) {
+        let validationResult = validationService.validateCardNumber(number)
+        if validationResult.isValid {
+          isValid = true
+          errorMessage = nil
+          scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: true)
+        } else {
+          isValid = false
+          errorMessage = nil
+          scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: false)
+        }
+      } else if number.count >= 16 {
+        let validationResult = validationService.validateCardNumber(number)
+        if validationResult.isValid {
+          isValid = true
+          errorMessage = nil
+          scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: true)
+        } else {
+          isValid = false
+          errorMessage = nil
+          scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: false)
+        }
+      } else {
+        isValid = false
+        errorMessage = nil
+        scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: false)
+      }
+    }
+
+    private func validateCardNumberFully(_ number: String) {
+      validationTimer?.invalidate()
+      let trimmedNumber = number.trimmingCharacters(in: .whitespacesAndNewlines)
+      if trimmedNumber.isEmpty {
+        isValid = false
+        errorMessage = nil
+        scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: false)
+        return
+      }
+
+      let validationResult = validationService.validateCardNumber(number)
+      isValid = validationResult.isValid
+      if validationResult.isValid {
+        errorMessage = nil
+        scope.clearFieldError(.cardNumber)
+        scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: true)
+      } else {
+        errorMessage = validationResult.errorMessage
+        if let errorMessage = validationResult.errorMessage {
+          scope.setFieldError(
+            .cardNumber, message: errorMessage, errorCode: validationResult.errorCode
+          )
+        }
+        scope.updateValidationStateIfNeeded(for: .cardNumber, isValid: false)
+      }
+    }
+    deinit {
+      validationTimer?.invalidate()
+      networkDetectionTimer?.invalidate()
+    }
+  }
+}
+
+extension String {
+  fileprivate func removing(at index: Index) -> String {
+    var result = self
+    result.remove(at: index)
+    return result
+  }
+  fileprivate func inserting(contentsOf newElements: String, at index: Index) -> String {
+    var result = self
+    result.insert(contentsOf: newElements, at: index)
+    return result
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField.swift
@@ -1,0 +1,216 @@
+//
+//  CardNumberInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CardNumberInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let scope: any PrimerCardFormScope
+  let selectedNetwork: CardNetwork?
+  let availableNetworks: [CardNetwork]
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @State private var validationService: ValidationService?
+  @State private var configurationService: ConfigurationService?
+  @State private var cardNumber: String = ""
+  @State private var isValid: Bool = false
+  @State private var cardNetwork: CardNetwork = .unknown
+  @State private var errorMessage: String?
+  @State private var surchargeAmount: String?
+  @State private var isFocused: Bool = false
+  @State private var localSelectedNetwork: CardNetwork = .unknown
+  @State private var networkSelectorStyle: CardNetworkSelectorStyle = .dropdown
+  @Environment(\.diContainer) private var container
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    scope: any PrimerCardFormScope,
+    selectedNetwork: CardNetwork? = nil,
+    availableNetworks: [CardNetwork] = [],
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.scope = scope
+    self.selectedNetwork = selectedNetwork
+    self.availableNetworks = availableNetworks
+    self.styling = styling
+  }
+
+  private var displayNetwork: CardNetwork {
+    selectedNetwork ?? cardNetwork
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $cardNumber,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      textFieldBuilder: {
+        if let validationService {
+          CardNumberTextField(
+            cardNumber: $cardNumber,
+            isValid: $isValid,
+            cardNetwork: $cardNetwork,
+            errorMessage: $errorMessage,
+            isFocused: $isFocused,
+            scope: scope,
+            placeholder: placeholder,
+            styling: styling,
+            validationService: validationService,
+            tokens: tokens
+          )
+        } else {
+          TextField(placeholder, text: .constant(""))
+            .disabled(true)
+        }
+      },
+      rightComponent: {
+        HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+          if let surchargeAmount {
+            Text(surchargeAmount)
+              .font(PrimerFont.caption(tokens: tokens))
+              .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+              .padding(.horizontal, PrimerSpacing.xsmall(tokens: tokens))
+              .padding(.vertical, 2)
+              .background(CheckoutColors.gray200(tokens: tokens))
+              .cornerRadius(PrimerRadius.xsmall(tokens: tokens))
+              .frame(height: PrimerSize.small(tokens: tokens))
+          }
+
+          if availableNetworks.count > 1 {
+            if availableNetworks.contains(where: { !$0.allowsUserSelection }) {
+              DualBadgeDisplay(networks: availableNetworks)
+            } else {
+              switch networkSelectorStyle {
+              case .dropdown:
+                DropdownCardNetworkSelector(
+                  availableNetworks: availableNetworks,
+                  selectedNetwork: $localSelectedNetwork,
+                  onNetworkSelected: { network in
+                    scope.updateSelectedCardNetwork(network.rawValue)
+                  }
+                )
+              case .inline:
+                InlineCardNetworkSelector(
+                  availableNetworks: availableNetworks,
+                  selectedNetwork: $localSelectedNetwork,
+                  onNetworkSelected: { network in
+                    scope.updateSelectedCardNetwork(network.rawValue)
+                  }
+                )
+              }
+            }
+          } else if displayNetwork != .unknown {
+            CardNetworkBadge(network: displayNetwork)
+          }
+        }
+      }
+    )
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.cardNumberField,
+        label: CheckoutComponentsStrings.a11yCardNumberLabel,
+        hint: CheckoutComponentsStrings.a11yCardNumberHint,
+        value: errorMessage,
+        traits: []
+      )
+    )
+    .onAppear {
+      setupValidationService()
+      localSelectedNetwork = displayNetwork
+    }
+    .onChange(of: selectedNetwork) { newNetwork in
+      if let newNetwork {
+        localSelectedNetwork = newNetwork
+        updateSurchargeAmount(for: newNetwork)
+      }
+    }
+    .onChange(of: cardNetwork) { newNetwork in
+      updateSurchargeAmount(for: newNetwork)
+    }
+  }
+
+  // MARK: - Private Methods
+
+  private func setupValidationService() {
+    guard let container else {
+      return logger.error(message: "DIContainer not available for CardNumberInputField")
+    }
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+
+    do {
+      configurationService = try container.resolveSync(ConfigurationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ConfigurationService: \(error)")
+    }
+
+    // Load network selector style from settings
+    do {
+      let settings = try container.resolveSync(PrimerSettings.self)
+      networkSelectorStyle = settings.paymentMethodOptions.cardPaymentOptions.networkSelectorStyle
+    } catch {
+      logger.debug(message: "[A11Y] Using default network selector style: dropdown")
+    }
+  }
+
+  private func updateSurchargeAmount(for network: CardNetwork) {
+    guard let configurationService,
+      let surcharge = network.surcharge,
+      configurationService.apiConfiguration?.clientSession?.order?.merchantAmount == nil,
+      let currency = configurationService.currency
+    else {
+      surchargeAmount = nil
+      return
+    }
+    surchargeAmount = "+ \(surcharge.toCurrencyString(currency: currency))"
+  }
+}
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    CardNumberInputField(
+      label: "Card Number",
+      placeholder: "1234 5678 9012 3456",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    CardNumberInputField(
+      label: "Card Number",
+      placeholder: "1234 5678 9012 3456",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField.swift
@@ -130,7 +130,8 @@ struct CardNumberInputField: View, LogReporter {
         hint: CheckoutComponentsStrings.a11yCardNumberHint,
         value: errorMessage,
         traits: []
-      )
+      ),
+      combinesChildren: false
     )
     .onAppear {
       setupValidationService()

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/DualBadgeDisplay.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/DualBadgeDisplay.swift
@@ -1,0 +1,51 @@
+//
+//  DualBadgeDisplay.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct DualBadgeDisplay: View {
+  let networks: [CardNetwork]
+
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Body
+
+  var body: some View {
+    HStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+      ForEach(networks, id: \.self) { network in
+        CardNetworkBadge(network: network)
+      }
+    }
+    .allowsHitTesting(false)
+  }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    VStack(spacing: 16) {
+      DualBadgeDisplay(networks: [.visa, .eftpos])
+      DualBadgeDisplay(networks: [.masterCard, .eftpos])
+    }
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    VStack(spacing: 16) {
+      DualBadgeDisplay(networks: [.visa, .eftpos])
+      DualBadgeDisplay(networks: [.masterCard, .eftpos])
+    }
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField+UIViewRepresentable.swift
@@ -1,0 +1,179 @@
+//
+//  CardholderNameInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// UIViewRepresentable wrapper for cardholder name input
+@available(iOS 15.0, *)
+struct CardholderNameTextField: UIViewRepresentable, LogReporter {
+  @Binding var cardholderName: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  let placeholder: String
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let scope: any PrimerCardFormScope
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.delegate = context.coordinator
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: .standard,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    textField.font = PrimerFont.uiFontBodyLarge(tokens: tokens)
+
+    return textField
+  }
+
+  func updateUIView(_ textField: UITextField, context: Context) {
+    if textField.text != cardholderName {
+      textField.text = cardholderName
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      validationService: validationService,
+      cardholderName: $cardholderName,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      scope: scope
+    )
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    private let validationService: ValidationService
+    @Binding private var cardholderName: String
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let scope: any PrimerCardFormScope
+
+    init(
+      validationService: ValidationService,
+      cardholderName: Binding<String>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>,
+      scope: any PrimerCardFormScope
+    ) {
+      self.validationService = validationService
+      _cardholderName = cardholderName
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+      self.scope = scope
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.errorMessage = nil
+        self.scope.clearFieldError(.cardholderName)
+        // Don't set isValid = false immediately - let validation happen on text change or focus loss
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+      }
+      validateCardholderName()
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+      textField.resignFirstResponder()
+      return true
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let currentText = cardholderName
+
+      guard let textRange = Range(range, in: currentText) else { return false }
+      let newText = currentText.replacingCharacters(in: textRange, with: string)
+
+      // Validate allowed characters (letters, spaces, apostrophes, hyphens)
+      if !string.isEmpty {
+        let allowedCharacterSet = CharacterSet.letters.union(CharacterSet(charactersIn: " '-"))
+        let characterSet = CharacterSet(charactersIn: string)
+        if !allowedCharacterSet.isSuperset(of: characterSet) {
+          return false
+        }
+      }
+
+      cardholderName = newText
+      scope.updateCardholderName(newText)
+
+      isValid = newText.count >= 2
+
+      if let scope = scope as? DefaultCardFormScope {
+        scope.updateValidationState(\.cardholderName, isValid: isValid)
+      }
+
+      return false
+    }
+
+    private func validateCardholderName() {
+      let trimmedName = cardholderName.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // Empty field handling - don't show errors for empty fields
+      if trimmedName.isEmpty {
+        isValid = false  // Cardholder name is required
+        errorMessage = nil  // Never show error message for empty fields
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.cardholderName, isValid: false)
+        }
+        return
+      }
+
+      let result = validationService.validate(
+        input: cardholderName,
+        with: CardholderNameRule()
+      )
+
+      isValid = result.isValid
+      errorMessage = result.errorMessage
+
+      if result.isValid {
+        scope.clearFieldError(.cardholderName)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.cardholderName, isValid: true)
+        }
+      } else {
+        if let message = result.errorMessage {
+          scope.setFieldError(.cardholderName, message: message, errorCode: result.errorCode)
+        }
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.cardholderName, isValid: false)
+        }
+      }
+
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField.swift
@@ -1,0 +1,126 @@
+//
+//  CardholderNameInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CardholderNameInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let scope: any PrimerCardFormScope
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var cardholderName: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    scope: any PrimerCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.scope = scope
+    self.styling = styling
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $cardholderName,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      if let validationService {
+        CardholderNameTextField(
+          cardholderName: $cardholderName,
+          isValid: $isValid,
+          errorMessage: $errorMessage,
+          isFocused: $isFocused,
+          placeholder: placeholder,
+          styling: styling,
+          validationService: validationService,
+          scope: scope,
+          tokens: tokens
+        )
+      } else {
+        // Fallback view while loading validation service
+        TextField(placeholder, text: $cardholderName)
+          .keyboardType(.default)
+          .autocapitalization(.words)
+          .disabled(true)
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.cardholderNameField,
+        label: CheckoutComponentsStrings.a11yCardholderNameLabel,
+        hint: CheckoutComponentsStrings.a11yCardholderNameHint,
+        value: errorMessage,
+        traits: []
+      )
+    )
+    .onAppear {
+      setupValidationService()
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for CardholderNameInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    CardholderNameInputField(
+      label: "Cardholder Name",
+      placeholder: "John Smith",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    CardholderNameInputField(
+      label: "Cardholder Name",
+      placeholder: "John Smith",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField+UIViewRepresentable.swift
@@ -1,0 +1,167 @@
+//
+//  CityInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+/// UIViewRepresentable wrapper for city input with focus-based validation
+@available(iOS 15.0, *)
+struct CityTextField: UIViewRepresentable, LogReporter {
+  @Binding var city: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  let placeholder: String
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let scope: any PrimerCardFormScope
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.delegate = context.coordinator
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: .standard,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    return textField
+  }
+
+  func updateUIView(_ textField: UITextField, context: Context) {
+    if textField.text != city {
+      textField.text = city
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      validationService: validationService,
+      city: $city,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      scope: scope
+    )
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    private let validationService: ValidationService
+    @Binding private var city: String
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let scope: any PrimerCardFormScope
+
+    init(
+      validationService: ValidationService,
+      city: Binding<String>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>,
+      scope: any PrimerCardFormScope
+    ) {
+      self.validationService = validationService
+      _city = city
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+      self.scope = scope
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.errorMessage = nil
+        self.scope.clearFieldError(.city)
+        // Don't set isValid = false immediately - let validation happen on text change or focus loss
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+      }
+      validateCity()
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+      textField.resignFirstResponder()
+      return true
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let currentText = city
+
+      guard let textRange = Range(range, in: currentText) else { return false }
+      let newText = currentText.replacingCharacters(in: textRange, with: string)
+
+      city = newText
+      scope.updateCity(newText)
+
+      // Simple validation while typing (don't show errors until focus loss)
+      isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+      if let scope = scope as? DefaultCardFormScope {
+        scope.updateValidationState(\.city, isValid: isValid)
+      }
+
+      return false
+    }
+
+    private func validateCity() {
+      let trimmedCity = city.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // Empty field handling - don't show errors for empty fields
+      if trimmedCity.isEmpty {
+        isValid = false  // City is required
+        errorMessage = nil  // Never show error message for empty fields
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.city, isValid: false)
+        }
+        return
+      }
+
+      let result = validationService.validate(
+        input: city,
+        with: CityRule()
+      )
+
+      isValid = result.isValid
+      errorMessage = result.errorMessage
+
+      if result.isValid {
+        scope.clearFieldError(.city)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.city, isValid: true)
+        }
+      } else if let message = result.errorMessage {
+        scope.setFieldError(.city, message: message, errorCode: result.errorCode)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.city, isValid: false)
+        }
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField.swift
@@ -1,0 +1,125 @@
+//
+//  CityInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CityInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let scope: any PrimerCardFormScope
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var city: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    scope: any PrimerCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.scope = scope
+    self.styling = styling
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $city,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      if let validationService {
+        CityTextField(
+          city: $city,
+          isValid: $isValid,
+          errorMessage: $errorMessage,
+          isFocused: $isFocused,
+          placeholder: placeholder,
+          styling: styling,
+          validationService: validationService,
+          scope: scope,
+          tokens: tokens
+        )
+      } else {
+        // Fallback view while loading validation service
+        TextField(placeholder, text: $city)
+          .autocapitalization(.words)
+          .disabled(true)
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.billingAddressField("city"),
+        label: label ?? "City",
+        hint: CheckoutComponentsStrings.a11yBillingAddressCityHint,
+        value: errorMessage,
+        traits: []
+      )
+    )
+    .onAppear {
+      setupValidationService()
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for CityInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    CityInputField(
+      label: "City",
+      placeholder: "Enter city",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    CityInputField(
+      label: "City",
+      placeholder: "Enter city",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField+SelectionButton.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField+SelectionButton.swift
@@ -1,0 +1,62 @@
+//
+//  CountryInputField+SelectionButton.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CountrySelectionButton: View {
+  let countryName: String
+  let placeholder: String
+  let styling: PrimerFieldStyling?
+  let tokens: DesignTokens?
+  let scope: any PrimerCardFormScope
+
+  @State private var showCountryPicker: Bool = false
+
+  // MARK: - Computed Properties
+
+  private var countryTextColor: Color {
+    guard !countryName.isEmpty else {
+      return styling?.placeholderColor ?? CheckoutColors.textPlaceholder(tokens: tokens)
+    }
+    return styling?.textColor ?? CheckoutColors.textPrimary(tokens: tokens)
+  }
+
+  private var fieldFont: Font {
+    styling?.resolvedFont(tokens: tokens) ?? PrimerFont.bodyLarge(tokens: tokens)
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    Button(
+      action: {
+        let impactFeedback = UIImpactFeedbackGenerator(style: .light)
+        impactFeedback.impactOccurred()
+        showCountryPicker = true
+      },
+      label: {
+        HStack(spacing: 0) {
+          Text(countryName.isEmpty ? placeholder : countryName)
+            .font(fieldFont)
+            .foregroundColor(countryTextColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(height: PrimerSize.xxlarge(tokens: tokens))
+        .contentShape(Rectangle())
+      }
+    )
+    .buttonStyle(PlainButtonStyle())
+    .sheet(isPresented: $showCountryPicker) {
+      SelectCountryScreen(
+        scope: scope.selectCountry,
+        onDismiss: {
+          showCountryPicker = false
+        }
+      )
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
@@ -1,0 +1,200 @@
+//
+//  CountryInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Combine
+import SwiftUI
+import UIKit
+
+@available(iOS 15.0, *)
+struct CountryInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  private let scope: DefaultCardFormScope
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var countryName: String = ""
+  @State private var countryCode: String = ""
+  @State private var countryFlag: String?
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @State private var showCountryPicker: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Computed Properties
+
+  private var countryTextColor: Color {
+    guard !countryName.isEmpty else {
+      return styling?.placeholderColor ?? CheckoutColors.textPlaceholder(tokens: tokens)
+    }
+    return styling?.textColor ?? CheckoutColors.textPrimary(tokens: tokens)
+  }
+
+  private var selectedCountryFromScope: PrimerCountry? {
+    scope.structuredState.selectedCountry
+  }
+
+  private var fieldFont: Font {
+    styling?.resolvedFont(tokens: tokens) ?? PrimerFont.bodyLarge(tokens: tokens)
+  }
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    scope: DefaultCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.scope = scope
+    self.styling = styling
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $countryName,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      textFieldBuilder: {
+        Button(
+          action: {
+            let impactFeedback = UIImpactFeedbackGenerator(style: .light)
+            impactFeedback.impactOccurred()
+
+            showCountryPicker = true
+          },
+          label: {
+            HStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+              // Flag emoji
+              if let countryFlag, !countryName.isEmpty {
+                Text(countryFlag)
+                  .font(fieldFont)
+              }
+
+              // Country name or placeholder
+              Text(countryName.isEmpty ? placeholder : countryName)
+                .font(fieldFont)
+                .foregroundColor(countryTextColor)
+                .frame(maxWidth: .infinity, alignment: .leading)
+              Spacer(minLength: 0)
+            }
+            .frame(height: PrimerSize.xxlarge(tokens: tokens))
+            .contentShape(Rectangle())
+          }
+        )
+        .buttonStyle(PlainButtonStyle())
+      },
+      rightComponent: {
+        Image(systemName: "chevron.down")
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+      }
+    )
+    .onAppear {
+      setupValidationService()
+      updateFromExternalState()
+    }
+    .onReceive(
+      scope.$structuredState
+        .map(\.selectedCountry)
+        .removeDuplicates()
+    ) { country in
+      updateFromExternalState(with: country)
+    }
+    .sheet(isPresented: $showCountryPicker) {
+      SelectCountryScreen(
+        scope: scope.selectCountry,
+        onDismiss: {
+          showCountryPicker = false
+        }
+      )
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for CountryInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+
+  @MainActor
+  private func updateFromExternalState() {
+    updateFromExternalState(with: selectedCountryFromScope)
+  }
+
+  @MainActor
+  private func updateFromExternalState(with country: PrimerCountry?) {
+    // Update directly from the PrimerCountry object from the scope
+    if let country, !country.name.isEmpty, !country.code.isEmpty {
+      countryName = country.name
+      countryCode = country.code
+      countryFlag = country.flag
+      validateCountry()
+    }
+  }
+
+  @MainActor
+  func updateCountry(name: String, code: String) {
+    countryName = name
+    countryCode = code
+    scope.updateCountryCode(code)
+    validateCountry()
+  }
+
+  @MainActor
+  private func clearFieldError() {
+    scope.clearFieldError(.countryCode)
+  }
+
+  @MainActor
+  private func setFieldError(message: String, errorCode: String?) {
+    scope.setFieldError(.countryCode, message: message, errorCode: errorCode)
+  }
+
+  @MainActor
+  private func validateCountry() {
+    guard let validationService else { return }
+
+    let result = validationService.validate(
+      input: countryCode,
+      with: CountryCodeRule()
+    )
+
+    isValid = result.isValid
+    errorMessage = result.errorMessage
+
+    if result.isValid {
+      clearFieldError()
+      scope.updateValidationState(\.countryCode, isValid: true)
+    } else if let message = result.errorMessage {
+      setFieldError(message: message, errorCode: result.errorCode)
+      scope.updateValidationState(\.countryCode, isValid: false)
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  // Note: Previews are disabled for CountryInputField because it requires DefaultCardFormScope
+  // which has complex initialization dependencies. Use the Debug App to test this component.
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputFieldWrapper.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputFieldWrapper.swift
@@ -1,0 +1,25 @@
+//
+//  CountryInputFieldWrapper.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CountryInputFieldWrapper: View, LogReporter {
+  let scope: DefaultCardFormScope
+
+  let label: String?
+  let placeholder: String
+  let styling: PrimerFieldStyling?
+
+  var body: some View {
+    CountryInputField(
+      label: label,
+      placeholder: placeholder,
+      scope: scope,
+      styling: styling
+    )
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField+UIViewRepresentable.swift
@@ -1,0 +1,177 @@
+//
+//  EmailInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+/// UIViewRepresentable wrapper for email input with focus-based validation
+@available(iOS 15.0, *)
+struct EmailTextField: UIViewRepresentable, LogReporter {
+  @Binding var email: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  let placeholder: String
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let scope: (any PrimerCardFormScope)?
+  let onEmailChange: ((String) -> Void)?
+  let onValidationChange: ((Bool) -> Void)?
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.delegate = context.coordinator
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: .email,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    return textField
+  }
+
+  func updateUIView(_ textField: UITextField, context: Context) {
+    if textField.text != email {
+      textField.text = email
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      validationService: validationService,
+      email: $email,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      scope: scope,
+      onEmailChange: onEmailChange,
+      onValidationChange: onValidationChange
+    )
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    private let validationService: ValidationService
+    @Binding private var email: String
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let scope: (any PrimerCardFormScope)?
+    private let onEmailChange: ((String) -> Void)?
+    private let onValidationChange: ((Bool) -> Void)?
+
+    init(
+      validationService: ValidationService,
+      email: Binding<String>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>,
+      scope: (any PrimerCardFormScope)?,
+      onEmailChange: ((String) -> Void)?,
+      onValidationChange: ((Bool) -> Void)?
+    ) {
+      self.validationService = validationService
+      _email = email
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+      self.scope = scope
+      self.onEmailChange = onEmailChange
+      self.onValidationChange = onValidationChange
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.errorMessage = nil
+        self.scope?.clearFieldError(.email)
+        // Don't set isValid = false immediately - let validation happen on text change or focus loss
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+      }
+      validateEmail()
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+      textField.resignFirstResponder()
+      return true
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let currentText = email
+
+      guard let textRange = Range(range, in: currentText) else { return false }
+      let newText = currentText.replacingCharacters(in: textRange, with: string)
+
+      email = newText
+      if let scope {
+        scope.updateEmail(newText)
+      } else {
+        onEmailChange?(newText)
+      }
+
+      // Simple validation while typing (don't show errors until focus loss)
+      isValid =
+        !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && newText.contains("@")
+
+      if let scope = scope as? DefaultCardFormScope {
+        scope.updateValidationState(\.email, isValid: isValid)
+      }
+
+      return false
+    }
+
+    private func validateEmail() {
+      let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // Empty field handling - don't show errors for empty fields
+      if trimmedEmail.isEmpty {
+        isValid = false  // Email is required
+        errorMessage = nil  // Never show error message for empty fields
+        onValidationChange?(false)
+        return
+      }
+
+      let result = validationService.validate(
+        input: email,
+        with: EmailRule()
+      )
+
+      isValid = result.isValid
+      errorMessage = result.errorMessage
+      onValidationChange?(result.isValid)
+
+      if let scope {
+        if result.isValid {
+          scope.clearFieldError(.email)
+        } else if let message = result.errorMessage {
+          scope.setFieldError(.email, message: message, errorCode: result.errorCode)
+        }
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField.swift
@@ -1,0 +1,156 @@
+//
+//  EmailInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct EmailInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let initialValue: String
+  let scope: (any PrimerCardFormScope)?
+  let onEmailChange: ((String) -> Void)?
+  let onValidationChange: ((Bool) -> Void)?
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var email: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    scope: any PrimerCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    initialValue = ""
+    self.scope = scope
+    self.styling = styling
+    onEmailChange = nil
+    onValidationChange = nil
+  }
+
+  init(
+    label: String?,
+    placeholder: String,
+    initialValue: String = "",
+    styling: PrimerFieldStyling? = nil,
+    onEmailChange: ((String) -> Void)? = nil,
+    onValidationChange: ((Bool) -> Void)? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.initialValue = initialValue
+    scope = nil
+    self.styling = styling
+    self.onEmailChange = onEmailChange
+    self.onValidationChange = onValidationChange
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $email,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      if let validationService {
+        EmailTextField(
+          email: $email,
+          isValid: $isValid,
+          errorMessage: $errorMessage,
+          isFocused: $isFocused,
+          placeholder: placeholder,
+          styling: styling,
+          validationService: validationService,
+          scope: scope,
+          onEmailChange: onEmailChange,
+          onValidationChange: onValidationChange,
+          tokens: tokens
+        )
+      } else {
+        // Fallback view while loading validation service
+        TextField(placeholder, text: $email)
+          .keyboardType(.emailAddress)
+          .autocapitalization(.none)
+          .disableAutocorrection(true)
+          .textContentType(.emailAddress)
+          .disabled(true)
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.billingAddressField("email"),
+        label: label ?? "Email",
+        hint: CheckoutComponentsStrings.a11yEmailFieldHint
+      ),
+      combinesChildren: false
+    )
+    .onAppear {
+      setupValidationService()
+      if !initialValue.isEmpty, email.isEmpty {
+        email = initialValue
+        onEmailChange?(initialValue)
+      }
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for EmailInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    EmailInputField(
+      label: "Email Address",
+      placeholder: "Enter your email",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    EmailInputField(
+      label: "Email Address",
+      placeholder: "Enter your email",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField+UIViewRepresentable.swift
@@ -1,0 +1,272 @@
+//
+//  ExpiryDateInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+/// UIViewRepresentable wrapper for expiry date input
+@available(iOS 15.0, *)
+struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
+  @Binding var expiryDate: String
+  @Binding var month: String
+  @Binding var year: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  let placeholder: String
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let scope: any PrimerCardFormScope
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.delegate = context.coordinator
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: .expiryDate,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    return textField
+  }
+
+  func updateUIView(_ textField: UITextField, context: Context) {
+    if textField.text != expiryDate {
+      textField.text = expiryDate
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      validationService: validationService,
+      expiryDate: $expiryDate,
+      month: $month,
+      year: $year,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      scope: scope
+    )
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    private let validationService: ValidationService
+    @Binding private var expiryDate: String
+    @Binding private var month: String
+    @Binding private var year: String
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let scope: any PrimerCardFormScope
+
+    init(
+      validationService: ValidationService,
+      expiryDate: Binding<String>,
+      month: Binding<String>,
+      year: Binding<String>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>,
+      scope: any PrimerCardFormScope
+    ) {
+      self.validationService = validationService
+      _expiryDate = expiryDate
+      _month = month
+      _year = year
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+      self.scope = scope
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.errorMessage = nil
+        self.scope.clearFieldError(.expiryDate)
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+      }
+      validateExpiryDate()
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let currentText = expiryDate
+
+      if string == "\n" {
+        textField.resignFirstResponder()
+        return false
+      }
+
+      // Only allow numbers and return for non-numeric input except deletion
+      if !string.isEmpty,
+        !CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: string)) {
+        return false
+      }
+
+      let newText = processInput(currentText: currentText, range: range, string: string)
+
+      expiryDate = newText
+      textField.text = newText
+
+      extractMonthAndYear(from: newText)
+
+      scope.updateExpiryDate(newText)
+
+      // Validate silently during typing (no error messages shown)
+      if newText.count == 5 {  // MM/YY format
+        validateExpiryDateSilently()
+      } else {
+        isValid = false
+        errorMessage = nil
+      }
+
+      return false
+    }
+
+    private func processInput(currentText: String, range: NSRange, string: String) -> String {
+      if string.isEmpty {
+        // If deleting the separator, also remove the character before it
+        if range.location == 2, range.length == 1, currentText.count >= 3,
+          currentText[currentText.index(currentText.startIndex, offsetBy: 2)] == "/" {
+          return String(currentText.prefix(1))
+        }
+
+        if let textRange = Range(range, in: currentText) {
+          return currentText.replacingCharacters(in: textRange, with: "")
+        }
+        return currentText
+      }
+
+      // Remove the / character temporarily for easier processing
+      let sanitizedText = currentText.replacingOccurrences(of: "/", with: "")
+
+      // Calculate where to insert the new text
+      var sanitizedLocation = range.location
+      if range.location > 2, currentText.count >= 3, currentText.contains("/") {
+        sanitizedLocation -= 1
+      }
+
+      var newSanitizedText = sanitizedText
+      if sanitizedLocation <= sanitizedText.count {
+        let index = newSanitizedText.index(
+          newSanitizedText.startIndex, offsetBy: min(sanitizedLocation, newSanitizedText.count)
+        )
+        newSanitizedText.insert(contentsOf: string, at: index)
+      } else {
+        newSanitizedText += string
+      }
+
+      // Limit to 4 digits total (MMYY format)
+      newSanitizedText = String(newSanitizedText.prefix(4))
+
+      if newSanitizedText.count > 2 {
+        return "\(newSanitizedText.prefix(2))/\(newSanitizedText.dropFirst(2))"
+      } else {
+        return newSanitizedText
+      }
+    }
+
+    private func extractMonthAndYear(from text: String) {
+      let parts = text.components(separatedBy: "/")
+
+      month = !parts.isEmpty ? parts[0] : ""
+      year = parts.count > 1 ? parts[1] : ""
+
+      scope.updateExpiryMonth(month)
+      scope.updateExpiryYear(year)
+    }
+
+    /// Validates expiry date and shows error messages (called on blur)
+    private func validateExpiryDate() {
+      validateExpiryDateSilently(showErrors: true)
+    }
+
+    /// Validates expiry date without showing error messages (called during typing)
+    private func validateExpiryDateSilently(showErrors: Bool = false) {
+      // Empty field handling - don't show errors for empty fields
+      let trimmedExpiry = expiryDate.trimmingCharacters(in: .whitespacesAndNewlines)
+      if trimmedExpiry.isEmpty {
+        isValid = false  // Expiry date is required
+        errorMessage = nil  // Never show error message for empty fields
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.expiry, isValid: false)
+        }
+        return
+      }
+
+      // Parse MM/YY format for non-empty fields
+      let components = expiryDate.components(separatedBy: "/")
+
+      guard components.count == 2 else {
+        isValid = false
+        if showErrors {
+          errorMessage = CheckoutComponentsStrings.enterValidExpiryDate
+          scope.setFieldError(
+            .expiryDate, message: CheckoutComponentsStrings.enterValidExpiryDate,
+            errorCode: "invalid_format"
+          )
+        }
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.expiry, isValid: false)
+        }
+        return
+      }
+
+      let month = components[0].trimmingCharacters(in: .whitespacesAndNewlines)
+      let year = components[1].trimmingCharacters(in: .whitespacesAndNewlines)
+
+      let expiryInput = ExpiryDateInput(month: month, year: year)
+      let result = validationService.validate(
+        input: expiryInput,
+        with: ExpiryDateRule()
+      )
+
+      isValid = result.isValid
+
+      // Only show error messages if showErrors is true (on blur)
+      if showErrors {
+        errorMessage = result.errorMessage
+      }
+
+      if result.isValid {
+        scope.clearFieldError(.expiryDate)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.expiry, isValid: true)
+        }
+      } else {
+        if showErrors, let message = result.errorMessage {
+          scope.setFieldError(.expiryDate, message: message, errorCode: result.errorCode)
+        }
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.expiry, isValid: false)
+        }
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField.swift
@@ -78,7 +78,8 @@ struct ExpiryDateInputField: View, LogReporter {
         hint: CheckoutComponentsStrings.a11yExpiryHint,
         value: errorMessage,
         traits: []
-      )
+      ),
+      combinesChildren: false
     )
     .onAppear {
       setupValidationService()

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField.swift
@@ -1,0 +1,129 @@
+//
+//  ExpiryDateInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct ExpiryDateInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let scope: any PrimerCardFormScope
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var expiryDate: String = ""
+  @State private var month: String = ""
+  @State private var year: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    scope: any PrimerCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.scope = scope
+    self.styling = styling
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $expiryDate,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      if let validationService {
+        ExpiryDateTextField(
+          expiryDate: $expiryDate,
+          month: $month,
+          year: $year,
+          isValid: $isValid,
+          errorMessage: $errorMessage,
+          isFocused: $isFocused,
+          placeholder: placeholder,
+          styling: styling,
+          validationService: validationService,
+          scope: scope,
+          tokens: tokens
+        )
+      } else {
+        // Fallback view while loading validation service
+        TextField(placeholder, text: $expiryDate)
+          .keyboardType(.numberPad)
+          .disabled(true)
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.expiryField,
+        label: CheckoutComponentsStrings.a11yExpiryLabel,
+        hint: CheckoutComponentsStrings.a11yExpiryHint,
+        value: errorMessage,
+        traits: []
+      )
+    )
+    .onAppear {
+      setupValidationService()
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for ExpiryDateInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    ExpiryDateInputField(
+      label: "Expiry Date",
+      placeholder: "MM / YY",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    ExpiryDateInputField(
+      label: "Expiry Date",
+      placeholder: "MM / YY",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField+UIViewRepresentable.swift
@@ -1,0 +1,212 @@
+//
+//  NameInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+/// UIViewRepresentable wrapper for name input with focus-based validation
+@available(iOS 15.0, *)
+struct NameTextField: UIViewRepresentable, LogReporter {
+  @Binding var name: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  let placeholder: String
+  let inputType: PrimerInputElementType
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let scope: (any PrimerCardFormScope)?
+  let onNameChange: ((String) -> Void)?
+  let onValidationChange: ((Bool) -> Void)?
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.delegate = context.coordinator
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: .standard,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    return textField
+  }
+
+  func updateUIView(_ textField: UITextField, context: Context) {
+    if textField.text != name {
+      textField.text = name
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      validationService: validationService,
+      name: $name,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      inputType: inputType,
+      scope: scope,
+      onNameChange: onNameChange,
+      onValidationChange: onValidationChange
+    )
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    private let validationService: ValidationService
+    @Binding private var name: String
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let inputType: PrimerInputElementType
+    private let scope: (any PrimerCardFormScope)?
+    private let onNameChange: ((String) -> Void)?
+    private let onValidationChange: ((Bool) -> Void)?
+
+    init(
+      validationService: ValidationService,
+      name: Binding<String>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>,
+      inputType: PrimerInputElementType,
+      scope: (any PrimerCardFormScope)?,
+      onNameChange: ((String) -> Void)?,
+      onValidationChange: ((Bool) -> Void)?
+    ) {
+      self.validationService = validationService
+      _name = name
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+      self.inputType = inputType
+      self.scope = scope
+      self.onNameChange = onNameChange
+      self.onValidationChange = onValidationChange
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.errorMessage = nil
+        self.scope?.clearFieldError(self.inputType)
+        // Don't set isValid = false immediately - let validation happen on text change or focus loss
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+      }
+      validateName()
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+      textField.resignFirstResponder()
+      return true
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let currentText = name
+
+      guard let textRange = Range(range, in: currentText) else { return false }
+      let newText = currentText.replacingCharacters(in: textRange, with: string)
+
+      name = newText
+
+      if let scope {
+        switch inputType {
+        case .firstName:
+          scope.updateFirstName(newText)
+        case .lastName:
+          scope.updateLastName(newText)
+        case .phoneNumber:
+          scope.updatePhoneNumber(newText)
+        default:
+          break
+        }
+      } else {
+        onNameChange?(newText)
+      }
+
+      // Simple validation while typing (don't show errors until focus loss)
+      isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+      if let scope = scope as? DefaultCardFormScope {
+        scope.updateValidationStateIfNeeded(for: inputType, isValid: isValid)
+      }
+
+      return false
+    }
+
+    private func validateName() {
+      let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // Empty field handling - don't show errors for empty fields
+      if trimmedName.isEmpty {
+        isValid = false  // Name fields are required
+        errorMessage = nil  // Never show error message for empty fields
+        onValidationChange?(false)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationStateIfNeeded(for: inputType, isValid: false)
+        }
+        return
+      }
+
+      // Convert PrimerInputElementType to ValidationError.InputElementType
+      let elementType: ValidationError.InputElementType = {
+        switch inputType {
+        case .firstName:
+          .firstName
+        case .lastName:
+          .lastName
+        default:
+          .firstName
+        }
+      }()
+
+      let result = validationService.validate(
+        input: name,
+        with: NameRule(inputElementType: elementType)
+      )
+
+      isValid = result.isValid
+      errorMessage = result.errorMessage
+      onValidationChange?(result.isValid)
+
+      if let scope {
+        if result.isValid {
+          scope.clearFieldError(inputType)
+          if let scope = scope as? DefaultCardFormScope {
+            scope.updateValidationStateIfNeeded(for: inputType, isValid: true)
+          }
+        } else if let message = result.errorMessage {
+          scope.setFieldError(inputType, message: message, errorCode: result.errorCode)
+          if let scope = scope as? DefaultCardFormScope {
+            scope.updateValidationStateIfNeeded(for: inputType, isValid: false)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField.swift
@@ -1,0 +1,162 @@
+//
+//  NameInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct NameInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let inputType: PrimerInputElementType
+  let initialValue: String
+  let scope: (any PrimerCardFormScope)?
+  let onNameChange: ((String) -> Void)?
+  let onValidationChange: ((Bool) -> Void)?
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var name: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    inputType: PrimerInputElementType,
+    scope: any PrimerCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.inputType = inputType
+    initialValue = ""
+    self.scope = scope
+    self.styling = styling
+    onNameChange = nil
+    onValidationChange = nil
+  }
+
+  init(
+    label: String?,
+    placeholder: String,
+    inputType: PrimerInputElementType,
+    initialValue: String = "",
+    styling: PrimerFieldStyling? = nil,
+    onNameChange: ((String) -> Void)? = nil,
+    onValidationChange: ((Bool) -> Void)? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.inputType = inputType
+    self.initialValue = initialValue
+    scope = nil
+    self.styling = styling
+    self.onNameChange = onNameChange
+    self.onValidationChange = onValidationChange
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $name,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      if let validationService {
+        NameTextField(
+          name: $name,
+          isValid: $isValid,
+          errorMessage: $errorMessage,
+          isFocused: $isFocused,
+          placeholder: placeholder,
+          inputType: inputType,
+          styling: styling,
+          validationService: validationService,
+          scope: scope,
+          onNameChange: onNameChange,
+          onValidationChange: onValidationChange,
+          tokens: tokens
+        )
+      } else {
+        // Fallback view while loading validation service
+        TextField(placeholder, text: $name)
+          .autocapitalization(.words)
+          .disableAutocorrection(true)
+          .disabled(true)
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.billingAddressField("\(inputType)"),
+        label: label ?? "Name",
+        hint: CheckoutComponentsStrings.a11yNameFieldHint
+      ),
+      combinesChildren: false
+    )
+    .onAppear {
+      setupValidationService()
+      if !initialValue.isEmpty, name.isEmpty {
+        name = initialValue
+        onNameChange?(initialValue)
+      }
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for NameInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    NameInputField(
+      label: "First Name",
+      placeholder: "Jane",
+      inputType: .firstName,
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    NameInputField(
+      label: "First Name",
+      placeholder: "Jane",
+      inputType: .firstName,
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/OTPCodeInputField/OTPCodeInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/OTPCodeInputField/OTPCodeInputField.swift
@@ -1,0 +1,178 @@
+//
+//  OTPCodeInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct OTPCodeInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let expectedLength: Int
+  let scope: (any PrimerCardFormScope)?
+  let onOTPCodeChange: ((String) -> Void)?
+  let onValidationChange: ((Bool) -> Void)?
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var otpCode: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  private var fieldFont: Font {
+    styling?.resolvedFont(tokens: tokens) ?? PrimerFont.bodyLarge(tokens: tokens)
+  }
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    scope: any PrimerCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    expectedLength = 6
+    self.scope = scope
+    self.styling = styling
+    onOTPCodeChange = nil
+    onValidationChange = nil
+  }
+
+  init(
+    label: String?,
+    placeholder: String,
+    expectedLength: Int,
+    styling: PrimerFieldStyling? = nil,
+    onOTPCodeChange: ((String) -> Void)? = nil,
+    onValidationChange: ((Bool) -> Void)? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.expectedLength = expectedLength
+    scope = nil
+    self.styling = styling
+    self.onOTPCodeChange = onOTPCodeChange
+    self.onValidationChange = onValidationChange
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $otpCode,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      TextField(
+        "",
+        text: $otpCode,
+        prompt: Text(placeholder)
+          .font(fieldFont)
+          .foregroundColor(
+            styling?.placeholderColor ?? CheckoutColors.textPlaceholder(tokens: tokens)
+          )
+      )
+      .font(fieldFont)
+      .foregroundColor(styling?.textColor ?? CheckoutColors.textPrimary(tokens: tokens))
+      .keyboardType(.numberPad)
+      .textContentType(.oneTimeCode)
+      .frame(height: PrimerSize.xxlarge(tokens: tokens))
+      .onChange(of: otpCode) { newValue in
+        if newValue.count > expectedLength {
+          otpCode = String(newValue.prefix(expectedLength))
+        } else {
+          if let scope {
+            scope.updateOtpCode(newValue)
+          } else {
+            onOTPCodeChange?(newValue)
+          }
+          validateOTPCode()
+        }
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.FormRedirect.otpField,
+        label: label ?? "OTP Code",
+        hint: CheckoutComponentsStrings.a11yOtpFieldHint
+      ),
+      combinesChildren: false
+    )
+    .onAppear {
+      setupValidationService()
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for OTPCodeInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+
+  @MainActor
+  private func validateOTPCode() {
+    // Use OTPCodeRule with expected length
+    let otpRule = OTPCodeRule(expectedLength: expectedLength)
+    let result = otpRule.validate(otpCode)
+
+    isValid = result.isValid
+    errorMessage = result.errorMessage
+    onValidationChange?(result.isValid)
+
+    if let scope {
+      if result.isValid {
+        scope.clearFieldError(.otp)
+      } else if let message = result.errorMessage {
+        scope.setFieldError(.otp, message: message, errorCode: result.errorCode)
+      }
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    OTPCodeInputField(
+      label: "Enter OTP Code",
+      placeholder: "000000",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    OTPCodeInputField(
+      label: "Enter OTP Code",
+      placeholder: "000000",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField+UIViewRepresentable.swift
@@ -1,0 +1,183 @@
+//
+//  PostalCodeInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+/// UIViewRepresentable wrapper for postal code input with focus-based validation
+@available(iOS 15.0, *)
+struct PostalCodeTextField: UIViewRepresentable, LogReporter {
+  @Binding var postalCode: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  let placeholder: String
+  let countryCode: String?
+  let keyboardType: UIKeyboardType
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let scope: any PrimerCardFormScope
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.delegate = context.coordinator
+
+    // Create custom configuration with dynamic keyboard type
+    let configuration = PrimerTextFieldConfiguration(
+      keyboardType: keyboardType,
+      autocapitalizationType: .allCharacters,
+      autocorrectionType: .no,
+      textContentType: nil,
+      returnKeyType: .done,
+      isSecureTextEntry: false
+    )
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: configuration,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    return textField
+  }
+
+  func updateUIView(_ textField: UITextField, context: Context) {
+    if textField.text != postalCode {
+      textField.text = postalCode
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      validationService: validationService,
+      postalCode: $postalCode,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      countryCode: countryCode,
+      scope: scope
+    )
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    private let validationService: ValidationService
+    @Binding private var postalCode: String
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let countryCode: String?
+    private let scope: any PrimerCardFormScope
+
+    init(
+      validationService: ValidationService,
+      postalCode: Binding<String>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>,
+      countryCode: String?,
+      scope: any PrimerCardFormScope
+    ) {
+      self.validationService = validationService
+      _postalCode = postalCode
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+      self.countryCode = countryCode
+      self.scope = scope
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.errorMessage = nil
+        self.scope.clearFieldError(.postalCode)
+        // Don't set isValid = false immediately - let validation happen on text change or focus loss
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+      }
+      validatePostalCode()
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+      textField.resignFirstResponder()
+      return true
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let currentText = postalCode
+
+      guard let textRange = Range(range, in: currentText) else { return false }
+      let newText = currentText.replacingCharacters(in: textRange, with: string)
+
+      postalCode = newText
+      scope.updatePostalCode(newText)
+
+      // Simple validation while typing (don't show errors until focus loss)
+      isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+      if let scope = scope as? DefaultCardFormScope {
+        scope.updateValidationState(\.postalCode, isValid: isValid)
+      }
+
+      return false
+    }
+
+    private func validatePostalCode() {
+      let trimmedPostalCode = postalCode.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // Empty field handling - don't show errors for empty fields
+      if trimmedPostalCode.isEmpty {
+        isValid = false  // Postal code is required
+        errorMessage = nil  // Never show error message for empty fields
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.postalCode, isValid: false)
+        }
+        return
+      }
+
+      let result = validationService.validate(
+        input: postalCode,
+        with: PostalCodeRule(countryCode: countryCode)
+      )
+
+      isValid = result.isValid
+      errorMessage = result.errorMessage
+
+      if result.isValid {
+        scope.clearFieldError(.postalCode)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.postalCode, isValid: true)
+        }
+      } else if let message = result.errorMessage {
+        scope.setFieldError(.postalCode, message: message, errorCode: result.errorCode)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.postalCode, isValid: false)
+        }
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField.swift
@@ -1,0 +1,141 @@
+//
+//  PostalCodeInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+@available(iOS 15.0, *)
+struct PostalCodeInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let countryCode: String?
+  let scope: any PrimerCardFormScope
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var postalCode: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Computed Properties
+
+  private var keyboardTypeForCountry: UIKeyboardType {
+    if countryCode == "US" {
+      return .numberPad
+    }
+    return .default
+  }
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    countryCode: String? = nil,
+    scope: any PrimerCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.countryCode = countryCode
+    self.scope = scope
+    self.styling = styling
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $postalCode,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      if let validationService {
+        PostalCodeTextField(
+          postalCode: $postalCode,
+          isValid: $isValid,
+          errorMessage: $errorMessage,
+          isFocused: $isFocused,
+          placeholder: placeholder,
+          countryCode: countryCode,
+          keyboardType: keyboardTypeForCountry,
+          styling: styling,
+          validationService: validationService,
+          scope: scope,
+          tokens: tokens
+        )
+      } else {
+        // Fallback view while loading validation service
+        TextField(placeholder, text: $postalCode)
+          .keyboardType(keyboardTypeForCountry)
+          .autocapitalization(.allCharacters)
+          .disabled(true)
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.billingAddressField("postal_code"),
+        label: label ?? "Postal code",
+        hint: CheckoutComponentsStrings.a11yBillingAddressPostalCodeHint,
+        value: errorMessage,
+        traits: []
+      )
+    )
+    .onAppear {
+      setupValidationService()
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for PostalCodeInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    PostalCodeInputField(
+      label: "Postal Code",
+      placeholder: "Enter postal code",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    PostalCodeInputField(
+      label: "Postal Code",
+      placeholder: "Enter postal code",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField+UIViewRepresentable.swift
@@ -1,0 +1,167 @@
+//
+//  StateInputField+UIViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+/// UIViewRepresentable wrapper for state input with focus-based validation
+@available(iOS 15.0, *)
+struct StateTextField: UIViewRepresentable, LogReporter {
+  @Binding var state: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+  @Binding var isFocused: Bool
+  let placeholder: String
+  let styling: PrimerFieldStyling?
+  let validationService: ValidationService
+  let scope: any PrimerCardFormScope
+  let tokens: DesignTokens?
+
+  func makeUIView(context: Context) -> UITextField {
+    let textField = UITextField()
+    textField.delegate = context.coordinator
+
+    textField.configurePrimerStyle(
+      placeholder: placeholder,
+      configuration: .standard,
+      styling: styling,
+      tokens: tokens,
+      doneButtonTarget: context.coordinator,
+      doneButtonAction: #selector(Coordinator.doneButtonTapped)
+    )
+
+    return textField
+  }
+
+  func updateUIView(_ textField: UITextField, context: Context) {
+    if textField.text != state {
+      textField.text = state
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      validationService: validationService,
+      state: $state,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused,
+      scope: scope
+    )
+  }
+
+  final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    private let validationService: ValidationService
+    @Binding private var state: String
+    @Binding private var isValid: Bool
+    @Binding private var errorMessage: String?
+    @Binding private var isFocused: Bool
+    private let scope: any PrimerCardFormScope
+
+    init(
+      validationService: ValidationService,
+      state: Binding<String>,
+      isValid: Binding<Bool>,
+      errorMessage: Binding<String?>,
+      isFocused: Binding<Bool>,
+      scope: any PrimerCardFormScope
+    ) {
+      self.validationService = validationService
+      _state = state
+      _isValid = isValid
+      _errorMessage = errorMessage
+      _isFocused = isFocused
+      self.scope = scope
+    }
+
+    @objc func doneButtonTapped() {
+      UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+      )
+      // Post accessibility notification to move focus away from the now-hidden Done button
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        UIAccessibility.post(notification: .layoutChanged, argument: nil)
+      }
+    }
+
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = true
+        self.errorMessage = nil
+        self.scope.clearFieldError(.state)
+        // Don't set isValid = false immediately - let validation happen on text change or focus loss
+      }
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+      DispatchQueue.main.async {
+        self.isFocused = false
+      }
+      validateState()
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+      textField.resignFirstResponder()
+      return true
+    }
+
+    func textField(
+      _ textField: UITextField, shouldChangeCharactersIn range: NSRange,
+      replacementString string: String
+    ) -> Bool {
+      let currentText = state
+
+      guard let textRange = Range(range, in: currentText) else { return false }
+      let newText = currentText.replacingCharacters(in: textRange, with: string)
+
+      state = newText
+      scope.updateState(newText)
+
+      // Simple validation while typing (don't show errors until focus loss)
+      isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+      if let scope = scope as? DefaultCardFormScope {
+        scope.updateValidationState(\.state, isValid: isValid)
+      }
+
+      return false
+    }
+
+    private func validateState() {
+      let trimmedState = state.trimmingCharacters(in: .whitespacesAndNewlines)
+
+      // Empty field handling - don't show errors for empty fields
+      if trimmedState.isEmpty {
+        isValid = false  // State is required
+        errorMessage = nil  // Never show error message for empty fields
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.state, isValid: false)
+        }
+        return
+      }
+
+      let result = validationService.validate(
+        input: state,
+        with: StateRule()
+      )
+
+      isValid = result.isValid
+      errorMessage = result.errorMessage
+
+      if result.isValid {
+        scope.clearFieldError(.state)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.state, isValid: true)
+        }
+      } else if let message = result.errorMessage {
+        scope.setFieldError(.state, message: message, errorCode: result.errorCode)
+        if let scope = scope as? DefaultCardFormScope {
+          scope.updateValidationState(\.state, isValid: false)
+        }
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField.swift
@@ -1,0 +1,124 @@
+//
+//  StateInputField.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct StateInputField: View, LogReporter {
+  let label: String?
+  let placeholder: String
+  let scope: any PrimerCardFormScope
+  let styling: PrimerFieldStyling?
+
+  // MARK: - Private Properties
+
+  @Environment(\.diContainer) private var container
+  @State private var validationService: ValidationService?
+  @State private var state: String = ""
+  @State private var isValid: Bool = false
+  @State private var errorMessage: String?
+  @State private var isFocused: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    label: String?,
+    placeholder: String,
+    scope: any PrimerCardFormScope,
+    styling: PrimerFieldStyling? = nil
+  ) {
+    self.label = label
+    self.placeholder = placeholder
+    self.scope = scope
+    self.styling = styling
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    PrimerInputFieldContainer(
+      label: label,
+      styling: styling,
+      text: $state,
+      isValid: $isValid,
+      errorMessage: $errorMessage,
+      isFocused: $isFocused
+    ) {
+      if let validationService {
+        StateTextField(
+          state: $state,
+          isValid: $isValid,
+          errorMessage: $errorMessage,
+          isFocused: $isFocused,
+          placeholder: placeholder,
+          styling: styling,
+          validationService: validationService,
+          scope: scope,
+          tokens: tokens
+        )
+      } else {
+        // Fallback view while loading validation service
+        TextField(placeholder, text: $state)
+          .autocapitalization(.words)
+          .disabled(true)
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.CardForm.billingAddressField("state"),
+        label: label ?? "State",
+        hint: CheckoutComponentsStrings.a11yBillingAddressStateHint
+      ),
+      combinesChildren: false
+    )
+    .onAppear {
+      setupValidationService()
+    }
+  }
+
+  private func setupValidationService() {
+    guard let container else {
+      logger.error(message: "DIContainer not available for StateInputField")
+      return
+    }
+
+    do {
+      validationService = try container.resolveSync(ValidationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ValidationService: \(error)")
+    }
+  }
+}
+
+#if DEBUG
+  // MARK: - Preview
+  @available(iOS 15.0, *)
+  #Preview("Light Mode") {
+    StateInputField(
+      label: "State",
+      placeholder: "Enter state",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Dark Mode") {
+    StateInputField(
+      label: "State",
+      placeholder: "Enter state",
+      scope: MockCardFormScope()
+    )
+    .padding()
+    .background(Color.black)
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
@@ -1,0 +1,123 @@
+//
+//  PaymentMethodButton.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct PaymentMethodButton: View {
+  let method: CheckoutPaymentMethod
+  let customItem: PaymentMethodItemComponent?
+  let onSelect: () -> Void
+
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    if let customItem {
+      AnyView(customItem(method))
+        .onTapGesture { onSelect() }
+    } else {
+      let radius = method.cornerRadius ?? PrimerRadius.medium(tokens: tokens)
+      Button(action: onSelect) {
+        HStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+          icon
+          Text(method.buttonText ?? method.name)
+            .font(PrimerFont.bodyLarge(tokens: tokens))
+            .foregroundColor(
+              method.textColor.map(Color.init) ?? CheckoutColors.textPrimary(tokens: tokens)
+            )
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+        .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+        .frame(minHeight: PrimerComponentHeight.paymentMethodCard)
+        .background(
+          RoundedRectangle(cornerRadius: radius)
+            .fill(
+              method.backgroundColor.map(Color.init) ?? CheckoutColors.background(tokens: tokens)
+            )
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: radius)
+            .strokeBorder(
+              borderColor(for: method),
+              lineWidth: borderWidth(for: method)
+            )
+        )
+      }
+      .buttonStyle(PaymentMethodButtonStyle())
+      .accessibility(config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.PaymentSelection.paymentMethodItem(
+          method.type, uniqueId: method.id
+        ),
+        label: CheckoutComponentsStrings.a11yPaymentMethodButton(method.buttonText ?? method.name),
+        traits: [.isButton]
+      ))
+      .background(
+        RoundedRectangle(cornerRadius: radius)
+          .fill(
+            method.backgroundColor.map(Color.init) ?? CheckoutColors.background(tokens: tokens)
+          )
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: radius)
+          .strokeBorder(
+            borderColor(for: method),
+            lineWidth: borderWidth(for: method)
+          )
+      )
+    }
+  }
+
+  private var hasVisibleBackground: Bool {
+    guard let bg = method.backgroundColor else { return false }
+    var white: CGFloat = 0
+    var alpha: CGFloat = 0
+    bg.getWhite(&white, alpha: &alpha)
+    return alpha > 0.1 && white < 0.95
+  }
+
+  private func borderColor(for method: CheckoutPaymentMethod) -> Color {
+    if let color = method.borderColor, color != .clear {
+      return Color(color)
+    }
+    guard !hasVisibleBackground else { return .clear }
+    return CheckoutColors.borderDefault(tokens: tokens)
+  }
+
+  private func borderWidth(for method: CheckoutPaymentMethod) -> CGFloat {
+    if let width = method.borderWidth, width > 0 {
+      return width
+    }
+    guard !hasVisibleBackground else { return 0 }
+    return PrimerBorderWidth.standard
+  }
+
+  @ViewBuilder
+  private var icon: some View {
+    let image =
+      method.icon ?? PrimerPaymentMethodType(rawValue: method.type)?.defaultImageName.image
+    if let image {
+      Image(uiImage: image)
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .frame(
+          width: PrimerComponentWidth.paymentMethodIcon, height: PrimerSize.large(tokens: tokens)
+        )
+    }
+  }
+}
+
+// MARK: - Button Style
+
+@available(iOS 15.0, *)
+struct PaymentMethodButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+      .opacity(configuration.isPressed ? 0.9 : 1.0)
+      .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodComponents.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodComponents.swift
@@ -1,0 +1,141 @@
+//
+//  PaymentMethodComponents.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+struct PaymentMethodScreen: View {
+  let paymentMethodType: String
+  let checkoutScope: PrimerCheckoutScope
+
+  @ViewBuilder
+  var body: some View {
+    // Truly generic dynamic view resolution via registry - NO hardcoded payment method checks!
+    // Each payment method registers its own view builder, making this fully extensible
+    if let paymentMethodView = PaymentMethodRegistry.shared.getView(
+      for: paymentMethodType,
+      checkoutScope: checkoutScope
+    ) {
+      // Payment method has a registered view implementation
+      paymentMethodView
+    } else {
+      // Payment method not registered or doesn't have view implementation yet
+      // Show placeholder that works for any payment method type
+      AnyView(
+        PaymentMethodPlaceholder(
+          paymentMethodType: paymentMethodType,
+          checkoutScope: checkoutScope
+        )
+      )
+    }
+  }
+}
+
+/// Placeholder screen for payment methods that don't have implemented scopes yet
+@available(iOS 15.0, *)
+@MainActor
+struct PaymentMethodPlaceholder: View {
+  let paymentMethodType: String
+  let checkoutScope: PrimerCheckoutScope
+
+  @Environment(\.designTokens) private var tokens
+  @Environment(\.sizeCategory) private var sizeCategory  // Observes Dynamic Type changes
+
+  var body: some View {
+    VStack(spacing: 0) {
+      navigationBar
+
+      VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+        Spacer()
+
+        paymentMethodLogo
+
+        Text(CheckoutComponentsStrings.paymentMethodDisplayName(displayName))
+          .font(PrimerFont.headline(tokens: tokens))
+
+        Text(CheckoutComponentsStrings.implementationComingSoon)
+          .font(PrimerFont.subheadline(tokens: tokens))
+          .foregroundColor(CheckoutColors.secondary(tokens: tokens))
+
+        Spacer()
+      }
+      .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(CheckoutColors.background(tokens: tokens))
+  }
+
+  private var navigationBar: some View {
+    HStack {
+      // Try to navigate back if we have access to the navigator, otherwise just show cancel
+      if let defaultScope = checkoutScope as? DefaultCheckoutScope {
+        Button(
+          action: {
+            defaultScope.checkoutNavigator.navigateBack()
+          },
+          label: {
+            HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+              Image(systemName: RTLIcon.backChevron)
+                .font(PrimerFont.bodyMedium(tokens: tokens))
+              Text(CheckoutComponentsStrings.backButton)
+            }
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          }
+        )
+        .accessibility(
+          config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.Common.backButton,
+            label: CheckoutComponentsStrings.a11yBack,
+            traits: [.isButton]
+          )
+        )
+      } else {
+        // Fallback to cancel button if we can't access internal navigator
+        Button(
+          CheckoutComponentsStrings.cancelButton,
+          action: {
+            checkoutScope.onDismiss()
+          }
+        )
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .accessibility(
+          config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.Common.closeButton,
+            label: CheckoutComponentsStrings.a11yCancel,
+            traits: [.isButton]
+          )
+        )
+      }
+
+      Spacer()
+    }
+    .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+    .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+  }
+
+  /// Payment method logo using bundled assets (same pattern as PaymentMethodSelectionScreen)
+  private var paymentMethodLogo: some View {
+    // Use bundled asset images based on payment method type
+    let paymentMethodType = PrimerPaymentMethodType(rawValue: paymentMethodType)
+    let imageName = paymentMethodType?.defaultImageName ?? .genericCard
+    let fallbackImage = imageName.image
+
+    return Image(uiImage: fallbackImage ?? UIImage())
+      .resizable()
+      .aspectRatio(contentMode: .fit)
+      .frame(width: 80, height: 80)
+      .accessibilityHidden(true)  // Decorative image, payment method name is announced via text
+  }
+
+  private var displayName: String {
+    // Use raw value with proper formatting as fallback
+    // Converts "PAYMENT_CARD" → "Payment Card", "PAYPAL" → "Paypal"
+    paymentMethodType
+      .replacingOccurrences(of: "_", with: " ")
+      .capitalized
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodComponents.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodComponents.swift
@@ -29,8 +29,7 @@ struct PaymentMethodScreen: View {
         PaymentMethodPlaceholder(
           paymentMethodType: paymentMethodType,
           checkoutScope: checkoutScope
-        )
-      )
+        ))
     }
   }
 }
@@ -91,8 +90,7 @@ struct PaymentMethodPlaceholder: View {
             identifier: AccessibilityIdentifiers.Common.backButton,
             label: CheckoutComponentsStrings.a11yBack,
             traits: [.isButton]
-          )
-        )
+          ))
       } else {
         // Fallback to cancel button if we can't access internal navigator
         Button(
@@ -107,8 +105,7 @@ struct PaymentMethodPlaceholder: View {
             identifier: AccessibilityIdentifiers.Common.closeButton,
             label: CheckoutComponentsStrings.a11yCancel,
             traits: [.isButton]
-          )
-        )
+          ))
       }
 
       Spacer()
@@ -127,7 +124,7 @@ struct PaymentMethodPlaceholder: View {
     return Image(uiImage: fallbackImage ?? UIImage())
       .resizable()
       .aspectRatio(contentMode: .fit)
-      .frame(width: 80, height: 80)
+      .frame(width: PrimerIconSize.paymentMethodLargeWidth, height: PrimerIconSize.paymentMethodLargeHeight)
       .accessibilityHidden(true)  // Decorative image, payment method name is announced via text
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodsSection.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodsSection.swift
@@ -18,6 +18,7 @@ struct PaymentMethodsSection: View {
       Text(CheckoutComponentsStrings.choosePaymentMethod)
         .font(PrimerFont.titleLarge(tokens: tokens))
         .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .accessibilityAddTraits(.isHeader)
 
       if state.isLoading {
         makeLoadingView()
@@ -44,6 +45,7 @@ struct PaymentMethodsSection: View {
       )
       .scaleEffect(PrimerScale.large)
       .frame(maxWidth: .infinity, minHeight: PrimerComponentHeight.emptyStateMinHeight)
+      .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
   }
 
   // MARK: - Empty State

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodsSection.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodsSection.swift
@@ -1,0 +1,82 @@
+//
+//  PaymentMethodsSection.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct PaymentMethodsSection: View {
+  let state: PrimerPaymentMethodSelectionState
+  let scope: PrimerPaymentMethodSelectionScope
+
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: PrimerSpacing.medium(tokens: tokens)) {
+      Text(CheckoutComponentsStrings.choosePaymentMethod)
+        .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+      if state.isLoading {
+        makeLoadingView()
+      } else if state.paymentMethods.isEmpty {
+        makeEmptyStateView()
+      } else {
+        makePaymentMethodsList()
+      }
+
+      if let error = state.error {
+        Text(error)
+          .font(PrimerFont.caption(tokens: tokens))
+          .foregroundColor(CheckoutColors.borderError(tokens: tokens))
+      }
+    }
+  }
+
+  // MARK: - Loading
+
+  private func makeLoadingView() -> some View {
+    ProgressView()
+      .progressViewStyle(
+        CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+      )
+      .scaleEffect(PrimerScale.large)
+      .frame(maxWidth: .infinity, minHeight: PrimerComponentHeight.emptyStateMinHeight)
+  }
+
+  // MARK: - Empty State
+
+  @ViewBuilder
+  private func makeEmptyStateView() -> some View {
+    if let customEmptyState = scope.emptyStateView {
+      AnyView(customEmptyState())
+    } else {
+      VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+        Image(systemName: "creditcard.and.123")
+          .font(PrimerFont.largeIcon(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        Text(CheckoutComponentsStrings.noPaymentMethodsAvailable)
+          .font(PrimerFont.body(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+      }
+      .frame(maxWidth: .infinity)
+      .padding(.top, PrimerComponentHeight.emptyStateTopPadding)
+    }
+  }
+
+  // MARK: - Payment Methods List
+
+  private func makePaymentMethodsList() -> some View {
+    LazyVStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+      ForEach(state.paymentMethods, id: \.id) { method in
+        PaymentMethodButton(
+          method: method,
+          customItem: scope.paymentMethodItem,
+          onSelect: { scope.onPaymentMethodSelected(paymentMethod: method) }
+        )
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/SDKInitializationViews.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/SDKInitializationViews.swift
@@ -1,0 +1,38 @@
+//
+//  SDKInitializationViews.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+// MARK: - SDK Initialization UI Components
+
+@available(iOS 15.0, *)
+struct SDKInitializationErrorView: View {
+  let error: PrimerError
+  let onRetry: () -> Void
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    VStack(spacing: 20) {
+      Image(systemName: "exclamationmark.triangle")
+        .font(PrimerFont.largeIcon(tokens: tokens))
+        .foregroundColor(CheckoutColors.orange(tokens: tokens))
+
+      Text(CheckoutComponentsStrings.paymentSystemError)
+        .font(PrimerFont.headline(tokens: tokens))
+
+      Text(error.localizedDescription)
+        .font(PrimerFont.subheadline(tokens: tokens))
+        .foregroundColor(CheckoutColors.secondary(tokens: tokens))
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+
+      Button(CheckoutComponentsStrings.retryButton, action: onRetry)
+      .buttonStyle(.borderedProminent)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .padding(PrimerSpacing.large(tokens: tokens))
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultSection.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultSection.swift
@@ -49,8 +49,7 @@ struct VaultSection: View {
           identifier: AccessibilityIdentifiers.PaymentSelection.showAllButton,
           label: CheckoutComponentsStrings.a11yShowAll,
           traits: [.isButton]
-        )
-      )
+        ))
     }
   }
 
@@ -70,8 +69,7 @@ struct VaultSection: View {
                 errorMessage: $cvvError,
                 cardNetwork: cardNetwork,
                 onCvvChange: scope.updateCvvInput
-              )
-            )
+              ))
           } : nil
       )
 
@@ -96,8 +94,8 @@ struct VaultSection: View {
         if isLoading {
           ProgressView()
             .progressViewStyle(
-              CircularProgressViewStyle(tint: CheckoutColors.background(tokens: tokens))
-            )
+              CircularProgressViewStyle(tint: CheckoutColors.background(tokens: tokens)))
+            .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
         } else {
           Text(CheckoutComponentsStrings.payButton)
         }
@@ -110,8 +108,7 @@ struct VaultSection: View {
         RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
           .fill(
             isPayButtonEnabled
-              ? CheckoutColors.borderFocus(tokens: tokens) : CheckoutColors.gray300(tokens: tokens)
-          )
+              ? CheckoutColors.borderFocus(tokens: tokens) : CheckoutColors.gray300(tokens: tokens))
       )
     }
     .disabled(!isPayButtonEnabled)
@@ -120,8 +117,7 @@ struct VaultSection: View {
         identifier: AccessibilityIdentifiers.Vault.payButton,
         label: CheckoutComponentsStrings.payButton,
         traits: [.isButton]
-      )
-    )
+      ))
   }
 
   // MARK: - Helpers

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultSection.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultSection.swift
@@ -1,0 +1,145 @@
+//
+//  VaultSection.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct VaultSection: View {
+  let vaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
+  let scope: PrimerPaymentMethodSelectionScope
+  let isLoading: Bool
+  let requiresCvvInput: Bool
+  @Binding var cvvInput: String
+  @Binding var isCvvValid: Bool
+  @Binding var cvvError: String?
+
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: PrimerSpacing.medium(tokens: tokens)) {
+      makeHeader()
+      makeContent()
+    }
+  }
+
+  // MARK: - Header
+
+  private func makeHeader() -> some View {
+    HStack {
+      Text(CheckoutComponentsStrings.savedPaymentMethods)
+        .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+      Spacer()
+
+      Button(action: scope.showAllVaultedPaymentMethods) {
+        HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+          Text(CheckoutComponentsStrings.showAll)
+            .font(PrimerFont.titleLarge(tokens: tokens))
+          Image(systemName: "chevron.down")
+            .font(PrimerFont.caption(tokens: tokens))
+        }
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      }
+      .accessibility(
+        config: AccessibilityConfiguration(
+          identifier: AccessibilityIdentifiers.PaymentSelection.showAllButton,
+          label: CheckoutComponentsStrings.a11yShowAll,
+          traits: [.isButton]
+        )
+      )
+    }
+  }
+
+  // MARK: - Content
+
+  private func makeContent() -> some View {
+    VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+      VaultedPaymentMethodCard(
+        vaultedPaymentMethod: vaultedPaymentMethod,
+        isSelected: true,
+        cvvInputContent: requiresCvvInput
+          ? {
+            AnyView(
+              VaultedCardCVVInput(
+                cvv: $cvvInput,
+                isValid: $isCvvValid,
+                errorMessage: $cvvError,
+                cardNetwork: cardNetwork,
+                onCvvChange: scope.updateCvvInput
+              )
+            )
+          } : nil
+      )
+
+      makePayButton()
+    }
+    .padding(PrimerSpacing.small(tokens: tokens))
+    .background(
+      RoundedRectangle(cornerRadius: PrimerRadius.large(tokens: tokens))
+        .fill(CheckoutColors.gray100(tokens: tokens))
+    )
+  }
+
+  // MARK: - Pay Button
+
+  private func makePayButton() -> some View {
+    Button(action: {
+      Task {
+        await scope.payWithVaultedPaymentMethod()
+      }
+    }) {
+      HStack {
+        if isLoading {
+          ProgressView()
+            .progressViewStyle(
+              CircularProgressViewStyle(tint: CheckoutColors.background(tokens: tokens))
+            )
+        } else {
+          Text(CheckoutComponentsStrings.payButton)
+        }
+      }
+      .font(PrimerFont.titleLarge(tokens: tokens))
+      .foregroundColor(CheckoutColors.background(tokens: tokens))
+      .frame(maxWidth: .infinity)
+      .padding(PrimerSpacing.medium(tokens: tokens))
+      .background(
+        RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+          .fill(
+            isPayButtonEnabled
+              ? CheckoutColors.borderFocus(tokens: tokens) : CheckoutColors.gray300(tokens: tokens)
+          )
+      )
+    }
+    .disabled(!isPayButtonEnabled)
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.Vault.payButton,
+        label: CheckoutComponentsStrings.payButton,
+        traits: [.isButton]
+      )
+    )
+  }
+
+  // MARK: - Helpers
+
+  private var isPayButtonEnabled: Bool {
+    if isLoading {
+      return false
+    }
+    if requiresCvvInput {
+      return isCvvValid
+    }
+    return true
+  }
+
+  private var cardNetwork: CardNetwork {
+    let network =
+      vaultedPaymentMethod.paymentInstrumentData.network ?? vaultedPaymentMethod
+      .paymentInstrumentData.binData?.network ?? "Card"
+    return CardNetwork(rawValue: network.uppercased()) ?? .unknown
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
@@ -77,8 +77,7 @@ struct VaultedCardCVVInput: View {
           identifier: AccessibilityIdentifiers.Vault.cvvSecurityLabel,
           label: CheckoutComponentsStrings.cvvRecaptureInstruction,
           traits: []
-        )
-      )
+        ))
 
       Spacer()
 
@@ -89,7 +88,7 @@ struct VaultedCardCVVInput: View {
   // MARK: - CVV Text Field
 
   private func makeCvvTextField() -> some View {
-    TextField(cvvPlaceholder, text: filteredCvvBinding)
+    SecureField(cvvPlaceholder, text: filteredCvvBinding)
       .keyboardType(.numberPad)
       .textContentType(.oneTimeCode)
       .focused($isFocused)
@@ -106,8 +105,7 @@ struct VaultedCardCVVInput: View {
         RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
           .stroke(
             cvvBorderColor,
-            lineWidth: isFocused ? PrimerBorderWidth.selected : PrimerBorderWidth.standard
-          )
+            lineWidth: isFocused ? PrimerBorderWidth.selected : PrimerBorderWidth.standard)
       )
       .accessibility(
         config: AccessibilityConfiguration(
@@ -115,8 +113,7 @@ struct VaultedCardCVVInput: View {
           label: CheckoutComponentsStrings.a11yVaultCVVLabel,
           hint: CheckoutComponentsStrings.a11yVaultCVVHint(length: expectedCvvLength),
           traits: []
-        )
-      )
+        ))
   }
 
   // MARK: - Error Label

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
@@ -1,0 +1,193 @@
+//
+//  VaultedCardCVVInput.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct VaultedCardCVVInput: View {
+  @Binding var cvv: String
+  @Binding var isValid: Bool
+  @Binding var errorMessage: String?
+
+  let cardNetwork: CardNetwork
+  let onCvvChange: (String) -> Void
+
+  @Environment(\.designTokens) private var tokens
+  @FocusState private var isFocused: Bool
+
+  // MARK: - Computed Properties
+
+  private var expectedCvvLength: Int {
+    cardNetwork.validation?.code.length ?? 3
+  }
+
+  private var cvvPlaceholder: String {
+    String(repeating: CheckoutComponentsStrings.cvvPlaceholderDigit, count: expectedCvvLength)
+  }
+
+  /// Custom binding that filters input to digits only and limits length
+  private var filteredCvvBinding: Binding<String> {
+    Binding(
+      get: { cvv },
+      set: { newValue in
+        let filtered = String(newValue.filter(\.isNumber).prefix(expectedCvvLength))
+        // Only update if the filtered value is different to avoid unnecessary updates
+        if cvv != filtered {
+          cvv = filtered
+        }
+        onCvvChange(filtered)
+      }
+    )
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: PrimerSpacing.small(tokens: tokens)) {
+      makeCvvInputRow()
+      errorMessage.map(makeErrorLabel)
+    }
+    .onAppear {
+      DispatchQueue.main.asyncAfter(deadline: .now() + PrimerAnimationDuration.focusDelay) {
+        isFocused = true
+      }
+    }
+  }
+
+  // MARK: - CVV Input Row
+
+  private func makeCvvInputRow() -> some View {
+    HStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+      HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+        Image(systemName: "lock.fill")
+          .font(PrimerFont.bodySmall(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+
+        Text(CheckoutComponentsStrings.cvvRecaptureInstruction)
+          .font(PrimerFont.bodySmall(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          .lineLimit(2)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .accessibility(
+        config: AccessibilityConfiguration(
+          identifier: AccessibilityIdentifiers.Vault.cvvSecurityLabel,
+          label: CheckoutComponentsStrings.cvvRecaptureInstruction,
+          traits: []
+        )
+      )
+
+      Spacer()
+
+      makeCvvTextField()
+    }
+  }
+
+  // MARK: - CVV Text Field
+
+  private func makeCvvTextField() -> some View {
+    TextField(cvvPlaceholder, text: filteredCvvBinding)
+      .keyboardType(.numberPad)
+      .textContentType(.oneTimeCode)
+      .focused($isFocused)
+      .multilineTextAlignment(.leading)
+      .font(PrimerFont.bodyLarge(tokens: tokens))
+      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
+      .frame(width: PrimerComponentWidth.cvvFieldMax, height: PrimerSize.xxlarge(tokens: tokens))
+      .background(
+        RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+          .fill(CheckoutColors.background(tokens: tokens))
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+          .stroke(
+            cvvBorderColor,
+            lineWidth: isFocused ? PrimerBorderWidth.selected : PrimerBorderWidth.standard
+          )
+      )
+      .accessibility(
+        config: AccessibilityConfiguration(
+          identifier: AccessibilityIdentifiers.Vault.cvvField,
+          label: CheckoutComponentsStrings.a11yVaultCVVLabel,
+          hint: CheckoutComponentsStrings.a11yVaultCVVHint(length: expectedCvvLength),
+          traits: []
+        )
+      )
+  }
+
+  // MARK: - Error Label
+
+  private func makeErrorLabel(_ message: String) -> some View {
+    Text(message)
+      .font(PrimerFont.bodySmall(tokens: tokens))
+      .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
+  }
+
+  // MARK: - Helpers
+
+  private var cvvBorderColor: Color {
+    if errorMessage != nil {
+      CheckoutColors.borderError(tokens: tokens)
+    } else if isFocused {
+      CheckoutColors.borderFocus(tokens: tokens)
+    } else {
+      CheckoutColors.borderDefault(tokens: tokens)
+    }
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+  @available(iOS 17.0, *)
+  #Preview("CVV Input - Empty") {
+    VaultedCardCVVInput(
+      cvv: .constant(""),
+      isValid: .constant(false),
+      errorMessage: .constant(nil),
+      cardNetwork: .visa,
+      onCvvChange: { _ in }
+    )
+    .padding()
+  }
+
+  @available(iOS 17.0, *)
+  #Preview("CVV Input - Valid") {
+    VaultedCardCVVInput(
+      cvv: .constant("123"),
+      isValid: .constant(true),
+      errorMessage: .constant(nil),
+      cardNetwork: .visa,
+      onCvvChange: { _ in }
+    )
+    .padding()
+  }
+
+  @available(iOS 17.0, *)
+  #Preview("CVV Input - Error") {
+    VaultedCardCVVInput(
+      cvv: .constant("12"),
+      isValid: .constant(false),
+      errorMessage: .constant("Please enter a valid CVV"),
+      cardNetwork: .visa,
+      onCvvChange: { _ in }
+    )
+    .padding()
+  }
+
+  @available(iOS 17.0, *)
+  #Preview("CVV Input - AMEX (4 digits)") {
+    VaultedCardCVVInput(
+      cvv: .constant(""),
+      isValid: .constant(false),
+      errorMessage: .constant(nil),
+      cardNetwork: .amex,
+      onCvvChange: { _ in }
+    )
+    .padding()
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedPaymentMethod+DisplayData.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedPaymentMethod+DisplayData.swift
@@ -1,0 +1,241 @@
+//
+//  VaultedPaymentMethod+DisplayData.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+// MARK: - VaultedPaymentMethod Display Data Extension
+
+@available(iOS 15.0, *)
+extension PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+
+  /// Extracts normalized display data based on payment instrument type.
+  /// This computed property handles the polymorphic nature of vaulted payment methods,
+  /// returning a unified display model regardless of the underlying payment type.
+  var displayData: VaultedPaymentMethodDisplayData {
+    switch paymentInstrumentType {
+    case .paymentCard, .cardOffSession:
+      cardDisplayData(from: paymentInstrumentData)
+    case .payPalBillingAgreement:
+      paypalDisplayData(from: paymentInstrumentData)
+    case .klarna, .klarnaCustomerToken, .klarnaPaymentSession:
+      klarnaDisplayData(from: paymentInstrumentData)
+    case .stripeAch:
+      achDisplayData(from: paymentInstrumentData)
+    case .goCardlessMandate:
+      goCardlessDisplayData(from: paymentInstrumentData)
+    case .applePay:
+      applePayDisplayData()
+    case .googlePay:
+      googlePayDisplayData()
+    default:
+      genericDisplayData()
+    }
+  }
+
+  // MARK: - Card Display Data
+
+  private func cardDisplayData(from data: Response.Body.Tokenization.PaymentInstrumentData)
+    -> VaultedPaymentMethodDisplayData {
+    let network = data.network ?? data.binData?.network ?? "Card"
+    let cardNetwork = CardNetwork(rawValue: network.uppercased()) ?? .unknown
+    let brandIcon = cardNetwork.icon ?? ImageName.creditCard.image
+
+    let last4 = data.last4Digits
+    let primaryValue = last4.map { CheckoutComponentsStrings.maskedCardNumberFormatted($0) }
+
+    var secondaryValue: String?
+    if let month = data.expirationMonth, let year = data.expirationYear {
+      let shortYear = year.count > 2 ? String(year.suffix(2)) : year
+      secondaryValue = CheckoutComponentsStrings.expiresDate(month: month, year: shortYear)
+    }
+
+    let accessibilityLabel = CheckoutComponentsStrings.a11yVaultedCard(
+      network: cardNetwork.displayName,
+      last4: last4 ?? "****",
+      expiry: secondaryValue ?? "",
+      name: data.cardholderName
+    )
+
+    return VaultedPaymentMethodDisplayData(
+      name: data.cardholderName,
+      brandIcon: brandIcon,
+      brandName: cardNetwork.displayName,
+      primaryValue: primaryValue,
+      secondaryValue: secondaryValue,
+      accessibilityLabel: accessibilityLabel
+    )
+  }
+
+  // MARK: - PayPal Display Data
+
+  private func paypalDisplayData(from data: Response.Body.Tokenization.PaymentInstrumentData)
+    -> VaultedPaymentMethodDisplayData {
+    let payerInfo = data.externalPayerInfo
+    let name = buildPayPalName(from: payerInfo)
+    let email = payerInfo?.email
+    let maskedEmail = email.map { maskEmail($0) }
+
+    let accessibilityLabel = CheckoutComponentsStrings.a11yVaultedPayPal(
+      email: email,
+      name: name
+    )
+
+    return VaultedPaymentMethodDisplayData(
+      name: name,
+      brandIcon: UIImage(primerResource: "paypal-icon-colored"),
+      brandName: CheckoutComponentsStrings.paypalBrandName,
+      primaryValue: maskedEmail,
+      secondaryValue: nil,
+      accessibilityLabel: accessibilityLabel
+    )
+  }
+
+  private func buildPayPalName(from payerInfo: Response.Body.Tokenization.PayPal.ExternalPayerInfo?)
+    -> String? {
+    guard let payerInfo else { return nil }
+
+    let firstName = payerInfo.firstName ?? payerInfo.firstNameSnakeCase
+    let lastName = payerInfo.lastName ?? payerInfo.lastNameSnakeCase
+
+    if let firstName, let lastName {
+      return "\(firstName) \(lastName)"
+    } else if let firstName {
+      return firstName
+    } else if let lastName {
+      return lastName
+    }
+    return nil
+  }
+
+  // MARK: - Klarna Display Data
+
+  private func klarnaDisplayData(from data: Response.Body.Tokenization.PaymentInstrumentData)
+    -> VaultedPaymentMethodDisplayData {
+    let email = data.sessionData?.billingAddress?.email
+    let maskedEmail = email.map { maskEmail($0) }
+
+    let accessibilityLabel = CheckoutComponentsStrings.a11yVaultedKlarna(email: email)
+
+    return VaultedPaymentMethodDisplayData(
+      name: nil,
+      brandIcon: UIImage(primerResource: "klarna-icon-colored"),
+      brandName: CheckoutComponentsStrings.klarnaBrandName,
+      primaryValue: maskedEmail,
+      secondaryValue: nil,
+      accessibilityLabel: accessibilityLabel
+    )
+  }
+
+  // MARK: - ACH Display Data
+
+  private func achDisplayData(from data: Response.Body.Tokenization.PaymentInstrumentData)
+    -> VaultedPaymentMethodDisplayData {
+    let bankName = data.bankName ?? "Bank"
+    let brandName = "\(bankName) \(CheckoutComponentsStrings.achSuffix)"
+
+    let last4 = data.accountNumberLast4Digits
+    let primaryValue = last4.map { CheckoutComponentsStrings.maskedCardNumberFormatted($0) }
+
+    let accessibilityLabel = CheckoutComponentsStrings.a11yVaultedACH(
+      bankName: bankName,
+      last4: last4
+    )
+
+    return VaultedPaymentMethodDisplayData(
+      name: data.cardholderName,
+      brandIcon: ImageName.achBank.image,
+      brandName: brandName,
+      primaryValue: primaryValue,
+      secondaryValue: nil,
+      accessibilityLabel: accessibilityLabel
+    )
+  }
+
+  // MARK: - GoCardless Display Data
+
+  private func goCardlessDisplayData(from data: Response.Body.Tokenization.PaymentInstrumentData)
+    -> VaultedPaymentMethodDisplayData {
+    let bankName = data.bankName ?? "Bank"
+    let brandName = "\(bankName) (Direct Debit)"
+
+    let last4 = data.accountNumberLast4Digits
+    let primaryValue = last4.map { CheckoutComponentsStrings.maskedCardNumberFormatted($0) }
+
+    let accessibilityLabel = CheckoutComponentsStrings.a11yVaultedACH(
+      bankName: bankName,
+      last4: last4
+    )
+
+    return VaultedPaymentMethodDisplayData(
+      name: data.cardholderName,
+      brandIcon: UIImage(primerResource: "gocardless-logo-colored"),
+      brandName: brandName,
+      primaryValue: primaryValue,
+      secondaryValue: nil,
+      accessibilityLabel: accessibilityLabel
+    )
+  }
+
+  // MARK: - Apple Pay Display Data
+
+  private func applePayDisplayData() -> VaultedPaymentMethodDisplayData {
+    VaultedPaymentMethodDisplayData(
+      name: nil,
+      brandIcon: UIImage(primerResource: "apple-pay-icon-colored"),
+      brandName: "Apple Pay",
+      primaryValue: nil,
+      secondaryValue: nil,
+      accessibilityLabel: CheckoutComponentsStrings.a11yVaultedPaymentMethod("Apple Pay")
+    )
+  }
+
+  // MARK: - Google Pay Display Data
+
+  private func googlePayDisplayData() -> VaultedPaymentMethodDisplayData {
+    VaultedPaymentMethodDisplayData(
+      name: nil,
+      brandIcon: UIImage(primerResource: "google-pay-icon"),
+      brandName: "Google Pay",
+      primaryValue: nil,
+      secondaryValue: nil,
+      accessibilityLabel: CheckoutComponentsStrings.a11yVaultedPaymentMethod("Google Pay")
+    )
+  }
+
+  // MARK: - Generic Display Data
+
+  private func genericDisplayData() -> VaultedPaymentMethodDisplayData {
+    let icon =
+      PrimerPaymentMethodType(rawValue: paymentMethodType)?.icon ?? ImageName.genericCard.image
+
+    return VaultedPaymentMethodDisplayData(
+      name: nil,
+      brandIcon: icon,
+      brandName: paymentMethodType,
+      primaryValue: nil,
+      secondaryValue: nil,
+      accessibilityLabel: CheckoutComponentsStrings.a11yVaultedPaymentMethod(paymentMethodType)
+    )
+  }
+
+  // MARK: - Email Masking
+
+  private func maskEmail(_ email: String) -> String {
+    guard let atIndex = email.firstIndex(of: "@") else {
+      return email
+    }
+
+    let localPart = String(email[..<atIndex])
+    let domain = String(email[atIndex...])
+
+    if localPart.count <= 2 {
+      return "\(localPart)••••\(domain)"
+    }
+
+    let visiblePrefix = String(localPart.prefix(2))
+    return "\(visiblePrefix)••••\(domain)"
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedPaymentMethodCard.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedPaymentMethodCard.swift
@@ -66,12 +66,10 @@ struct VaultedPaymentMethodCard: View {
     .accessibility(
       config: AccessibilityConfiguration(
         identifier: AccessibilityIdentifiers.PaymentSelection.vaultedPaymentMethodItem(
-          vaultedPaymentMethod.id
-        ),
+          vaultedPaymentMethod.id),
         label: vaultedPaymentMethod.displayData.accessibilityLabel,
         traits: isEditMode ? [] : (isSelected ? [.isButton, .isSelected] : [.isButton])
-      )
-    )
+      ))
   }
 
   // MARK: - Main Card Row
@@ -99,19 +97,17 @@ struct VaultedPaymentMethodCard: View {
           .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
           .frame(width: 20, height: 20)
       }
-      .frame(width: 36, height: 36)
+      .frame(width: 44, height: 44)
       .contentShape(Rectangle())
     }
     .buttonStyle(PlainButtonStyle())
     .accessibility(
       config: AccessibilityConfiguration(
         identifier: AccessibilityIdentifiers.PaymentSelection.deletePaymentMethodButton(
-          vaultedPaymentMethod.id
-        ),
+          vaultedPaymentMethod.id),
         label: CheckoutComponentsStrings.a11yDeletePaymentMethod,
         traits: [.isButton]
-      )
-    )
+      ))
   }
 
   // MARK: - Display Data

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedPaymentMethodCard.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedPaymentMethodCard.swift
@@ -1,0 +1,410 @@
+//
+//  VaultedPaymentMethodCard.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct VaultedPaymentMethodCard: View {
+  let vaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
+  let isSelected: Bool
+  let isEditMode: Bool
+  let cvvInputContent: (() -> AnyView)?
+  let onTap: (() -> Void)?
+  let onDeleteTapped: (() -> Void)?
+
+  @Environment(\.designTokens) private var tokens
+
+  // MARK: - Initialization
+
+  init(
+    vaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod,
+    isSelected: Bool = false,
+    isEditMode: Bool = false,
+    cvvInputContent: (() -> AnyView)? = nil,
+    onTap: (() -> Void)? = nil,
+    onDeleteTapped: (() -> Void)? = nil
+  ) {
+    self.vaultedPaymentMethod = vaultedPaymentMethod
+    self.isSelected = isSelected
+    self.isEditMode = isEditMode
+    self.cvvInputContent = cvvInputContent
+    self.onTap = onTap
+    self.onDeleteTapped = onDeleteTapped
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    HStack(spacing: 0) {
+      makeCardContent()
+      if isEditMode {
+        makeDeleteButton()
+      }
+    }
+  }
+
+  // MARK: - Card Content
+
+  private func makeCardContent() -> some View {
+    Button(action: { if !isEditMode { onTap?() } }) {
+      VStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+        makeMainCardRow()
+
+        if let cvvInputContent {
+          cvvInputContent()
+        }
+      }
+      .padding(PrimerSpacing.medium(tokens: tokens))
+      .frame(height: cvvInputContent == nil ? PrimerComponentHeight.vaultedPaymentMethodCard : nil)
+      .background(makeCardBackground())
+      .overlay(makeCardBorder())
+    }
+    .buttonStyle(PlainButtonStyle())
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.PaymentSelection.vaultedPaymentMethodItem(
+          vaultedPaymentMethod.id
+        ),
+        label: vaultedPaymentMethod.displayData.accessibilityLabel,
+        traits: isEditMode ? [] : (isSelected ? [.isButton, .isSelected] : [.isButton])
+      )
+    )
+  }
+
+  // MARK: - Main Card Row
+
+  private func makeMainCardRow() -> some View {
+    HStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+      makeLeftContent()
+      Spacer()
+      makeRightContent()
+      if isSelected, !isEditMode {
+        makeCheckmark()
+      }
+    }
+    .frame(height: PrimerComponentHeight.vaultedPaymentMethodCardContentRow)
+  }
+
+  // MARK: - Delete Button
+
+  private func makeDeleteButton() -> some View {
+    Button(action: { onDeleteTapped?() }) {
+      HStack {
+        Spacer()
+        Image(systemName: "xmark")
+          .font(.system(size: 10))
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          .frame(width: 20, height: 20)
+      }
+      .frame(width: 36, height: 36)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(PlainButtonStyle())
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.PaymentSelection.deletePaymentMethodButton(
+          vaultedPaymentMethod.id
+        ),
+        label: CheckoutComponentsStrings.a11yDeletePaymentMethod,
+        traits: [.isButton]
+      )
+    )
+  }
+
+  // MARK: - Display Data
+
+  private var displayData: VaultedPaymentMethodDisplayData {
+    vaultedPaymentMethod.displayData
+  }
+
+  // MARK: - Left Content
+
+  private func makeLeftContent() -> some View {
+    VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+      // Name row (hidden if nil)
+      if let name = displayData.name {
+        Text(name)
+          .font(PrimerFont.bodyLarge(tokens: tokens))
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          .lineLimit(1)
+      }
+
+      // Brand row
+      HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+        makeBrandBadge()
+        Text(displayData.brandName)
+          .font(PrimerFont.bodySmall(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          .lineLimit(1)
+      }
+    }
+  }
+
+  // MARK: - Brand Badge
+
+  private func makeBrandBadge() -> some View {
+    Group {
+      if let icon = displayData.brandIcon {
+        Image(uiImage: icon)
+          .resizable()
+          .aspectRatio(contentMode: .fill)
+          .frame(
+            width: PrimerCardNetworkSelector.badgeWidth,
+            height: PrimerCardNetworkSelector.badgeHeight
+          )
+          .clipped()
+          .cornerRadius(PrimerRadius.xsmall(tokens: tokens))
+      } else {
+        // Fallback: 2-letter abbreviation
+        Text(displayData.brandName.prefix(2).uppercased())
+          .font(PrimerFont.smallBadge(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          .frame(
+            width: PrimerCardNetworkSelector.badgeWidth,
+            height: PrimerCardNetworkSelector.badgeHeight
+          )
+          .background(CheckoutColors.gray100(tokens: tokens))
+          .cornerRadius(PrimerRadius.xsmall(tokens: tokens))
+      }
+    }
+  }
+
+  // MARK: - Right Content
+
+  @ViewBuilder
+  private func makeRightContent() -> some View {
+    VStack(alignment: .trailing, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+      if let primaryValue = displayData.primaryValue {
+        Text(primaryValue)
+          .font(PrimerFont.bodyMedium(tokens: tokens))
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          .lineLimit(1)
+      }
+
+      if let secondaryValue = displayData.secondaryValue {
+        Text(secondaryValue)
+          .font(PrimerFont.bodySmall(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          .lineLimit(1)
+      }
+    }
+  }
+
+  // MARK: - Checkmark
+
+  private func makeCheckmark() -> some View {
+    Image(systemName: "checkmark")
+      .font(PrimerFont.body(tokens: tokens))
+      .foregroundColor(CheckoutColors.borderFocus(tokens: tokens))
+  }
+
+  // MARK: - Card Background
+
+  private func makeCardBackground() -> some View {
+    RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+      .fill(CheckoutColors.background(tokens: tokens))
+  }
+
+  // MARK: - Card Border
+
+  private func makeCardBorder() -> some View {
+    RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+      .stroke(
+        isSelected
+          ? CheckoutColors.borderFocus(tokens: tokens)
+          : CheckoutColors.borderDefault(tokens: tokens),
+        lineWidth: isSelected ? PrimerBorderWidth.selected : PrimerBorderWidth.standard
+      )
+  }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  private enum VaultedPaymentMethodPreviewData {
+
+    // MARK: - Mock PaymentInstrumentData
+
+    static func makePaymentInstrumentData(
+      last4Digits: String? = nil,
+      expirationMonth: String? = nil,
+      expirationYear: String? = nil,
+      cardholderName: String? = nil,
+      network: String? = nil,
+      bankName: String? = nil,
+      accountNumberLast4Digits: String? = nil,
+      externalPayerInfo: [String: Any]? = nil
+    ) -> Response.Body.Tokenization.PaymentInstrumentData {
+      var json: [String: Any] = [:]
+
+      if let last4Digits { json["last4Digits"] = last4Digits }
+      if let expirationMonth { json["expirationMonth"] = expirationMonth }
+      if let expirationYear { json["expirationYear"] = expirationYear }
+      if let cardholderName { json["cardholderName"] = cardholderName }
+      if let network { json["network"] = network }
+      if let bankName { json["bankName"] = bankName }
+      if let accountNumberLast4Digits {
+        json["accountNumberLast4Digits"] = accountNumberLast4Digits
+      }
+      if let externalPayerInfo { json["externalPayerInfo"] = externalPayerInfo }
+
+      let data = try! JSONSerialization.data(withJSONObject: json)  // swiftlint:disable:this force_try
+      return try! JSONDecoder().decode(  // swiftlint:disable:this force_try
+        Response.Body.Tokenization.PaymentInstrumentData.self, from: data)
+    }
+
+    // MARK: - Mock VaultedPaymentMethod
+
+    static func makeVaultedPaymentMethod(
+      id: String = UUID().uuidString,
+      paymentMethodType: String,
+      paymentInstrumentType: PaymentInstrumentType,
+      paymentInstrumentData: Response.Body.Tokenization.PaymentInstrumentData
+    ) -> PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+      PrimerHeadlessUniversalCheckout.VaultedPaymentMethod(
+        id: id,
+        paymentMethodType: paymentMethodType,
+        paymentInstrumentType: paymentInstrumentType,
+        paymentInstrumentData: paymentInstrumentData,
+        analyticsId: "preview-analytics-id"
+      )
+    }
+
+    // MARK: - Sample Data
+
+    static var visaCard: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+      makeVaultedPaymentMethod(
+        paymentMethodType: "PAYMENT_CARD",
+        paymentInstrumentType: .paymentCard,
+        paymentInstrumentData: makePaymentInstrumentData(
+          last4Digits: "4242",
+          expirationMonth: "12",
+          expirationYear: "2026",
+          cardholderName: "John Appleseed",
+          network: "Visa"
+        )
+      )
+    }
+
+    static var mastercard: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+      makeVaultedPaymentMethod(
+        paymentMethodType: "PAYMENT_CARD",
+        paymentInstrumentType: .paymentCard,
+        paymentInstrumentData: makePaymentInstrumentData(
+          last4Digits: "5678",
+          expirationMonth: "03",
+          expirationYear: "2025",
+          network: "Mastercard"
+        )
+      )
+    }
+
+    static var paypal: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+      makeVaultedPaymentMethod(
+        paymentMethodType: "PAYPAL",
+        paymentInstrumentType: .payPalBillingAgreement,
+        paymentInstrumentData: makePaymentInstrumentData(
+          externalPayerInfo: [
+            "email": "john.appleseed@gmail.com",
+            "firstName": "John",
+            "lastName": "Appleseed"
+          ]
+        )
+      )
+    }
+
+    static var klarna: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+      makeVaultedPaymentMethod(
+        paymentMethodType: "KLARNA",
+        paymentInstrumentType: .klarnaCustomerToken,
+        paymentInstrumentData: makePaymentInstrumentData()
+      )
+    }
+
+    static var achBank: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod {
+      makeVaultedPaymentMethod(
+        paymentMethodType: "STRIPE_ACH",
+        paymentInstrumentType: .stripeAch,
+        paymentInstrumentData: makePaymentInstrumentData(
+          cardholderName: "Jane Smith",
+          bankName: "Chase",
+          accountNumberLast4Digits: "9876"
+        )
+      )
+    }
+  }
+
+  // MARK: - All Payment Methods
+
+  @available(iOS 17.0, *)
+  #Preview("All Payment Methods") {
+    ScrollView {
+      VStack(spacing: PrimerSpacing.small(tokens: nil)) {
+        VaultedPaymentMethodCard(
+          vaultedPaymentMethod: VaultedPaymentMethodPreviewData.visaCard,
+          isSelected: true
+        )
+        VaultedPaymentMethodCard(
+          vaultedPaymentMethod: VaultedPaymentMethodPreviewData.mastercard
+        )
+        VaultedPaymentMethodCard(
+          vaultedPaymentMethod: VaultedPaymentMethodPreviewData.paypal
+        )
+        VaultedPaymentMethodCard(
+          vaultedPaymentMethod: VaultedPaymentMethodPreviewData.klarna
+        )
+        VaultedPaymentMethodCard(
+          vaultedPaymentMethod: VaultedPaymentMethodPreviewData.achBank
+        )
+      }
+      .padding()
+    }
+  }
+
+  // MARK: - Selection States
+
+  @available(iOS 17.0, *)
+  #Preview("Selected") {
+    VaultedPaymentMethodCard(
+      vaultedPaymentMethod: VaultedPaymentMethodPreviewData.visaCard,
+      isSelected: true
+    )
+    .padding()
+  }
+
+  @available(iOS 17.0, *)
+  #Preview("Unselected") {
+    VaultedPaymentMethodCard(
+      vaultedPaymentMethod: VaultedPaymentMethodPreviewData.visaCard
+    )
+    .padding()
+  }
+
+  // MARK: - Edit Mode
+
+  @available(iOS 17.0, *)
+  #Preview("Edit Mode") {
+    VaultedPaymentMethodCard(
+      vaultedPaymentMethod: VaultedPaymentMethodPreviewData.visaCard,
+      isEditMode: true,
+      onDeleteTapped: {}
+    )
+    .padding()
+  }
+
+  // MARK: - Dark Mode
+
+  @available(iOS 17.0, *)
+  #Preview("Dark Mode") {
+    VaultedPaymentMethodCard(
+      vaultedPaymentMethod: VaultedPaymentMethodPreviewData.visaCard,
+      isSelected: true
+    )
+    .padding()
+    .preferredColorScheme(.dark)
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedPaymentMethodDisplayData.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedPaymentMethodDisplayData.swift
@@ -1,0 +1,30 @@
+//
+//  VaultedPaymentMethodDisplayData.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import UIKit
+
+@available(iOS 15.0, *)
+struct VaultedPaymentMethodDisplayData {
+  /// Cardholder or account holder name. When nil, the name row should be hidden entirely.
+  let name: String?
+
+  /// Brand icon image (e.g., Visa logo, PayPal icon).
+  let brandIcon: UIImage?
+
+  /// Brand name for display (e.g., "Visa", "PayPal", "Chase (ACH)").
+  let brandName: String
+
+  /// Primary display value (e.g., "•••• 1234" for cards, "jo••••@gmail.com" for PayPal).
+  /// When nil, the primary value should be hidden.
+  let primaryValue: String?
+
+  /// Secondary display value (e.g., "Expires 12/26" for cards).
+  /// When nil, the secondary value should be hidden.
+  let secondaryValue: String?
+
+  /// VoiceOver accessibility label describing the complete payment method.
+  let accessibilityLabel: String
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
@@ -1,0 +1,87 @@
+//
+//  AchMandateView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct AchMandateView: View, LogReporter {
+  let scope: any PrimerAchScope
+  let achState: PrimerAchState
+
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      Text(CheckoutComponentsStrings.achMandateTitle)
+        .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .multilineTextAlignment(.center)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateTitle)
+
+      ScrollView {
+        Text(achState.mandateText ?? "")
+          .font(PrimerFont.bodyMedium(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          .multilineTextAlignment(.leading)
+          .padding(PrimerSpacing.medium(tokens: tokens))
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(
+            RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+              .fill(CheckoutColors.gray100(tokens: tokens))
+          )
+      }
+      .frame(maxHeight: Layout.mandateTextMaxHeight)
+      .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateTextContainer)
+      .accessibilityLabel(achState.mandateText ?? "")
+
+      Spacer()
+        .frame(height: PrimerSpacing.medium(tokens: tokens))
+
+      VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+        makeAcceptButton()
+        makeDeclineButton()
+      }
+    }
+    .padding(.top, PrimerSpacing.large(tokens: tokens))
+    .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateContainer)
+  }
+
+  private func makeAcceptButton() -> some View {
+    Button(action: scope.acceptMandate) {
+      Text(CheckoutComponentsStrings.achMandateAcceptButton)
+        .font(PrimerFont.body(tokens: tokens))
+        .foregroundColor(CheckoutColors.white(tokens: tokens))
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+        .background(CheckoutColors.textPrimary(tokens: tokens))
+        .cornerRadius(PrimerRadius.small(tokens: tokens))
+    }
+    .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateAcceptButton)
+    .accessibilityLabel(CheckoutComponentsStrings.achMandateAcceptButton)
+    .accessibilityHint(CheckoutComponentsStrings.a11yAchMandateAcceptHint)
+  }
+
+  private func makeDeclineButton() -> some View {
+    Button(action: scope.declineMandate) {
+      Text(CheckoutComponentsStrings.achMandateDeclineButton)
+        .font(PrimerFont.body(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+        .background(
+          RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+            .stroke(CheckoutColors.borderDefault(tokens: tokens), lineWidth: 1)
+        )
+    }
+    .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateDeclineButton)
+    .accessibilityLabel(CheckoutComponentsStrings.achMandateDeclineButton)
+    .accessibilityHint(CheckoutComponentsStrings.a11yAchMandateDeclineHint)
+  }
+
+  private enum Layout {
+    static let mandateTextMaxHeight: CGFloat = 300
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchStateObserver.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchStateObserver.swift
@@ -1,0 +1,59 @@
+//
+//  AchStateObserver.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+final class AchStateObserver: ObservableObject {
+  @Published var achState: PrimerAchState = .init()
+  @Published var showBankCollector: Bool = false
+
+  private var stripeFlowCompleted: Bool = false
+  private let scope: any PrimerAchScope
+  private var observationTask: Task<Void, Never>?
+
+  private var shouldShowBankCollector: Bool {
+    achState.step == .bankAccountCollection && scope.bankCollectorViewController != nil && !stripeFlowCompleted
+  }
+
+  private var shouldHideBankCollector: Bool {
+    achState.step != .bankAccountCollection && achState.step != .processing
+  }
+
+  init(scope: any PrimerAchScope) {
+    self.scope = scope
+  }
+
+  deinit {
+    observationTask?.cancel()
+  }
+
+  func startObserving() {
+    guard observationTask == nil else { return }
+
+    observationTask = Task { [self] in
+      for await state in scope.state {
+        if Task.isCancelled { break }
+
+        achState = state
+
+        if shouldShowBankCollector {
+          showBankCollector = true
+        } else if state.step == .mandateAcceptance {
+          stripeFlowCompleted = true
+        } else if shouldHideBankCollector {
+          showBankCollector = false
+        }
+      }
+    }
+  }
+
+  func stopObserving() {
+    observationTask?.cancel()
+    observationTask = nil
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchUserDetailsView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchUserDetailsView.swift
@@ -1,0 +1,104 @@
+//
+//  AchUserDetailsView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct AchUserDetailsView: View, LogReporter {
+  let scope: any PrimerAchScope
+  let achState: PrimerAchState
+
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      Text(CheckoutComponentsStrings.achPersonalDetailsSubtitle)
+        .font(PrimerFont.bodyLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .multilineTextAlignment(.center)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Ach.userDetailsTitle)
+
+      VStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+        HStack(alignment: .top, spacing: PrimerSpacing.medium(tokens: tokens)) {
+          firstNameField
+          lastNameField
+        }
+        emailField
+      }
+
+      submitButton
+    }
+    .accessibilityIdentifier(AccessibilityIdentifiers.Ach.userDetailsContainer)
+  }
+
+  private var firstNameField: some View {
+    NameInputField(
+      label: CheckoutComponentsStrings.firstNameLabel,
+      placeholder: CheckoutComponentsStrings.firstNamePlaceholder,
+      inputType: .firstName,
+      initialValue: achState.userDetails.firstName,
+      onNameChange: scope.updateFirstName
+    )
+    .accessibilityIdentifier(AccessibilityIdentifiers.Ach.firstNameField)
+  }
+
+  private var lastNameField: some View {
+    NameInputField(
+      label: CheckoutComponentsStrings.lastNameLabel,
+      placeholder: CheckoutComponentsStrings.lastNamePlaceholder,
+      inputType: .lastName,
+      initialValue: achState.userDetails.lastName,
+      onNameChange: scope.updateLastName
+    )
+    .accessibilityIdentifier(AccessibilityIdentifiers.Ach.lastNameField)
+  }
+
+  private var emailField: some View {
+    VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+      EmailInputField(
+        label: CheckoutComponentsStrings.emailLabel,
+        placeholder: CheckoutComponentsStrings.emailPlaceholder,
+        initialValue: achState.userDetails.emailAddress,
+        onEmailChange: scope.updateEmailAddress
+      )
+      .accessibilityIdentifier(AccessibilityIdentifiers.Ach.emailField)
+
+      Text(CheckoutComponentsStrings.achEmailDisclaimer)
+        .font(PrimerFont.bodySmall(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.Ach.emailDisclaimer)
+    }
+  }
+
+  @ViewBuilder private var submitButton: some View {
+    if let customButton = scope.submitButton {
+      AnyView(customButton(scope))
+    } else {
+      Button(action: scope.submitUserDetails) {
+        Text(CheckoutComponentsStrings.achContinueButton)
+          .font(PrimerFont.body(tokens: tokens))
+          .foregroundColor(CheckoutColors.white(tokens: tokens))
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+          .background(
+            achState.isSubmitEnabled
+              ? CheckoutColors.textPrimary(tokens: tokens)
+              : CheckoutColors.textSecondary(tokens: tokens)
+          )
+          .cornerRadius(PrimerRadius.small(tokens: tokens))
+      }
+      .disabled(!achState.isSubmitEnabled)
+      .accessibilityIdentifier(AccessibilityIdentifiers.Ach.submitButton)
+      .accessibilityLabel(CheckoutComponentsStrings.achContinueButton)
+      .accessibilityHint(
+        achState.isSubmitEnabled
+          ? CheckoutComponentsStrings.a11yAchContinueHint
+          : CheckoutComponentsStrings.a11ySubmitButtonDisabled
+      )
+    }
+  }
+
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchUserDetailsView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchUserDetailsView.swift
@@ -12,6 +12,7 @@ struct AchUserDetailsView: View, LogReporter {
   let achState: PrimerAchState
 
   @Environment(\.designTokens) private var tokens
+  @FocusState private var focusedField: PrimerInputElementType?
 
   var body: some View {
     VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
@@ -42,6 +43,8 @@ struct AchUserDetailsView: View, LogReporter {
       initialValue: achState.userDetails.firstName,
       onNameChange: scope.updateFirstName
     )
+    .focused($focusedField, equals: .firstName)
+    .onSubmit { focusedField = .lastName }
     .accessibilityIdentifier(AccessibilityIdentifiers.Ach.firstNameField)
   }
 
@@ -53,6 +56,8 @@ struct AchUserDetailsView: View, LogReporter {
       initialValue: achState.userDetails.lastName,
       onNameChange: scope.updateLastName
     )
+    .focused($focusedField, equals: .lastName)
+    .onSubmit { focusedField = .email }
     .accessibilityIdentifier(AccessibilityIdentifiers.Ach.lastNameField)
   }
 
@@ -64,6 +69,8 @@ struct AchUserDetailsView: View, LogReporter {
         initialValue: achState.userDetails.emailAddress,
         onEmailChange: scope.updateEmailAddress
       )
+      .focused($focusedField, equals: .email)
+      .onSubmit { focusedField = nil }
       .accessibilityIdentifier(AccessibilityIdentifiers.Ach.emailField)
 
       Text(CheckoutComponentsStrings.achEmailDisclaimer)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchView.swift
@@ -1,0 +1,218 @@
+//
+//  AchView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct AchView: View, LogReporter {
+  let scope: any PrimerAchScope
+
+  @StateObject private var observer: AchStateObserver
+
+  @Environment(\.designTokens) private var tokens
+
+  private enum Layout {
+    static let spinnerSize: CGFloat = 56
+  }
+
+  init(scope: any PrimerAchScope) {
+    self.scope = scope
+    _observer = StateObject(wrappedValue: AchStateObserver(scope: scope))
+  }
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: PrimerSpacing.xxlarge(tokens: tokens)) {
+        headerSection
+        contentSection
+      }
+      .padding(PrimerSpacing.large(tokens: tokens))
+    }
+    .navigationBarHidden(true)
+    .background(CheckoutColors.background(tokens: tokens))
+    .accessibilityIdentifier(AccessibilityIdentifiers.Ach.container)
+    .onAppear {
+      observer.startObserving()
+    }
+    .onDisappear {
+      observer.stopObserving()
+    }
+    .onChange(of: observer.achState.step) { step in
+      let message: String = switch step {
+      case .loading, .processing:
+        CheckoutComponentsStrings.loading
+      case .userDetailsCollection:
+        CheckoutComponentsStrings.achUserDetailsTitle
+      case .bankAccountCollection:
+        CheckoutComponentsStrings.loading
+      case .mandateAcceptance:
+        CheckoutComponentsStrings.achMandateTitle
+      }
+      UIAccessibility.post(notification: .screenChanged, argument: message)
+    }
+    .fullScreenCover(isPresented: $observer.showBankCollector) {
+      if let bankCollectorVC = scope.bankCollectorViewController {
+        StripeBankCollectorRepresentable(viewController: bankCollectorVC)
+          .ignoresSafeArea()
+          .accessibilityIdentifier(AccessibilityIdentifiers.Ach.bankCollectorContainer)
+      }
+    }
+  }
+
+  @ViewBuilder private var headerSection: some View {
+    HStack {
+      if scope.presentationContext.shouldShowBackButton {
+        Button(action: scope.onBack) {
+          HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+            Image(systemName: RTLIcon.backChevron)
+              .font(PrimerFont.bodyMedium(tokens: tokens))
+            Text(CheckoutComponentsStrings.backButton)
+          }
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        }
+        .accessibility(
+          config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.Common.backButton,
+            label: CheckoutComponentsStrings.a11yBack,
+            traits: [.isButton]
+          )
+        )
+      }
+
+      Spacer()
+
+      Text(CheckoutComponentsStrings.achPayWithTitle)
+        .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+      Spacer()
+
+      if scope.dismissalMechanism.contains(.closeButton) {
+        Button(CheckoutComponentsStrings.cancelButton, action: scope.cancel)
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          .accessibility(
+            config: AccessibilityConfiguration(
+              identifier: AccessibilityIdentifiers.Common.closeButton,
+              label: CheckoutComponentsStrings.a11yCancel,
+              traits: [.isButton]
+            )
+          )
+      } else {
+        Text(CheckoutComponentsStrings.cancelButton)
+          .hidden()
+      }
+    }
+  }
+
+  @ViewBuilder private var contentSection: some View {
+    switch observer.achState.step {
+    case .loading:
+      makeLoadingContent()
+    case .userDetailsCollection:
+      if let customScreen = scope.userDetailsScreen {
+        AnyView(customScreen(scope))
+      } else {
+        AchUserDetailsView(scope: scope, achState: observer.achState)
+      }
+    case .bankAccountCollection:
+      makeLoadingContent()
+    case .mandateAcceptance:
+      if let customScreen = scope.mandateScreen {
+        AnyView(customScreen(scope))
+      } else {
+        AchMandateView(scope: scope, achState: observer.achState)
+      }
+    case .processing:
+      makeLoadingContent()
+    }
+  }
+
+  private func makeLoadingContent() -> some View {
+    VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+      Spacer()
+        .frame(height: PrimerSpacing.xxlarge(tokens: tokens) * 2)
+
+      ProgressView()
+        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.blue(tokens: tokens)))
+        .scaleEffect(PrimerScale.large)
+        .frame(width: Layout.spinnerSize, height: Layout.spinnerSize)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Ach.loadingIndicator)
+
+      Spacer()
+        .frame(height: PrimerSpacing.small(tokens: tokens))
+
+      Text(CheckoutComponentsStrings.loading)
+        .font(PrimerFont.bodyLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+      Spacer()
+        .frame(height: PrimerSpacing.xxlarge(tokens: tokens) * 2)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.horizontal, PrimerSpacing.xlarge(tokens: tokens))
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
+  }
+
+}
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  #Preview("ACH - Loading") {
+    AchView(scope: MockAchScope(step: .loading))
+      .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("ACH - User Details") {
+    AchView(scope: MockAchScope(step: .userDetailsCollection))
+      .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  @MainActor
+  private final class MockAchScope: PrimerAchScope, ObservableObject {
+    var presentationContext: PresentationContext = .fromPaymentSelection
+    var dismissalMechanism: [DismissalMechanism] = [.closeButton]
+    var bankCollectorViewController: UIViewController?
+    var screen: AchScreenComponent?
+    var userDetailsScreen: AchScreenComponent?
+    var mandateScreen: AchScreenComponent?
+    var submitButton: AchButtonComponent?
+
+    @Published private var mockState: PrimerAchState
+
+    var state: AsyncStream<PrimerAchState> {
+      AsyncStream { continuation in
+        continuation.yield(mockState)
+      }
+    }
+
+    init(step: PrimerAchState.Step = .userDetailsCollection) {
+      let userDetails = PrimerAchState.UserDetails(
+        firstName: "John",
+        lastName: "Doe",
+        emailAddress: "john.doe@example.com"
+      )
+      mockState = PrimerAchState(
+        step: step,
+        userDetails: userDetails,
+        isSubmitEnabled: true
+      )
+    }
+
+    func start() {}
+    func submit() {}
+    func cancel() {}
+    func updateFirstName(_ value: String) {}
+    func updateLastName(_ value: String) {}
+    func updateEmailAddress(_ value: String) {}
+    func submitUserDetails() {}
+    func acceptMandate() {}
+    func declineMandate() {}
+    func onBack() {}
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/StripeBankCollectorRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/StripeBankCollectorRepresentable.swift
@@ -1,0 +1,20 @@
+//
+//  StripeBankCollectorRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct StripeBankCollectorRepresentable: UIViewControllerRepresentable {
+  let viewController: UIViewController
+
+  func makeUIViewController(context: Context) -> UIViewController {
+    viewController
+  }
+
+  func updateUIViewController(_: UIViewController, context _: Context) {
+    // No update needed — the bank collector manages its own state
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ApplePayScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ApplePayScreen.swift
@@ -1,0 +1,207 @@
+//
+//  ApplePayScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PassKit
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct ApplePayScreen: View {
+  @ObservedObject private var scope: DefaultApplePayScope
+  @Environment(\.designTokens) private var tokens
+
+  private let presentationContext: PresentationContext
+
+  init(
+    scope: DefaultApplePayScope, presentationContext: PresentationContext = .fromPaymentSelection
+  ) {
+    self.scope = scope
+    self.presentationContext = presentationContext
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      makeNavigationBar()
+      makeContent()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    .background(CheckoutColors.background(tokens: tokens))
+  }
+
+  private func makeNavigationBar() -> some View {
+    HStack {
+      if presentationContext.shouldShowBackButton {
+        Button(action: scope.onBack) {
+          Image(systemName: RTLIcon.backChevron)
+            .font(PrimerFont.bodyMedium(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        }
+        .padding(.leading, PrimerSpacing.large(tokens: tokens))
+        .accessibility(
+          config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.Common.backButton,
+            label: CheckoutComponentsStrings.a11yBack,
+            traits: [.isButton]
+          )
+        )
+      }
+
+      Spacer()
+
+      Text(CheckoutComponentsStrings.applePayTitle)
+        .font(PrimerFont.titleLarge(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.title)
+        .accessibilityAddTraits(.isHeader)
+
+      Spacer()
+
+      Button(action: scope.onDismiss) {
+        Image(systemName: "xmark")
+          .font(PrimerFont.bodyMedium(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+      }
+      .padding(.trailing, PrimerSpacing.large(tokens: tokens))
+      .accessibility(
+        config: AccessibilityConfiguration(
+          identifier: AccessibilityIdentifiers.Common.closeButton,
+          label: CheckoutComponentsStrings.a11yCancel,
+          traits: [.isButton]
+        )
+      )
+    }
+    .frame(height: 56)
+    .background(CheckoutColors.background(tokens: tokens))
+  }
+
+  @ViewBuilder
+  private func makeContent() -> some View {
+    if scope.structuredState.isAvailable {
+      makeAvailableContent()
+    } else {
+      makeUnavailableContent()
+    }
+  }
+
+  private func makeAvailableContent() -> some View {
+    VStack(spacing: PrimerSpacing.xxlarge(tokens: tokens)) {
+      Spacer()
+
+      Image(systemName: "apple.logo")
+        .font(PrimerFont.extraLargeIcon(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .accessibilityHidden(true)
+
+      Text(CheckoutComponentsStrings.applePayDescription)
+        .font(PrimerFont.bodyMedium(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, PrimerSpacing.xxlarge(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.description)
+
+      Spacer()
+
+      if scope.structuredState.isLoading {
+        makeLoadingView()
+      } else {
+        makeApplePayButton()
+      }
+
+      Spacer()
+        .frame(height: PrimerSpacing.xxlarge(tokens: tokens))
+    }
+    .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+  }
+
+  @ViewBuilder
+  private func makeApplePayButton() -> some View {
+    if let customButton = scope.applePayButton {
+      AnyView(customButton(scope.submit))
+        .frame(height: 50)
+        .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.payButton)
+    } else {
+      scope.PrimerApplePayButton(action: scope.submit)
+        .frame(height: 50)
+        .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.payButton)
+    }
+  }
+
+  private func makeLoadingView() -> some View {
+    HStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+      ProgressView()
+        .progressViewStyle(CircularProgressViewStyle())
+        .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.processingIndicator)
+
+      Text(CheckoutComponentsStrings.applePayProcessing)
+        .font(PrimerFont.bodyMedium(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.processingLabel)
+    }
+    .frame(height: 50)
+  }
+
+  private func makeUnavailableContent() -> some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      Spacer()
+
+      Image(systemName: "exclamationmark.triangle")
+        .font(PrimerFont.largeIcon(tokens: tokens))
+        .foregroundColor(CheckoutColors.orange(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.unavailableIcon)
+        .accessibilityHidden(true)
+
+      Text(CheckoutComponentsStrings.applePayUnavailable)
+        .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.unavailableTitle)
+        .accessibilityAddTraits(.isHeader)
+
+      if let error = scope.structuredState.availabilityError {
+        Text(error)
+          .font(PrimerFont.bodyMedium(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          .multilineTextAlignment(.center)
+          .padding(.horizontal, PrimerSpacing.xxlarge(tokens: tokens))
+          .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.unavailableDescription)
+      }
+
+      Spacer()
+
+      if presentationContext.shouldShowBackButton {
+        Button(action: scope.onBack) {
+          Text(CheckoutComponentsStrings.applePayChooseOther)
+            .font(PrimerFont.bodyMedium(tokens: tokens))
+            .fontWeight(.medium)
+            .foregroundColor(CheckoutColors.white(tokens: tokens))
+            .frame(maxWidth: .infinity)
+            .frame(height: 50)
+            .background(CheckoutColors.blue(tokens: tokens))
+            .cornerRadius(PrimerRadius.medium(tokens: tokens))
+        }
+        .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+        .accessibility(
+          config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.ApplePay.chooseOtherButton,
+            label: CheckoutComponentsStrings.applePayChooseOther,
+            traits: [.isButton]
+          )
+        )
+      }
+
+      Spacer()
+        .frame(height: PrimerSpacing.xxlarge(tokens: tokens))
+    }
+  }
+}
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  struct ApplePayScreen_Previews: PreviewProvider {
+    static var previews: some View {
+      Text("Apple Pay Screen Preview")
+    }
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen+Previews.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen+Previews.swift
@@ -1,0 +1,208 @@
+//
+//  CardFormScreen+Previews.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+  import SwiftUI
+
+  @available(iOS 15.0, *)
+  #Preview("All Fields - Light") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        selectedNetwork: .visa,
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv, .cardholderName],
+          billingFields: [
+            .countryCode,
+            .addressLine1,
+            .addressLine2,
+            .city,
+            .state,
+            .postalCode,
+            .firstName,
+            .lastName,
+            .email,
+            .phoneNumber,
+            .otp
+          ]
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("All Fields - Dark") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        selectedNetwork: .masterCard,
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv, .cardholderName],
+          billingFields: [
+            .countryCode,
+            .addressLine1,
+            .addressLine2,
+            .city,
+            .state,
+            .postalCode,
+            .firstName,
+            .lastName,
+            .email,
+            .phoneNumber,
+            .otp
+          ]
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Card Fields Only - Light") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        selectedNetwork: .amex,
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv, .cardholderName],
+          billingFields: []
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Card Fields Only - Dark") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        selectedNetwork: .discover,
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv, .cardholderName],
+          billingFields: []
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Co-badged Cards - Light") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        selectedNetwork: .visa,
+        availableNetworks: [.visa, .masterCard, .discover],
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv],
+          billingFields: []
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Co-badged Cards - Dark") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        selectedNetwork: .visa,
+        availableNetworks: [.visa, .masterCard, .discover],
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv],
+          billingFields: []
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Loading State") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        isLoading: true,
+        isValid: true,
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv, .cardholderName],
+          billingFields: []
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Valid State") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        isLoading: false,
+        isValid: true,
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv, .cardholderName],
+          billingFields: []
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("With Billing Address - Light") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        selectedNetwork: .masterCard,
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv],
+          billingFields: [.countryCode, .addressLine1, .city, .state, .postalCode]
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("With Billing Address - Dark") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        selectedNetwork: .jcb,
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv],
+          billingFields: [.countryCode, .addressLine1, .city, .state, .postalCode]
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.dark)
+    .environment(\.diContainer, MockDIContainer())
+    .preferredColorScheme(.dark)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("With Surcharge") {
+    CardFormScreen(
+      scope: MockCardFormScope(
+        isValid: true,
+        selectedNetwork: .visa,
+        surchargeAmount: "+ 1.50€",
+        formConfiguration: CardFormConfiguration(
+          cardFields: [.cardNumber, .expiryDate, .cvv],
+          billingFields: []
+        )
+      )
+    )
+    .environment(\.designTokens, MockDesignTokens.light)
+    .environment(\.diContainer, MockDIContainer())
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
@@ -55,8 +55,7 @@ struct CardFormScreen: View, LogReporter {
               identifier: AccessibilityIdentifiers.Common.backButton,
               label: CheckoutComponentsStrings.a11yBack,
               traits: [.isButton]
-            )
-          )
+            ))
         }
 
         Spacer()
@@ -69,8 +68,7 @@ struct CardFormScreen: View, LogReporter {
                 identifier: AccessibilityIdentifiers.Common.closeButton,
                 label: CheckoutComponentsStrings.a11yCancel,
                 traits: [.isButton]
-              )
-            )
+              ))
         }
       }
 
@@ -184,12 +182,10 @@ struct CardFormScreen: View, LogReporter {
   private var submitButtonSection: some View {
     // Check scope configuration for full button replacement
     if let customContent = scope.submitButton {
-      AnyView(customContent())
-        .onTapGesture {
-          if cardFormState.isValid, !cardFormState.isLoading {
-            submitAction()
-          }
-        }
+      Button(action: submitAction) {
+        AnyView(customContent())
+      }
+      .disabled(!cardFormState.isValid || cardFormState.isLoading)
     } else {
       Button(action: submitAction) {
         submitButtonContent
@@ -223,14 +219,11 @@ struct CardFormScreen: View, LogReporter {
           ? CheckoutComponentsStrings.a11ySubmitButtonLoading : submitButtonAccessibilityLabel,
         hint: cardFormState.isLoading
           ? nil
-          : (
-            isEnabled
+          : (isEnabled
             ? CheckoutComponentsStrings.a11ySubmitButtonHint
-            : CheckoutComponentsStrings.a11ySubmitButtonDisabled
-          ),
+            : CheckoutComponentsStrings.a11ySubmitButtonDisabled),
         traits: [.isButton]
-      )
-    )
+      ))
   }
 
   /// Accessibility-friendly version of submit button text for VoiceOver.
@@ -333,10 +326,9 @@ struct CardFormScreen: View, LogReporter {
         await MainActor.run {
           let newErrors = state.fieldErrors
           if newErrors.count > previousErrorCount, let firstError = newErrors.first {
-            UIAccessibility.post(
-              notification: .announcement,
-              argument: firstError.message
-            )
+            if let announcementService = try? container?.resolveSync(AccessibilityAnnouncementService.self) {
+              announcementService.announceError(firstError.message)
+            }
           }
           previousErrorCount = newErrors.count
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
@@ -1,0 +1,667 @@
+//
+//  CardFormScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CardFormScreen: View, LogReporter {
+  let scope: any PrimerCardFormScope
+
+  @Environment(\.designTokens) private var tokens
+  @Environment(\.bridgeController) private var bridgeController
+  @Environment(\.diContainer) private var container
+  @Environment(\.sizeCategory) private var sizeCategory  // Observes Dynamic Type changes
+  @State private var cardFormState: PrimerCardFormState = .init()
+  @State private var previousErrorCount = 0
+  @State private var selectedCardNetwork: CardNetwork = .unknown
+  @State private var formConfiguration: CardFormConfiguration = .default
+  @State private var configurationService: ConfigurationService?
+  @State private var observationTask: Task<Void, Never>?
+  @FocusState private var focusedField: PrimerInputElementType?
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: PrimerSpacing.xxlarge(tokens: tokens)) {
+        headerSection
+        formContent
+      }
+      .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+      .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+      .frame(maxWidth: .infinity)
+    }
+    .navigationBarHidden(true)
+    .background(CheckoutColors.background(tokens: tokens))
+    .environment(\.primerCardFormScope, scope)
+  }
+
+  @MainActor
+  private var headerSection: some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      HStack {
+        if scope.presentationContext.shouldShowBackButton {
+          Button(action: scope.onBack) {
+            HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+              Image(systemName: RTLIcon.backChevron)
+                .font(PrimerFont.bodyMedium(tokens: tokens))
+              Text(CheckoutComponentsStrings.backButton)
+            }
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          }
+          .accessibility(
+            config: AccessibilityConfiguration(
+              identifier: AccessibilityIdentifiers.Common.backButton,
+              label: CheckoutComponentsStrings.a11yBack,
+              traits: [.isButton]
+            )
+          )
+        }
+
+        Spacer()
+
+        if scope.dismissalMechanism.contains(.closeButton) {
+          Button(CheckoutComponentsStrings.cancelButton, action: scope.cancel)
+            .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+            .accessibility(
+              config: AccessibilityConfiguration(
+                identifier: AccessibilityIdentifiers.Common.closeButton,
+                label: CheckoutComponentsStrings.a11yCancel,
+                traits: [.isButton]
+              )
+            )
+        }
+      }
+
+      titleSection
+    }
+  }
+
+  @MainActor
+  private var formContent: some View {
+    VStack(spacing: PrimerSpacing.xlarge(tokens: tokens)) {
+      dynamicFieldsSection
+      submitButtonSection
+    }
+    .onAppear {
+      resolveConfigurationService()
+      observeState()
+    }
+    .onDisappear {
+      observationTask?.cancel()
+      observationTask = nil
+    }
+  }
+
+  private var titleSection: some View {
+    Text(scope.title ?? CheckoutComponentsStrings.cardPaymentTitle)
+      .font(PrimerFont.titleXLarge(tokens: tokens))
+      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .accessibilityAddTraits(.isHeader)
+  }
+
+  @MainActor
+  @ViewBuilder
+  private var dynamicFieldsSection: some View {
+    if let customScreen = scope.screen {
+      AnyView(customScreen(scope))
+    } else {
+      VStack(spacing: 0) {
+        cardFieldsSection
+        billingAddressSection
+      }
+    }
+  }
+
+  @MainActor
+  @ViewBuilder
+  private var cardFieldsSection: some View {
+    // Check scope configuration for full section replacement
+    if let customContent = scope.cardInputSection {
+      AnyView(customContent())
+    } else {
+      VStack(spacing: 0) {
+        ForEach(Array(formConfiguration.cardFields.enumerated()), id: \.element) { index, fieldType in
+          if fieldType == .expiryDate,
+            index + 1 < formConfiguration.cardFields.count,
+            formConfiguration.cardFields[index + 1] == .cvv {
+            HStack(alignment: .top, spacing: PrimerSpacing.medium(tokens: tokens)) {
+              renderField(.expiryDate)
+              renderField(.cvv)
+            }
+          } else if index > 0,
+            formConfiguration.cardFields[index - 1] == .expiryDate,
+            fieldType == .cvv {
+            EmptyView()
+          } else {
+            renderField(fieldType)
+          }
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  @MainActor
+  private var billingAddressSection: some View {
+    if !formConfiguration.billingFields.isEmpty {
+      // Check scope configuration for full section replacement
+      if let customContent = scope.billingAddressSection {
+        AnyView(customContent())
+      } else {
+        VStack(alignment: .leading, spacing: PrimerSpacing.small(tokens: tokens)) {
+          Text(CheckoutComponentsStrings.billingAddressTitle)
+            .font(PrimerFont.headline(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+          VStack(spacing: 0) {
+            ForEach(Array(formConfiguration.billingFields.enumerated()), id: \.element) { index, fieldType in
+              if fieldType == .firstName,
+                index + 1 < formConfiguration.billingFields.count,
+                formConfiguration.billingFields[index + 1] == .lastName {
+                HStack(alignment: .top, spacing: PrimerSpacing.medium(tokens: tokens)) {
+                  renderField(.firstName)
+                  renderField(.lastName)
+                }
+              } else if index > 0,
+                formConfiguration.billingFields[index - 1] == .firstName,
+                fieldType == .lastName {
+                EmptyView()
+              } else {
+                renderField(fieldType)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @MainActor
+  @ViewBuilder
+  private var submitButtonSection: some View {
+    // Check scope configuration for full button replacement
+    if let customContent = scope.submitButton {
+      AnyView(customContent())
+        .onTapGesture {
+          if cardFormState.isValid, !cardFormState.isLoading {
+            submitAction()
+          }
+        }
+    } else {
+      Button(action: submitAction) {
+        submitButtonContent
+      }
+      .disabled(!cardFormState.isValid || cardFormState.isLoading)
+    }
+  }
+
+  private var submitButtonContent: some View {
+    let isEnabled = cardFormState.isValid && !cardFormState.isLoading
+
+    return HStack {
+      if cardFormState.isLoading, scope.showSubmitLoadingIndicator {
+        ProgressView()
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.white(tokens: tokens)))
+          .scaleEffect(PrimerScale.small)
+      } else {
+        Text(submitButtonText)
+      }
+    }
+    .font(PrimerFont.body(tokens: tokens))
+    .foregroundColor(CheckoutColors.white(tokens: tokens))
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+    .background(submitButtonBackground)
+    .cornerRadius(PrimerRadius.small(tokens: tokens))
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.Common.submitButton,
+        label: cardFormState.isLoading
+          ? CheckoutComponentsStrings.a11ySubmitButtonLoading : submitButtonAccessibilityLabel,
+        hint: cardFormState.isLoading
+          ? nil
+          : (
+            isEnabled
+            ? CheckoutComponentsStrings.a11ySubmitButtonHint
+            : CheckoutComponentsStrings.a11ySubmitButtonDisabled
+          ),
+        traits: [.isButton]
+      )
+    )
+  }
+
+  /// Accessibility-friendly version of submit button text for VoiceOver.
+  /// Uses period as decimal separator to avoid misreading "6,00€" as "600 euros".
+  private var submitButtonAccessibilityLabel: String {
+    if scope.cardFormUIOptions?.payButtonAddNewCard == true {
+      return CheckoutComponentsStrings.addCardButton
+    }
+
+    guard PrimerInternal.shared.intent == .checkout,
+      let currency = configurationService?.currency
+    else {
+      return CheckoutComponentsStrings.payButton
+    }
+
+    let amount = configurationService?.amount ?? 0
+    let merchantAmount = configurationService?.apiConfiguration?.clientSession?.order?
+      .merchantAmount
+
+    if let merchantAmount,
+      let surchargeRaw = cardFormState.surchargeAmountRaw,
+      cardFormState.selectedNetwork != nil {
+      let totalAmount = merchantAmount + surchargeRaw
+      let accessibilityAmount = totalAmount.toAccessibilityCurrencyString(currency: currency)
+      return CheckoutComponentsStrings.paymentAmountTitle(accessibilityAmount)
+    }
+
+    let accessibilityAmount = amount.toAccessibilityCurrencyString(currency: currency)
+    return CheckoutComponentsStrings.paymentAmountTitle(accessibilityAmount)
+  }
+
+  private var submitButtonText: String {
+    // First check scope configuration
+    if let customText = scope.submitButtonText {
+      return customText
+    }
+
+    if scope.cardFormUIOptions?.payButtonAddNewCard == true {
+      return CheckoutComponentsStrings.addCardButton
+    }
+
+    guard PrimerInternal.shared.intent == .checkout,
+      let currency = configurationService?.currency
+    else {
+      return CheckoutComponentsStrings.payButton
+    }
+
+    let amount = configurationService?.amount ?? 0
+    let merchantAmount = configurationService?.apiConfiguration?.clientSession?.order?
+      .merchantAmount
+
+    if let merchantAmount,
+      let surchargeRaw = cardFormState.surchargeAmountRaw,
+      cardFormState.selectedNetwork != nil {
+      let totalAmount = merchantAmount + surchargeRaw
+      let formattedTotalAmount = totalAmount.toCurrencyString(currency: currency)
+      return CheckoutComponentsStrings.paymentAmountTitle(formattedTotalAmount)
+    }
+
+    let formattedAmount = amount.toCurrencyString(currency: currency)
+    return CheckoutComponentsStrings.paymentAmountTitle(formattedAmount)
+  }
+
+  private var submitButtonBackground: Color {
+    cardFormState.isValid && !cardFormState.isLoading
+      ? CheckoutColors.textPrimary(tokens: tokens)
+      : CheckoutColors.gray300(tokens: tokens)
+  }
+
+  private func submitAction() {
+    Task {
+      await (scope as? DefaultCardFormScope)?.performSubmit()
+    }
+  }
+
+  private func resolveConfigurationService() {
+    guard let container else {
+      return logger.error(message: "DIContainer not available for CardFormScreen")
+    }
+    do {
+      configurationService = try container.resolveSync(ConfigurationService.self)
+    } catch {
+      logger.error(message: "Failed to resolve ConfigurationService: \(error)")
+    }
+  }
+
+  private func observeState() {
+    observationTask?.cancel()
+    observationTask = Task {
+      await MainActor.run {
+        formConfiguration = scope.getFormConfiguration()
+        bridgeController?.invalidateContentSize()
+      }
+
+      for await state in scope.state {
+        let updatedFormConfig = await MainActor.run {
+          scope.getFormConfiguration()
+        }
+
+        await MainActor.run {
+          let newErrors = state.fieldErrors
+          if newErrors.count > previousErrorCount, let firstError = newErrors.first {
+            UIAccessibility.post(
+              notification: .announcement,
+              argument: firstError.message
+            )
+          }
+          previousErrorCount = newErrors.count
+
+          cardFormState = state
+
+          formConfiguration = updatedFormConfig
+
+          if let selectedNetwork = state.selectedNetwork {
+            selectedCardNetwork = selectedNetwork.network
+          } else if state.availableNetworks.count == 1,
+            let firstNetwork = state.availableNetworks.first {
+            selectedCardNetwork = firstNetwork.network
+          } else if state.availableNetworks.count > 1 {
+            if let firstNetwork = state.availableNetworks.first,
+              selectedCardNetwork == .unknown {
+              selectedCardNetwork = firstNetwork.network
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Dynamic Field Rendering
+
+  // swiftlint:disable cyclomatic_complexity function_body_length
+  @MainActor
+  @ViewBuilder
+  private func renderField(_ fieldType: PrimerInputElementType) -> some View {
+    switch fieldType {
+    case .cardNumber:
+      let config = scope.cardNumberConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+          .focused($focusedField, equals: .cardNumber)
+      } else {
+        CardNumberInputField(
+          label: config?.label ?? CheckoutComponentsStrings.cardNumberLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.cardNumberPlaceholder,
+          scope: scope,
+          selectedNetwork: getSelectedCardNetwork(),
+          availableNetworks: cardFormState.availableNetworks.map(\.network),
+          styling: config?.styling
+        )
+        .focused($focusedField, equals: .cardNumber)
+        .onSubmit { moveToNextField(from: .cardNumber) }
+      }
+
+    case .expiryDate:
+      let config = scope.expiryDateConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+          .focused($focusedField, equals: .expiryDate)
+      } else {
+        ExpiryDateInputField(
+          label: config?.label ?? CheckoutComponentsStrings.expiryDateLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.expiryDatePlaceholder,
+          scope: scope,
+          styling: config?.styling
+        )
+        .focused($focusedField, equals: .expiryDate)
+        .onSubmit { moveToNextField(from: .expiryDate) }
+      }
+
+    case .cvv:
+      let config = scope.cvvConfig
+      let defaultPlaceholder =
+        getCardNetworkForCvv() == .amex
+        ? CheckoutComponentsStrings.cvvAmexPlaceholder
+        : CheckoutComponentsStrings.cvvStandardPlaceholder
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+          .focused($focusedField, equals: .cvv)
+      } else {
+        CVVInputField(
+          label: config?.label ?? CheckoutComponentsStrings.cvvLabel,
+          placeholder: config?.placeholder ?? defaultPlaceholder,
+          scope: scope,
+          cardNetwork: getCardNetworkForCvv(),
+          styling: config?.styling
+        )
+        .focused($focusedField, equals: .cvv)
+        .onSubmit { moveToNextField(from: .cvv) }
+      }
+
+    case .cardholderName:
+      let config = scope.cardholderNameConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+          .focused($focusedField, equals: .cardholderName)
+      } else {
+        CardholderNameInputField(
+          label: config?.label ?? CheckoutComponentsStrings.cardholderNameLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.fullNamePlaceholder,
+          scope: scope,
+          styling: config?.styling
+        )
+        .focused($focusedField, equals: .cardholderName)
+        .onSubmit { moveToNextField(from: .cardholderName) }
+      }
+
+    case .postalCode:
+      let config = scope.postalCodeConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+          .focused($focusedField, equals: .postalCode)
+      } else {
+        PostalCodeInputField(
+          label: config?.label ?? CheckoutComponentsStrings.postalCodeLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.postalCodePlaceholder,
+          scope: scope,
+          styling: config?.styling
+        )
+        .focused($focusedField, equals: .postalCode)
+        .onSubmit { moveToNextField(from: .postalCode) }
+      }
+
+    case .countryCode:
+      let config = scope.countryConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+          .focused($focusedField, equals: .countryCode)
+      } else if let defaultCardFormScope = scope as? DefaultCardFormScope {
+        CountryInputField(
+          label: config?.label ?? CheckoutComponentsStrings.countryLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.selectCountryPlaceholder,
+          scope: defaultCardFormScope,
+          styling: config?.styling
+        )
+        .focused($focusedField, equals: .countryCode)
+        .onSubmit { moveToNextField(from: .countryCode) }
+      }
+
+    case .city:
+      let config = scope.cityConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+          .focused($focusedField, equals: .city)
+      } else {
+        CityInputField(
+          label: config?.label ?? CheckoutComponentsStrings.cityLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.cityPlaceholder,
+          scope: scope,
+          styling: config?.styling
+        )
+        .focused($focusedField, equals: .city)
+        .onSubmit { moveToNextField(from: .city) }
+      }
+
+    case .state:
+      let config = scope.stateConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+      } else {
+        StateInputField(
+          label: config?.label ?? CheckoutComponentsStrings.stateLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.statePlaceholder,
+          scope: scope,
+          styling: config?.styling
+        )
+      }
+
+    case .addressLine1:
+      let config = scope.addressLine1Config
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+      } else {
+        AddressLineInputField(
+          label: config?.label ?? CheckoutComponentsStrings.addressLine1Label,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.addressLine1Placeholder,
+          isRequired: true,
+          inputType: .addressLine1,
+          scope: scope,
+          styling: config?.styling
+        )
+      }
+
+    case .addressLine2:
+      let config = scope.addressLine2Config
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+      } else {
+        AddressLineInputField(
+          label: config?.label ?? CheckoutComponentsStrings.addressLine2Label,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.addressLine2Placeholder,
+          isRequired: false,
+          inputType: .addressLine2,
+          scope: scope,
+          styling: config?.styling
+        )
+      }
+
+    case .phoneNumber:
+      let config = scope.phoneNumberConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+      } else {
+        NameInputField(
+          label: config?.label ?? CheckoutComponentsStrings.phoneNumberLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.phoneNumberPlaceholder,
+          inputType: .phoneNumber,
+          scope: scope,
+          styling: config?.styling
+        )
+      }
+
+    case .firstName:
+      let config = scope.firstNameConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+      } else {
+        NameInputField(
+          label: config?.label ?? CheckoutComponentsStrings.firstNameLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.firstNamePlaceholder,
+          inputType: .firstName,
+          scope: scope,
+          styling: config?.styling
+        )
+      }
+
+    case .lastName:
+      let config = scope.lastNameConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+      } else {
+        NameInputField(
+          label: config?.label ?? CheckoutComponentsStrings.lastNameLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.lastNamePlaceholder,
+          inputType: .lastName,
+          scope: scope,
+          styling: config?.styling
+        )
+      }
+
+    case .email:
+      let config = scope.emailConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+      } else {
+        EmailInputField(
+          label: config?.label ?? CheckoutComponentsStrings.emailLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.emailPlaceholder,
+          scope: scope,
+          styling: config?.styling
+        )
+      }
+
+    case .retailer:
+      let config = scope.retailOutletConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+      } else {
+        Text(CheckoutComponentsStrings.retailOutletNotImplemented)
+          .font(PrimerFont.caption(tokens: tokens))
+          .foregroundColor(CheckoutColors.gray(tokens: tokens))
+          .padding(PrimerSpacing.large(tokens: tokens))
+      }
+
+    case .otp:
+      let config = scope.otpCodeConfig
+      if let customComponent = config?.component {
+        AnyView(customComponent())
+      } else {
+        OTPCodeInputField(
+          label: CheckoutComponentsStrings.otpLabel,
+          placeholder: config?.placeholder ?? CheckoutComponentsStrings.otpCodeNumericPlaceholder,
+          scope: scope,
+          styling: config?.styling
+        )
+      }
+
+    case .unknown, .all:
+      EmptyView()
+    }
+  }
+
+  // swiftlint:enable cyclomatic_complexity function_body_length
+
+  // MARK: - Helper Methods
+
+  private func getSelectedCardNetwork() -> CardNetwork? {
+    if let network = cardFormState.selectedNetwork {
+      return network.network
+    }
+    return nil
+  }
+
+  private func getCardNetworkForCvv() -> CardNetwork {
+    if let network = cardFormState.selectedNetwork {
+      return network.network
+    }
+    return .unknown
+  }
+
+  // MARK: - Focus Management
+
+  /// Moves keyboard focus to the next field in logical order
+  /// cardNumber → expiry → cvv → cardholderName → submit
+  private func moveToNextField(from currentField: PrimerInputElementType) {
+    let cardFields = formConfiguration.cardFields
+    let billingFields = formConfiguration.billingFields
+
+    if let currentIndex = cardFields.firstIndex(of: currentField) {
+      if currentIndex + 1 < cardFields.count {
+        focusedField = cardFields[currentIndex + 1]
+        return
+      }
+      if !billingFields.isEmpty {
+        focusedField = billingFields.first
+        return
+      }
+      focusedField = nil
+      return
+    }
+
+    if let currentIndex = billingFields.firstIndex(of: currentField) {
+      if currentIndex + 1 < billingFields.count {
+        focusedField = billingFields[currentIndex + 1]
+        return
+      }
+      focusedField = nil
+      return
+    }
+
+    focusedField = nil
+  }
+
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DefaultLoadingScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DefaultLoadingScreen.swift
@@ -1,0 +1,36 @@
+//
+//  DefaultLoadingScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct DefaultLoadingScreen: View {
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+      ProgressView()
+        .progressViewStyle(
+          CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+        )
+        .scaleEffect(PrimerScale.large)
+        .accessibility(
+          config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.Common.loadingIndicator,
+            label: CheckoutComponentsStrings.a11yLoading
+          )
+        )
+
+      Text(CheckoutComponentsStrings.loading)
+        .font(PrimerFont.bodyMedium(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+    }
+    .frame(height: 300)
+    .frame(maxWidth: .infinity)
+    .background(CheckoutColors.background(tokens: tokens))
+    .accessibilityIdentifier(AccessibilityIdentifiers.Common.loadingIndicator)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DeleteVaultedPaymentMethodConfirmationScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DeleteVaultedPaymentMethodConfirmationScreen.swift
@@ -1,0 +1,170 @@
+//
+//  DeleteVaultedPaymentMethodConfirmationScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Screen displaying a confirmation dialog for deleting a vaulted payment method
+@available(iOS 15.0, *)
+struct DeleteVaultedPaymentMethodConfirmationScreen: View, LogReporter {
+  let vaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
+  let navigator: CheckoutNavigator
+  let scope: DefaultPaymentMethodSelectionScope
+
+  @Environment(\.designTokens) private var tokens
+
+  @State private var isDeleting = false
+  @State private var deleteTask: Task<Void, Never>?
+
+  // MARK: - Body
+
+  var body: some View {
+    VStack(spacing: 0) {
+      makeHeader()
+      makePaymentMethodCard()
+      makeConfirmationSection()
+      Spacer()
+    }
+    .background(CheckoutColors.background(tokens: tokens))
+    .onDisappear {
+      deleteTask?.cancel()
+      deleteTask = nil
+    }
+  }
+
+  // MARK: - Header
+
+  private func makeHeader() -> some View {
+    CheckoutHeaderView(
+      showBackButton: true,
+      onBack: navigator.navigateBack,
+      rightButton: .doneButton(action: navigator.navigateBack)
+    )
+  }
+
+  // MARK: - Payment Method Card (Read-only)
+
+  private func makePaymentMethodCard() -> some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      // Title
+      HStack {
+        Text(CheckoutComponentsStrings.allSavedPaymentMethods)
+          .font(PrimerFont.titleXLarge(tokens: tokens))
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        Spacer()
+      }
+
+      // Card display (non-interactive, reusing VaultedPaymentMethodCard)
+      VaultedPaymentMethodCard(
+        vaultedPaymentMethod: vaultedPaymentMethod
+      )
+    }
+    .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+    .padding(.bottom, PrimerSpacing.large(tokens: tokens))
+  }
+
+  // MARK: - Confirmation Section
+
+  private func makeConfirmationSection() -> some View {
+    VStack(alignment: .leading, spacing: PrimerSpacing.small(tokens: tokens)) {
+      Text(CheckoutComponentsStrings.deletePaymentMethodConfirmation)
+        .font(PrimerFont.bodySmall(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+
+      HStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+        makeCancelButton()
+        makeDeleteButton()
+      }
+    }
+    .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+  }
+
+  // MARK: - Cancel Button
+
+  private func makeCancelButton() -> some View {
+    Button(action: { navigator.navigateBack() }) {
+      Text(CheckoutComponentsStrings.cancelButton)
+        .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .frame(maxWidth: .infinity)
+        .padding(PrimerSpacing.medium(tokens: tokens))
+        .background(
+          RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+            .fill(CheckoutColors.background(tokens: tokens))
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+            .stroke(
+              CheckoutColors.borderDefault(tokens: tokens),
+              lineWidth: PrimerBorderWidth.standard
+            )
+        )
+    }
+    .buttonStyle(PlainButtonStyle())
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.Common.cancelButton,
+        label: CheckoutComponentsStrings.a11yCancel,
+        traits: [.isButton]
+      )
+    )
+  }
+
+  // MARK: - Delete Button
+
+  private func makeDeleteButton() -> some View {
+    Button(action: handleDelete) {
+      Group {
+        if isDeleting {
+          ProgressView()
+            .progressViewStyle(
+              CircularProgressViewStyle(tint: CheckoutColors.background(tokens: tokens))
+            )
+        } else {
+          Text(CheckoutComponentsStrings.deleteButton)
+            .font(PrimerFont.titleLarge(tokens: tokens))
+        }
+      }
+      .foregroundColor(CheckoutColors.background(tokens: tokens))
+      .frame(maxWidth: .infinity)
+      .padding(PrimerSpacing.medium(tokens: tokens))
+      .background(
+        RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+          .fill(CheckoutColors.borderFocus(tokens: tokens))
+      )
+    }
+    .buttonStyle(PlainButtonStyle())
+    .disabled(isDeleting)
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.Common.deleteButton,
+        label: CheckoutComponentsStrings.a11yDelete,
+        traits: [.isButton]
+      )
+    )
+  }
+
+  // MARK: - Actions
+
+  private func handleDelete() {
+    guard !isDeleting else { return }
+
+    isDeleting = true
+
+    Task { [self] in
+      do {
+        try await scope.deleteVaultedPaymentMethod(vaultedPaymentMethod)
+        logger.info(message: "[Vault] Successfully deleted payment method from confirmation screen")
+      } catch {
+        logger.error(
+          message: "[Vault] Failed to delete payment method: \(error.localizedDescription)"
+        )
+      }
+
+      isDeleting = false
+      navigator.navigateBack()
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ErrorScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ErrorScreen.swift
@@ -1,0 +1,109 @@
+//
+//  ErrorScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct ErrorScreen: View {
+  let error: PrimerError
+  let onRetry: (() -> Void)?
+  let onChooseOtherPaymentMethods: (() -> Void)?
+
+  @Environment(\.designTokens) private var tokens
+
+  init(
+    error: PrimerError,
+    onRetry: (() -> Void)? = nil,
+    onChooseOtherPaymentMethods: (() -> Void)? = nil
+  ) {
+    self.error = error
+    self.onRetry = onRetry
+    self.onChooseOtherPaymentMethods = onChooseOtherPaymentMethods
+  }
+
+  var body: some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      Spacer()
+
+      Image(systemName: "exclamationmark.triangle.fill")
+        .font(PrimerFont.largeIcon(tokens: tokens))
+        .foregroundColor(CheckoutColors.borderError(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.Error.icon)
+        .accessibilityHidden(true)
+
+      Text(CheckoutComponentsStrings.paymentFailed)
+        .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.Error.title)
+        .accessibilityAddTraits(.isHeader)
+
+      Text(error.errorDescription ?? CheckoutComponentsStrings.unexpectedError)
+        .font(PrimerFont.bodyMedium(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, PrimerSpacing.xxlarge(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.Error.description)
+
+      Spacer()
+
+      VStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+        makeRetryButton()
+        makeOtherPaymentButton()
+      }
+      .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+      .padding(.bottom, PrimerSpacing.xxlarge(tokens: tokens))
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(CheckoutColors.background(tokens: tokens))
+  }
+
+  private func makeRetryButton() -> some View {
+    Button {
+      onRetry?()
+    } label: {
+      Text(CheckoutComponentsStrings.retryButton)
+        .font(PrimerFont.bodyMedium(tokens: tokens))
+        .fontWeight(.semibold)
+        .foregroundColor(.white)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+        .background(CheckoutColors.blue(tokens: tokens))
+        .cornerRadius(PrimerRadius.medium(tokens: tokens))
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.Error.retryButton,
+        label: CheckoutComponentsStrings.retryButton,
+        traits: [.isButton]
+      )
+    )
+  }
+
+  private func makeOtherPaymentButton() -> some View {
+    Button {
+      onChooseOtherPaymentMethods?()
+    } label: {
+      Text(CheckoutComponentsStrings.chooseOtherPaymentMethod)
+        .font(PrimerFont.bodyMedium(tokens: tokens))
+        .fontWeight(.semibold)
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+        .background(Color.clear)
+        .overlay(
+          RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+            .stroke(CheckoutColors.borderDefault(tokens: tokens), lineWidth: 1)
+        )
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.Error.otherPaymentMethodButton,
+        label: CheckoutComponentsStrings.chooseOtherPaymentMethod,
+        traits: [.isButton]
+      )
+    )
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectPendingScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectPendingScreen.swift
@@ -1,0 +1,124 @@
+//
+//  FormRedirectPendingScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct FormRedirectPendingScreen: View {
+
+    // MARK: - Properties
+
+    @ObservedObject private var scope: DefaultFormRedirectScope
+    private let currentState: PrimerFormRedirectState
+
+    @Environment(\.designTokens) private var tokens
+
+    // MARK: - Initialization
+
+    init(scope: DefaultFormRedirectScope, state: PrimerFormRedirectState) {
+        self.scope = scope
+        currentState = state
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            makeHeaderView()
+
+            VStack(spacing: PrimerSpacing.xlarge(tokens: tokens)) {
+                Spacer()
+
+                makePaymentMethodIcon()
+
+                Text(CheckoutComponentsStrings.formRedirectPendingTitle)
+                    .font(PrimerFont.titleLarge(tokens: tokens))
+                    .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+                    .multilineTextAlignment(.center)
+
+                Text(currentState.pendingMessage ?? CheckoutComponentsStrings.formRedirectPendingMessage)
+                    .font(PrimerFont.bodyLarge(tokens: tokens))
+                    .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, PrimerSpacing.xlarge(tokens: tokens))
+                    .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.pendingMessage)
+
+                ProgressView()
+                    .progressViewStyle(
+                        CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+                    )
+                    .scaleEffect(PrimerScale.large)
+                    .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.loadingIndicator)
+                    .accessibility(
+                        config: AccessibilityConfiguration(
+                            identifier: AccessibilityIdentifiers.FormRedirect.loadingIndicator,
+                            label: CheckoutComponentsStrings.a11yLoading
+                        )
+                    )
+
+                Spacer()
+            }
+            .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+        }
+        .background(CheckoutColors.screenBackground(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.pendingScreen)
+        .onAppear(perform: announceScreenChange)
+    }
+
+    // MARK: - Header
+
+    private func makeHeaderView() -> some View {
+        HStack {
+            Spacer()
+
+            Button(action: scope.cancel) {
+                Text(CheckoutComponentsStrings.cancelButton)
+                    .font(PrimerFont.titleLarge(tokens: tokens))
+                    .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+            }
+            .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.cancelButton)
+            .accessibility(
+                config: AccessibilityConfiguration(
+                    identifier: AccessibilityIdentifiers.FormRedirect.cancelButton,
+                    label: CheckoutComponentsStrings.a11yCancel,
+                    traits: [.isButton]
+                )
+            )
+        }
+        .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+        .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+    }
+
+    // MARK: - Payment Method Icon
+
+    @ViewBuilder
+    private func makePaymentMethodIcon() -> some View {
+        if let icon = PrimerPaymentMethodType(rawValue: scope.paymentMethodType)?.icon {
+            Image(uiImage: icon)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: PrimerIconSize.paymentMethodLargeWidth, height: PrimerIconSize.paymentMethodLargeHeight)
+        }
+    }
+
+    // MARK: - Accessibility
+
+    private func announceScreenChange() {
+        let announcement = "\(CheckoutComponentsStrings.formRedirectPendingTitle). \(currentState.pendingMessage ?? CheckoutComponentsStrings.formRedirectPendingMessage)"
+        UIAccessibility.post(notification: .screenChanged, argument: announcement)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+@available(iOS 15.0, *)
+struct FormRedirectPendingScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        Text("Form Redirect Pending Screen Preview")
+    }
+}
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -1,0 +1,314 @@
+//
+//  FormRedirectScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct FormRedirectScreen: View {
+
+    // MARK: - Properties
+
+    @ObservedObject private var scope: DefaultFormRedirectScope
+    private let currentState: PrimerFormRedirectState
+
+    @Environment(\.designTokens) private var tokens
+
+    // MARK: - Initialization
+
+    init(scope: DefaultFormRedirectScope, state: PrimerFormRedirectState) {
+        self.scope = scope
+        currentState = state
+    }
+
+    // MARK: - Computed Properties
+
+    private var paymentMethodIcon: UIImage? {
+        PrimerPaymentMethodType(rawValue: scope.paymentMethodType)?.icon
+    }
+
+    private var defaultSubmitButtonText: String {
+        switch scope.paymentMethodType {
+        case PrimerPaymentMethodType.adyenBlik.rawValue:
+            CheckoutComponentsStrings.payWithBlik
+        case PrimerPaymentMethodType.adyenMBWay.rawValue:
+            CheckoutComponentsStrings.payWithMBWay
+        default:
+            CheckoutComponentsStrings.payButton
+        }
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            makeHeaderView()
+
+            ScrollView {
+                VStack(spacing: PrimerSpacing.xlarge(tokens: tokens)) {
+                    makePaymentMethodHeader()
+                    makeFormSection()
+
+                    Spacer()
+                        .frame(height: PrimerSpacing.large(tokens: tokens))
+
+                    makeSubmitButtonSection()
+                }
+                .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+                .padding(.top, PrimerSpacing.large(tokens: tokens))
+            }
+        }
+        .background(CheckoutColors.screenBackground(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.screen)
+        .onAppear(perform: scope.start)
+    }
+
+    // MARK: - Header
+
+    private func makeHeaderView() -> some View {
+        CheckoutHeaderView(
+            showBackButton: scope.presentationContext.shouldShowBackButton,
+            onBack: scope.onBack,
+            rightButton: .closeButton(action: scope.cancel)
+        )
+    }
+
+    // MARK: - Payment Method Header
+
+    @ViewBuilder
+    private func makePaymentMethodHeader() -> some View {
+        if let icon = paymentMethodIcon {
+            VStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+                Image(uiImage: icon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: PrimerIconSize.paymentMethodWidth, height: PrimerIconSize.paymentMethodHeight)
+            }
+            .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+        }
+    }
+
+    // MARK: - Form Section
+
+    @ViewBuilder
+    private func makeFormSection() -> some View {
+        if let customFormSection = scope.formSection {
+            AnyView(customFormSection(scope))
+        } else {
+            makeDefaultFormSection()
+        }
+    }
+
+    private func makeDefaultFormSection() -> some View {
+        VStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+            ForEach(currentState.fields) { field in
+                FormFieldView(
+                    field: field,
+                    onValueChanged: { value in
+                        scope.updateField(field.fieldType, value: value)
+                    },
+                    onSubmit: scope.submit
+                )
+            }
+        }
+    }
+
+    // MARK: - Submit Button Section
+
+    @ViewBuilder
+    private func makeSubmitButtonSection() -> some View {
+        if let customButton = scope.submitButton {
+            AnyView(customButton(scope))
+        } else {
+            makeDefaultSubmitButton()
+        }
+    }
+
+    private func makeDefaultSubmitButton() -> some View {
+        Button(action: scope.submit) {
+            HStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+                if currentState.isLoading {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                }
+
+                Text(scope.submitButtonText ?? defaultSubmitButtonText)
+                    .font(PrimerFont.bodyMedium(tokens: tokens))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: PrimerComponentHeight.button)
+            .foregroundColor(CheckoutColors.buttonTextPrimary(tokens: tokens))
+            .background(
+                RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+                    .fill(
+                        currentState.isSubmitEnabled && !currentState.isLoading
+                          ? CheckoutColors.buttonPrimary(tokens: tokens)
+                          : CheckoutColors.buttonDisabled(tokens: tokens)
+                    )
+            )
+        }
+        .disabled(!currentState.isSubmitEnabled || currentState.isLoading)
+        .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.submitButton)
+        .accessibility(
+            config: AccessibilityConfiguration(
+                identifier: AccessibilityIdentifiers.FormRedirect.submitButton,
+                label: CheckoutComponentsStrings.a11ySubmitButtonLabel,
+                hint: currentState.isSubmitEnabled ? nil : CheckoutComponentsStrings.a11ySubmitButtonHint,
+                traits: [.isButton]
+            )
+        )
+    }
+}
+
+// MARK: - Form Field View
+
+@available(iOS 15.0, *)
+private struct FormFieldView: View {
+
+    let field: PrimerFormFieldState
+    let onValueChanged: (String) -> Void
+    let onSubmit: () -> Void
+
+    @Environment(\.designTokens) private var tokens
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: PrimerSpacing.small(tokens: tokens)) {
+            Text(field.label)
+                .font(PrimerFont.caption(tokens: tokens))
+                .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+
+            makeInputField()
+
+            if let errorMessage = field.errorMessage {
+                Text(errorMessage)
+                    .font(PrimerFont.caption(tokens: tokens))
+                    .foregroundColor(CheckoutColors.error(tokens: tokens))
+            } else if let helperText = field.helperText {
+                Text(helperText)
+                    .font(PrimerFont.caption(tokens: tokens))
+                    .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+            }
+        }
+    }
+
+    private func makeInputField() -> some View {
+        HStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+            if let prefix = field.countryCodePrefix, field.fieldType == .phoneNumber {
+                Text(prefix)
+                    .font(PrimerFont.bodyLarge(tokens: tokens))
+                    .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+                    .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.phonePrefix)
+            }
+
+            TextField(field.placeholder, text: Binding(
+                get: { field.value },
+                set: { onValueChanged($0) }
+            ))
+            .font(PrimerFont.bodyLarge(tokens: tokens))
+            .keyboardType(field.keyboardType.uiKeyboardType)
+            .textContentType(field.fieldType.textContentType)
+            .focused($isFocused)
+            .onSubmit { onSubmit() }
+            .accessibilityIdentifier(accessibilityIdentifier)
+            .accessibility(
+                config: AccessibilityConfiguration(
+                    identifier: accessibilityIdentifier,
+                    label: accessibilityLabel,
+                    hint: accessibilityHint,
+                    traits: []
+                )
+            )
+        }
+        .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
+        .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+        .background(
+            RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+                .stroke(borderColor, lineWidth: PrimerBorderWidth.standard)
+                .background(
+                    RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+                        .fill(CheckoutColors.inputBackground(tokens: tokens))
+                )
+        )
+    }
+
+    private var borderColor: Color {
+        if field.errorMessage != nil {
+            CheckoutColors.error(tokens: tokens)
+        } else if isFocused {
+            CheckoutColors.inputBorderFocused(tokens: tokens)
+        } else {
+            CheckoutColors.inputBorder(tokens: tokens)
+        }
+    }
+
+    private var accessibilityIdentifier: String {
+        switch field.fieldType {
+        case .otpCode:
+            AccessibilityIdentifiers.FormRedirect.otpField
+        case .phoneNumber:
+            AccessibilityIdentifiers.FormRedirect.phoneField
+        }
+    }
+
+    private var accessibilityLabel: String {
+        switch field.fieldType {
+        case .otpCode:
+            CheckoutComponentsStrings.a11yFormRedirectOtpLabel
+        case .phoneNumber:
+            CheckoutComponentsStrings.a11yFormRedirectPhoneLabel
+        }
+    }
+
+    private var accessibilityHint: String {
+        switch field.fieldType {
+        case .otpCode:
+            CheckoutComponentsStrings.a11yFormRedirectOtpHint
+        case .phoneNumber:
+            CheckoutComponentsStrings.a11yFormRedirectPhoneHint
+        }
+    }
+}
+
+// MARK: - Keyboard Type Extension
+
+@available(iOS 15.0, *)
+private extension PrimerFormFieldState.KeyboardType {
+    var uiKeyboardType: UIKeyboardType {
+        switch self {
+        case .numberPad:
+            .numberPad
+        case .phonePad:
+            .phonePad
+        case .default:
+            .default
+        }
+    }
+}
+
+// MARK: - Text Content Type Extension
+
+@available(iOS 15.0, *)
+private extension PrimerFormFieldState.FieldType {
+    var textContentType: UITextContentType? {
+        switch self {
+        case .otpCode:
+            .oneTimeCode
+        case .phoneNumber:
+            .telephoneNumber
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+@available(iOS 15.0, *)
+struct FormRedirectScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        Text("Form Redirect Screen Preview")
+    }
+}
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaPaymentViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaPaymentViewRepresentable.swift
@@ -1,0 +1,42 @@
+//
+//  KlarnaPaymentViewRepresentable.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+import UIKit
+
+@available(iOS 15.0, *)
+struct KlarnaPaymentViewRepresentable: UIViewRepresentable {
+
+  let paymentView: UIView
+
+  func makeUIView(context: Context) -> UIView {
+    let container = UIView()
+    container.backgroundColor = .clear
+    embedPaymentView(in: container)
+    return container
+  }
+
+  func updateUIView(_ uiView: UIView, context: Context) {
+    // Check if the payment view has changed (e.g., after switching categories)
+    guard paymentView.superview !== uiView else { return }
+
+    // Remove old subviews and embed the new payment view
+    uiView.subviews.forEach { $0.removeFromSuperview() }
+    embedPaymentView(in: uiView)
+  }
+
+  private func embedPaymentView(in container: UIView) {
+    paymentView.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(paymentView)
+
+    NSLayoutConstraint.activate([
+      paymentView.topAnchor.constraint(equalTo: container.topAnchor),
+      paymentView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      paymentView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      paymentView.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+    ])
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -1,0 +1,403 @@
+//
+//  KlarnaView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct KlarnaView: View, LogReporter {
+  let scope: any PrimerKlarnaScope
+
+  @Environment(\.designTokens) private var tokens
+  @State private var klarnaState: PrimerKlarnaState = .init()
+
+  // MARK: - Layout Constants
+
+  private enum Layout {
+    static let logoWidth: CGFloat = 56
+    static let logoHeight: CGFloat = 24
+    static let spinnerSize: CGFloat = 56
+    static let badgeWidth: CGFloat = 56
+    static let badgeHeight: CGFloat = 40
+    static let paymentViewMinHeight: CGFloat = 200
+    static let inlineLoadingMinHeight: CGFloat = 100
+    static let selectedBorderWidth: CGFloat = 2
+    static let defaultBorderWidth: CGFloat = 1
+    static let badgeCornerRadius: CGFloat = 2
+    static let placeholderOpacity: Double = 0.8
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      makeHeaderSection()
+        .padding(.bottom, PrimerSpacing.xlarge(tokens: tokens))
+
+      ScrollView {
+        makeContentSection()
+      }
+    }
+    .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+    .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+    .navigationBarHidden(true)
+    .background(CheckoutColors.background(tokens: tokens))
+    .accessibilityIdentifier(AccessibilityIdentifiers.Klarna.container)
+    .task {
+      for await state in scope.state {
+        klarnaState = state
+      }
+    }
+  }
+
+  // MARK: - Header Section
+
+  @MainActor
+  private func makeHeaderSection() -> some View {
+    HStack {
+      if scope.presentationContext.shouldShowBackButton {
+        Button(
+          action: scope.onBack,
+          label: {
+            HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+              Image(systemName: RTLIcon.backChevron)
+                .font(PrimerFont.bodyMedium(tokens: tokens))
+              Text(CheckoutComponentsStrings.backButton)
+            }
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          }
+        )
+        .accessibility(
+          config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.Common.backButton,
+            label: CheckoutComponentsStrings.a11yBack,
+            traits: [.isButton]
+          )
+        )
+      }
+
+      Spacer()
+
+      // Klarna logo
+      makeKlarnaLogo()
+
+      Spacer()
+
+      if scope.dismissalMechanism.contains(.closeButton) {
+        Button(
+          CheckoutComponentsStrings.cancelButton,
+          action: scope.cancel
+        )
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .accessibility(
+          config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.Common.closeButton,
+            label: CheckoutComponentsStrings.a11yCancel,
+            traits: [.isButton]
+          )
+        )
+      } else {
+        // Invisible spacer to keep logo centered
+        Text(CheckoutComponentsStrings.cancelButton)
+          .hidden()
+      }
+    }
+  }
+
+  @MainActor
+  private func makeKlarnaLogo() -> some View {
+    Group {
+      if let logoImage = UIImage(named: "klarna", in: .primerResources, compatibleWith: nil) {
+        Image(uiImage: logoImage)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: Layout.logoWidth, height: Layout.logoHeight)
+      } else {
+        Text(CheckoutComponentsStrings.klarnaBrandName)
+          .font(PrimerFont.titleLarge(tokens: tokens))
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.Klarna.logo,
+        label: CheckoutComponentsStrings.klarnaBrandName
+      )
+    )
+  }
+
+  // MARK: - Content Section
+
+  @MainActor
+  @ViewBuilder
+  private func makeContentSection() -> some View {
+    switch klarnaState.step {
+    case .loading:
+      makeLoadingContent()
+    case .categorySelection, .viewReady:
+      makeCategorySelectionContent()
+    case .authorizationStarted:
+      makeLoadingContent()
+    case .awaitingFinalization:
+      makeFinalizationContent()
+    }
+  }
+
+  // MARK: - Loading Content
+
+  @MainActor
+  private func makeLoadingContent() -> some View {
+    VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+      Spacer()
+        .frame(height: PrimerSpacing.xxlarge(tokens: tokens) * 2)
+
+      ProgressView()
+        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.blue(tokens: tokens)))
+        .scaleEffect(PrimerScale.large)
+        .frame(width: Layout.spinnerSize, height: Layout.spinnerSize)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Klarna.loadingIndicator)
+
+      Spacer()
+        .frame(height: PrimerSpacing.small(tokens: tokens))
+
+      Text(CheckoutComponentsStrings.klarnaLoadingTitle)
+        .font(PrimerFont.bodyLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+      Text(CheckoutComponentsStrings.klarnaLoadingSubtitle)
+        .font(PrimerFont.bodyMedium(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+
+      Spacer()
+        .frame(height: PrimerSpacing.xxlarge(tokens: tokens) * 2)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.horizontal, PrimerSpacing.xlarge(tokens: tokens))
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
+  }
+
+  // MARK: - Category Selection Content
+
+  @MainActor
+  private func makeCategorySelectionContent() -> some View {
+    VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+      // Category cards
+      VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+        ForEach(klarnaState.categories, id: \.id) { category in
+          makeCategoryCard(for: category)
+        }
+      }
+      .accessibilityIdentifier(AccessibilityIdentifiers.Klarna.categoriesContainer)
+
+      // Authorize button (visible when a category is selected and view is ready)
+      if klarnaState.step == .viewReady {
+        makeAuthorizeButtonSection()
+          .padding(.top, PrimerSpacing.large(tokens: tokens))
+      }
+    }
+  }
+
+  @MainActor
+  private func makeCategoryCard(for category: KlarnaPaymentCategory) -> some View {
+    let isSelected = klarnaState.selectedCategoryId == category.id
+
+    return VStack(
+      alignment: .leading, spacing: isSelected ? PrimerSpacing.medium(tokens: tokens) : 0
+    ) {
+      // Category header
+      Button(action: {
+        scope.selectPaymentCategory(category.id)
+      }) {
+        HStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+          // Category badge image
+          makeCategoryBadge(for: category)
+
+          // Category name
+          Text(category.name)
+            .font(PrimerFont.bodyLarge(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+          Spacer()
+
+          // Checkmark for selected
+          if isSelected {
+            Image(systemName: "checkmark")
+              .foregroundColor(CheckoutColors.blue(tokens: tokens))
+              .font(PrimerFont.bodyMedium(tokens: tokens))
+          }
+        }
+      }
+      .accessibilityIdentifier(AccessibilityIdentifiers.Klarna.categoryButton(category.id))
+      .accessibilityLabel(
+        isSelected
+          ? CheckoutComponentsStrings.a11yKlarnaCategorySelected(category.name)
+          : CheckoutComponentsStrings.a11yKlarnaCategory(category.name)
+      )
+
+      // Expanded Klarna SDK view or inline loading indicator
+      if isSelected, let paymentView = scope.paymentView {
+        KlarnaPaymentViewRepresentable(paymentView: paymentView)
+          .id(category.id)
+          .frame(minHeight: Layout.paymentViewMinHeight)
+          .accessibilityIdentifier(AccessibilityIdentifiers.Klarna.paymentViewContainer)
+          .accessibilityLabel(CheckoutComponentsStrings.a11yKlarnaPaymentView)
+      } else if isSelected, scope.paymentView == nil, klarnaState.step != .viewReady {
+        ProgressView()
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.blue(tokens: tokens)))
+          .frame(maxWidth: .infinity, minHeight: Layout.inlineLoadingMinHeight)
+          .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
+      }
+    }
+    .padding(PrimerSpacing.medium(tokens: tokens))
+    .background(CheckoutColors.background(tokens: tokens))
+    .overlay(
+      RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+        .stroke(
+          isSelected
+            ? CheckoutColors.blue(tokens: tokens) : CheckoutColors.borderDefault(tokens: tokens),
+          lineWidth: isSelected ? Layout.selectedBorderWidth : Layout.defaultBorderWidth
+        )
+    )
+    .clipShape(RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens)))
+  }
+
+  @MainActor
+  private func makeCategoryBadge(for category: KlarnaPaymentCategory) -> some View {
+    AsyncImage(url: URL(string: category.standardAssetUrl)) { image in
+      image
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+    } placeholder: {
+      RoundedRectangle(cornerRadius: Layout.badgeCornerRadius)
+        .fill(Color.pink.opacity(Layout.placeholderOpacity))
+        .overlay(
+          Text("K")
+            .font(PrimerFont.bodyLarge(tokens: tokens))
+            .foregroundColor(.white)
+        )
+    }
+    .frame(width: Layout.badgeWidth, height: Layout.badgeHeight)
+    .clipShape(RoundedRectangle(cornerRadius: Layout.badgeCornerRadius))
+  }
+
+  // MARK: - Shared Button Builder
+
+  @MainActor
+  private func makePrimaryButton(title: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      Text(title)
+        .font(PrimerFont.body(tokens: tokens))
+        .foregroundColor(CheckoutColors.white(tokens: tokens))
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+        .background(CheckoutColors.textPrimary(tokens: tokens))
+        .cornerRadius(PrimerRadius.small(tokens: tokens))
+    }
+  }
+
+  // MARK: - Authorize Button
+
+  @MainActor
+  @ViewBuilder
+  private func makeAuthorizeButtonSection() -> some View {
+    if let customButton = scope.authorizeButton {
+      AnyView(customButton(scope))
+    } else {
+      makePrimaryButton(title: CheckoutComponentsStrings.klarnaAuthorizeButton, action: scope.authorizePayment)
+        .accessibilityIdentifier(AccessibilityIdentifiers.Klarna.authorizeButton)
+        .accessibilityLabel(CheckoutComponentsStrings.klarnaAuthorizeButton)
+        .accessibilityHint(CheckoutComponentsStrings.a11yKlarnaAuthorizeHint)
+    }
+  }
+
+  // MARK: - Finalization Content
+
+  @MainActor
+  private func makeFinalizationContent() -> some View {
+    VStack(spacing: PrimerSpacing.xlarge(tokens: tokens)) {
+      Text(CheckoutComponentsStrings.klarnaSelectCategoryDescription)
+        .font(PrimerFont.bodyMedium(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .multilineTextAlignment(.center)
+
+      if let customButton = scope.finalizeButton {
+        AnyView(customButton(scope))
+      } else {
+        makePrimaryButton(title: CheckoutComponentsStrings.klarnaFinalizeButton, action: scope.finalizePayment)
+          .accessibilityIdentifier(AccessibilityIdentifiers.Klarna.finalizeButton)
+          .accessibilityLabel(CheckoutComponentsStrings.klarnaFinalizeButton)
+          .accessibilityHint(CheckoutComponentsStrings.a11yKlarnaFinalizeHint)
+      }
+    }
+    .padding(.top, PrimerSpacing.xlarge(tokens: tokens))
+  }
+
+}
+
+// MARK: - Preview
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  #Preview("Klarna - Category Selection") {
+    KlarnaView(scope: MockKlarnaScope())
+      .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("Klarna - Loading") {
+    KlarnaView(scope: MockKlarnaScope(step: .loading))
+      .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  @MainActor
+  private final class MockKlarnaScope: PrimerKlarnaScope, ObservableObject {
+    var presentationContext: PresentationContext = .fromPaymentSelection
+    var dismissalMechanism: [DismissalMechanism] = [.closeButton]
+    var paymentView: UIView?
+    var screen: KlarnaScreenComponent?
+    var authorizeButton: KlarnaButtonComponent?
+    var finalizeButton: KlarnaButtonComponent?
+
+    @Published private var mockState: PrimerKlarnaState
+
+    var state: AsyncStream<PrimerKlarnaState> {
+      AsyncStream { continuation in
+        continuation.yield(mockState)
+      }
+    }
+
+    init(step: PrimerKlarnaState.Step = .categorySelection) {
+      let categories = [
+        KlarnaPaymentCategory(
+          response: Response.Body.Klarna.SessionCategory(
+            identifier: "pay_now", name: "Pay now",
+            descriptiveAssetUrl: "", standardAssetUrl: ""
+          )
+        ),
+        KlarnaPaymentCategory(
+          response: Response.Body.Klarna.SessionCategory(
+            identifier: "pay_later", name: "Pay in 30 days",
+            descriptiveAssetUrl: "", standardAssetUrl: ""
+          )
+        )
+      ]
+      mockState = PrimerKlarnaState(step: step, categories: categories)
+    }
+
+    func start() {}
+    func submit() {}
+    func cancel() {}
+    func selectPaymentCategory(_ categoryId: String) {
+      mockState = PrimerKlarnaState(
+        step: mockState.step,
+        categories: mockState.categories,
+        selectedCategoryId: categoryId
+      )
+    }
+    func authorizePayment() {}
+    func finalizePayment() {}
+    func onBack() {}
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -72,8 +72,7 @@ struct KlarnaView: View, LogReporter {
             identifier: AccessibilityIdentifiers.Common.backButton,
             label: CheckoutComponentsStrings.a11yBack,
             traits: [.isButton]
-          )
-        )
+          ))
       }
 
       Spacer()
@@ -94,8 +93,7 @@ struct KlarnaView: View, LogReporter {
             identifier: AccessibilityIdentifiers.Common.closeButton,
             label: CheckoutComponentsStrings.a11yCancel,
             traits: [.isButton]
-          )
-        )
+          ))
       } else {
         // Invisible spacer to keep logo centered
         Text(CheckoutComponentsStrings.cancelButton)
@@ -122,8 +120,7 @@ struct KlarnaView: View, LogReporter {
       config: AccessibilityConfiguration(
         identifier: AccessibilityIdentifiers.Klarna.logo,
         label: CheckoutComponentsStrings.klarnaBrandName
-      )
-    )
+      ))
   }
 
   // MARK: - Content Section
@@ -270,7 +267,7 @@ struct KlarnaView: View, LogReporter {
         .aspectRatio(contentMode: .fit)
     } placeholder: {
       RoundedRectangle(cornerRadius: Layout.badgeCornerRadius)
-        .fill(Color.pink.opacity(Layout.placeholderOpacity))
+        .fill(CheckoutColors.gray300(tokens: tokens).opacity(Layout.placeholderOpacity))
         .overlay(
           Text("K")
             .font(PrimerFont.bodyLarge(tokens: tokens))
@@ -374,14 +371,12 @@ struct KlarnaView: View, LogReporter {
           response: Response.Body.Klarna.SessionCategory(
             identifier: "pay_now", name: "Pay now",
             descriptiveAssetUrl: "", standardAssetUrl: ""
-          )
-        ),
+          )),
         KlarnaPaymentCategory(
           response: Response.Body.Klarna.SessionCategory(
             identifier: "pay_later", name: "Pay in 30 days",
             descriptiveAssetUrl: "", standardAssetUrl: ""
-          )
-        )
+          ))
       ]
       mockState = PrimerKlarnaState(step: step, categories: categories)
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/PayPalView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/PayPalView.swift
@@ -1,0 +1,261 @@
+//
+//  PayPalView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Default PayPal payment screen for CheckoutComponents.
+/// Shows PayPal branding and a button to initiate the PayPal redirect flow.
+@available(iOS 15.0, *)
+struct PayPalView: View, LogReporter {
+  let scope: any PrimerPayPalScope
+
+  @Environment(\.designTokens) private var tokens
+  @State private var payPalState: PrimerPayPalState = .init()
+
+  var body: some View {
+    VStack(spacing: PrimerSpacing.xxlarge(tokens: tokens)) {
+      headerSection
+      contentSection
+      Spacer()
+      submitButtonSection
+    }
+    .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+    .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+    .frame(maxWidth: .infinity)
+    .navigationBarHidden(true)
+    .background(CheckoutColors.background(tokens: tokens))
+    .task {
+      for await state in scope.state {
+        payPalState = state
+      }
+    }
+  }
+
+  // MARK: - Header Section
+
+  @MainActor
+  private var headerSection: some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      HStack {
+        if scope.presentationContext.shouldShowBackButton {
+          Button(
+            action: scope.onBack,
+            label: {
+              HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+                Image(systemName: RTLIcon.backChevron)
+                  .font(PrimerFont.bodyMedium(tokens: tokens))
+                Text(CheckoutComponentsStrings.backButton)
+              }
+              .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+            }
+          )
+          .accessibility(
+            config: AccessibilityConfiguration(
+              identifier: AccessibilityIdentifiers.Common.backButton,
+              label: CheckoutComponentsStrings.a11yBack,
+              traits: [.isButton]
+            )
+          )
+        }
+
+        Spacer()
+
+        if scope.dismissalMechanism.contains(.closeButton) {
+          Button(
+            CheckoutComponentsStrings.cancelButton,
+            action: scope.cancel
+          )
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          .accessibility(
+            config: AccessibilityConfiguration(
+              identifier: AccessibilityIdentifiers.Common.closeButton,
+              label: CheckoutComponentsStrings.a11yCancel,
+              traits: [.isButton]
+            )
+          )
+        }
+      }
+
+      titleSection
+    }
+  }
+
+  @MainActor
+  private var titleSection: some View {
+    Text(CheckoutComponentsStrings.payPalTitle)
+      .font(PrimerFont.titleXLarge(tokens: tokens))
+      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .accessibilityAddTraits(.isHeader)
+  }
+
+  // MARK: - Content Section
+
+  @MainActor
+  private var contentSection: some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      // PayPal logo
+      payPalLogo
+
+      // Redirect description
+      Text(CheckoutComponentsStrings.payPalRedirectDescription)
+        .font(PrimerFont.body(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: .infinity)
+    }
+    .padding(.vertical, PrimerSpacing.xlarge(tokens: tokens))
+  }
+
+  @MainActor
+  private var payPalLogo: some View {
+    Group {
+      if let logoImage = UIImage(named: "paypal", in: Bundle.primerResources, compatibleWith: nil) {
+        Image(uiImage: logoImage)
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(height: 60)
+      } else {
+        // Fallback text if image not found
+        Text("PayPal")
+          .font(PrimerFont.titleXLarge(tokens: tokens))
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      }
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.PayPal.logo,
+        label: CheckoutComponentsStrings.a11yPayPalLogo
+      )
+    )
+  }
+
+  // MARK: - Submit Button Section
+
+  @MainActor
+  @ViewBuilder
+  private var submitButtonSection: some View {
+    // Check for custom button
+    if let customButton = scope.payButton {
+      AnyView(customButton(scope))
+    } else {
+      Button(action: submitAction) {
+        submitButtonContent
+      }
+      .disabled(isButtonDisabled)
+    }
+  }
+
+  private var submitButtonContent: some View {
+    let isLoading = payPalState.step == .loading || payPalState.step == .redirecting
+
+    return HStack {
+      if isLoading {
+        ProgressView()
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.white(tokens: tokens)))
+          .scaleEffect(PrimerScale.small)
+      } else {
+        Text(submitButtonText)
+      }
+    }
+    .font(PrimerFont.body(tokens: tokens))
+    .foregroundColor(CheckoutColors.white(tokens: tokens))
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+    .background(submitButtonBackground)
+    .cornerRadius(PrimerRadius.small(tokens: tokens))
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.PayPal.submitButton,
+        label: submitButtonAccessibilityLabel,
+        hint: isButtonDisabled
+          ? CheckoutComponentsStrings.a11ySubmitButtonDisabled
+          : CheckoutComponentsStrings.a11ySubmitButtonHint,
+        traits: [.isButton]
+      )
+    )
+  }
+
+  private var submitButtonText: String {
+    scope.submitButtonText ?? CheckoutComponentsStrings.payPalContinueButton
+  }
+
+  private var submitButtonAccessibilityLabel: String {
+    let isLoading = payPalState.step == .loading || payPalState.step == .redirecting
+    if isLoading {
+      return CheckoutComponentsStrings.a11ySubmitButtonLoading
+    }
+    return submitButtonText
+  }
+
+  private var submitButtonBackground: Color {
+    isButtonDisabled
+      ? CheckoutColors.gray300(tokens: tokens)
+      : CheckoutColors.textPrimary(tokens: tokens)
+  }
+
+  private var isButtonDisabled: Bool {
+    payPalState.step == .loading || payPalState.step == .redirecting
+  }
+
+  private func submitAction() {
+    scope.submit()
+  }
+
+}
+
+// MARK: - Preview
+
+#if DEBUG
+  @available(iOS 15.0, *)
+  #Preview("PayPal - Light") {
+    PayPalView(scope: MockPayPalScope())
+      .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("PayPal - Dark") {
+    PayPalView(scope: MockPayPalScope())
+      .environment(\.designTokens, MockDesignTokens.dark)
+      .preferredColorScheme(.dark)
+  }
+
+  @available(iOS 15.0, *)
+  #Preview("PayPal - Loading") {
+    PayPalView(scope: MockPayPalScope(step: .loading))
+      .environment(\.designTokens, MockDesignTokens.light)
+  }
+
+  @available(iOS 15.0, *)
+  @MainActor
+  private final class MockPayPalScope: PrimerPayPalScope, ObservableObject {
+    var presentationContext: PresentationContext = .fromPaymentSelection
+    var dismissalMechanism: [DismissalMechanism] = [.closeButton]
+    var screen: PayPalScreenComponent?
+    var payButton: PayPalButtonComponent?
+    var submitButtonText: String?
+
+    @Published private var mockState: PrimerPayPalState
+
+    var state: AsyncStream<PrimerPayPalState> {
+      AsyncStream { continuation in
+        continuation.yield(mockState)
+      }
+    }
+
+    init(step: PrimerPayPalState.Step = .idle) {
+      mockState = PrimerPayPalState(step: step)
+    }
+
+    func start() {}
+    func submit() {
+      mockState.step = .loading
+    }
+
+    func cancel() {}
+    func onBack() {}
+  }
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/PaymentMethodSelectionScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/PaymentMethodSelectionScreen.swift
@@ -25,6 +25,7 @@ struct PaymentMethodSelectionScreen: View, LogReporter {
     }
     .environment(\.primerPaymentMethodSelectionScope, scope)
     .onAppear {
+      UIAccessibility.post(notification: .screenChanged, argument: nil)
       resolveConfigurationService()
       observeState()
     }
@@ -55,8 +56,7 @@ struct PaymentMethodSelectionScreen: View, LogReporter {
               identifier: AccessibilityIdentifiers.Common.closeButton,
               label: CheckoutComponentsStrings.a11yCancel,
               traits: [.isButton]
-            )
-          )
+            ))
       }
     }
     .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
@@ -105,8 +105,7 @@ struct PaymentMethodSelectionScreen: View, LogReporter {
         .background(
           RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
             .stroke(
-              CheckoutColors.borderDefault(tokens: tokens), lineWidth: PrimerBorderWidth.standard
-            )
+              CheckoutColors.borderDefault(tokens: tokens), lineWidth: PrimerBorderWidth.standard)
         )
     }
     .accessibility(
@@ -114,8 +113,7 @@ struct PaymentMethodSelectionScreen: View, LogReporter {
         identifier: AccessibilityIdentifiers.PaymentSelection.showOtherWaysButton,
         label: CheckoutComponentsStrings.a11yShowOtherWaysToPay,
         traits: [.isButton]
-      )
-    )
+      ))
   }
 
   // MARK: - Helpers

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/PaymentMethodSelectionScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/PaymentMethodSelectionScreen.swift
@@ -1,0 +1,150 @@
+//
+//  PaymentMethodSelectionScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Default payment method selection screen for CheckoutComponents
+@available(iOS 15.0, *)
+struct PaymentMethodSelectionScreen: View, LogReporter {
+  let scope: PrimerPaymentMethodSelectionScope
+
+  @Environment(\.designTokens) private var tokens
+  @Environment(\.bridgeController) private var bridgeController
+  @Environment(\.diContainer) private var container
+  @State private var selectionState: PrimerPaymentMethodSelectionState = .init()
+  @State private var configurationService: ConfigurationService?
+  @State private var observationTask: Task<Void, Never>?
+
+  var body: some View {
+    VStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+      makeHeader()
+      makeContent()
+    }
+    .environment(\.primerPaymentMethodSelectionScope, scope)
+    .onAppear {
+      resolveConfigurationService()
+      observeState()
+    }
+    .onDisappear {
+      observationTask?.cancel()
+      observationTask = nil
+    }
+  }
+
+  // MARK: - Header
+
+  private func makeHeader() -> some View {
+    HStack {
+      if let formattedAmount {
+        Text(CheckoutComponentsStrings.paymentAmountTitle(formattedAmount))
+          .font(PrimerFont.titleXLarge(tokens: tokens))
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          .accessibilityAddTraits(.isHeader)
+      }
+
+      Spacer()
+
+      if scope.dismissalMechanism.contains(.closeButton) {
+        Button(CheckoutComponentsStrings.cancelButton, action: scope.cancel)
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          .accessibility(
+            config: AccessibilityConfiguration(
+              identifier: AccessibilityIdentifiers.Common.closeButton,
+              label: CheckoutComponentsStrings.a11yCancel,
+              traits: [.isButton]
+            )
+          )
+      }
+    }
+    .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+    .padding(.top, PrimerSpacing.large(tokens: tokens))
+  }
+
+  // MARK: - Content
+
+  private func makeContent() -> some View {
+    ScrollView {
+      VStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+        if let vaultedPaymentMethod = selectionState.selectedVaultedPaymentMethod {
+          VaultSection(
+            vaultedPaymentMethod: vaultedPaymentMethod,
+            scope: scope,
+            isLoading: selectionState.isVaultPaymentLoading,
+            requiresCvvInput: selectionState.requiresCvvInput,
+            cvvInput: $selectionState.cvvInput,
+            isCvvValid: $selectionState.isCvvValid,
+            cvvError: $selectionState.cvvError
+          )
+        }
+
+        if shouldShowCollapsedView {
+          makeShowOtherWaysToPayButton()
+        } else {
+          PaymentMethodsSection(state: selectionState, scope: scope)
+        }
+      }
+      .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+      .padding(.bottom, PrimerSpacing.xlarge(tokens: tokens))
+    }
+  }
+
+  private var shouldShowCollapsedView: Bool {
+    !selectionState.isPaymentMethodsExpanded
+  }
+
+  private func makeShowOtherWaysToPayButton() -> some View {
+    Button(action: scope.showOtherWaysToPay) {
+      Text(CheckoutComponentsStrings.showOtherWaysToPay)
+        .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .frame(maxWidth: .infinity)
+        .padding(PrimerSpacing.medium(tokens: tokens))
+        .background(
+          RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
+            .stroke(
+              CheckoutColors.borderDefault(tokens: tokens), lineWidth: PrimerBorderWidth.standard
+            )
+        )
+    }
+    .accessibility(
+      config: AccessibilityConfiguration(
+        identifier: AccessibilityIdentifiers.PaymentSelection.showOtherWaysButton,
+        label: CheckoutComponentsStrings.a11yShowOtherWaysToPay,
+        traits: [.isButton]
+      )
+    )
+  }
+
+  // MARK: - Helpers
+
+  private var formattedAmount: String? {
+    guard let amount = configurationService?.amount,
+      let currency = configurationService?.currency
+    else {
+      return nil
+    }
+    return amount.toCurrencyString(currency: currency)
+  }
+
+  private func resolveConfigurationService() {
+    guard let container else { return }
+    configurationService = try? container.resolveSync(ConfigurationService.self)
+  }
+
+  private func observeState() {
+    observationTask?.cancel()
+    observationTask = Task {
+      for await state in scope.state {
+        await MainActor.run {
+          selectionState = state
+          if !state.paymentMethods.isEmpty {
+            bridgeController?.invalidateContentSize()
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/QRCodeView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/QRCodeView.swift
@@ -1,0 +1,183 @@
+//
+//  QRCodeView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct QRCodeView: View, LogReporter {
+  let scope: any PrimerQRCodeScope
+
+  @Environment(\.designTokens) private var tokens
+  @State private var qrCodeState = PrimerQRCodeState()
+
+  private enum Layout {
+    static let amountFontSize: CGFloat = 34
+    static let titleFontSize: CGFloat = 20
+    static let subtitleFontSize: CGFloat = 15
+    static let iconSize: CGFloat = 48
+    static let qrCodeSize: CGFloat = 270
+    static let qrCodePadding: CGFloat = 10
+  }
+
+  var body: some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      makeHeaderSection()
+      makeContentSection()
+    }
+    .frame(maxHeight: .infinity, alignment: .top)
+    .padding(PrimerSpacing.large(tokens: tokens))
+    .frame(maxWidth: .infinity)
+    .navigationBarHidden(true)
+    .background(CheckoutColors.background(tokens: tokens))
+    .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.container)
+    .task {
+      for await state in scope.state {
+        qrCodeState = state
+      }
+    }
+  }
+
+  // MARK: - Header Section
+
+  private func makeHeaderSection() -> some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      HStack {
+        if scope.presentationContext.shouldShowBackButton {
+          Button(
+            action: scope.onBack,
+            label: {
+              HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+                Image(systemName: RTLIcon.backChevron)
+                  .font(PrimerFont.bodyMedium(tokens: tokens))
+                Text(CheckoutComponentsStrings.backButton)
+              }
+              .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+            }
+          )
+          .accessibility(
+            config: AccessibilityConfiguration(
+              identifier: AccessibilityIdentifiers.Common.backButton,
+              label: CheckoutComponentsStrings.a11yBack,
+              traits: [.isButton]
+            )
+          )
+        }
+
+        Spacer()
+
+        if scope.dismissalMechanism.contains(.closeButton) {
+          Button(
+            CheckoutComponentsStrings.cancelButton,
+            action: scope.cancel
+          )
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          .accessibility(
+            config: AccessibilityConfiguration(
+              identifier: AccessibilityIdentifiers.Common.closeButton,
+              label: CheckoutComponentsStrings.a11yCancel,
+              traits: [.isButton]
+            )
+          )
+        }
+      }
+    }
+  }
+
+  // MARK: - Content Section
+
+  private func makeContentSection() -> some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      switch qrCodeState.status {
+      case .loading:
+        Spacer()
+        ProgressView()
+          .progressViewStyle(CircularProgressViewStyle())
+          .scaleEffect(PrimerScale.large)
+          .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.loadingIndicator)
+          .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
+        Spacer()
+
+      case .displaying:
+        ScrollView {
+          VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+            makeAmountLabel()
+            makeTitleSection()
+            makeQRCodeImage()
+          }
+        }
+
+      case .success:
+        Spacer()
+        Image(systemName: "checkmark.circle.fill")
+          .font(.system(size: Layout.iconSize))
+          .foregroundColor(.green)
+          .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.successIcon)
+          .accessibilityLabel(CheckoutComponentsStrings.a11yQrCodeSuccessIcon)
+        Spacer()
+
+      case .failure:
+        Spacer()
+        Image(systemName: "xmark.circle.fill")
+          .font(.system(size: Layout.iconSize))
+          .foregroundColor(.red)
+          .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.failureIcon)
+          .accessibilityLabel(CheckoutComponentsStrings.a11yQrCodeFailureIcon)
+        Spacer()
+      }
+    }
+  }
+
+  private func makeAmountLabel() -> some View {
+    Group {
+      if let amount = AppState.current.amount,
+        let currency = AppState.current.currency {
+        Text(amount.toCurrencyString(currency: currency))
+          .font(.system(size: Layout.amountFontSize, weight: .bold))
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.amountLabel)
+      }
+    }
+  }
+
+  private func makeTitleSection() -> some View {
+    VStack(alignment: .leading, spacing: PrimerSpacing.small(tokens: tokens)) {
+      Text(CheckoutComponentsStrings.qrCodeScanInstruction)
+        .font(.system(size: Layout.titleFontSize))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.instructionTitle)
+
+      Text(CheckoutComponentsStrings.qrCodeUploadInstruction)
+        .font(.system(size: Layout.subtitleFontSize))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.instructionSubtitle)
+    }
+  }
+
+  private func makeQRCodeImage() -> some View {
+    Group {
+      if let imageData = qrCodeState.qrCodeImageData, let uiImage = UIImage(data: imageData) {
+        Image(uiImage: uiImage)
+          .resizable()
+          .interpolation(.none)
+          .aspectRatio(contentMode: .fit)
+          .frame(width: Layout.qrCodeSize, height: Layout.qrCodeSize)
+          .padding(Layout.qrCodePadding)
+          .overlay(
+            RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+              .stroke(Color.gray.opacity(0.5), lineWidth: PrimerBorderWidth.standard)
+          )
+          .frame(maxWidth: .infinity)
+          .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.qrCodeImage)
+          .accessibilityLabel(CheckoutComponentsStrings.a11yQrCodeImage)
+          .accessibilityHint(CheckoutComponentsStrings.a11yQrCodeScanHint)
+      }
+    }
+  }
+
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/QRCodeView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/QRCodeView.swift
@@ -62,8 +62,7 @@ struct QRCodeView: View, LogReporter {
               identifier: AccessibilityIdentifiers.Common.backButton,
               label: CheckoutComponentsStrings.a11yBack,
               traits: [.isButton]
-            )
-          )
+            ))
         }
 
         Spacer()
@@ -79,8 +78,7 @@ struct QRCodeView: View, LogReporter {
               identifier: AccessibilityIdentifiers.Common.closeButton,
               label: CheckoutComponentsStrings.a11yCancel,
               traits: [.isButton]
-            )
-          )
+            ))
         }
       }
     }
@@ -112,8 +110,8 @@ struct QRCodeView: View, LogReporter {
       case .success:
         Spacer()
         Image(systemName: "checkmark.circle.fill")
-          .font(.system(size: Layout.iconSize))
-          .foregroundColor(.green)
+          .font(PrimerFont.largeIcon(tokens: tokens))
+          .foregroundColor(CheckoutColors.iconPositive(tokens: tokens))
           .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.successIcon)
           .accessibilityLabel(CheckoutComponentsStrings.a11yQrCodeSuccessIcon)
         Spacer()
@@ -121,8 +119,8 @@ struct QRCodeView: View, LogReporter {
       case .failure:
         Spacer()
         Image(systemName: "xmark.circle.fill")
-          .font(.system(size: Layout.iconSize))
-          .foregroundColor(.red)
+          .font(PrimerFont.largeIcon(tokens: tokens))
+          .foregroundColor(CheckoutColors.iconNegative(tokens: tokens))
           .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.failureIcon)
           .accessibilityLabel(CheckoutComponentsStrings.a11yQrCodeFailureIcon)
         Spacer()
@@ -135,7 +133,7 @@ struct QRCodeView: View, LogReporter {
       if let amount = AppState.current.amount,
         let currency = AppState.current.currency {
         Text(amount.toCurrencyString(currency: currency))
-          .font(.system(size: Layout.amountFontSize, weight: .bold))
+          .font(PrimerFont.titleXLarge(tokens: tokens))
           .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
           .frame(maxWidth: .infinity, alignment: .leading)
           .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.amountLabel)
@@ -146,13 +144,13 @@ struct QRCodeView: View, LogReporter {
   private func makeTitleSection() -> some View {
     VStack(alignment: .leading, spacing: PrimerSpacing.small(tokens: tokens)) {
       Text(CheckoutComponentsStrings.qrCodeScanInstruction)
-        .font(.system(size: Layout.titleFontSize))
+        .font(PrimerFont.titleLarge(tokens: tokens))
         .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.instructionTitle)
 
       Text(CheckoutComponentsStrings.qrCodeUploadInstruction)
-        .font(.system(size: Layout.subtitleFontSize))
+        .font(PrimerFont.bodyMedium(tokens: tokens))
         .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.instructionSubtitle)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
@@ -1,0 +1,221 @@
+//
+//  SelectCountryScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Default country selection screen for CheckoutComponents
+@available(iOS 15.0, *)
+struct SelectCountryScreen: View, LogReporter {
+  let scope: PrimerSelectCountryScope
+  let onDismiss: (() -> Void)?
+
+  @Environment(\.designTokens) private var tokens
+  @State private var countryState: PrimerSelectCountryState = .init()
+
+  var body: some View {
+    NavigationView {
+      mainContent
+    }
+    .environment(\.primerSelectCountryScope, scope)
+    .task {
+      for await state in scope.state {
+        countryState = state
+      }
+    }
+  }
+
+  private var mainContent: some View {
+    VStack(spacing: 0) {
+      searchBarSection
+      countryListSection
+    }
+    .background(CheckoutColors.background(tokens: tokens))
+    .navigationTitle(CheckoutComponentsStrings.selectCountryTitle)
+    .navigationBarTitleDisplayMode(.inline)
+    .navigationBarItems(
+      trailing: Button(CheckoutComponentsStrings.cancelButton) {
+        onDismiss?()
+      }
+      .foregroundColor(CheckoutColors.blue(tokens: tokens))
+      .accessibilityLabel(CheckoutComponentsStrings.a11yCancel)
+    )
+  }
+
+  private var searchBarSection: some View {
+    Group {
+      if let customSearchBar = scope.searchBar {
+        customSearchBar(
+          countryState.searchQuery,
+          { query in
+            scope.onSearch(query: query)
+          }, CheckoutComponentsStrings.searchCountriesPlaceholder
+        )
+      } else {
+        defaultSearchBar
+      }
+    }
+  }
+
+  private var defaultSearchBar: some View {
+    HStack {
+      Image(systemName: "magnifyingglass")
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+
+      TextField(
+        CheckoutComponentsStrings.searchCountriesPlaceholder,
+        text: Binding(
+          get: { countryState.searchQuery },
+          set: { scope.onSearch(query: $0) }
+        )
+      )
+      .textFieldStyle(PlainTextFieldStyle())
+
+      if !countryState.searchQuery.isEmpty {
+        Button(
+          action: {
+            scope.onSearch(query: "")
+          },
+          label: {
+            Image(systemName: "xmark.circle.fill")
+              .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          }
+        )
+      }
+    }
+    .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
+    .padding(.vertical, PrimerSpacing.small(tokens: tokens))
+    .background(CheckoutColors.gray100(tokens: tokens))
+    .cornerRadius(PrimerRadius.small(tokens: tokens))
+    .padding(PrimerSpacing.large(tokens: tokens))
+  }
+
+  private var countryListSection: some View {
+    Group {
+      if countryState.isLoading {
+        loadingView
+      } else if countryState.filteredCountries.isEmpty {
+        emptyStateView
+      } else {
+        countryListView
+      }
+    }
+  }
+
+  private var loadingView: some View {
+    VStack {
+      Spacer()
+      ProgressView()
+        .progressViewStyle(
+          CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+        )
+        .scaleEffect(PrimerScale.small)
+        .accessibility(
+          config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.Common.loadingIndicator,
+            label: CheckoutComponentsStrings.a11yLoading
+          )
+        )
+      Spacer()
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  @ViewBuilder
+  private var emptyStateView: some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      Image(systemName: "globe")
+        .font(PrimerFont.largeIcon(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+
+      Text(CheckoutComponentsStrings.noCountriesFound)
+        .font(PrimerFont.body(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+  }
+
+  private var countryListView: some View {
+    List {
+      ForEach(countryState.filteredCountries, id: \.code) { country in
+        Group {
+          if let customCountryItem = scope.countryItem {
+            AnyView(
+              customCountryItem(country) {
+                selectCountry(country)
+              }
+            )
+          } else {
+            CountryItemView(
+              country: country,
+              isSelected: false,  // No selection state in current scope
+              onTap: {
+                selectCountry(country)
+              }
+            )
+          }
+        }
+      }
+    }
+    .listStyle(PlainListStyle())
+  }
+
+  private func selectCountry(_ country: PrimerCountry) {
+    scope.onCountrySelected(countryCode: country.code, countryName: country.name)
+    onDismiss?()
+  }
+
+}
+
+/// Country item view
+@available(iOS 15.0, *)
+private struct CountryItemView: View {
+  let country: PrimerCountry
+  let isSelected: Bool
+  let onTap: () -> Void
+
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    Button(action: onTap) {
+      HStack {
+        // Flag
+        if let flag = country.flag {
+          Text(flag)
+            .font(PrimerFont.title2(tokens: tokens))
+        }
+
+        // Country name
+        VStack(alignment: .leading, spacing: PrimerSpacing.xxsmall(tokens: tokens)) {
+          Text(country.name)
+            .font(PrimerFont.body(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+          if let dialCode = country.dialCode {
+            Text("\(country.code) • \(dialCode)")
+              .font(PrimerFont.caption(tokens: tokens))
+              .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          } else {
+            Text(country.code)
+              .font(PrimerFont.caption(tokens: tokens))
+              .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+          }
+        }
+
+        Spacer()
+
+        // Selection indicator
+        if isSelected {
+          Image(systemName: "checkmark")
+            .foregroundColor(CheckoutColors.blue(tokens: tokens))
+        }
+      }
+      .padding(.vertical, PrimerSpacing.small(tokens: tokens))
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(PlainButtonStyle())
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
@@ -47,12 +47,11 @@ struct SelectCountryScreen: View, LogReporter {
   private var searchBarSection: some View {
     Group {
       if let customSearchBar = scope.searchBar {
-        customSearchBar(
+        AnyView(customSearchBar(
           countryState.searchQuery,
           { query in
             scope.onSearch(query: query)
-          }, CheckoutComponentsStrings.searchCountriesPlaceholder
-        )
+          }, CheckoutComponentsStrings.searchCountriesPlaceholder))
       } else {
         defaultSearchBar
       }
@@ -81,8 +80,7 @@ struct SelectCountryScreen: View, LogReporter {
           label: {
             Image(systemName: "xmark.circle.fill")
               .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
-          }
-        )
+          })
       }
     }
     .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
@@ -116,8 +114,7 @@ struct SelectCountryScreen: View, LogReporter {
           config: AccessibilityConfiguration(
             identifier: AccessibilityIdentifiers.Common.loadingIndicator,
             label: CheckoutComponentsStrings.a11yLoading
-          )
-        )
+          ))
       Spacer()
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -145,8 +142,7 @@ struct SelectCountryScreen: View, LogReporter {
             AnyView(
               customCountryItem(country) {
                 selectCountry(country)
-              }
-            )
+              })
           } else {
             CountryItemView(
               country: country,

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SplashScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SplashScreen.swift
@@ -1,0 +1,52 @@
+//
+//  SplashScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct SplashScreen: View {
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    ZStack {
+      CheckoutColors.background(tokens: tokens)
+        .ignoresSafeArea()
+
+      VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+        ProgressView()
+          .progressViewStyle(
+            CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+          )
+          .scaleEffect(PrimerScale.large)
+          .frame(
+            width: PrimerComponentHeight.progressIndicator,
+            height: PrimerComponentHeight.progressIndicator
+          )
+          .accessibility(
+            config: AccessibilityConfiguration(
+              identifier: AccessibilityIdentifiers.Common.loadingIndicator,
+              label: CheckoutComponentsStrings.a11yLoading
+            )
+          )
+
+        VStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+          // Primary loading message
+          Text(CheckoutComponentsStrings.loadingSecureCheckout)
+            .font(PrimerFont.bodyLarge(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+            .multilineTextAlignment(.center)
+
+          // Secondary loading message
+          Text(CheckoutComponentsStrings.loadingWontTakeLong)
+            .font(PrimerFont.bodyMedium(tokens: tokens))
+            .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+            .multilineTextAlignment(.center)
+        }
+      }
+      .padding(.horizontal, PrimerSpacing.xxlarge(tokens: tokens))
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SuccessScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SuccessScreen.swift
@@ -1,0 +1,61 @@
+//
+//  SuccessScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct SuccessScreen: View {
+  let result: PaymentResult
+  let onDismiss: (() -> Void)?
+
+  @Environment(\.designTokens) private var tokens
+  @State private var iconScale: CGFloat = 0.3
+
+  init(result: PaymentResult, onDismiss: (() -> Void)? = nil) {
+    self.result = result
+    self.onDismiss = onDismiss
+  }
+
+  var body: some View {
+    ZStack {
+      CheckoutColors.background(tokens: tokens)
+        .ignoresSafeArea()
+
+      VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+        Image(systemName: "checkmark.circle.fill")
+          .font(PrimerFont.extraLargeIcon(tokens: tokens))
+          .foregroundColor(CheckoutColors.green(tokens: tokens))
+          .scaleEffect(iconScale)
+
+        VStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+          // Primary success message
+          Text(CheckoutComponentsStrings.paymentSuccessful)
+            .font(PrimerFont.bodyLarge(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+            .multilineTextAlignment(.center)
+
+          // Secondary redirect message
+          Text(CheckoutComponentsStrings.redirectConfirmationMessage)
+            .font(PrimerFont.bodyMedium(tokens: tokens))
+            .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+            .multilineTextAlignment(.center)
+        }
+      }
+      .padding(.horizontal, PrimerSpacing.xxlarge(tokens: tokens))
+    }
+    .onAppear {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+        withAnimation(AnimationConstants.successSpringAnimation) {
+          iconScale = 1.0
+        }
+      }
+    }
+    .task {
+      try? await Task.sleep(nanoseconds: UInt64(AnimationConstants.autoDismissDelay * 1_000_000_000))
+      onDismiss?()
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/VaultedPaymentMethodsListScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/VaultedPaymentMethodsListScreen.swift
@@ -1,0 +1,77 @@
+//
+//  VaultedPaymentMethodsListScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Screen displaying all vaulted/saved payment methods with edit mode support
+@available(iOS 15.0, *)
+struct VaultedPaymentMethodsListScreen: View {
+  let vaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod]
+  let selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod?
+  let onSelect: (PrimerHeadlessUniversalCheckout.VaultedPaymentMethod) -> Void
+  let onBack: () -> Void
+  let onDeleteTapped: (PrimerHeadlessUniversalCheckout.VaultedPaymentMethod) -> Void
+
+  @State private var isEditMode: Bool = false
+  @Environment(\.designTokens) private var tokens
+
+  var body: some View {
+    VStack(spacing: 0) {
+      CheckoutHeaderView(
+        showBackButton: true,
+        onBack: onBack,
+        rightButton: isEditMode
+          ? .doneButton(action: { isEditMode = false })
+          : .editButton(action: { isEditMode = true })
+      )
+      makeTitle()
+      makeContent()
+    }
+    .background(CheckoutColors.background(tokens: tokens))
+  }
+
+  // MARK: - Title
+
+  private func makeTitle() -> some View {
+    HStack {
+      Text(CheckoutComponentsStrings.allSavedPaymentMethods)
+        .font(PrimerFont.titleXLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+      Spacer()
+    }
+    .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+    .padding(.bottom, PrimerSpacing.large(tokens: tokens))
+  }
+
+  // MARK: - Content
+
+  private func makeContent() -> some View {
+    ScrollView {
+      LazyVStack(spacing: PrimerSpacing.small(tokens: tokens)) {
+        ForEach(vaultedPaymentMethods, id: \.id) { method in
+          VaultedPaymentMethodCard(
+            vaultedPaymentMethod: method,
+            isSelected: isEditMode ? false : isMethodSelected(method),
+            isEditMode: isEditMode,
+            onTap: {
+              onSelect(method)
+            },
+            onDeleteTapped: {
+              onDeleteTapped(method)
+            }
+          )
+        }
+      }
+      .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+      .padding(.bottom, PrimerSpacing.xlarge(tokens: tokens))
+    }
+  }
+
+  private func isMethodSelected(_ method: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod) -> Bool {
+    method.id == selectedVaultedPaymentMethod?.id
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/WebRedirect/WebRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/WebRedirect/WebRedirectScreen.swift
@@ -1,0 +1,281 @@
+//
+//  WebRedirectScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct WebRedirectScreen: View {
+
+    private enum Constants {
+        static let logoHeight: CGFloat = 60
+    }
+
+    let scope: any PrimerWebRedirectScope
+
+    @Environment(\.designTokens) private var tokens
+    @State private var webRedirectState = PrimerWebRedirectState()
+
+    var body: some View {
+        VStack(spacing: PrimerSpacing.xxlarge(tokens: tokens)) {
+            makeHeaderSection()
+            makeContentSection()
+            Spacer()
+            makeSubmitButtonSection()
+        }
+        .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+        .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+        .frame(maxWidth: UIScreen.main.bounds.width)
+        .navigationBarHidden(true)
+        .background(CheckoutColors.background(tokens: tokens))
+        .accessibilityIdentifier(AccessibilityIdentifiers.WebRedirect.container)
+        .task {
+            for await state in scope.state {
+                webRedirectState = state
+            }
+        }
+    }
+
+    // MARK: - Header Section
+
+    private func makeHeaderSection() -> some View {
+        VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+            HStack {
+                if scope.presentationContext.shouldShowBackButton {
+                    Button(action: scope.onBack, label: {
+                        HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+                            Image(systemName: RTLIcon.backChevron)
+                                .font(PrimerFont.bodyMedium(tokens: tokens))
+                            Text(CheckoutComponentsStrings.backButton)
+                        }
+                        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+                    })
+                    .accessibility(config: AccessibilityConfiguration(
+                        identifier: AccessibilityIdentifiers.WebRedirect.backButton,
+                        label: CheckoutComponentsStrings.a11yBack,
+                        traits: [.isButton]
+                    ))
+                }
+
+                Spacer()
+
+                if scope.dismissalMechanism.contains(.closeButton) {
+                    Button(CheckoutComponentsStrings.cancelButton, action: scope.cancel)
+                    .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+                    .accessibility(config: AccessibilityConfiguration(
+                        identifier: AccessibilityIdentifiers.WebRedirect.cancelButton,
+                        label: CheckoutComponentsStrings.a11yCancel,
+                        traits: [.isButton]
+                    ))
+                }
+            }
+
+            makeTitleSection()
+        }
+    }
+
+    private func makeTitleSection() -> some View {
+        Text(paymentMethodDisplayName)
+            .font(PrimerFont.titleXLarge(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityIdentifier(AccessibilityIdentifiers.WebRedirect.title)
+    }
+
+    // MARK: - Content Section
+
+    private func makeContentSection() -> some View {
+        VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+            makePaymentMethodLogo()
+
+            Text(CheckoutComponentsStrings.webRedirectDescription)
+                .font(PrimerFont.body(tokens: tokens))
+                .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .accessibilityIdentifier(AccessibilityIdentifiers.WebRedirect.description)
+
+            if let surcharge = webRedirectState.surchargeAmount {
+                Text(surcharge)
+                    .font(PrimerFont.bodySmall(tokens: tokens))
+                    .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+                    .accessibilityIdentifier(AccessibilityIdentifiers.WebRedirect.surcharge)
+            }
+        }
+        .padding(.vertical, PrimerSpacing.xlarge(tokens: tokens))
+    }
+
+    private func makePaymentMethodLogo() -> some View {
+        Group {
+            if let icon = webRedirectState.paymentMethod?.icon {
+                Image(uiImage: icon)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: Constants.logoHeight)
+            } else {
+                makeFallbackLogo()
+            }
+        }
+        .accessibility(config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.WebRedirect.logo,
+            label: paymentMethodDisplayName
+        ))
+    }
+
+    private func makeFallbackLogo() -> some View {
+        Text(paymentMethodDisplayName)
+            .font(PrimerFont.titleXLarge(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+    }
+
+    // MARK: - Submit Button Section
+
+    @ViewBuilder
+    private func makeSubmitButtonSection() -> some View {
+        if let customButton = scope.payButton {
+            AnyView(customButton(scope))
+        } else {
+            Button(action: submitAction) {
+                makeSubmitButtonContent()
+            }
+            .disabled(isButtonDisabled)
+        }
+    }
+
+    private func makeSubmitButtonContent() -> some View {
+        let isLoading = [.loading, .redirecting, .polling].contains(webRedirectState.status)
+
+        return HStack {
+            if isLoading {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.white(tokens: tokens)))
+                    .scaleEffect(PrimerScale.small)
+            } else {
+                Text(submitButtonText)
+            }
+        }
+        .font(PrimerFont.body(tokens: tokens))
+        .foregroundColor(CheckoutColors.white(tokens: tokens))
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+        .background(submitButtonBackground)
+        .cornerRadius(PrimerRadius.small(tokens: tokens))
+        .accessibility(config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.WebRedirect.submitButton,
+            label: submitButtonAccessibilityLabel,
+            hint: isButtonDisabled ? CheckoutComponentsStrings.a11ySubmitButtonDisabled : CheckoutComponentsStrings.a11ySubmitButtonHint,
+            traits: [.isButton]
+        ))
+    }
+
+    private var submitButtonText: String {
+        scope.submitButtonText ?? CheckoutComponentsStrings.webRedirectButtonContinue(paymentMethodDisplayName)
+    }
+
+    private var submitButtonAccessibilityLabel: String {
+        let isLoading = [.loading, .redirecting, .polling].contains(webRedirectState.status)
+        return isLoading
+            ? CheckoutComponentsStrings.a11ySubmitButtonLoading
+            : CheckoutComponentsStrings.a11yWebRedirectSubmitButton(paymentMethodDisplayName)
+    }
+
+    private var submitButtonBackground: Color {
+        isButtonDisabled
+            ? CheckoutColors.gray300(tokens: tokens)
+            : CheckoutColors.textPrimary(tokens: tokens)
+    }
+
+    private var isButtonDisabled: Bool {
+        [.loading, .redirecting, .polling].contains(webRedirectState.status)
+    }
+
+    private var paymentMethodDisplayName: String {
+        webRedirectState.paymentMethod?.name ?? scope.paymentMethodType
+    }
+
+    private func submitAction() {
+        scope.submit()
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+@available(iOS 15.0, *)
+#Preview("WebRedirect - Light") {
+    WebRedirectScreen(scope: MockWebRedirectScope())
+        .environment(\.designTokens, MockDesignTokens.light)
+}
+
+@available(iOS 15.0, *)
+#Preview("WebRedirect - Dark") {
+    WebRedirectScreen(scope: MockWebRedirectScope())
+        .environment(\.designTokens, MockDesignTokens.dark)
+        .preferredColorScheme(.dark)
+}
+
+@available(iOS 15.0, *)
+#Preview("WebRedirect - Loading") {
+    WebRedirectScreen(scope: MockWebRedirectScope(status: .loading))
+        .environment(\.designTokens, MockDesignTokens.light)
+}
+
+@available(iOS 15.0, *)
+#Preview("WebRedirect - Redirecting") {
+    WebRedirectScreen(scope: MockWebRedirectScope(status: .redirecting))
+        .environment(\.designTokens, MockDesignTokens.light)
+}
+
+@available(iOS 15.0, *)
+@MainActor
+private final class MockWebRedirectScope: PrimerWebRedirectScope, ObservableObject {
+
+    // MARK: - Protocol Properties
+
+    let paymentMethodType: String = "ADYEN_SOFORT"
+    var presentationContext: PresentationContext = .fromPaymentSelection
+    var dismissalMechanism: [DismissalMechanism] = [.closeButton]
+
+    var state: AsyncStream<PrimerWebRedirectState> {
+        AsyncStream { continuation in
+            continuation.yield(mockState)
+        }
+    }
+
+    // MARK: - UI Customization Properties
+
+    var screen: WebRedirectScreenComponent?
+    var payButton: WebRedirectButtonComponent?
+    var submitButtonText: String?
+
+    // MARK: - Private Properties
+
+    @Published private var mockState: PrimerWebRedirectState
+
+    // MARK: - Initialization
+
+    init(status: PrimerWebRedirectState.Status = .idle) {
+        let mockPaymentMethod = CheckoutPaymentMethod(
+            id: "mock-sofort",
+            type: "ADYEN_SOFORT",
+            name: "Sofort"
+        )
+        mockState = PrimerWebRedirectState(
+            status: status,
+            paymentMethod: mockPaymentMethod,
+            surchargeAmount: "+ €0.50"
+        )
+    }
+
+    func start() { /* No-op: preview mock */ }
+    func submit() {
+        mockState.status = .loading
+    }
+
+    func cancel() { /* No-op: preview mock */ }
+    func onBack() { /* No-op: preview mock */ }
+}
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Views/CardFormFieldsView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Views/CardFormFieldsView.swift
@@ -1,0 +1,346 @@
+//
+//  CardFormFieldsView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+// swiftlint:disable file_length
+// swiftlint:disable cyclomatic_complexity
+// swiftlint:disable function_body_length
+
+import SwiftUI
+
+/// Reusable card form fields view that renders card input fields and billing address fields.
+/// This component is used by both `CardFormScreen` (full screen) and `DefaultCardFormView` (embeddable).
+///
+/// Features:
+/// - Dynamic card fields (card number, expiry, CVV, cardholder name)
+/// - Allowed card networks view
+/// - Co-badged cards selector (when multiple networks detected)
+/// - Dynamic billing address fields (based on configuration)
+@available(iOS 15.0, *)
+struct CardFormFieldsView: View {
+  let scope: any PrimerCardFormScope
+  let styling: PrimerFieldStyling?
+
+  @Environment(\.designTokens) private var tokens
+  @State private var cardFormState: PrimerCardFormState = .init()
+  @State private var formConfiguration: CardFormConfiguration = .default
+  @State private var observationTask: Task<Void, Never>?
+  @FocusState private var focusedField: PrimerInputElementType?
+
+  var body: some View {
+    VStack(spacing: 0) {
+      cardFieldsSection
+      billingAddressSection
+    }
+    .onAppear {
+      formConfiguration = scope.getFormConfiguration()
+      observeState()
+    }
+    .onDisappear {
+      observationTask?.cancel()
+      observationTask = nil
+    }
+  }
+
+  // MARK: - Card Fields Section
+
+  @MainActor
+  @ViewBuilder
+  private var cardFieldsSection: some View {
+    VStack(spacing: 0) {
+      ForEach(0..<formConfiguration.cardFields.count, id: \.self) { index in
+        let fieldType = formConfiguration.cardFields[index]
+
+        if fieldType == .expiryDate,
+          index + 1 < formConfiguration.cardFields.count,
+          formConfiguration.cardFields[index + 1] == .cvv {
+          HStack(alignment: .top, spacing: PrimerSpacing.medium(tokens: tokens)) {
+            renderField(.expiryDate)
+            renderField(.cvv)
+          }
+        } else if index > 0,
+          formConfiguration.cardFields[index - 1] == .expiryDate,
+          fieldType == .cvv {
+          EmptyView()
+        } else {
+          renderField(fieldType)
+        }
+      }
+    }
+  }
+
+  // MARK: - Billing Address Section
+
+  @ViewBuilder
+  @MainActor
+  private var billingAddressSection: some View {
+    if !formConfiguration.billingFields.isEmpty {
+      VStack(alignment: .leading, spacing: PrimerSpacing.small(tokens: tokens)) {
+        Text(CheckoutComponentsStrings.billingAddressTitle)
+          .font(PrimerFont.headline(tokens: tokens))
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+
+        VStack(spacing: 0) {
+          ForEach(0..<formConfiguration.billingFields.count, id: \.self) { index in
+            let fieldType = formConfiguration.billingFields[index]
+
+            if fieldType == .firstName,
+              index + 1 < formConfiguration.billingFields.count,
+              formConfiguration.billingFields[index + 1] == .lastName {
+              HStack(alignment: .top, spacing: PrimerSpacing.medium(tokens: tokens)) {
+                renderField(.firstName)
+                renderField(.lastName)
+              }
+            } else if index > 0,
+              formConfiguration.billingFields[index - 1] == .firstName,
+              fieldType == .lastName {
+              EmptyView()
+            } else {
+              renderField(fieldType)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Dynamic Field Rendering
+
+  @MainActor
+  @ViewBuilder
+  private func renderField(_ fieldType: PrimerInputElementType) -> some View {
+    switch fieldType {
+    case .cardNumber:
+      CardNumberInputField(
+        label: CheckoutComponentsStrings.cardNumberLabel,
+        placeholder: CheckoutComponentsStrings.cardNumberPlaceholder,
+        scope: scope,
+        selectedNetwork: getSelectedCardNetwork(),
+        availableNetworks: cardFormState.availableNetworks.map(\.network),
+        styling: styling
+      )
+      .focused($focusedField, equals: .cardNumber)
+      .onSubmit { moveToNextField(from: .cardNumber) }
+
+    case .expiryDate:
+      ExpiryDateInputField(
+        label: CheckoutComponentsStrings.expiryDateLabel,
+        placeholder: CheckoutComponentsStrings.expiryDatePlaceholder,
+        scope: scope,
+        styling: styling
+      )
+      .focused($focusedField, equals: .expiryDate)
+      .onSubmit { moveToNextField(from: .expiryDate) }
+
+    case .cvv:
+      CVVInputField(
+        label: CheckoutComponentsStrings.cvvLabel,
+        placeholder: getCardNetworkForCvv() == .amex
+          ? CheckoutComponentsStrings.cvvAmexPlaceholder
+          : CheckoutComponentsStrings.cvvStandardPlaceholder,
+        scope: scope,
+        cardNetwork: getCardNetworkForCvv(),
+        styling: styling
+      )
+      .focused($focusedField, equals: .cvv)
+      .onSubmit { moveToNextField(from: .cvv) }
+
+    case .cardholderName:
+      CardholderNameInputField(
+        label: CheckoutComponentsStrings.cardholderNameLabel,
+        placeholder: CheckoutComponentsStrings.fullNamePlaceholder,
+        scope: scope,
+        styling: styling
+      )
+      .focused($focusedField, equals: .cardholderName)
+      .onSubmit { moveToNextField(from: .cardholderName) }
+
+    case .postalCode:
+      PostalCodeInputField(
+        label: CheckoutComponentsStrings.postalCodeLabel,
+        placeholder: CheckoutComponentsStrings.postalCodePlaceholder,
+        scope: scope,
+        styling: styling
+      )
+      .focused($focusedField, equals: .postalCode)
+      .onSubmit { moveToNextField(from: .postalCode) }
+
+    case .countryCode:
+      if let defaultCardFormScope = scope as? DefaultCardFormScope {
+        CountryInputField(
+          label: CheckoutComponentsStrings.countryLabel,
+          placeholder: CheckoutComponentsStrings.selectCountryPlaceholder,
+          scope: defaultCardFormScope,
+          styling: styling
+        )
+        .focused($focusedField, equals: .countryCode)
+        .onSubmit { moveToNextField(from: .countryCode) }
+      }
+
+    case .city:
+      CityInputField(
+        label: CheckoutComponentsStrings.cityLabel,
+        placeholder: CheckoutComponentsStrings.cityPlaceholder,
+        scope: scope,
+        styling: styling
+      )
+      .focused($focusedField, equals: .city)
+      .onSubmit { moveToNextField(from: .city) }
+
+    case .state:
+      StateInputField(
+        label: CheckoutComponentsStrings.stateLabel,
+        placeholder: CheckoutComponentsStrings.statePlaceholder,
+        scope: scope,
+        styling: styling
+      )
+
+    case .addressLine1:
+      AddressLineInputField(
+        label: CheckoutComponentsStrings.addressLine1Label,
+        placeholder: CheckoutComponentsStrings.addressLine1Placeholder,
+        isRequired: true,
+        inputType: .addressLine1,
+        scope: scope,
+        styling: styling
+      )
+
+    case .addressLine2:
+      AddressLineInputField(
+        label: CheckoutComponentsStrings.addressLine2Label,
+        placeholder: CheckoutComponentsStrings.addressLine2Placeholder,
+        isRequired: false,
+        inputType: .addressLine2,
+        scope: scope,
+        styling: styling
+      )
+
+    case .phoneNumber:
+      NameInputField(
+        label: CheckoutComponentsStrings.phoneNumberLabel,
+        placeholder: CheckoutComponentsStrings.phoneNumberPlaceholder,
+        inputType: .phoneNumber,
+        scope: scope,
+        styling: styling
+      )
+
+    case .firstName:
+      NameInputField(
+        label: CheckoutComponentsStrings.firstNameLabel,
+        placeholder: CheckoutComponentsStrings.firstNamePlaceholder,
+        inputType: .firstName,
+        scope: scope,
+        styling: styling
+      )
+
+    case .lastName:
+      NameInputField(
+        label: CheckoutComponentsStrings.lastNameLabel,
+        placeholder: CheckoutComponentsStrings.lastNamePlaceholder,
+        inputType: .lastName,
+        scope: scope,
+        styling: styling
+      )
+
+    case .email:
+      EmailInputField(
+        label: CheckoutComponentsStrings.emailLabel,
+        placeholder: CheckoutComponentsStrings.emailPlaceholder,
+        scope: scope,
+        styling: styling
+      )
+
+    case .retailer:
+      Text(CheckoutComponentsStrings.retailOutletNotImplemented)
+        .font(PrimerFont.caption(tokens: tokens))
+        .foregroundColor(CheckoutColors.gray(tokens: tokens))
+        .padding(PrimerSpacing.large(tokens: tokens))
+
+    case .otp:
+      OTPCodeInputField(
+        label: CheckoutComponentsStrings.otpLabel,
+        placeholder: CheckoutComponentsStrings.otpCodeNumericPlaceholder,
+        scope: scope,
+        styling: styling
+      )
+
+    case .unknown, .all:
+      EmptyView()
+    }
+  }
+
+  // MARK: - Helper Methods
+
+  private func getSelectedCardNetwork() -> CardNetwork? {
+    if let network = cardFormState.selectedNetwork {
+      return network.network
+    }
+    return nil
+  }
+
+  private func getCardNetworkForCvv() -> CardNetwork {
+    if let network = cardFormState.selectedNetwork {
+      return network.network
+    }
+    return .unknown
+  }
+
+  // MARK: - Focus Management
+
+  private func moveToNextField(from currentField: PrimerInputElementType) {
+    let cardFields = formConfiguration.cardFields
+    let billingFields = formConfiguration.billingFields
+
+    if let currentIndex = cardFields.firstIndex(of: currentField) {
+      if currentIndex + 1 < cardFields.count {
+        focusedField = cardFields[currentIndex + 1]
+        return
+      }
+      if !billingFields.isEmpty {
+        focusedField = billingFields.first
+        return
+      }
+      focusedField = nil
+      return
+    }
+
+    if let currentIndex = billingFields.firstIndex(of: currentField) {
+      if currentIndex + 1 < billingFields.count {
+        focusedField = billingFields[currentIndex + 1]
+        return
+      }
+      focusedField = nil
+      return
+    }
+
+    focusedField = nil
+  }
+
+  // MARK: - State Observation
+
+  private func observeState() {
+    observationTask?.cancel()
+    observationTask = Task {
+      await MainActor.run {
+        formConfiguration = scope.getFormConfiguration()
+      }
+
+      for await state in scope.state {
+        let updatedFormConfig = await MainActor.run {
+          scope.getFormConfiguration()
+        }
+
+        await MainActor.run {
+          cardFormState = state
+          formConfiguration = updatedFormConfig
+        }
+      }
+    }
+  }
+}
+
+// swiftlint:enable file_length
+// swiftlint:enable cyclomatic_complexity
+// swiftlint:enable function_body_length

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/PrimerSwiftUIBridgeViewController.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/PrimerSwiftUIBridgeViewController.swift
@@ -1,0 +1,294 @@
+//
+//  PrimerSwiftUIBridgeViewController.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+private struct BridgeControllerKey: EnvironmentKey {
+  static let defaultValue: PrimerSwiftUIBridgeViewController? = nil
+}
+
+@available(iOS 15.0, *)
+extension EnvironmentValues {
+  var bridgeController: PrimerSwiftUIBridgeViewController? {
+    get { self[BridgeControllerKey.self] }
+    set { self[BridgeControllerKey.self] = newValue }
+  }
+}
+
+/// Bridge view controller that embeds SwiftUI content into the traditional Primer UI system
+/// This allows CheckoutComponents to work seamlessly with PrimerRootViewController and result screens
+@available(iOS 15.0, *)
+final class PrimerSwiftUIBridgeViewController: PrimerViewController {
+
+  // MARK: - Constants
+
+  private enum SheetSizing {
+    static let minimumHeight: CGFloat = 200
+    static let maximumScreenRatio: CGFloat = 0.9
+    static let heightUpdateThreshold: CGFloat = 5.0
+    static let boundsChangeThreshold: CGFloat = 10.0
+  }
+
+  // MARK: - Properties
+
+  weak var customSheetPresentationController: UISheetPresentationController?
+
+  private let hostingController: UIHostingController<AnyView>
+  private let logger = PrimerLogging.shared.logger
+  private var lastRecordedSize: CGSize = .zero
+  private var isUpdatingSize = false
+
+  // MARK: - Initialization
+
+  init<Content: View>(swiftUIView: Content) {
+    hostingController = UIHostingController(rootView: AnyView(swiftUIView))
+    super.init()
+
+    hostingController.rootView = AnyView(
+      swiftUIView.environment(\.bridgeController, self)
+    )
+
+    logger.info(message: "🌉 [SwiftUIBridge] Initialized bridge controller for SwiftUI integration")
+  }
+
+  // MARK: - Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    setupSwiftUIContent()
+    setupSizeObservation()
+    logger.debug(message: "🌉 [SwiftUIBridge] Bridge controller view loaded")
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    updateContentSize()
+  }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+
+    // Update size when layout changes
+    updateContentSize()
+  }
+
+  // MARK: - Private Methods
+
+  private func setupSwiftUIContent() {
+    // Configure hosting controller
+    hostingController.view.backgroundColor = UIColor.clear
+
+    // Add as child view controller
+    addChild(hostingController)
+    view.addSubview(hostingController.view)
+
+    // Setup constraints
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+      hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+    ])
+
+    // Complete the child view controller setup
+    hostingController.didMove(toParent: self)
+
+    logger.debug(message: "🌉 [SwiftUIBridge] SwiftUI content embedded successfully")
+  }
+
+  private func setupSizeObservation() {
+    // Add observer for SwiftUI view size changes
+    hostingController.view.addObserver(
+      self, forKeyPath: "bounds", options: [.new, .old], context: nil
+    )
+
+    logger.debug(message: "🌉 [SwiftUIBridge] Size observation setup completed")
+  }
+
+  override func observeValue(
+    forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?,
+    context: UnsafeMutableRawPointer?
+  ) {
+    if keyPath == "bounds", let newBounds = change?[NSKeyValueChangeKey.newKey] as? NSValue {
+      let newRect = newBounds.cgRectValue
+
+      // Prevent infinite loops - don't update if we're already updating or size hasn't meaningfully changed
+      guard !isUpdatingSize else { return }
+      guard abs(newRect.height - lastRecordedSize.height) > SheetSizing.boundsChangeThreshold else {
+        return
+      }
+      guard abs(newRect.width - lastRecordedSize.width) > SheetSizing.boundsChangeThreshold else {
+        return
+      }
+
+      logger.debug(
+        message:
+          "🌉 [SwiftUIBridge] SwiftUI bounds changed significantly: \(lastRecordedSize) -> \(newRect.size)"
+      )
+      lastRecordedSize = newRect.size
+      updateContentSize()
+    } else {
+      super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+    }
+  }
+
+  deinit {
+    // Clean up observer
+    hostingController.view.removeObserver(self, forKeyPath: "bounds")
+  }
+
+  @MainActor
+  private func updateContentSize() {
+    guard modalPresentationStyle == .pageSheet else { return }
+
+    // Prevent recursive calls
+    guard !isUpdatingSize else { return }
+
+    isUpdatingSize = true
+    defer { isUpdatingSize = false }
+
+    // Get the intrinsic content size from SwiftUI
+    let targetSize = CGSize(
+      width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height
+    )
+    let fittingSize = hostingController.view.systemLayoutSizeFitting(targetSize)
+    let newSize = CGSize(width: view.bounds.width, height: fittingSize.height)
+
+    // Only update if size actually changed significantly
+    let heightDifference = abs(newSize.height - preferredContentSize.height)
+    guard heightDifference > SheetSizing.heightUpdateThreshold else { return }
+
+    // Update preferred content size for proper height calculation
+    preferredContentSize = newSize
+
+    // Notify parent controller about size change for dynamic layout updates
+    if let parent {
+      parent.preferredContentSizeDidChange(forChildContentContainer: self)
+    }
+
+    // Invalidate sheet detents to update sheet height
+    invalidateSheetDetents()
+
+    logger.debug(
+      message:
+        "🌉 [SwiftUIBridge] Updated content size: \(preferredContentSize) (fitting: \(fittingSize))"
+    )
+  }
+
+  func invalidateContentSize() {
+    guard modalPresentationStyle == .pageSheet else { return }
+
+    hostingController.view.invalidateIntrinsicContentSize()
+    hostingController.view.setNeedsLayout()
+    hostingController.view.layoutIfNeeded()
+
+    let targetSize = CGSize(
+      width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height
+    )
+    let fittingSize = hostingController.view.systemLayoutSizeFitting(targetSize)
+
+    preferredContentSize = CGSize(width: view.bounds.width, height: fittingSize.height)
+    invalidateSheetDetents()
+  }
+
+  private func invalidateSheetDetents() {
+    guard let customSheetPresentationController else { return }
+
+    if #available(iOS 16.0, *) {
+      customSheetPresentationController.animateChanges {
+        customSheetPresentationController.invalidateDetents()
+      }
+    }
+  }
+}
+
+// MARK: - Size Management
+
+@available(iOS 15.0, *)
+extension PrimerSwiftUIBridgeViewController {
+
+  /// Override to provide proper sizing information to the traditional UI system
+  override var preferredContentSize: CGSize {
+    get {
+      // Use the stored preferredContentSize if available, otherwise calculate dynamically
+      if super.preferredContentSize.height > 0 {
+        return super.preferredContentSize
+      }
+
+      // Calculate based on SwiftUI content size
+      let width = view.bounds.width > 0 ? view.bounds.width : UIScreen.main.bounds.width
+      let targetSize = CGSize(width: width, height: UIView.layoutFittingCompressedSize.height)
+      let fittingSize = hostingController.view.systemLayoutSizeFitting(targetSize)
+
+      // Return the actual fitting size - let the sheet detent handle minimum size
+      return CGSize(width: width, height: fittingSize.height)
+    }
+    set {
+      super.preferredContentSize = newValue
+
+      // Trigger layout update when size changes
+      DispatchQueue.main.async { [weak self] in
+        self?.view.setNeedsLayout()
+        self?.view.layoutIfNeeded()
+      }
+    }
+  }
+}
+
+// MARK: - Integration with Traditional System
+
+@available(iOS 15.0, *)
+extension PrimerSwiftUIBridgeViewController {
+
+  static func createForCheckoutComponents(
+    clientToken: String,
+    settings primerSettings: PrimerSettings,
+    theme primerTheme: PrimerCheckoutTheme = PrimerCheckoutTheme(),
+    diContainer: DIContainer,
+    navigator: CheckoutNavigator,
+    presentationContext: PresentationContext = .direct,
+    integrationType: CheckoutComponentsIntegrationType = .uiKit,
+    scope: ((PrimerCheckoutScope) -> Void)? = nil,
+    onCompletion: ((PrimerCheckoutState) -> Void)? = nil
+  ) -> PrimerSwiftUIBridgeViewController {
+
+    let logger = PrimerLogging.shared.logger
+    logger.info(message: "🌉 [SwiftUIBridge] Creating bridge for CheckoutComponents")
+
+    // Create the SwiftUI checkout view
+    let checkoutView = PrimerCheckout(
+      clientToken: clientToken,
+      primerSettings: primerSettings,
+      primerTheme: primerTheme,
+      diContainer: diContainer,
+      navigator: navigator,
+      presentationContext: presentationContext,
+      integrationType: integrationType,
+      scope: scope,
+      onCompletion: onCompletion
+    )
+
+    // Create bridge controller
+    let bridgeController = PrimerSwiftUIBridgeViewController(swiftUIView: checkoutView)
+    bridgeController.title = CheckoutComponentsStrings.checkoutTitle
+
+    // Apply appearance mode for modal presentation
+    switch primerSettings.uiOptions.appearanceMode {
+    case .system:
+      bridgeController.overrideUserInterfaceStyle = .unspecified
+    case .light:
+      bridgeController.overrideUserInterfaceStyle = .light
+    case .dark:
+      bridgeController.overrideUserInterfaceStyle = .dark
+    }
+
+    logger.info(message: "🌉 [SwiftUIBridge] CheckoutComponents bridge created successfully")
+    return bridgeController
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/PrimerSwiftUIBridgeViewController.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/PrimerSwiftUIBridgeViewController.swift
@@ -52,7 +52,7 @@ final class PrimerSwiftUIBridgeViewController: PrimerViewController {
       swiftUIView.environment(\.bridgeController, self)
     )
 
-    logger.info(message: "🌉 [SwiftUIBridge] Initialized bridge controller for SwiftUI integration")
+    logger.info(message: "[SwiftUIBridge] Initialized bridge controller for SwiftUI integration")
   }
 
   // MARK: - Lifecycle
@@ -62,7 +62,7 @@ final class PrimerSwiftUIBridgeViewController: PrimerViewController {
 
     setupSwiftUIContent()
     setupSizeObservation()
-    logger.debug(message: "🌉 [SwiftUIBridge] Bridge controller view loaded")
+    logger.debug(message: "[SwiftUIBridge] Bridge controller view loaded")
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -99,16 +99,15 @@ final class PrimerSwiftUIBridgeViewController: PrimerViewController {
     // Complete the child view controller setup
     hostingController.didMove(toParent: self)
 
-    logger.debug(message: "🌉 [SwiftUIBridge] SwiftUI content embedded successfully")
+    logger.debug(message: "[SwiftUIBridge] SwiftUI content embedded successfully")
   }
 
   private func setupSizeObservation() {
     // Add observer for SwiftUI view size changes
     hostingController.view.addObserver(
-      self, forKeyPath: "bounds", options: [.new, .old], context: nil
-    )
+      self, forKeyPath: "bounds", options: [.new, .old], context: nil)
 
-    logger.debug(message: "🌉 [SwiftUIBridge] Size observation setup completed")
+    logger.debug(message: "[SwiftUIBridge] Size observation setup completed")
   }
 
   override func observeValue(
@@ -129,7 +128,7 @@ final class PrimerSwiftUIBridgeViewController: PrimerViewController {
 
       logger.debug(
         message:
-          "🌉 [SwiftUIBridge] SwiftUI bounds changed significantly: \(lastRecordedSize) -> \(newRect.size)"
+          "[SwiftUIBridge] SwiftUI bounds changed significantly: \(lastRecordedSize) -> \(newRect.size)"
       )
       lastRecordedSize = newRect.size
       updateContentSize()
@@ -155,8 +154,7 @@ final class PrimerSwiftUIBridgeViewController: PrimerViewController {
 
     // Get the intrinsic content size from SwiftUI
     let targetSize = CGSize(
-      width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height
-    )
+      width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height)
     let fittingSize = hostingController.view.systemLayoutSizeFitting(targetSize)
     let newSize = CGSize(width: view.bounds.width, height: fittingSize.height)
 
@@ -177,8 +175,7 @@ final class PrimerSwiftUIBridgeViewController: PrimerViewController {
 
     logger.debug(
       message:
-        "🌉 [SwiftUIBridge] Updated content size: \(preferredContentSize) (fitting: \(fittingSize))"
-    )
+        "[SwiftUIBridge] Updated content size: \(preferredContentSize) (fitting: \(fittingSize))")
   }
 
   func invalidateContentSize() {
@@ -189,8 +186,7 @@ final class PrimerSwiftUIBridgeViewController: PrimerViewController {
     hostingController.view.layoutIfNeeded()
 
     let targetSize = CGSize(
-      width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height
-    )
+      width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height)
     let fittingSize = hostingController.view.systemLayoutSizeFitting(targetSize)
 
     preferredContentSize = CGSize(width: view.bounds.width, height: fittingSize.height)
@@ -259,7 +255,7 @@ extension PrimerSwiftUIBridgeViewController {
   ) -> PrimerSwiftUIBridgeViewController {
 
     let logger = PrimerLogging.shared.logger
-    logger.info(message: "🌉 [SwiftUIBridge] Creating bridge for CheckoutComponents")
+    logger.info(message: "[SwiftUIBridge] Creating bridge for CheckoutComponents")
 
     // Create the SwiftUI checkout view
     let checkoutView = PrimerCheckout(
@@ -288,7 +284,7 @@ extension PrimerSwiftUIBridgeViewController {
       bridgeController.overrideUserInterfaceStyle = .dark
     }
 
-    logger.info(message: "🌉 [SwiftUIBridge] CheckoutComponents bridge created successfully")
+    logger.info(message: "[SwiftUIBridge] CheckoutComponents bridge created successfully")
     return bridgeController
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
@@ -1,0 +1,351 @@
+//
+//  MockCardFormScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+// swiftlint:disable all
+#if DEBUG
+  import SwiftUI
+
+  /// Mock implementation of PrimerCardFormScope for SwiftUI previews
+  /// Provides configurable behavior and debug logging to help test different UI states
+  @available(iOS 15.0, *)
+  public class MockCardFormScope: PrimerCardFormScope {
+
+    // MARK: - Configuration Properties
+
+    private let initialIsLoading: Bool
+    private let initialIsValid: Bool
+    private let initialSelectedNetwork: CardNetwork?
+    private let initialAvailableNetworks: [CardNetwork]
+    private let initialSurchargeAmount: String?
+    private let configuration: CardFormConfiguration
+    private let enableLogging: Bool
+
+    // MARK: - Protocol Properties
+
+    public var presentationContext: PresentationContext
+
+    public var cardFormUIOptions: PrimerCardFormUIOptions?
+
+    public var dismissalMechanism: [DismissalMechanism]
+
+    public var state: AsyncStream<PrimerCardFormState> {
+      AsyncStream { continuation in
+        continuation.yield(
+          PrimerCardFormState(
+            data: FormData(),
+            isLoading: self.initialIsLoading,
+            isValid: self.initialIsValid,
+            selectedNetwork: self.initialSelectedNetwork.map { PrimerCardNetwork(network: $0) },
+            availableNetworks: self.initialAvailableNetworks.map { PrimerCardNetwork(network: $0) },
+            surchargeAmount: self.initialSurchargeAmount
+          )
+        )
+      }
+    }
+
+    // MARK: - Screen-Level Customization
+
+    public var title: String?
+    public var screen: CardFormScreenComponent?
+    public var cobadgedCardsView: (([String], @escaping (String) -> Void) -> any View)?
+    public var errorScreen: ErrorComponent?
+
+    // MARK: - Submit Button Customization
+
+    public var submitButtonText: String?
+    public var showSubmitLoadingIndicator: Bool = true
+
+    // MARK: - Field-Level Customization via InputFieldConfig
+
+    public var cardNumberConfig: InputFieldConfig?
+    public var expiryDateConfig: InputFieldConfig?
+    public var cvvConfig: InputFieldConfig?
+    public var cardholderNameConfig: InputFieldConfig?
+    public var postalCodeConfig: InputFieldConfig?
+    public var countryConfig: InputFieldConfig?
+    public var cityConfig: InputFieldConfig?
+    public var stateConfig: InputFieldConfig?
+    public var addressLine1Config: InputFieldConfig?
+    public var addressLine2Config: InputFieldConfig?
+    public var phoneNumberConfig: InputFieldConfig?
+    public var firstNameConfig: InputFieldConfig?
+    public var lastNameConfig: InputFieldConfig?
+    public var emailConfig: InputFieldConfig?
+    public var retailOutletConfig: InputFieldConfig?
+    public var otpCodeConfig: InputFieldConfig?
+
+    // MARK: - Section-Level Customization
+
+    public var cardInputSection: Component?
+    public var billingAddressSection: Component?
+    public var submitButton: Component?
+
+    public var selectCountry: PrimerSelectCountryScope {
+      fatalError("Not implemented for preview")
+    }
+
+    // MARK: - Initialization
+
+    /// Creates a mock card form scope for SwiftUI previews
+    /// - Parameters:
+    ///   - isLoading: Initial loading state
+    ///   - isValid: Initial validation state
+    ///   - selectedNetwork: Initially selected card network
+    ///   - availableNetworks: Available card networks for selection
+    ///   - surchargeAmount: Formatted surcharge amount string (e.g., "+ 1.50€")
+    ///   - presentationContext: Context for how the form is presented
+    ///   - formConfiguration: Configuration defining which fields to show
+    ///   - cardFormUIOptions: UI options for the card form
+    ///   - dismissalMechanism: Available dismissal mechanisms
+    ///   - enableLogging: Whether to print debug logs for method calls
+    public init(
+      isLoading: Bool = false,
+      isValid: Bool = false,
+      selectedNetwork: CardNetwork? = nil,
+      availableNetworks: [CardNetwork] = [],
+      surchargeAmount: String? = nil,
+      presentationContext: PresentationContext = .fromPaymentSelection,
+      formConfiguration: CardFormConfiguration = .default,
+      cardFormUIOptions: PrimerCardFormUIOptions? = nil,
+      dismissalMechanism: [DismissalMechanism] = [],
+      enableLogging: Bool = true
+    ) {
+      initialIsLoading = isLoading
+      initialIsValid = isValid
+      initialSelectedNetwork = selectedNetwork
+      initialAvailableNetworks = availableNetworks
+      initialSurchargeAmount = surchargeAmount
+      self.presentationContext = presentationContext
+      configuration = formConfiguration
+      self.cardFormUIOptions = cardFormUIOptions
+      self.dismissalMechanism = dismissalMechanism
+      self.enableLogging = enableLogging
+    }
+
+    // MARK: - Logging Helper
+
+    private func log(_ message: String) {
+      if enableLogging {
+        print("🎭 [MockCardFormScope] \(message)")
+      }
+    }
+
+    // MARK: - Lifecycle Methods
+
+    public func start() {
+      log("start() called")
+    }
+
+    public func submit() {
+      log("submit() called")
+    }
+
+    public func cancel() {
+      log("cancel() called")
+    }
+
+    // MARK: - Navigation Methods
+
+    public func onBack() {
+      log("onBack() called")
+    }
+
+    public func onDismiss() {
+      log("onDismiss() called")
+    }
+
+    // MARK: - Update Methods
+
+    public func updateCardNumber(_ cardNumber: String) {
+      log("updateCardNumber: \(cardNumber)")
+    }
+
+    public func updateCvv(_ cvv: String) {
+      log("updateCvv: \(cvv)")
+    }
+
+    public func updateExpiryDate(_ expiryDate: String) {
+      log("updateExpiryDate: \(expiryDate)")
+    }
+
+    public func updateCardholderName(_ cardholderName: String) {
+      log("updateCardholderName: \(cardholderName)")
+    }
+
+    public func updatePostalCode(_ postalCode: String) {
+      log("updatePostalCode: \(postalCode)")
+    }
+
+    public func updateCity(_ city: String) {
+      log("updateCity: \(city)")
+    }
+
+    public func updateState(_ state: String) {
+      log("updateState: \(state)")
+    }
+
+    public func updateAddressLine1(_ addressLine1: String) {
+      log("updateAddressLine1: \(addressLine1)")
+    }
+
+    public func updateAddressLine2(_ addressLine2: String) {
+      log("updateAddressLine2: \(addressLine2)")
+    }
+
+    public func updatePhoneNumber(_ phoneNumber: String) {
+      log("updatePhoneNumber: \(phoneNumber)")
+    }
+
+    public func updateFirstName(_ firstName: String) {
+      log("updateFirstName: \(firstName)")
+    }
+
+    public func updateLastName(_ lastName: String) {
+      log("updateLastName: \(lastName)")
+    }
+
+    public func updateRetailOutlet(_ retailOutlet: String) {
+      log("updateRetailOutlet: \(retailOutlet)")
+    }
+
+    public func updateOtpCode(_ otpCode: String) {
+      log("updateOtpCode: \(otpCode)")
+    }
+
+    public func updateEmail(_ email: String) {
+      log("updateEmail: \(email)")
+    }
+
+    public func updateExpiryMonth(_ month: String) {
+      log("updateExpiryMonth: \(month)")
+    }
+
+    public func updateExpiryYear(_ year: String) {
+      log("updateExpiryYear: \(year)")
+    }
+
+    public func updateSelectedCardNetwork(_ network: String) {
+      log("updateSelectedCardNetwork: \(network)")
+    }
+
+    public func updateCountryCode(_ countryCode: String) {
+      log("updateCountryCode: \(countryCode)")
+    }
+
+    public func updateValidationState(
+      cardNumber: Bool, cvv: Bool, expiry: Bool, cardholderName: Bool
+    ) {
+      log(
+        "updateValidationState - cardNumber: \(cardNumber), cvv: \(cvv), expiry: \(expiry), cardholderName: \(cardholderName)"
+      )
+    }
+
+    // MARK: - Structured State Support
+
+    public func updateField(_ fieldType: PrimerInputElementType, value: String) {
+      log("updateField(\(fieldType)): \(value)")
+    }
+
+    public func getFieldValue(_ fieldType: PrimerInputElementType) -> String {
+      log("getFieldValue(\(fieldType))")
+      return ""
+    }
+
+    public func setFieldError(
+      _ fieldType: PrimerInputElementType, message: String, errorCode: String?
+    ) {
+      log("setFieldError(\(fieldType)): \(message) [code: \(errorCode ?? "nil")]")
+    }
+
+    public func clearFieldError(_ fieldType: PrimerInputElementType) {
+      log("clearFieldError(\(fieldType))")
+    }
+
+    public func getFieldError(_ fieldType: PrimerInputElementType) -> String? {
+      log("getFieldError(\(fieldType))")
+      return nil
+    }
+
+    // MARK: - ViewBuilder Methods
+
+    public func PrimerCardNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerExpiryDateField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerCvvField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerCardholderNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerCountryField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerPostalCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerCityField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerStateField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerAddressLine1Field(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerAddressLine2Field(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerFirstNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerLastNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerEmailField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerPhoneNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerRetailOutletField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func PrimerOtpCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    public func DefaultCardFormView(styling _: PrimerFieldStyling?) -> AnyView {
+      AnyView(EmptyView())
+    }
+
+    // MARK: - Form Configuration
+
+    public func getFormConfiguration() -> CardFormConfiguration {
+      log("getFormConfiguration() -> \(configuration)")
+      return configuration
+    }
+  }
+
+#endif  // DEBUG
+// swiftlint:enable all

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockDIContainer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockDIContainer.swift
@@ -1,0 +1,54 @@
+//
+//  MockDIContainer.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+  import SwiftUI
+
+  /// Mock implementation of ContainerProtocol for SwiftUI previews
+  /// Provides basic dependency resolution for preview environments
+  @available(iOS 15.0, *)
+  public final class MockDIContainer: ContainerProtocol, @unchecked Sendable {
+    private var registrations: [String: Any] = [:]
+
+    /// Creates a mock DI container for previews
+    /// - Parameter validationService: Custom validation service to use (defaults to MockValidationService with valid results)
+    public init(validationService: ValidationService = MockValidationService()) {
+      // Register the provided validation service
+      registrations["ValidationService"] = validationService
+    }
+
+    public func register<T>(_ type: T.Type) -> any RegistrationBuilder<T> {
+      fatalError("Not needed for preview mocks")
+    }
+
+    public func unregister<T>(_ type: T.Type, name: String?) -> Self {
+      self
+    }
+
+    public func resolve<T>(_ type: T.Type, name: String?) async throws -> T {
+      try resolveSync(type, name: name)
+    }
+
+    public func resolveSync<T>(_ type: T.Type, name: String?) throws -> T {
+      let key = String(describing: type)
+      guard let instance = registrations[key] as? T else {
+        throw NSError(
+          domain: "MockDIContainer",
+          code: 404,
+          userInfo: [NSLocalizedDescriptionKey: "Type not registered: \(key)"]
+        )
+      }
+      return instance
+    }
+
+    public func resolveAll<T>(_ type: T.Type) async -> [T] {
+      []
+    }
+
+    public func reset<T>(ignoreDependencies: [T.Type]) async {}
+  }
+
+#endif  // DEBUG

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockDIContainer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockDIContainer.swift
@@ -10,29 +10,29 @@
   /// Mock implementation of ContainerProtocol for SwiftUI previews
   /// Provides basic dependency resolution for preview environments
   @available(iOS 15.0, *)
-  public final class MockDIContainer: ContainerProtocol, @unchecked Sendable {
+  final class MockDIContainer: ContainerProtocol, @unchecked Sendable {
     private var registrations: [String: Any] = [:]
 
     /// Creates a mock DI container for previews
-    /// - Parameter validationService: Custom validation service to use (defaults to MockValidationService with valid results)
-    public init(validationService: ValidationService = MockValidationService()) {
+    /// - Parameter validationService: Custom validation service to use (defaults to PreviewValidationService with valid results)
+    init(validationService: ValidationService = PreviewValidationService()) {
       // Register the provided validation service
       registrations["ValidationService"] = validationService
     }
 
-    public func register<T>(_ type: T.Type) -> any RegistrationBuilder<T> {
+    func register<T>(_ type: T.Type) -> any RegistrationBuilder<T> {
       fatalError("Not needed for preview mocks")
     }
 
-    public func unregister<T>(_ type: T.Type, name: String?) -> Self {
+    func unregister<T>(_ type: T.Type, name: String?) -> Self {
       self
     }
 
-    public func resolve<T>(_ type: T.Type, name: String?) async throws -> T {
+    func resolve<T>(_ type: T.Type, name: String?) async throws -> T {
       try resolveSync(type, name: name)
     }
 
-    public func resolveSync<T>(_ type: T.Type, name: String?) throws -> T {
+    func resolveSync<T>(_ type: T.Type, name: String?) throws -> T {
       let key = String(describing: type)
       guard let instance = registrations[key] as? T else {
         throw NSError(
@@ -44,11 +44,11 @@
       return instance
     }
 
-    public func resolveAll<T>(_ type: T.Type) async -> [T] {
+    func resolveAll<T>(_ type: T.Type) async -> [T] {
       []
     }
 
-    public func reset<T>(ignoreDependencies: [T.Type]) async {}
+    func reset<T>(ignoreDependencies: [T.Type]) async {}
   }
 
 #endif  // DEBUG

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockDesignTokens.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockDesignTokens.swift
@@ -1,0 +1,70 @@
+//
+//  MockDesignTokens.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+// swiftlint:disable all
+
+#if DEBUG
+  import SwiftUI
+
+  /// Mock design tokens for SwiftUI previews and testing
+  /// Provides convenient access to both light and dark theme tokens
+  @available(iOS 15.0, *)
+  struct MockDesignTokens {
+
+    // MARK: - Static Instances
+
+    /// Light theme design tokens with default Primer values
+    static let light: DesignTokens = {
+      // Create instance with default values
+      DesignTokens()
+    }()
+
+    /// Dark theme design tokens with default Primer dark mode values
+    static let dark: DesignTokens = {
+      // Create light tokens with defaults
+      let lightTokens = DesignTokens()
+
+      // Create dark tokens from empty JSON to override colors
+      let emptyJSON = "{}"
+      let data = Data(emptyJSON.utf8)
+      let decoder = JSONDecoder()
+      let darkTokens = try! decoder.decode(DesignTokensDark.self, from: data)
+
+      // Merge dark theme colors into light theme structure
+      // Dark theme only overrides colors, everything else stays the same
+      lightTokens.primerColorGray100 = darkTokens.primerColorGray100
+      lightTokens.primerColorGray200 = darkTokens.primerColorGray200
+      lightTokens.primerColorGray300 = darkTokens.primerColorGray300
+      lightTokens.primerColorGray400 = darkTokens.primerColorGray400
+      lightTokens.primerColorGray500 = darkTokens.primerColorGray500
+      lightTokens.primerColorGray600 = darkTokens.primerColorGray600
+      lightTokens.primerColorGray900 = darkTokens.primerColorGray900
+      lightTokens.primerColorGray000 = darkTokens.primerColorGray000
+      lightTokens.primerColorGreen500 = darkTokens.primerColorGreen500
+      lightTokens.primerColorBrand = darkTokens.primerColorBrand
+      lightTokens.primerColorRed100 = darkTokens.primerColorRed100
+      lightTokens.primerColorRed500 = darkTokens.primerColorRed500
+      lightTokens.primerColorRed900 = darkTokens.primerColorRed900
+      lightTokens.primerColorBlue500 = darkTokens.primerColorBlue500
+      lightTokens.primerColorBlue900 = darkTokens.primerColorBlue900
+
+      return lightTokens
+    }()
+
+    // MARK: - Custom Token Creation
+
+    /// Creates a custom DesignTokens instance for testing specific scenarios
+    /// - Parameter modifications: A closure to modify the default light theme tokens
+    /// - Returns: A customized DesignTokens instance
+    static func custom(modifications: (DesignTokens) -> Void) -> DesignTokens {
+      let tokens = DesignTokens()
+      modifications(tokens)
+      return tokens
+    }
+  }
+
+#endif  // DEBUG
+// swiftlint:enable all

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockValidationService.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockValidationService.swift
@@ -7,10 +7,10 @@
 #if DEBUG
   import SwiftUI
 
-  /// Mock implementation of ValidationService for SwiftUI previews
+  /// Preview implementation of ValidationService for SwiftUI previews
   /// Configurable to return either valid or invalid results for testing different UI states
   @available(iOS 15.0, *)
-  public class MockValidationService: ValidationService {
+  final class PreviewValidationService: ValidationService {
 
     // MARK: - Configuration Properties
 
@@ -23,7 +23,7 @@
     /// - Parameters:
     ///   - shouldFailValidation: Whether validation should fail (default: false)
     ///   - errorMessage: Error message to return when validation fails (default: "Please enter a valid value")
-    public init(
+    init(
       shouldFailValidation: Bool = false, errorMessage: String = "Please enter a valid value"
     ) {
       self.shouldFailValidation = shouldFailValidation
@@ -32,72 +32,66 @@
 
     // MARK: - ValidationService Protocol Implementation
 
-    public func validateCardNumber(_ number: String) -> ValidationResult {
+    func validateCardNumber(_ number: String) -> ValidationResult {
       if shouldFailValidation {
         return ValidationResult(
-          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
-        )
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage)
       }
       return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
     }
 
-    public func validateExpiry(month: String, year: String) -> ValidationResult {
+    func validateExpiry(month: String, year: String) -> ValidationResult {
       if shouldFailValidation {
         return ValidationResult(
-          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
-        )
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage)
       }
       return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
     }
 
-    public func validateCVV(_ cvv: String, cardNetwork: CardNetwork) -> ValidationResult {
+    func validateCVV(_ cvv: String, cardNetwork: CardNetwork) -> ValidationResult {
       if shouldFailValidation {
         return ValidationResult(
-          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
-        )
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage)
       }
       return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
     }
 
-    public func validateCardholderName(_ name: String) -> ValidationResult {
+    func validateCardholderName(_ name: String) -> ValidationResult {
       if shouldFailValidation {
         return ValidationResult(
-          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
-        )
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage)
       }
       return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
     }
 
-    public func validateField(type: PrimerInputElementType, value: String?) -> ValidationResult {
+    func validateField(type: PrimerInputElementType, value: String?) -> ValidationResult {
       if shouldFailValidation {
         return ValidationResult(
-          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
-        )
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage)
       }
       return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
     }
 
-    public func validate<T, R: ValidationRule>(input: T, with rule: R) -> ValidationResult
+    func validate<T, R: ValidationRule>(input: T, with rule: R) -> ValidationResult
     where R.Input == T {
       if shouldFailValidation {
         return ValidationResult(
-          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
-        )
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage)
       }
       return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
     }
 
-    public func validateFormData(_ formData: FormData, configuration: CardFormConfiguration)
+    func validateFormData(_ formData: FormData, configuration: CardFormConfiguration)
       -> [FieldError] {
       []
     }
 
-    public func validateFields(_ fieldTypes: [PrimerInputElementType], formData: FormData)
+    func validateFields(_ fieldTypes: [PrimerInputElementType], formData: FormData)
       -> [FieldError] {
       []
     }
 
-    public func validateFieldWithStructuredResult(type: PrimerInputElementType, value: String?)
+    func validateFieldWithStructuredResult(type: PrimerInputElementType, value: String?)
       -> FieldError? {
       nil
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockValidationService.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockValidationService.swift
@@ -1,0 +1,106 @@
+//
+//  MockValidationService.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+#if DEBUG
+  import SwiftUI
+
+  /// Mock implementation of ValidationService for SwiftUI previews
+  /// Configurable to return either valid or invalid results for testing different UI states
+  @available(iOS 15.0, *)
+  public class MockValidationService: ValidationService {
+
+    // MARK: - Configuration Properties
+
+    private let shouldFailValidation: Bool
+    private let errorMessage: String
+
+    // MARK: - Initialization
+
+    /// Creates a mock validation service for previews
+    /// - Parameters:
+    ///   - shouldFailValidation: Whether validation should fail (default: false)
+    ///   - errorMessage: Error message to return when validation fails (default: "Please enter a valid value")
+    public init(
+      shouldFailValidation: Bool = false, errorMessage: String = "Please enter a valid value"
+    ) {
+      self.shouldFailValidation = shouldFailValidation
+      self.errorMessage = errorMessage
+    }
+
+    // MARK: - ValidationService Protocol Implementation
+
+    public func validateCardNumber(_ number: String) -> ValidationResult {
+      if shouldFailValidation {
+        return ValidationResult(
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
+        )
+      }
+      return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
+    }
+
+    public func validateExpiry(month: String, year: String) -> ValidationResult {
+      if shouldFailValidation {
+        return ValidationResult(
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
+        )
+      }
+      return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
+    }
+
+    public func validateCVV(_ cvv: String, cardNetwork: CardNetwork) -> ValidationResult {
+      if shouldFailValidation {
+        return ValidationResult(
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
+        )
+      }
+      return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
+    }
+
+    public func validateCardholderName(_ name: String) -> ValidationResult {
+      if shouldFailValidation {
+        return ValidationResult(
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
+        )
+      }
+      return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
+    }
+
+    public func validateField(type: PrimerInputElementType, value: String?) -> ValidationResult {
+      if shouldFailValidation {
+        return ValidationResult(
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
+        )
+      }
+      return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
+    }
+
+    public func validate<T, R: ValidationRule>(input: T, with rule: R) -> ValidationResult
+    where R.Input == T {
+      if shouldFailValidation {
+        return ValidationResult(
+          isValid: false, errorCode: "validation_error", errorMessage: errorMessage
+        )
+      }
+      return ValidationResult(isValid: true, errorCode: nil, errorMessage: nil)
+    }
+
+    public func validateFormData(_ formData: FormData, configuration: CardFormConfiguration)
+      -> [FieldError] {
+      []
+    }
+
+    public func validateFields(_ fieldTypes: [PrimerInputElementType], formData: FormData)
+      -> [FieldError] {
+      []
+    }
+
+    public func validateFieldWithStructuredResult(type: PrimerInputElementType, value: String?)
+      -> FieldError? {
+      nil
+    }
+  }
+
+#endif  // DEBUG

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/RTLIcon.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/RTLIcon.swift
@@ -1,0 +1,16 @@
+//
+//  RTLIcon.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@available(iOS 15.0, *)
+enum RTLIcon {
+  static var backChevron: String {
+    RTLSupport.isRightToLeft ? "chevron.right" : "chevron.left"
+  }
+
+  static var forwardChevron: String {
+    RTLSupport.isRightToLeft ? "chevron.left" : "chevron.right"
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/RTLSupport.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/RTLSupport.swift
@@ -1,0 +1,18 @@
+//
+//  RTLSupport.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+enum RTLSupport {
+  static var isRightToLeft: Bool {
+    UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft
+  }
+
+  static var layoutDirection: LayoutDirection {
+    isRightToLeft ? .rightToLeft : .leftToRight
+  }
+}


### PR DESCRIPTION
## Summary
- Add 20+ SwiftUI screens: card form, payment method selection, ACH (mandate, user details, bank collector), Apple Pay, Klarna, PayPal, QR Code, web/form redirect, vaulted payment methods list, country selection, success, error, loading, splash, and delete confirmation
- Add reusable UI components: input fields (card number, CVV, expiry, cardholder name, email, address, city, state, postal code, OTP), card network selectors (inline + dropdown), payment method buttons/sections, vault section, Apple Pay button
- Add infrastructure: `PrimerInputFieldContainer` system with styling/rendering extensions, `SecureTextField`, `PrimerTextFieldExtension`
- Add design system: `CheckoutColors`, `PrimerLayout`, `AnimationConstants`, `SlideInModifier`
- Add `PrimerSwiftUIBridgeViewController` for UIKit integration
- Add preview utilities: `MockCardFormScope`, `MockDIContainer`, `MockDesignTokens`, `MockValidationService`
- Add RTL support utilities

## Context
PR 14 of 16 in the CheckoutComponents feature split. Depends on [PR 13](https://github.com/primer-io/primer-sdk-ios/pull/1642) (presentation scopes & container wiring).

[Notion tracker](https://www.notion.so/32fca65dc30e81dabf66f33e2b58c3a1)

## Test plan
- [ ] Visual review of SwiftUI screens via Xcode previews
- [ ] Verify input field components render correctly with various states
- [ ] Verify card network selector displays inline and dropdown variants
- [ ] Verify RTL layout support works correctly
- [ ] Verify PrimerSwiftUIBridgeViewController presents SwiftUI views in UIKit host