### PR TITLE
feat: Add entry points & Debug App

### DIFF
--- a/Debug App/.swiftlint.yml
+++ b/Debug App/.swiftlint.yml
@@ -1,5 +1,17 @@
 disabled_rules:
     - superfluous_disable_command
+    - type_body_length
+
+opt_in_rules:
+    - shorthand_optional_binding
+    - implicit_return
+    - empty_count
+    - direct_return
+    - redundant_type_annotation
+    - final_test_case
+    - contains_over_filter_count
+    - first_where
+    - redundant_self_in_closure
 
 line_length:
   warning: 150
@@ -7,9 +19,50 @@ line_length:
   ignores_comments: true
   ignores_interpolated_strings: true
   ignores_urls: true
-  
+
+file_length:
+  warning: 500
+  error: 800
+  ignore_comment_only_lines: true
+
+function_body_length:
+  warning: 60
+  error: 100
+
+cyclomatic_complexity:
+  warning: 12
+  error: 20
+  ignores_case_statements: false
+
+function_parameter_count:
+  warning: 6
+  error: 8
+
+empty_count:
+  severity: warning
+
 included:
   - ../Sources
 
 excluded:
   - ../Sources/PrimerSDK/Classes/Third Party/PromiseKit
+
+# Configuration for type names:
+# Enforces a minimum length of 3 and a maximum length of 40 characters,
+# but excludes the generic type "T" from this rule.
+type_name:
+  min_length: 3
+  max_length: 40
+  excluded:
+    - '^T$'  # Regex to ignore type name "T"
+
+# Configuration for identifier names:
+# Enforces a minimum length of 3 and a maximum length of 40 characters,
+# but excludes the loop counter "i" from this rule.
+identifier_name:
+  min_length: 3
+  max_length: 40
+  excluded:
+    - '^i$'  # Regex to ignore identifier "i" in for loops
+    - '^id$' # Regex to ignore identifier "id"
+

--- a/Debug App/Info.plist
+++ b/Debug App/Info.plist
@@ -76,10 +76,27 @@
 	<array>
 		<string>chocolate_bar_demo.otf</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -1,51 +1,49 @@
 PODS:
-  - IQKeyboardCore (1.0.5)
-  - IQKeyboardManagerSwift (8.0.0):
-    - IQKeyboardManagerSwift/Appearance (= 8.0.0)
-    - IQKeyboardManagerSwift/Core (= 8.0.0)
-    - IQKeyboardManagerSwift/IQKeyboardReturnManager (= 8.0.0)
-    - IQKeyboardManagerSwift/IQKeyboardToolbarManager (= 8.0.0)
-    - IQKeyboardManagerSwift/IQTextView (= 8.0.0)
-    - IQKeyboardManagerSwift/Resign (= 8.0.0)
-  - IQKeyboardManagerSwift/Appearance (8.0.0):
+  - IQKeyboardCore (1.0.8)
+  - IQKeyboardManagerSwift (8.0.1):
+    - IQKeyboardManagerSwift/Appearance (= 8.0.1)
+    - IQKeyboardManagerSwift/Core (= 8.0.1)
+    - IQKeyboardManagerSwift/IQKeyboardReturnManager (= 8.0.1)
+    - IQKeyboardManagerSwift/IQKeyboardToolbarManager (= 8.0.1)
+    - IQKeyboardManagerSwift/IQTextView (= 8.0.1)
+    - IQKeyboardManagerSwift/Resign (= 8.0.1)
+  - IQKeyboardManagerSwift/Appearance (8.0.1):
     - IQKeyboardManagerSwift/Core
-  - IQKeyboardManagerSwift/Core (8.0.0):
+  - IQKeyboardManagerSwift/Core (8.0.1):
     - IQKeyboardNotification
     - IQTextInputViewNotification
-  - IQKeyboardManagerSwift/IQKeyboardReturnManager (8.0.0):
+  - IQKeyboardManagerSwift/IQKeyboardReturnManager (8.0.1):
     - IQKeyboardReturnManager
-  - IQKeyboardManagerSwift/IQKeyboardToolbarManager (8.0.0):
+  - IQKeyboardManagerSwift/IQKeyboardToolbarManager (8.0.1):
     - IQKeyboardManagerSwift/Core
     - IQKeyboardToolbarManager
-  - IQKeyboardManagerSwift/IQTextView (8.0.0):
+  - IQKeyboardManagerSwift/IQTextView (8.0.1):
     - IQTextView
-  - IQKeyboardManagerSwift/Resign (8.0.0):
+  - IQKeyboardManagerSwift/Resign (8.0.1):
     - IQKeyboardManagerSwift/Core
-  - IQKeyboardNotification (1.0.3)
-  - IQKeyboardReturnManager (1.0.4):
-    - IQKeyboardCore (= 1.0.5)
-  - IQKeyboardToolbar (1.1.1):
+  - IQKeyboardNotification (1.0.6)
+  - IQKeyboardReturnManager (1.0.6):
     - IQKeyboardCore
-    - IQKeyboardToolbar/Core (= 1.1.1)
-  - IQKeyboardToolbar/Core (1.1.1):
+  - IQKeyboardToolbar (1.1.3):
+    - IQKeyboardToolbar/Core (= 1.1.3)
+  - IQKeyboardToolbar/Core (1.1.3):
     - IQKeyboardCore
     - IQKeyboardToolbar/Placeholderable
-  - IQKeyboardToolbar/Placeholderable (1.1.1):
-    - IQKeyboardCore
-  - IQKeyboardToolbarManager (1.1.3):
+  - IQKeyboardToolbar/Placeholderable (1.1.3)
+  - IQKeyboardToolbarManager (1.1.4):
     - IQKeyboardToolbar
     - IQTextInputViewNotification
-  - IQTextInputViewNotification (1.0.8):
+  - IQTextInputViewNotification (1.0.9):
     - IQKeyboardCore
   - IQTextView (1.0.5):
     - IQKeyboardToolbar/Placeholderable
   - Primer3DS (2.8.0)
   - PrimerIPay88MYSDK (0.1.7)
-  - PrimerKlarnaSDK (1.1.2)
+  - PrimerKlarnaSDK (1.3.1)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerSDK (2.44.1):
-    - PrimerSDK/Core (= 2.44.1)
-  - PrimerSDK/Core (2.44.1)
+  - PrimerSDK (3.0.0-b0):
+    - PrimerSDK/Core (= 3.0.0-b0)
+  - PrimerSDK/Core (3.0.0-b0)
   - PrimerStripeSDK (1.0.1)
 
 DEPENDENCIES:
@@ -78,19 +76,19 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  IQKeyboardCore: 28c8bf3bcd8ba5aa1570b318cbc4da94b861711e
-  IQKeyboardManagerSwift: 0c6fbbaa2e60739e48d7cf59f25661471a7a3a65
-  IQKeyboardNotification: d7382c4466c5a5adef92c7452ebf861b36050088
-  IQKeyboardReturnManager: 972be48528ce9e7508ab3ab15ac7efac803f17f5
-  IQKeyboardToolbar: d4bdccfb78324aec2f3920659c77bb89acd33312
-  IQKeyboardToolbarManager: 6c693c8478d6327a7ef2107528d29698b3514dbb
-  IQTextInputViewNotification: f5e954d8881fd9808b744e49e024cc0d4bcfe572
+  IQKeyboardCore: 8652977ec919cf5351aa2977fedd1a6546476fbc
+  IQKeyboardManagerSwift: 835fc9c6e4732398113406d84900ad2e8f141218
+  IQKeyboardNotification: eb4910401f5a0e68f97e71c62f8a0c5b7e9d535c
+  IQKeyboardReturnManager: fcbf51fc68d7536fc1fbcca5231c4e82576b12ac
+  IQKeyboardToolbar: 9fe900f8e7def414be4025af0ca098df764d4fe3
+  IQKeyboardToolbarManager: c8a575e8b5fffe5873d0e75312244498a0759473
+  IQTextInputViewNotification: 3b9fb27a16e7ee8958cc9092cfb07a1a9e1fd559
   IQTextView: ae13b4922f22e6f027f62c557d9f4f236b19d5c7
   Primer3DS: b8b583ef260f703180870358bc55069de74f8f51
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
-  PrimerKlarnaSDK: c39536a4eb070da5b43ec99a4edbede241e91d25
+  PrimerKlarnaSDK: 104962584ac6baad20424f73ee8493c8503fd487
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerSDK: fde30db8ff5cf09d8186caeaf4d17beb4fedbe16
+  PrimerSDK: 695f94c80622e24c23e0a737d9bdb64c4e49fafc
   PrimerStripeSDK: dce5e37d10223ee724f33d1cdeaa17235a71ddbb
 
 PODFILE CHECKSUM: 665eac28ae49fa5a7b983ebc01493e77d5e13406

--- a/Debug App/Primer.io Debug App SPM.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App SPM.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		044F805B2C6B4F9800E9F878 /* MerchantHeadlessCheckoutStripeAchViewController+StripeAch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044F80562C6B4F9800E9F878 /* MerchantHeadlessCheckoutStripeAchViewController+StripeAch.swift */; };
 		044F805C2C6B4F9800E9F878 /* MerchantHeadlessStripeAchFieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044F80572C6B4F9800E9F878 /* MerchantHeadlessStripeAchFieldsView.swift */; };
 		044F805D2C6B4F9800E9F878 /* MerchantHeadlessStripeAchFieldsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044F80582C6B4F9800E9F878 /* MerchantHeadlessStripeAchFieldsViewModel.swift */; };
-		0498E1CF2BFB509F00EEF9EE /* PrimerNolPaySDK in Frameworks */ = {isa = PBXBuildFile; productRef = 0498E1CE2BFB509F00EEF9EE /* PrimerNolPaySDK */; };
 		049A055C2B4BF044002CEEBA /* MerchantHeadlessVaultManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049A055B2B4BF044002CEEBA /* MerchantHeadlessVaultManagerViewController.swift */; };
 		8723ADDD2B8E0F5100A5FE23 /* MerchantHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADDC2B8E0F5100A5FE23 /* MerchantHelpers.swift */; };
 		8723ADE42B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADDF2B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView.swift */; };
@@ -24,7 +23,18 @@
 		8723ADE62B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView+Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADE12B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView+Elements.swift */; };
 		8723ADE72B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController+Klarna.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADE22B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController+Klarna.swift */; };
 		8723ADE82B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADE32B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController.swift */; };
-		87BD7B802C2350B900BE70E8 /* PrimerStripeSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 87BD7B7F2C2350B900BE70E8 /* PrimerStripeSDK */; };
+		A79D98422EE700350024B330 /* DefaultCheckoutDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98322EE700350024B330 /* DefaultCheckoutDemo.swift */; };
+		A79D98432EE700350024B330 /* CustomPaymentSelectionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98312EE700350024B330 /* CustomPaymentSelectionDemo.swift */; };
+		A79D98442EE700350024B330 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98362EE700350024B330 /* LoadingView.swift */; };
+		A79D98452EE700350024B330 /* CheckoutComponentsExamplesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D983B2EE700350024B330 /* CheckoutComponentsExamplesView.swift */; };
+		A79D98462EE700350024B330 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98352EE700350024B330 /* ErrorView.swift */; };
+		A79D98472EE700350024B330 /* DemoProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D983E2EE700350024B330 /* DemoProtocol.swift */; };
+		A79D98482EE700350024B330 /* DemoRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D983F2EE700350024B330 /* DemoRegistry.swift */; };
+		A79D98492EE700350024B330 /* DemoRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98342EE700350024B330 /* DemoRow.swift */; };
+		A79D984A2EE700350024B330 /* SimpleCountryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98392EE700350024B330 /* SimpleCountryPicker.swift */; };
+		A79D984B2EE700350024B330 /* CheckoutComponentsMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D983C2EE700350024B330 /* CheckoutComponentsMenuViewController.swift */; };
+		A79D984C2EE700350024B330 /* NetworkingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98382EE700350024B330 /* NetworkingUtils.swift */; };
+		A7C561392EF2F08100689089 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C561382EF2F08100689089 /* SceneDelegate.swift */; };
 		BA6BF5912E78581C003D8B3D /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6BF5902E78581A003D8B3D /* Collection+Extensions.swift */; };
 		E11F475C2B06C5A40091C31F /* MerchantHeadlessCheckoutBankViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11F47582B06C5A40091C31F /* MerchantHeadlessCheckoutBankViewController.swift */; };
 		E11F475D2B06C5A40091C31F /* BanksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11F47592B06C5A40091C31F /* BanksListView.swift */; };
@@ -57,7 +67,6 @@
 		F00C66152ACC67FA00187028 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = FC701AFD94F96F0F1D108D1A /* LaunchScreen.xib */; };
 		F00C66162ACC67FA00187028 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE259612A00F85709107B872 /* Main.storyboard */; };
 		F04510E32ACD98E100A0A48C /* PrimerSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F04510E22ACD98E100A0A48C /* PrimerSDK */; };
-		F04510E62ACD990A00A0A48C /* PrimerKlarnaSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F04510E52ACD990A00A0A48C /* PrimerKlarnaSDK */; };
 		F04DFC6B2DAE4F130006AEDC /* AppLinkConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04DFC6A2DAE4F130006AEDC /* AppLinkConfigProvider.swift */; };
 		F04DFC6F2DAE4F4D0006AEDC /* TestSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04DFC6E2DAE4F4D0006AEDC /* TestSettings.swift */; };
 		F04DFC712DAE4F5E0006AEDC /* TestSettings+PrimerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04DFC702DAE4F5E0006AEDC /* TestSettings+PrimerSettings.swift */; };
@@ -133,6 +142,18 @@
 		9874F439DA3EA5854A454687 /* MerchantDropInUIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantDropInUIViewController.swift; sourceTree = "<group>"; };
 		A1604A656AF654D7422A2A5E /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
 		A6AEF11B151368BF993C3EA9 /* TestScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestScenario.swift; sourceTree = "<group>"; };
+		A79D98312EE700350024B330 /* CustomPaymentSelectionDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPaymentSelectionDemo.swift; sourceTree = "<group>"; };
+		A79D98322EE700350024B330 /* DefaultCheckoutDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCheckoutDemo.swift; sourceTree = "<group>"; };
+		A79D98342EE700350024B330 /* DemoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoRow.swift; sourceTree = "<group>"; };
+		A79D98352EE700350024B330 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
+		A79D98362EE700350024B330 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		A79D98382EE700350024B330 /* NetworkingUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingUtils.swift; sourceTree = "<group>"; };
+		A79D98392EE700350024B330 /* SimpleCountryPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCountryPicker.swift; sourceTree = "<group>"; };
+		A79D983B2EE700350024B330 /* CheckoutComponentsExamplesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutComponentsExamplesView.swift; sourceTree = "<group>"; };
+		A79D983C2EE700350024B330 /* CheckoutComponentsMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutComponentsMenuViewController.swift; sourceTree = "<group>"; };
+		A79D983E2EE700350024B330 /* DemoProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoProtocol.swift; sourceTree = "<group>"; };
+		A79D983F2EE700350024B330 /* DemoRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoRegistry.swift; sourceTree = "<group>"; };
+		A7C561382EF2F08100689089 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		B18D7E7738BF86467B0F1465 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		B1FD8065D40A2D691F643F3B /* UIViewController+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+API.swift"; sourceTree = "<group>"; };
 		B866FF13033A5CB8B4C3388E /* MerchantHeadlessCheckoutRawDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutRawDataViewController.swift; sourceTree = "<group>"; };
@@ -175,9 +196,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				F04510E32ACD98E100A0A48C /* PrimerSDK in Frameworks */,
-				F04510E62ACD990A00A0A48C /* PrimerKlarnaSDK in Frameworks */,
-				0498E1CF2BFB509F00EEF9EE /* PrimerNolPaySDK in Frameworks */,
-				87BD7B802C2350B900BE70E8 /* PrimerStripeSDK in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,6 +245,7 @@
 		0E5CB4D963647832FF985B29 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				A79D98402EE700350024B330 /* CheckoutComponents */,
 				8723ADDB2B8E0F5100A5FE23 /* Merchant Helpers */,
 				EF5FBE3673FBCB40F55F4DC0 /* New UI */,
 				9874F439DA3EA5854A454687 /* MerchantDropInUIViewController.swift */,
@@ -280,6 +299,7 @@
 		5E99BB590FD6521F2D5403BB /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				A7C561382EF2F08100689089 /* SceneDelegate.swift */,
 				0442C4052B7CE1E900EAD8EE /* Utilities */,
 				553A7EDE72B8249F55A0E6B9 /* Extension */,
 				D9AC6F54A87D432982864A63 /* Model */,
@@ -329,6 +349,48 @@
 				8723ADE32B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController.swift */,
 			);
 			path = KlarnaHeadless;
+			sourceTree = "<group>";
+		};
+		A79D98332EE700350024B330 /* Demos */ = {
+			isa = PBXGroup;
+			children = (
+				A79D98312EE700350024B330 /* CustomPaymentSelectionDemo.swift */,
+				A79D98322EE700350024B330 /* DefaultCheckoutDemo.swift */,
+			);
+			path = Demos;
+			sourceTree = "<group>";
+		};
+		A79D98372EE700350024B330 /* SharedComponents */ = {
+			isa = PBXGroup;
+			children = (
+				A79D98342EE700350024B330 /* DemoRow.swift */,
+				A79D98352EE700350024B330 /* ErrorView.swift */,
+				A79D98362EE700350024B330 /* LoadingView.swift */,
+			);
+			path = SharedComponents;
+			sourceTree = "<group>";
+		};
+		A79D983A2EE700350024B330 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				A79D98382EE700350024B330 /* NetworkingUtils.swift */,
+				A79D98392EE700350024B330 /* SimpleCountryPicker.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		A79D98402EE700350024B330 /* CheckoutComponents */ = {
+			isa = PBXGroup;
+			children = (
+				A79D98332EE700350024B330 /* Demos */,
+				A79D98372EE700350024B330 /* SharedComponents */,
+				A79D983A2EE700350024B330 /* Utils */,
+				A79D983B2EE700350024B330 /* CheckoutComponentsExamplesView.swift */,
+				A79D983C2EE700350024B330 /* CheckoutComponentsMenuViewController.swift */,
+				A79D983E2EE700350024B330 /* DemoProtocol.swift */,
+				A79D983F2EE700350024B330 /* DemoRegistry.swift */,
+			);
+			path = CheckoutComponents;
 			sourceTree = "<group>";
 		};
 		D9AC6F54A87D432982864A63 /* Model */ = {
@@ -422,9 +484,6 @@
 			name = "Debug App SPM";
 			packageProductDependencies = (
 				F04510E22ACD98E100A0A48C /* PrimerSDK */,
-				F04510E52ACD990A00A0A48C /* PrimerKlarnaSDK */,
-				0498E1CE2BFB509F00EEF9EE /* PrimerNolPaySDK */,
-				87BD7B7F2C2350B900BE70E8 /* PrimerStripeSDK */,
 			);
 			productName = "Debug App";
 			productReference = F00C661E2ACC67FA00187028 /* Debug App SPM.app */;
@@ -463,9 +522,6 @@
 			);
 			mainGroup = 1C9799A622D0CCDBBF94925B;
 			packageReferences = (
-				F04510E42ACD990A00A0A48C /* XCRemoteSwiftPackageReference "primer-klarna-sdk-ios" */,
-				0498E1CD2BFB509F00EEF9EE /* XCRemoteSwiftPackageReference "primer-nol-pay-sdk-ios" */,
-				87BD7B7E2C2350B900BE70E8 /* XCRemoteSwiftPackageReference "primer-stripe-sdk-ios" */,
 			);
 			productRefGroup = DF30711EB149C64C364BB79A /* Products */;
 			projectDirPath = "";
@@ -511,6 +567,7 @@
 				F00C65FB2ACC67FA00187028 /* String+Extensions.swift in Sources */,
 				049A055C2B4BF044002CEEBA /* MerchantHeadlessVaultManagerViewController.swift in Sources */,
 				F00C65FC2ACC67FA00187028 /* UIStackViewExtensions.swift in Sources */,
+				A7C561392EF2F08100689089 /* SceneDelegate.swift in Sources */,
 				F00C65FD2ACC67FA00187028 /* UIViewController+API.swift in Sources */,
 				043C7FA22C49749E0018929E /* TestHelper.swift in Sources */,
 				F00C65FE2ACC67FA00187028 /* ViewController+Primer.swift in Sources */,
@@ -524,6 +581,17 @@
 				E11F475D2B06C5A40091C31F /* BanksListView.swift in Sources */,
 				F00C66052ACC67FA00187028 /* Networking.swift in Sources */,
 				F00C66062ACC67FA00187028 /* MerchantDropInUIViewController.swift in Sources */,
+				A79D98422EE700350024B330 /* DefaultCheckoutDemo.swift in Sources */,
+				A79D98432EE700350024B330 /* CustomPaymentSelectionDemo.swift in Sources */,
+				A79D98442EE700350024B330 /* LoadingView.swift in Sources */,
+				A79D98452EE700350024B330 /* CheckoutComponentsExamplesView.swift in Sources */,
+				A79D98462EE700350024B330 /* ErrorView.swift in Sources */,
+				A79D98472EE700350024B330 /* DemoProtocol.swift in Sources */,
+				A79D98482EE700350024B330 /* DemoRegistry.swift in Sources */,
+				A79D98492EE700350024B330 /* DemoRow.swift in Sources */,
+				A79D984A2EE700350024B330 /* SimpleCountryPicker.swift in Sources */,
+				A79D984B2EE700350024B330 /* CheckoutComponentsMenuViewController.swift in Sources */,
+				A79D984C2EE700350024B330 /* NetworkingUtils.swift in Sources */,
 				0442C4072B7CE1E900EAD8EE /* TapGestureRecognizer.swift in Sources */,
 				8723ADE52B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationViewModel.swift in Sources */,
 				8723ADE82B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController.swift in Sources */,
@@ -798,52 +866,10 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		0498E1CD2BFB509F00EEF9EE /* XCRemoteSwiftPackageReference "primer-nol-pay-sdk-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/primer-io/primer-nol-pay-sdk-ios";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.2;
-			};
-		};
-		87BD7B7E2C2350B900BE70E8 /* XCRemoteSwiftPackageReference "primer-stripe-sdk-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/primer-io/primer-stripe-sdk-ios";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
-			};
-		};
-		F04510E42ACD990A00A0A48C /* XCRemoteSwiftPackageReference "primer-klarna-sdk-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/primer-io/primer-klarna-sdk-ios";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
 /* Begin XCSwiftPackageProductDependency section */
-		0498E1CE2BFB509F00EEF9EE /* PrimerNolPaySDK */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0498E1CD2BFB509F00EEF9EE /* XCRemoteSwiftPackageReference "primer-nol-pay-sdk-ios" */;
-			productName = PrimerNolPaySDK;
-		};
-		87BD7B7F2C2350B900BE70E8 /* PrimerStripeSDK */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 87BD7B7E2C2350B900BE70E8 /* XCRemoteSwiftPackageReference "primer-stripe-sdk-ios" */;
-			productName = PrimerStripeSDK;
-		};
 		F04510E22ACD98E100A0A48C /* PrimerSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = PrimerSDK;
-		};
-		F04510E52ACD990A00A0A48C /* PrimerKlarnaSDK */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F04510E42ACD990A00A0A48C /* XCRemoteSwiftPackageReference "primer-klarna-sdk-ios" */;
-			productName = PrimerKlarnaSDK;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -45,6 +45,19 @@
 		949864026D1CDE6F5C62C66E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE259612A00F85709107B872 /* Main.storyboard */; };
 		A19EF5632B20E22E00A72F60 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A19EF5622B20E22E00A72F60 /* .swiftlint.yml */; };
 		A1A1FD8B2DA599550069B0DB /* chocolate_bar_demo.otf in Resources */ = {isa = PBXBuildFile; fileRef = A1A1FD8A2DA599550069B0DB /* chocolate_bar_demo.otf */; };
+		A79D98242EE6DCE70024B330 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98182EE6DCE70024B330 /* LoadingView.swift */; };
+		A79D98252EE6DCE70024B330 /* DemoRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98162EE6DCE70024B330 /* DemoRow.swift */; };
+		A79D98262EE6DCE70024B330 /* SimpleCountryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98222EE6DCE70024B330 /* SimpleCountryPicker.swift */; };
+		A79D98272EE6DCE70024B330 /* NetworkingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98212EE6DCE70024B330 /* NetworkingUtils.swift */; };
+		A79D98282EE6DCE70024B330 /* CustomPaymentSelectionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98132EE6DCE70024B330 /* CustomPaymentSelectionDemo.swift */; };
+		A79D982A2EE6DCE70024B330 /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98172EE6DCE70024B330 /* ErrorView.swift */; };
+		A79D982B2EE6DCE70024B330 /* CheckoutComponentsMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D981D2EE6DCE70024B330 /* CheckoutComponentsMenuViewController.swift */; };
+		A79D982C2EE6DCE70024B330 /* DefaultCheckoutDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98142EE6DCE70024B330 /* DefaultCheckoutDemo.swift */; };
+		A79D982D2EE6DCE70024B330 /* DemoRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98202EE6DCE70024B330 /* DemoRegistry.swift */; };
+		A79D982E2EE6DCE70024B330 /* DemoProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D981F2EE6DCE70024B330 /* DemoProtocol.swift */; };
+		A79D982F2EE6DCE70024B330 /* CheckoutComponentsExamplesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D981C2EE6DCE70024B330 /* CheckoutComponentsExamplesView.swift */; };
+		A7C561362EF2F07100689089 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C561352EF2F07100689089 /* SceneDelegate.swift */; };
+		A7C561372EF2F07100689089 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C561352EF2F07100689089 /* SceneDelegate.swift */; };
 		AAE3B30B64B6822A20987FCA /* CreateClientToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229849A3DBE0858EE90673B9 /* CreateClientToken.swift */; };
 		AD9CF1073EE0676E6640481A /* MerchantHeadlessCheckoutRawDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B866FF13033A5CB8B4C3388E /* MerchantHeadlessCheckoutRawDataViewController.swift */; };
 		BA6BF5952E7858A5003D8B3D /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6BF5942E7858A5003D8B3D /* Collection+Extensions.swift */; };
@@ -210,6 +223,18 @@
 		A1A701452C739C1D002E236F /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		A1A701462C739C1D002E236F /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/Main.strings; sourceTree = "<group>"; };
 		A6AEF11B151368BF993C3EA9 /* TestScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestScenario.swift; sourceTree = "<group>"; };
+		A79D98132EE6DCE70024B330 /* CustomPaymentSelectionDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPaymentSelectionDemo.swift; sourceTree = "<group>"; };
+		A79D98142EE6DCE70024B330 /* DefaultCheckoutDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCheckoutDemo.swift; sourceTree = "<group>"; };
+		A79D98162EE6DCE70024B330 /* DemoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoRow.swift; sourceTree = "<group>"; };
+		A79D98172EE6DCE70024B330 /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
+		A79D98182EE6DCE70024B330 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		A79D981C2EE6DCE70024B330 /* CheckoutComponentsExamplesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutComponentsExamplesView.swift; sourceTree = "<group>"; };
+		A79D981D2EE6DCE70024B330 /* CheckoutComponentsMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutComponentsMenuViewController.swift; sourceTree = "<group>"; };
+		A79D981F2EE6DCE70024B330 /* DemoProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoProtocol.swift; sourceTree = "<group>"; };
+		A79D98202EE6DCE70024B330 /* DemoRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoRegistry.swift; sourceTree = "<group>"; };
+		A79D98212EE6DCE70024B330 /* NetworkingUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingUtils.swift; sourceTree = "<group>"; };
+		A79D98222EE6DCE70024B330 /* SimpleCountryPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCountryPicker.swift; sourceTree = "<group>"; };
+		A7C561352EF2F07100689089 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		B18D7E7738BF86467B0F1465 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		B1FD8065D40A2D691F643F3B /* UIViewController+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+API.swift"; sourceTree = "<group>"; };
 		B866FF13033A5CB8B4C3388E /* MerchantHeadlessCheckoutRawDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutRawDataViewController.swift; sourceTree = "<group>"; };
@@ -320,6 +345,7 @@
 		0E5CB4D963647832FF985B29 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				A79D98232EE6DCE70024B330 /* CheckoutComponents */,
 				876140ED2B6BE8860058CA8C /* Merchant Helpers */,
 				EF5FBE3673FBCB40F55F4DC0 /* New UI */,
 				9874F439DA3EA5854A454687 /* MerchantDropInUIViewController.swift */,
@@ -373,6 +399,7 @@
 		5E99BB590FD6521F2D5403BB /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				A7C561352EF2F07100689089 /* SceneDelegate.swift */,
 				553A7EDE72B8249F55A0E6B9 /* Extension */,
 				D9AC6F54A87D432982864A63 /* Model */,
 				64FB843527A1671D550B536F /* Network */,
@@ -430,6 +457,48 @@
 				87FC1ACA2BE5194100C9F474 /* MerchantHeadlessStripeAchFieldsViewModel.swift */,
 			);
 			path = StripeAchHeadless;
+			sourceTree = "<group>";
+		};
+		A79D98152EE6DCE70024B330 /* Demos */ = {
+			isa = PBXGroup;
+			children = (
+				A79D98132EE6DCE70024B330 /* CustomPaymentSelectionDemo.swift */,
+				A79D98142EE6DCE70024B330 /* DefaultCheckoutDemo.swift */,
+			);
+			path = Demos;
+			sourceTree = "<group>";
+		};
+		A79D98192EE6DCE70024B330 /* SharedComponents */ = {
+			isa = PBXGroup;
+			children = (
+				A79D98162EE6DCE70024B330 /* DemoRow.swift */,
+				A79D98172EE6DCE70024B330 /* ErrorView.swift */,
+				A79D98182EE6DCE70024B330 /* LoadingView.swift */,
+			);
+			path = SharedComponents;
+			sourceTree = "<group>";
+		};
+		A79D981B2EE6DCE70024B330 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				A79D98222EE6DCE70024B330 /* SimpleCountryPicker.swift */,
+				A79D98212EE6DCE70024B330 /* NetworkingUtils.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		A79D98232EE6DCE70024B330 /* CheckoutComponents */ = {
+			isa = PBXGroup;
+			children = (
+				A79D98152EE6DCE70024B330 /* Demos */,
+				A79D98192EE6DCE70024B330 /* SharedComponents */,
+				A79D981B2EE6DCE70024B330 /* Utils */,
+				A79D981C2EE6DCE70024B330 /* CheckoutComponentsExamplesView.swift */,
+				A79D981D2EE6DCE70024B330 /* CheckoutComponentsMenuViewController.swift */,
+				A79D981F2EE6DCE70024B330 /* DemoProtocol.swift */,
+				A79D98202EE6DCE70024B330 /* DemoRegistry.swift */,
+			);
+			path = CheckoutComponents;
 			sourceTree = "<group>";
 		};
 		B3C27ED9956EBEE65B9D054E /* Frameworks */ = {
@@ -710,6 +779,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A7C561372EF2F07100689089 /* SceneDelegate.swift in Sources */,
 				F04DFC692DAE42390006AEDC /* AppLinkConfigProviderTests.swift in Sources */,
 				F046FCBC2DACEADA00B2A4E7 /* RNPrimerSettingsTests.swift in Sources */,
 				044DE11F2CC0023200AAE28A /* SecretsManagerTests.swift in Sources */,
@@ -726,6 +796,18 @@
 				85605C241F1CD45BA676D4A7 /* String+Extensions.swift in Sources */,
 				04F323662BD40A2300F5927C /* MerchantNewLineItemViewController.swift in Sources */,
 				87FC1AC72BE50E0B00C9F474 /* MerchantHeadlessCheckoutStripeAchViewController.swift in Sources */,
+				A79D98242EE6DCE70024B330 /* LoadingView.swift in Sources */,
+				A79D98252EE6DCE70024B330 /* DemoRow.swift in Sources */,
+				A79D98262EE6DCE70024B330 /* SimpleCountryPicker.swift in Sources */,
+				A79D98272EE6DCE70024B330 /* NetworkingUtils.swift in Sources */,
+				A79D98282EE6DCE70024B330 /* CustomPaymentSelectionDemo.swift in Sources */,
+				A79D982A2EE6DCE70024B330 /* ErrorView.swift in Sources */,
+				A79D982B2EE6DCE70024B330 /* CheckoutComponentsMenuViewController.swift in Sources */,
+				A79D982C2EE6DCE70024B330 /* DefaultCheckoutDemo.swift in Sources */,
+				A79D982D2EE6DCE70024B330 /* DemoRegistry.swift in Sources */,
+				A79D982E2EE6DCE70024B330 /* DemoProtocol.swift in Sources */,
+				A7C561362EF2F07100689089 /* SceneDelegate.swift in Sources */,
+				A79D982F2EE6DCE70024B330 /* CheckoutComponentsExamplesView.swift in Sources */,
 				0BB8BB3F9A6AC28A0C107DC8 /* UIStackViewExtensions.swift in Sources */,
 				87FC1ACD2BE51DCA00C9F474 /* MerchantHeadlessCheckoutStripeAchViewController+StripeAch.swift in Sources */,
 				DE53DA2D0AD108306C92E198 /* UIViewController+API.swift in Sources */,
@@ -881,12 +963,11 @@
 			baseConfigurationReference = CD03E9D5965C6840D8546A29 /* Pods-Debug App.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/ExampleApp.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = N8UN9TR5DY;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N8UN9TR5DY;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Primer Debug";
@@ -897,7 +978,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.primerapi.PrimerSDKExample;
 				PRODUCT_NAME = "Debug App";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.primerapi.PrimerSDKExample";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -918,10 +998,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/ExampleApp.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = N8UN9TR5DY;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = N8UN9TR5DY;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Primer Debug";
@@ -932,7 +1010,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.primerapi.PrimerSDKExample;
 				PRODUCT_NAME = "Debug App";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.primerapi.PrimerSDKExample";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
+++ b/Debug App/Resources/Localized Views/Base.lproj/Main.storyboard
@@ -1393,58 +1393,60 @@
                                     <constraint firstItem="Yce-hH-uhX" firstAttribute="top" secondItem="fED-8r-rOM" secondAttribute="top" constant="20" id="YYf-mh-nKe"/>
                                 </constraints>
                             </scrollView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJ8-WE-cU8">
-                                <rect key="frame" x="20" y="710" width="374" height="45"/>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <accessibility key="accessibilityConfiguration" identifier="Primer SDK Button"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="45" id="iJd-a8-l4a"/>
-                                </constraints>
-                                <state key="normal" title="Primer SDK">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                                <buttonConfiguration key="configuration" style="plain" title="Primer SDK">
-                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="primerSDKButtonTapped:" destination="jAd-Lg-hf8" eventType="touchUpInside" id="6yQ-K0-Ren"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0FS-cB-H3t">
-                                <rect key="frame" x="20" y="763" width="374" height="45"/>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <accessibility key="accessibilityConfiguration" identifier="Primer Headless SDK Button"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="45" id="WWY-2r-9EB"/>
-                                </constraints>
-                                <state key="normal" title="Primer Headless">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                                <buttonConfiguration key="configuration" style="plain" title="Primer Headless">
-                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </buttonConfiguration>
-                                <connections>
-                                    <action selector="primerHeadlessButtonTapped:" destination="jAd-Lg-hf8" eventType="touchUpInside" id="Fj9-Yh-7To"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="hvo-lR-TEc">
+                                <rect key="frame" x="20" y="710" width="374" height="98"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJ8-WE-cU8">
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="45"/>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Primer SDK Button"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="45" id="iJd-a8-l4a"/>
+                                        </constraints>
+                                        <state key="normal" title="Primer SDK">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <buttonConfiguration key="configuration" style="plain" title="Primer SDK">
+                                            <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="primerSDKButtonTapped:" destination="jAd-Lg-hf8" eventType="touchUpInside" id="6yQ-K0-Ren"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0FS-cB-H3t">
+                                        <rect key="frame" x="0.0" y="53" width="374" height="45"/>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Primer Headless SDK Button"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="45" id="WWY-2r-9EB"/>
+                                        </constraints>
+                                        <state key="normal" title="Primer Headless">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <buttonConfiguration key="configuration" style="plain" title="Primer Headless">
+                                            <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </buttonConfiguration>
+                                        <connections>
+                                            <action selector="primerHeadlessButtonTapped:" destination="jAd-Lg-hf8" eventType="touchUpInside" id="Fj9-Yh-7To"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Zrd-hK-BPB"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Zrd-hK-BPB" firstAttribute="trailing" secondItem="fED-8r-rOM" secondAttribute="trailing" id="3hj-R0-nxA"/>
-                            <constraint firstItem="Zrd-hK-BPB" firstAttribute="bottom" secondItem="0FS-cB-H3t" secondAttribute="bottom" constant="20" id="4aU-Bq-QKi"/>
                             <constraint firstItem="Yce-hH-uhX" firstAttribute="width" secondItem="mBo-uS-Zxo" secondAttribute="width" constant="-40" id="6lX-9N-h8F"/>
                             <constraint firstItem="fED-8r-rOM" firstAttribute="top" secondItem="hgd-Bd-Btv" secondAttribute="bottom" constant="20" id="B4Q-01-hOc"/>
                             <constraint firstItem="fED-8r-rOM" firstAttribute="leading" secondItem="Zrd-hK-BPB" secondAttribute="leading" id="CI3-3Q-Ofs"/>
-                            <constraint firstItem="0FS-cB-H3t" firstAttribute="top" secondItem="QJ8-WE-cU8" secondAttribute="bottom" constant="8" id="Jqp-pP-fzB"/>
                             <constraint firstItem="Zrd-hK-BPB" firstAttribute="trailing" secondItem="hgd-Bd-Btv" secondAttribute="trailing" constant="20" id="Jwc-cu-e85"/>
-                            <constraint firstItem="QJ8-WE-cU8" firstAttribute="top" secondItem="fED-8r-rOM" secondAttribute="bottom" constant="20" id="OuA-PJ-gJs"/>
-                            <constraint firstItem="0FS-cB-H3t" firstAttribute="leading" secondItem="Zrd-hK-BPB" secondAttribute="leading" constant="20" id="PN6-tb-LPi"/>
+                            <constraint firstItem="Zrd-hK-BPB" firstAttribute="bottom" secondItem="hvo-lR-TEc" secondAttribute="bottom" constant="20" id="Qcd-BK-z2j"/>
                             <constraint firstItem="hgd-Bd-Btv" firstAttribute="top" secondItem="Zrd-hK-BPB" secondAttribute="top" constant="20" id="QzY-En-9eF"/>
-                            <constraint firstItem="Zrd-hK-BPB" firstAttribute="trailing" secondItem="QJ8-WE-cU8" secondAttribute="trailing" constant="20" id="R2W-5K-OkP"/>
-                            <constraint firstItem="QJ8-WE-cU8" firstAttribute="leading" secondItem="Zrd-hK-BPB" secondAttribute="leading" constant="20" id="RcB-UZ-pNx"/>
+                            <constraint firstItem="QJ8-WE-cU8" firstAttribute="top" secondItem="fED-8r-rOM" secondAttribute="bottom" constant="-14" id="c7C-kG-74I"/>
                             <constraint firstItem="hgd-Bd-Btv" firstAttribute="leading" secondItem="Zrd-hK-BPB" secondAttribute="leading" constant="20" id="eGJ-wA-ArM"/>
-                            <constraint firstItem="Zrd-hK-BPB" firstAttribute="trailing" secondItem="0FS-cB-H3t" secondAttribute="trailing" constant="20" id="z2s-e4-vto"/>
+                            <constraint firstItem="hvo-lR-TEc" firstAttribute="leading" secondItem="Zrd-hK-BPB" secondAttribute="leading" constant="20" id="nY9-wc-3kL"/>
+                            <constraint firstItem="Zrd-hK-BPB" firstAttribute="trailing" secondItem="hvo-lR-TEc" secondAttribute="trailing" constant="20" id="pQG-R3-1fn"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="ajD-hG-M6S"/>
@@ -1477,6 +1479,7 @@
                         <outlet property="billingAddressStackView" destination="bM9-q3-7b4" id="tfD-RC-unz"/>
                         <outlet property="billingAddressStateTextField" destination="9XT-5Y-iB0" id="O4F-QT-v2W"/>
                         <outlet property="billingAddressSwitch" destination="Tgl-HM-zu5" id="0zQ-d2-QoW"/>
+                        <outlet property="bottomButtonHolderStackView" destination="hvo-lR-TEc" id="MGp-lz-end"/>
                         <outlet property="clearAppLinkButton" destination="Vrb-fD-qLk" id="dR3-Lw-EKV"/>
                         <outlet property="clientTokenStackView" destination="IFG-cl-uk6" id="MaN-wY-MoO"/>
                         <outlet property="clientTokenTextField" destination="xjQ-Kj-2GL" id="5mh-UG-g6v"/>
@@ -2050,13 +2053,13 @@
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="placeholderTextColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29803921568627451" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29803921570000003" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Debug App/Sources/SceneDelegate.swift
+++ b/Debug App/Sources/SceneDelegate.swift
@@ -1,0 +1,60 @@
+//
+//  SceneDelegate.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+
+        window = UIWindow(windowScene: windowScene)
+
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        let initialViewController = storyboard.instantiateInitialViewController()
+        window?.rootViewController = initialViewController
+        window?.makeKeyAndVisible()
+
+        // Handle URL context if app was launched via URL
+        if let urlContext = connectionOptions.urlContexts.first {
+            handleURL(urlContext.url)
+        }
+
+        // Handle user activity if app was launched via universal link
+        if let userActivity = connectionOptions.userActivities.first {
+            handleUserActivity(userActivity)
+        }
+    }
+
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let url = URLContexts.first?.url else { return }
+        handleURL(url)
+    }
+
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        handleUserActivity(userActivity)
+    }
+
+    private func handleURL(_ url: URL) {
+        #if DEBUG
+        TestHelper.handle(url: url)
+        #endif
+        _ = Primer.shared.application(UIApplication.shared, open: url, options: [:])
+    }
+
+    private func handleUserActivity(_ userActivity: NSUserActivity) {
+        if let url = userActivity.webpageURL {
+            let handled = SDKDemoUrlHandler.handleUrl(url)
+            if handled {
+                return
+            }
+        }
+        _ = Primer.shared.application(UIApplication.shared, continue: userActivity, restorationHandler: { _ in })
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/CheckoutComponentsExamplesView.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/CheckoutComponentsExamplesView.swift
@@ -1,0 +1,45 @@
+//
+//  CheckoutComponentsExamplesView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CheckoutComponentsExamplesView: View {
+    private let configuration: DemoConfiguration
+
+    @State private var selectedDemoId: UUID?
+
+    init(settings: PrimerSettings, apiVersion: PrimerApiVersion, clientSession: ClientSessionRequestBody? = nil, clientToken: String? = nil) {
+        configuration = DemoConfiguration(
+            settings: settings,
+            apiVersion: apiVersion,
+            clientSession: clientSession,
+            clientToken: clientToken
+        )
+    }
+
+    var body: some View {
+        List {
+            ForEach(DemoRegistry.allMetadata) { metadata in
+                DemoRow(metadata: metadata) {
+                    selectedDemoId = metadata.id
+                }
+            }
+        }
+        .navigationTitle("Examples")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $selectedDemoId) { demoId in
+            if let demoView = DemoRegistry.createDemo(id: demoId, configuration: configuration) {
+                demoView
+            }
+        }
+    }
+}
+
+extension UUID: @retroactive Identifiable {
+    public var id: UUID { self }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/CheckoutComponentsMenuViewController.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/CheckoutComponentsMenuViewController.swift
@@ -1,0 +1,184 @@
+//
+//  CheckoutComponentsMenuViewController.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+import UIKit
+
+final class CheckoutComponentsMenuViewController: UIViewController {
+    
+    var settings: PrimerSettings!
+    var clientSession: ClientSessionRequestBody!
+    var apiVersion: PrimerApiVersion!
+    var renderMode: MerchantSessionAndSettingsViewController.RenderMode = .createClientSession
+    var clientToken: String?
+    var deepLinkClientToken: String?
+    
+    private var uikitIntegrationButton: UIButton!
+    private var swiftUIExamplesButton: UIButton!
+    private var stackView: UIStackView!
+    
+    private var checkoutComponentsDelegate: AnyObject?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupConstraints()
+    }
+    
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        title = "CheckoutComponents"
+        
+        uikitIntegrationButton = createButton(
+            title: "UIKit Integration",
+            backgroundColor: .systemBlue,
+            action: #selector(uikitIntegrationTapped)
+        )
+        
+        swiftUIExamplesButton = createButton(
+            title: "SwiftUI Examples",
+            backgroundColor: .systemPurple,
+            action: #selector(swiftUIExamplesTapped)
+        )
+        
+        stackView = UIStackView(arrangedSubviews: [uikitIntegrationButton, swiftUIExamplesButton])
+        stackView.axis = .vertical
+        stackView.spacing = 20
+        stackView.distribution = .fillEqually
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stackView)
+        
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .cancel,
+            target: self,
+            action: #selector(cancelTapped)
+        )
+    }
+    
+    private func createButton(title: String, backgroundColor: UIColor, action: Selector) -> UIButton {
+        let button = UIButton(type: .system)
+        button.setTitle(title, for: .normal)
+        button.backgroundColor = backgroundColor
+        button.setTitleColor(.white, for: .normal)
+        button.titleLabel?.font = .boldSystemFont(ofSize: 16)
+        button.layer.cornerRadius = 8
+        button.addTarget(self, action: action, for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }
+    
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+            
+            uikitIntegrationButton.heightAnchor.constraint(equalToConstant: 50),
+            swiftUIExamplesButton.heightAnchor.constraint(equalToConstant: 50)
+        ])
+    }
+    
+    @objc private func cancelTapped() {
+        dismiss(animated: true)
+    }
+    
+    @objc private func uikitIntegrationTapped() {
+        if #available(iOS 15.0, *) {
+            let delegate = DebugAppPrimerCheckoutPresenterDelegate()
+            checkoutComponentsDelegate = delegate
+            PrimerCheckoutPresenter.shared.delegate = delegate
+        }
+
+        switch renderMode {
+        case .createClientSession, .testScenario:
+            let ccSession = clientSession!
+
+            if #available(iOS 15.0, *) {
+                Task { [self] in
+                    do {
+                        let clientToken = try await NetworkingUtils.requestClientSession(
+                            body: ccSession,
+                            apiVersion: apiVersion
+                        )
+                        await MainActor.run {
+                            self.presentUIKitIntegration(with: clientToken)
+                        }
+                    } catch {
+                        await MainActor.run {
+                            self.showErrorMessage("Failed to fetch client token: \(error.localizedDescription)")
+                        }
+                    }
+                }
+            } else {
+                Networking.requestClientSession(requestBody: ccSession, apiVersion: apiVersion) { [weak self] (clientToken, error) in
+                    DispatchQueue.main.async {
+                        if let error {
+                            self?.showErrorMessage("Failed to fetch client token: \(error.localizedDescription)")
+                        } else if let clientToken {
+                            self?.presentUIKitIntegration(with: clientToken)
+                        }
+                    }
+                }
+            }
+
+        case .clientToken:
+            if let clientToken, !clientToken.isEmpty {
+                presentUIKitIntegration(with: clientToken)
+            } else {
+                showErrorMessage("Please provide a client token")
+            }
+
+        case .deepLink:
+            if let deepLinkClientToken {
+                presentUIKitIntegration(with: deepLinkClientToken)
+            } else {
+                showErrorMessage("No deep link client token available")
+            }
+        }
+    }
+    
+    @objc private func swiftUIExamplesTapped() {
+        if #available(iOS 15.0, *) {
+            let resolvedClientToken: String? = switch renderMode {
+            case .clientToken:
+                clientToken
+            case .deepLink:
+                deepLinkClientToken
+            case .createClientSession, .testScenario:
+                nil
+            }
+
+            let examplesView = CheckoutComponentsExamplesView(
+                settings: settings,
+                apiVersion: apiVersion,
+                clientSession: clientSession,
+                clientToken: resolvedClientToken
+            )
+
+            let hostingController = UIHostingController(rootView: examplesView)
+            hostingController.title = "CheckoutComponents Examples"
+            hostingController.view.backgroundColor = .clear
+
+            if let navController = navigationController {
+                navController.pushViewController(hostingController, animated: true)
+            } else {
+                showErrorMessage("Navigation controller not available")
+            }
+        } else {
+            showErrorMessage("CheckoutComponents requires iOS 15.0 or later")
+        }
+    }
+    
+    private func presentUIKitIntegration(with clientToken: String) {
+        if #available(iOS 15.0, *) {
+            PrimerCheckoutPresenter.presentCheckout(clientToken: clientToken, from: self, primerSettings: settings)
+        } else {
+            showErrorMessage("CheckoutComponents requires iOS 15.0 or later")
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/DemoProtocol.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/DemoProtocol.swift
@@ -1,0 +1,30 @@
+//
+//  DemoProtocol.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct DemoConfiguration {
+    let settings: PrimerSettings
+    let apiVersion: PrimerApiVersion
+    let clientSession: ClientSessionRequestBody?
+    let clientToken: String?
+}
+
+struct DemoMetadata: Identifiable {
+    let id = UUID()
+    let name: String
+    let description: String
+    let tags: [String]
+    let isCustom: Bool
+}
+
+@available(iOS 15.0, *)
+protocol CheckoutComponentsDemo: View {
+    static var metadata: DemoMetadata { get }
+    init(configuration: DemoConfiguration)
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/DemoRegistry.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/DemoRegistry.swift
@@ -1,0 +1,27 @@
+//
+//  DemoRegistry.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+@available(iOS 15.0, *)
+enum DemoRegistry {
+    static let allDemos: [(metadata: DemoMetadata, factory: (DemoConfiguration) -> AnyView)] = [
+        (DefaultCheckoutDemo.metadata, { config in AnyView(DefaultCheckoutDemo(configuration: config)) }),
+        (CustomPaymentSelectionDemo.metadata, { config in AnyView(CustomPaymentSelectionDemo(configuration: config)) })
+    ]
+
+    static var allMetadata: [DemoMetadata] {
+        allDemos.map(\.metadata)
+    }
+
+    static func createDemo(id: UUID, configuration: DemoConfiguration) -> AnyView? {
+        guard let demo = allDemos.first(where: { $0.metadata.id == id }) else {
+            return nil
+        }
+        return demo.factory(configuration)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomPaymentSelectionDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomPaymentSelectionDemo.swift
@@ -1,0 +1,922 @@
+//
+//  CustomPaymentSelectionDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+// MARK: - Custom Payment Selection Demo
+
+/// Self-contained demo showing a fully custom payment selection screen.
+/// This demo handles its own session creation, PrimerCheckout initialization, and all custom UI.
+@available(iOS 15.0, *)
+struct CustomPaymentSelectionDemo: View, CheckoutComponentsDemo {
+
+    // MARK: - Metadata
+
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Custom Payment Selection",
+            description: "Fully custom payment screen with merchant-controlled layout, product details, and payment method display",
+            tags: ["PAYMENT_CARD", "APPLE_PAY", "PAYPAL"],
+            isCustom: true
+        )
+    }
+
+    // MARK: - Configuration
+
+    private let configuration: DemoConfiguration
+
+    // MARK: - State
+
+    @SwiftUI.Environment(\.dismiss) private var dismiss
+    @State private var clientToken: String?
+    @State private var isLoading = true
+    @State private var error: String?
+
+    // MARK: - Theme
+
+    /// Custom theme using demo color palette for SDK components
+    private var demoTheme: PrimerCheckoutTheme {
+        PrimerCheckoutTheme(
+            colors: ColorOverrides(
+                primerColorBrand: DemoColors.primary,
+                primerColorGray000: DemoColors.cardBackground,
+                primerColorGray100: DemoColors.primaryBackground,
+                primerColorGray200: DemoColors.border,
+                primerColorGreen500: DemoColors.success,
+                primerColorBackground: DemoColors.background,
+                primerColorTextPrimary: DemoColors.textPrimary,
+                primerColorTextSecondary: DemoColors.textSecondary,
+                primerColorBorderOutlinedDefault: DemoColors.border,
+                primerColorBorderOutlinedFocus: DemoColors.primary
+            )
+        )
+    }
+
+    // MARK: - Init
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        NavigationView {
+            contentView
+                .navigationBarHidden(true)
+        }
+        .task {
+            await createSession()
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if isLoading {
+            LoadingView()
+        } else if let error {
+            ErrorView(error: error, onRetry: { Task { await createSession() } })
+        } else if let clientToken {
+            PrimerCheckout(
+                clientToken: clientToken,
+                primerSettings: configuration.settings,
+                primerTheme: demoTheme,
+                scope: { checkoutScope in
+                    // Override the payment method selection screen with custom content
+                    // Pass checkoutScope as a parameter to access card form and checkout state
+                    checkoutScope.paymentMethodSelection.screen = { selectionScope in
+                        CustomPaymentSelectionContent(
+                            scope: selectionScope,
+                            checkoutScope: checkoutScope,
+                            onDismiss: { dismiss() }
+                        )
+                    }
+
+                    // Custom loading screen during payment processing (matches Android's checkout.loading)
+                    checkoutScope.loadingScreen = {
+                        CustomProcessingOverlay()
+                    }
+                },
+                onCompletion: { _ in dismiss() }
+            )
+        }
+    }
+
+    // MARK: - Session Creation
+
+    private func createSession() async {
+        isLoading = true
+        error = nil
+
+        if let existingToken = configuration.clientToken, !existingToken.isEmpty {
+            clientToken = existingToken
+            isLoading = false
+            return
+        }
+
+        guard let clientSession = configuration.clientSession else {
+            error = "No session configuration provided - please configure session in main settings"
+            isLoading = false
+            return
+        }
+
+        do {
+            clientToken = try await NetworkingUtils.requestClientSession(
+                body: clientSession,
+                apiVersion: configuration.apiVersion
+            )
+            isLoading = false
+        } catch {
+            self.error = error.localizedDescription
+            isLoading = false
+        }
+    }
+}
+
+// MARK: - Selected Payment Option
+
+@available(iOS 15.0, *)
+private enum SelectedPaymentOption: Equatable {
+    case paymentMethod(CheckoutPaymentMethod)
+    case card
+    case none
+
+    static func == (lhs: SelectedPaymentOption, rhs: SelectedPaymentOption) -> Bool {
+        switch (lhs, rhs) {
+        case (.none, .none), (.card, .card):
+            true
+        case let (.paymentMethod(lhsMethod), .paymentMethod(rhsMethod)):
+            lhsMethod.id == rhsMethod.id
+        default:
+            false
+        }
+    }
+}
+
+// MARK: - Demo Color Scheme
+
+/// Warm, modern color palette for the checkout demo
+/// These colors are used for demo-specific UI elements not covered by SDK design tokens
+@available(iOS 15.0, *)
+private enum DemoColors {
+    /// Warm cream/beige background
+    static let background = Color(red: 254/255, green: 245/255, blue: 236/255)
+
+    /// Primary orange accent
+    static let primary = Color(red: 249/255, green: 115/255, blue: 22/255)
+
+    /// Light orange for highlights
+    static let primaryLight = Color(red: 253/255, green: 186/255, blue: 116/255)
+
+    /// Very light orange for backgrounds
+    static let primaryBackground = Color(red: 255/255, green: 247/255, blue: 237/255)
+
+    /// Card background - white
+    static let cardBackground = Color.white
+
+    /// Text primary - dark gray
+    static let textPrimary = Color(red: 31/255, green: 41/255, blue: 55/255)
+
+    /// Text secondary - medium gray
+    static let textSecondary = Color(red: 107/255, green: 114/255, blue: 128/255)
+
+    /// Success green
+    static let success = Color(red: 34/255, green: 197/255, blue: 94/255)
+
+    /// Border color
+    static let border = Color(red: 229/255, green: 231/255, blue: 235/255)
+}
+
+// MARK: - Custom Payment Selection Content
+
+/// AIR-style payment selection screen demonstrating the scope-based customization API.
+/// Features:
+/// - Custom warm cream/beige background
+/// - Product info section with package details
+/// - Promotional banner with rewards info
+/// - Billing info section with country picker
+/// - Dynamic payment methods from SDK
+/// - Always-visible inline card form
+/// - Promo code section
+/// - Footer with total and dynamic Pay button
+@available(iOS 15.0, *)
+private struct CustomPaymentSelectionContent: View {
+    let scope: PrimerPaymentMethodSelectionScope
+    let checkoutScope: PrimerCheckoutScope
+    let onDismiss: () -> Void
+
+    @State private var selectionState = PrimerPaymentMethodSelectionState()
+    @State private var cardState: PrimerCardFormState?
+    @State private var selectedOption: SelectedPaymentOption = .none
+    @State private var selectedBillingCountry: String? = "RS" // Default to Serbia for demo
+    @State private var showPromoCodeModal = false
+    @State private var appliedPromoCode: String?
+    @State private var isPaymentInProgress = false
+    @State private var checkoutState: PrimerCheckoutState = .initializing
+
+    /// Card form scope for inline card form
+    private var cardFormScope: DefaultCardFormScope? {
+        checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self)
+    }
+
+    /// Computed property to check if loading overlay should be shown
+    private var isLoading: Bool {
+        isPaymentInProgress || (cardState?.isLoading ?? false)
+    }
+
+    /// Extract amount from checkout state
+    private var amount: Int {
+        if case let .ready(totalAmount, _) = checkoutState {
+            return totalAmount
+        }
+        return 400 // Default
+    }
+
+    /// Extract currency from checkout state
+    private var currencyCode: String {
+        if case let .ready(_, currency) = checkoutState {
+            return currency
+        }
+        return "USD" // Default
+    }
+
+    var body: some View {
+        ZStack {
+            // Warm cream background
+            DemoColors.background
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                // Header
+                headerView
+
+                // Content
+                ScrollView {
+                    VStack(spacing: 16) {
+                        // Product info section
+                        productInfoSection
+
+                        // Promotional banner
+                        promotionalBanner
+
+                        // Billing info (expandable)
+                        billingInfoSection
+
+                        // Payment methods section
+                        paymentMethodsSection
+
+                        // Inline card form section
+                        cardFormSection
+
+                        // Promo code section
+                        promoCodeSection
+
+                        // Spacer for footer
+                        Color.clear.frame(height: 100)
+                    }
+                    .padding()
+                }
+
+                // Footer with total and pay button
+                footerView
+            }
+            .allowsHitTesting(!isLoading)
+
+            // Loading overlay
+            if isLoading {
+                loadingOverlay
+            }
+        }
+        .onAppear {
+            observeSelectionState()
+            observeCardFormState()
+            observeCheckoutState()
+        }
+    }
+
+    // MARK: - Loading Overlay
+
+    private var loadingOverlay: some View {
+        ZStack {
+            // Semi-transparent background
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+
+            // Loading indicator
+            VStack(spacing: 16) {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                    .scaleEffect(1.5)
+
+                Text("Processing payment...")
+                    .font(.headline)
+                    .foregroundColor(.white)
+            }
+            .padding(32)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(DemoColors.textPrimary.opacity(0.9))
+            )
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerView: some View {
+        HStack {
+            Button(action: {
+                scope.cancel()
+            }) {
+                Image(systemName: "chevron.left")
+                    .font(.title3)
+                    .foregroundColor(DemoColors.textPrimary)
+            }
+
+            Spacer()
+
+            Text("Secure checkout")
+                .font(.headline)
+                .foregroundColor(DemoColors.textPrimary)
+
+            Spacer()
+
+            // Placeholder for symmetry
+            Color.clear.frame(width: 24, height: 24)
+        }
+        .padding()
+        .background(DemoColors.cardBackground)
+    }
+
+    // MARK: - Product Info Section
+
+    private var productInfoSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Country flag and name (dynamic based on selected billing country)
+            HStack {
+                if let code = selectedBillingCountry,
+                   let country = CountryDataProvider.country(for: code) {
+                    Text("\(country.flag) \(country.name)")
+                        .font(.subheadline)
+                        .foregroundColor(DemoColors.textSecondary)
+                } else {
+                    Text("Select a country")
+                        .font(.subheadline)
+                        .foregroundColor(DemoColors.textSecondary)
+                }
+            }
+            .padding(.vertical, 8)
+
+            Divider()
+                .background(DemoColors.border)
+
+            // Product details
+            HStack(alignment: .top, spacing: 12) {
+                // Product icon with orange
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(DemoColors.primaryBackground)
+                    .frame(width: 50, height: 50)
+                    .overlay(
+                        Image(systemName: "antenna.radiowaves.left.and.right")
+                            .foregroundColor(DemoColors.primary)
+                    )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Mobile Data Package")
+                        .font(.headline)
+                        .foregroundColor(DemoColors.textPrimary)
+                }
+            }
+
+            // Package details
+            VStack(spacing: 8) {
+                packageDetailRow(icon: "mappin.circle", label: "Coverage", value: selectedCountryName)
+                packageDetailRow(icon: "arrow.up.arrow.down", label: "Data", value: "1 GB")
+                packageDetailRow(icon: "calendar", label: "Validity", value: "3 Days")
+            }
+            .padding(.top, 8)
+        }
+        .padding()
+        .background(DemoColors.cardBackground)
+        .cornerRadius(16)
+    }
+
+    private var selectedCountryName: String {
+        guard let code = selectedBillingCountry,
+              let country = CountryDataProvider.country(for: code) else {
+            return "Not selected"
+        }
+        return country.name
+    }
+
+    private func packageDetailRow(icon: String, label: String, value: String) -> some View {
+        HStack {
+            Image(systemName: icon)
+                .foregroundColor(DemoColors.textSecondary)
+                .frame(width: 24)
+            Text(label)
+                .foregroundColor(DemoColors.textSecondary)
+            Spacer()
+            Text(value)
+                .fontWeight(.medium)
+                .foregroundColor(DemoColors.textPrimary)
+        }
+        .font(.subheadline)
+    }
+
+    // MARK: - Promotional Banner
+
+    private var promotionalBanner: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "gift.circle.fill")
+                .foregroundColor(DemoColors.primary)
+                .font(.title2)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("You'll earn rewards from this purchase:")
+                    .font(.subheadline)
+                    .foregroundColor(DemoColors.textPrimary)
+                Text("$0.28 USD")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(DemoColors.textPrimary)
+            }
+
+            Spacer()
+        }
+        .padding()
+        .background(DemoColors.primaryBackground)
+        .cornerRadius(16)
+    }
+
+    // MARK: - Billing Info Section
+
+    private var billingInfoSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Billing info")
+                .font(.subheadline)
+                .foregroundColor(DemoColors.textSecondary)
+
+            ThemedCountryPickerButton(
+                selectedCountryCode: $selectedBillingCountry,
+                placeholder: "Select billing country"
+            )
+        }
+    }
+
+    // MARK: - Payment Methods Section
+
+    private var paymentMethodsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Pay with")
+                .font(.subheadline)
+                .foregroundColor(DemoColors.textSecondary)
+
+            if selectionState.isLoading {
+                ProgressView()
+                    .tint(DemoColors.primary)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+            } else if nonCardPaymentMethods.isEmpty {
+                Text("No alternative payment methods available")
+                    .font(.caption)
+                    .foregroundColor(DemoColors.textSecondary)
+                    .padding()
+            } else {
+                // Display payment methods dynamically
+                ForEach(nonCardPaymentMethods, id: \.id) { method in
+                    paymentMethodButton(method)
+                }
+            }
+        }
+    }
+
+    private var nonCardPaymentMethods: [CheckoutPaymentMethod] {
+        selectionState.paymentMethods.filter { $0.type != "PAYMENT_CARD" }
+    }
+
+    private func paymentMethodButton(_ method: CheckoutPaymentMethod) -> some View {
+        let isSelected = {
+            if case let .paymentMethod(selectedMethod) = selectedOption {
+                return selectedMethod.id == method.id
+            }
+            return false
+        }()
+
+        return Button(action: {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                selectedOption = .paymentMethod(method)
+            }
+        }) {
+            HStack(spacing: 12) {
+                // Payment method icon
+                if let icon = method.icon {
+                    Image(uiImage: icon)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 32, height: 32)
+                } else {
+                    Image(systemName: iconForPaymentMethod(method.type))
+                        .font(.title2)
+                        .foregroundColor(DemoColors.textPrimary)
+                        .frame(width: 32, height: 32)
+                }
+
+                Text(method.name)
+                    .fontWeight(.medium)
+                    .foregroundColor(DemoColors.textPrimary)
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(DemoColors.primary)
+                }
+            }
+            .padding()
+            .background(DemoColors.cardBackground)
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(isSelected ? DemoColors.primary : DemoColors.border, lineWidth: isSelected ? 2 : 1)
+            )
+            .cornerRadius(16)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+
+    private func iconForPaymentMethod(_ type: String) -> String {
+        switch type {
+        case "APPLE_PAY":
+            "applelogo"
+        case "PAYPAL":
+            "p.circle.fill"
+        case "GOOGLE_PAY":
+            "g.circle.fill"
+        default:
+            "creditcard.fill"
+        }
+    }
+
+    // MARK: - Card Form Section
+
+    private var cardFormSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Pay with card")
+                .font(.subheadline)
+                .foregroundColor(DemoColors.textSecondary)
+
+            // Card selection indicator
+            Button(action: {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    selectedOption = .card
+                }
+            }) {
+                HStack {
+                    Image(systemName: "creditcard.fill")
+                        .foregroundColor(DemoColors.primary)
+                    Text("Credit or Debit Card")
+                        .fontWeight(.medium)
+                        .foregroundColor(DemoColors.textPrimary)
+                    Spacer()
+                    if case .card = selectedOption {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(DemoColors.primary)
+                    }
+                }
+                .padding()
+                .background(DemoColors.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(selectedOption == .card ? DemoColors.primary : DemoColors.border, lineWidth: selectedOption == .card ? 2 : 1)
+                )
+                .cornerRadius(16)
+            }
+            .buttonStyle(PlainButtonStyle())
+
+            // Always visible card form - using SDK's default card form view
+            if let cardFormScope {
+                cardFormScope.DefaultCardFormView(
+                    styling: PrimerFieldStyling(
+                        backgroundColor: DemoColors.cardBackground,
+                        borderColor: DemoColors.border,
+                        cornerRadius: 12,
+                        borderWidth: 1
+                    )
+                )
+                .padding()
+                .background(DemoColors.cardBackground)
+                .cornerRadius(16)
+                .onTapGesture {
+                    // Auto-select card when user taps on form
+                    if selectedOption != .card {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            selectedOption = .card
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Promo Code Section
+
+    private var promoCodeSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Promo code")
+                .font(.subheadline)
+                .foregroundColor(DemoColors.textSecondary)
+
+            Button(action: {
+                showPromoCodeModal = true
+            }) {
+                HStack {
+                    if let promoCode = appliedPromoCode {
+                        // Show applied promo code
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(DemoColors.success)
+                        Text(promoCode)
+                            .foregroundColor(DemoColors.textPrimary)
+                            .fontWeight(.medium)
+                        Spacer()
+                        Button(action: {
+                            appliedPromoCode = nil
+                        }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundColor(DemoColors.textSecondary)
+                        }
+                    } else {
+                        // Show "Use promo code" prompt
+                        Text("Use promo code")
+                            .foregroundColor(DemoColors.textPrimary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(DemoColors.textSecondary)
+                    }
+                }
+                .padding()
+                .background(DemoColors.cardBackground)
+                .cornerRadius(16)
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .sheet(isPresented: $showPromoCodeModal) {
+            PromoCodeModal(
+                onApply: { code in
+                    appliedPromoCode = code
+                }
+            )
+        }
+    }
+
+    // MARK: - Footer
+
+    private var footerView: some View {
+        VStack(spacing: 0) {
+            Divider()
+                .background(DemoColors.border)
+
+            VStack(spacing: 12) {
+                // Total amount
+                HStack {
+                    Text("Total")
+                        .font(.headline)
+                        .foregroundColor(DemoColors.textPrimary)
+                    Spacer()
+                    Text(formattedAmount)
+                        .font(.headline)
+                        .foregroundColor(DemoColors.textPrimary)
+                }
+
+                // Dynamic Pay button with orange theme
+                Button(action: {
+                    handlePayment()
+                }) {
+                    HStack {
+                        if case let .paymentMethod(method) = selectedOption {
+                            if let icon = method.icon {
+                                Image(uiImage: icon)
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: 24, height: 24)
+                            }
+                        }
+
+                        Text(payButtonTitle)
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isPayButtonEnabled ? DemoColors.primary : DemoColors.primaryLight)
+                    .foregroundColor(.white)
+                    .cornerRadius(16)
+                }
+                .disabled(!isPayButtonEnabled)
+            }
+            .padding()
+            .background(DemoColors.cardBackground)
+        }
+    }
+
+    // MARK: - Computed Properties
+
+    private var formattedAmount: String {
+        // Format amount from minor units (e.g., 400 cents = $4.00)
+        let majorUnits = Double(amount) / 100.0
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = currencyCode
+        return formatter.string(from: NSNumber(value: majorUnits)) ?? "$\(majorUnits)"
+    }
+
+    private var payButtonTitle: String {
+        switch selectedOption {
+        case let .paymentMethod(method):
+            "Pay with \(method.name)"
+        case .card:
+            "Pay \(formattedAmount)"
+        case .none:
+            "Select payment method"
+        }
+    }
+
+    private var isPayButtonEnabled: Bool {
+        switch selectedOption {
+        case .paymentMethod:
+            true
+        case .card:
+            cardState?.isValid ?? false
+        case .none:
+            false
+        }
+    }
+
+    // MARK: - Actions
+
+    private func handlePayment() {
+        // Dismiss keyboard from all text fields
+        dismissKeyboard()
+
+        // Set loading state
+        isPaymentInProgress = true
+
+        switch selectedOption {
+        case let .paymentMethod(method):
+            // Trigger the payment method flow (same as tapping in default UI)
+            scope.onPaymentMethodSelected(paymentMethod: method)
+        case .card:
+            // Submit the card form
+            cardFormScope?.submit()
+        case .none:
+            isPaymentInProgress = false
+        }
+    }
+
+    /// Dismisses the keyboard by resigning first responder from all text fields
+    private func dismissKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+
+    // MARK: - State Observation
+
+    private func observeSelectionState() {
+        Task {
+            for await state in scope.state {
+                await MainActor.run {
+                    selectionState = state
+                }
+            }
+        }
+    }
+
+    private func observeCardFormState() {
+        guard let cardFormScope else { return }
+        Task {
+            for await state in cardFormScope.state {
+                await MainActor.run {
+                    cardState = state
+                    // Auto-select card when user starts typing
+                    let hasCardInput = !state.data[.cardNumber].isEmpty ||
+                        !state.data[.expiryDate].isEmpty ||
+                        !state.data[.cvv].isEmpty ||
+                        !state.data[.cardholderName].isEmpty
+                    if hasCardInput, selectedOption == .none {
+                        selectedOption = .card
+                    }
+                }
+            }
+        }
+    }
+
+    private func observeCheckoutState() {
+        Task {
+            for await state in checkoutScope.state {
+                await MainActor.run {
+                    checkoutState = state
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Promo Code Modal
+
+@available(iOS 15.0, *)
+private struct PromoCodeModal: View {
+    @SwiftUI.Environment(\.presentationMode) private var presentationMode
+
+    let onApply: (String) -> Void
+
+    @State private var promoCode = ""
+    @FocusState private var isTextFieldFocused: Bool
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 24) {
+                // Header description
+                Text("Enter your promo code below to apply a discount to your order.")
+                    .font(.subheadline)
+                    .foregroundColor(DemoColors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top)
+
+                // Promo code input
+                TextField("Enter promo code", text: $promoCode)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .autocapitalization(.allCharacters)
+                    .disableAutocorrection(true)
+                    .focused($isTextFieldFocused)
+                    .padding(.horizontal)
+
+                // Apply button
+                Button(action: {
+                    if !promoCode.isEmpty {
+                        onApply(promoCode)
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }) {
+                    Text("Apply Code")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(promoCode.isEmpty ? DemoColors.primaryLight : DemoColors.primary)
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
+                }
+                .disabled(promoCode.isEmpty)
+                .padding(.horizontal)
+
+                Spacer()
+            }
+            .navigationTitle("Promo Code")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cancel") {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+            }
+        }
+        .onAppear {
+            isTextFieldFocused = true
+        }
+    }
+}
+
+// MARK: - Custom Processing Overlay
+
+/// Custom processing screen shown during payment processing
+/// Uses the demo's orange color theme for consistency
+@available(iOS 15.0, *)
+private struct CustomProcessingOverlay: View {
+    var body: some View {
+        ZStack {
+            // Warm cream background matching the demo theme
+            DemoColors.background
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                // Animated loading indicator
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: DemoColors.primary))
+                    .scaleEffect(2.0)
+
+                VStack(spacing: 8) {
+                    Text("Processing your payment")
+                        .font(.title2)
+                        .fontWeight(.semibold)
+                        .foregroundColor(DemoColors.textPrimary)
+
+                    Text("Please wait while we securely process your transaction...")
+                        .font(.subheadline)
+                        .foregroundColor(DemoColors.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal, 32)
+            }
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/DefaultCheckoutDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/DefaultCheckoutDemo.swift
@@ -1,0 +1,136 @@
+//
+//  DefaultCheckoutDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct DefaultCheckoutDemo: View, CheckoutComponentsDemo {
+
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Default Checkout",
+            description: "Standard CheckoutComponents with SDK-provided UI",
+            tags: ["PAYMENT_CARD", "APPLE_PAY"],
+            isCustom: false
+        )
+    }
+
+    private let configuration: DemoConfiguration
+
+    @SwiftUI.Environment(\.dismiss) private var dismiss
+    @State private var clientToken: String?
+    @State private var isLoading = true
+    @State private var error: String?
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        NavigationView {
+            contentView
+                .navigationTitle(Self.metadata.name)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+        }
+        .task {
+            await createSession()
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if isLoading {
+            LoadingView()
+        } else if let error {
+            ErrorView(error: error, onRetry: { Task { await createSession() } })
+        } else if let clientToken {
+            checkoutView(clientToken: clientToken)
+        }
+    }
+
+    private func checkoutView(clientToken: String) -> some View {
+        VStack(spacing: 0) {
+            infoHeader
+
+            VStack {
+                Text("Pure SwiftUI PrimerCheckout")
+                    .font(.headline)
+                    .padding()
+
+                Text("Client Token: \(clientToken.prefix(20))...")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.bottom)
+
+                PrimerCheckout(
+                    clientToken: clientToken,
+                    primerSettings: configuration.settings,
+                    onCompletion: { _ in dismiss() }
+                )
+            }
+        }
+    }
+
+    private var infoHeader: some View {
+        VStack(spacing: 0) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(Self.metadata.description)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    Text("Tags: \(Self.metadata.tags.joined(separator: ", "))")
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                }
+
+                Spacer()
+            }
+            .padding()
+            .background(Color(.systemGroupedBackground))
+        }
+        .overlay(
+            Rectangle()
+                .frame(height: 1)
+                .foregroundColor(Color(.separator)),
+            alignment: .bottom
+        )
+    }
+
+    private func createSession() async {
+        isLoading = true
+        error = nil
+
+        if let existingToken = configuration.clientToken, !existingToken.isEmpty {
+            clientToken = existingToken
+            isLoading = false
+            return
+        }
+
+        guard let clientSession = configuration.clientSession else {
+            error = "No session configuration provided - please configure session in main settings"
+            isLoading = false
+            return
+        }
+
+        do {
+            clientToken = try await NetworkingUtils.requestClientSession(
+                body: clientSession,
+                apiVersion: configuration.apiVersion
+            )
+            isLoading = false
+        } catch {
+            self.error = error.localizedDescription
+            isLoading = false
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/DemoRow.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/DemoRow.swift
@@ -1,0 +1,57 @@
+//
+//  DemoRow.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct DemoRow: View {
+    let metadata: DemoMetadata
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text(metadata.name)
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    if metadata.isCustom {
+                        Text("Custom")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.blue)
+                            .cornerRadius(4)
+                    }
+                }
+
+                Text(metadata.description)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+
+                HStack {
+                    Text("Tags:")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Text(metadata.tags.joined(separator: ", "))
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundColor(.blue)
+
+                    Spacer()
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/ErrorView.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/ErrorView.swift
@@ -1,0 +1,36 @@
+//
+//  ErrorView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct ErrorView: View {
+    let error: String
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 48))
+                .foregroundColor(.orange)
+
+            Text("Session Creation Failed")
+                .font(.headline)
+
+            Text(error)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            Button("Retry") {
+                onRetry()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/LoadingView.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/LoadingView.swift
@@ -1,0 +1,21 @@
+//
+//  LoadingView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct LoadingView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            ProgressView()
+                .scaleEffect(1.5)
+
+            Text("Creating session...")
+                .font(.headline)
+                .foregroundColor(.secondary)
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Utils/NetworkingUtils.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Utils/NetworkingUtils.swift
@@ -1,0 +1,58 @@
+//
+//  NetworkingUtils.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+import PrimerSDK
+
+/// Unified networking utilities for CheckoutComponents demos
+/// Provides modern async/await interface with consistent error handling
+@available(iOS 15.0, *)
+enum NetworkingUtils {
+
+    // MARK: - Error Types
+
+    enum NetworkingError: LocalizedError {
+        case invalidResponse
+        case noToken
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidResponse:
+                "Invalid response from server"
+            case .noToken:
+                "No client token received"
+            }
+        }
+    }
+
+    // MARK: - Client Session Request
+
+    /// Request a client session with async/await interface
+    /// - Parameters:
+    ///   - body: The client session request configuration
+    ///   - apiVersion: The API version to use for the request
+    /// - Returns: The client token string
+    /// - Throws: Network errors or invalid response errors
+    static func requestClientSession(
+        body: ClientSessionRequestBody,
+        apiVersion: PrimerApiVersion
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            Networking.requestClientSession(
+                requestBody: body,
+                apiVersion: apiVersion
+            ) { clientToken, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let clientToken {
+                    continuation.resume(returning: clientToken)
+                } else {
+                    continuation.resume(throwing: NetworkingError.noToken)
+                }
+            }
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Utils/SimpleCountryPicker.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Utils/SimpleCountryPicker.swift
@@ -1,0 +1,248 @@
+//
+//  SimpleCountryPicker.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+struct SimpleCountry: Identifiable, Equatable {
+    let id: String // ISO country code
+    let name: String
+    let flag: String
+
+    var code: String { id }
+}
+
+enum CountryDataProvider {
+
+    static var allCountries: [SimpleCountry] {
+        let countryCodes = NSLocale.isoCountryCodes
+
+        return countryCodes.compactMap { code in
+            guard let name = Locale.current.localizedString(forRegionCode: code),
+                  !name.isEmpty,
+                  name != code else {
+                return nil
+            }
+            let flag = flagEmoji(for: code)
+            return SimpleCountry(id: code, name: name, flag: flag)
+        }
+        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    private static func flagEmoji(for countryCode: String) -> String {
+        let base: UInt32 = 127397
+        var emoji = ""
+        for scalar in countryCode.uppercased().unicodeScalars {
+            if let unicode = UnicodeScalar(base + scalar.value) {
+                emoji.append(String(unicode))
+            }
+        }
+        return emoji
+    }
+
+    static func country(for code: String) -> SimpleCountry? {
+        allCountries.first { $0.code.uppercased() == code.uppercased() }
+    }
+}
+
+@available(iOS 15.0, *)
+struct SimpleCountryPicker: View {
+    @SwiftUI.Environment(\.presentationMode) private var presentationMode
+
+    let selectedCountryCode: String?
+    let onSelect: (SimpleCountry) -> Void
+
+    @State private var searchText = ""
+    @State private var countries: [SimpleCountry] = []
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(filteredCountries) { country in
+                    Button(action: {
+                        onSelect(country)
+                        presentationMode.wrappedValue.dismiss()
+                    }) {
+                        HStack(spacing: 12) {
+                            Text(country.flag)
+                                .font(.title2)
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(country.name)
+                                    .foregroundColor(.primary)
+                                Text(country.code)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+
+                            Spacer()
+
+                            if country.code == selectedCountryCode {
+                                Image(systemName: "checkmark")
+                                    .foregroundColor(.blue)
+                            }
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .listStyle(.plain)
+            .searchable(text: $searchText, prompt: "Search countries")
+            .navigationTitle("Select Country")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cancel") {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+            }
+        }
+        .onAppear {
+            countries = CountryDataProvider.allCountries
+        }
+    }
+
+    private var filteredCountries: [SimpleCountry] {
+        guard !searchText.isEmpty else {
+            return countries
+        }
+
+        let normalizedSearch = searchText.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+
+        return countries.filter { country in
+            let normalizedName = country.name.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+            let normalizedCode = country.code.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+
+            return normalizedName.contains(normalizedSearch) || normalizedCode.contains(normalizedSearch)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+struct CountryPickerButton: View {
+    @Binding var selectedCountryCode: String?
+    let placeholder: String
+
+    @State private var showPicker = false
+
+    var body: some View {
+        Button(action: {
+            showPicker = true
+        }) {
+            HStack {
+                if let code = selectedCountryCode,
+                   let country = CountryDataProvider.country(for: code) {
+                    Text(country.flag)
+                    Text(country.name)
+                        .foregroundColor(.primary)
+                } else {
+                    Text(placeholder)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.down")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+            .background(Color(.systemBackground))
+            .cornerRadius(12)
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showPicker) {
+            SimpleCountryPicker(
+                selectedCountryCode: selectedCountryCode,
+                onSelect: { country in
+                    selectedCountryCode = country.code
+                }
+            )
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+struct ThemedCountryPickerButton: View {
+    @Binding var selectedCountryCode: String?
+    let placeholder: String
+
+    @State private var showPicker = false
+
+    var body: some View {
+        Button(action: {
+            showPicker = true
+        }) {
+            HStack {
+                if let code = selectedCountryCode,
+                   let country = CountryDataProvider.country(for: code) {
+                    Text(country.flag)
+                    Text(country.name)
+                        .foregroundColor(Color(red: 31/255, green: 41/255, blue: 55/255))
+                } else {
+                    Text(placeholder)
+                        .foregroundColor(Color(red: 107/255, green: 114/255, blue: 128/255))
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(Color(red: 107/255, green: 114/255, blue: 128/255))
+            }
+            .padding()
+            .background(Color.white)
+            .cornerRadius(16)
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $showPicker) {
+            SimpleCountryPicker(
+                selectedCountryCode: selectedCountryCode,
+                onSelect: { country in
+                    selectedCountryCode = country.code
+                }
+            )
+        }
+    }
+}
+
+#if DEBUG
+@available(iOS 15.0, *)
+#Preview("Country Picker") {
+    SimpleCountryPicker(
+        selectedCountryCode: "US",
+        onSelect: { country in
+            print("Selected: \(country.name) (\(country.code))")
+        }
+    )
+}
+
+@available(iOS 15.0, *)
+#Preview("Country Button") {
+    struct PreviewWrapper: View {
+        @State private var selectedCode: String? = "RS"
+
+        var body: some View {
+            VStack(spacing: 20) {
+                CountryPickerButton(
+                    selectedCountryCode: $selectedCode,
+                    placeholder: "Select a country"
+                )
+
+                if let code = selectedCode {
+                    Text("Selected: \(code)")
+                        .font(.caption)
+                }
+            }
+            .padding()
+            .background(Color(.systemGroupedBackground))
+        }
+    }
+
+    return PreviewWrapper()
+}
+#endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/API_REFERENCE.md
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/API_REFERENCE.md
@@ -1,0 +1,841 @@
+# CheckoutComponents API Reference
+
+Complete public API reference for the CheckoutComponents framework (iOS 15+).
+
+---
+
+## Entry Points
+
+### PrimerCheckout (SwiftUI)
+
+```swift
+@available(iOS 15.0, *)
+public struct PrimerCheckout: View {
+  public init(
+    clientToken: String,
+    primerSettings: PrimerSettings = PrimerSettings(),
+    primerTheme: PrimerCheckoutTheme = PrimerCheckoutTheme(),
+    scope: ((PrimerCheckoutScope) -> Void)? = nil,
+    onCompletion: ((PrimerCheckoutState) -> Void)? = nil
+  )
+}
+```
+
+### PrimerCheckoutPresenter (UIKit)
+
+```swift
+@available(iOS 15.0, *)
+public final class PrimerCheckoutPresenter {
+  public static let shared: PrimerCheckoutPresenter
+  public weak var delegate: PrimerCheckoutPresenterDelegate?
+  public static var isAvailable: Bool
+  public static var isPresenting: Bool
+
+  // Present checkout
+  public static func presentCheckout(
+    clientToken: String,
+    from viewController: UIViewController,
+    primerSettings: PrimerSettings,
+    primerTheme: PrimerCheckoutTheme,
+    scope: ((PrimerCheckoutScope) -> Void)? = nil,
+    completion: (() -> Void)? = nil
+  )
+
+  // Convenience overloads
+  public static func presentCheckout(clientToken: String, completion: (() -> Void)? = nil)
+  public static func presentCheckout(clientToken: String, from: UIViewController, completion: (() -> Void)? = nil)
+  public static func presentCheckout(clientToken: String, from: UIViewController, primerSettings: PrimerSettings, completion: (() -> Void)? = nil)
+  public static func presentCheckout(clientToken: String, primerSettings: PrimerSettings, completion: (() -> Void)? = nil)
+
+  // Dismiss
+  public static func dismiss(animated: Bool = true, completion: (() -> Void)? = nil)
+}
+```
+
+### PrimerCheckoutPresenterDelegate
+
+```swift
+@available(iOS 15.0, *)
+public protocol PrimerCheckoutPresenterDelegate: AnyObject {
+  // Required
+  func primerCheckoutPresenterDidCompleteWithSuccess(_ result: PaymentResult)
+  func primerCheckoutPresenterDidFailWithError(_ error: PrimerError)
+  func primerCheckoutPresenterDidDismiss()
+
+  // Optional (3DS)
+  func primerCheckoutPresenterWillPresent3DSChallenge(_ paymentMethodTokenData: PrimerPaymentMethodTokenData)
+  func primerCheckoutPresenterDidDismiss3DSChallenge()
+  func primerCheckoutPresenterDidComplete3DSChallenge(success: Bool, resumeToken: String?, error: Error?)
+}
+```
+
+---
+
+## Core Scopes
+
+### PrimerPaymentMethodScope (Base Protocol)
+
+All payment method scopes conform to this protocol.
+
+```
+Lifecycle: start() -> [user interaction] -> submit()  or  start() -> cancel()
+```
+
+```swift
+@MainActor
+public protocol PrimerPaymentMethodScope: AnyObject {
+  associatedtype State: Equatable
+
+  var state: AsyncStream<State> { get }
+  var presentationContext: PresentationContext { get }   // default: .fromPaymentSelection
+  var dismissalMechanism: [DismissalMechanism] { get }  // default: []
+
+  func start()     // Initialize payment flow
+  func submit()    // Validate and process payment
+  func cancel()    // Terminate flow
+  func onBack()    // Navigate back (default: calls cancel())
+  func onDismiss() // Handle dismissal (default: calls cancel())
+}
+```
+
+### PrimerCheckoutScope
+
+Top-level scope for managing the checkout session.
+
+```swift
+@MainActor
+public protocol PrimerCheckoutScope: AnyObject {
+  var state: AsyncStream<PrimerCheckoutState> { get }
+  var paymentMethodSelection: PrimerPaymentMethodSelectionScope { get }
+  var paymentHandling: PrimerPaymentHandling { get }
+
+  // Scope access
+  func getPaymentMethodScope<T: PrimerPaymentMethodScope>(_ scopeType: T.Type) -> T?
+  func getPaymentMethodScope<T: PrimerPaymentMethodScope>(for methodType: PrimerPaymentMethodType) -> T?
+  func getPaymentMethodScope<T: PrimerPaymentMethodScope>(for paymentMethodType: String) -> T?
+  func onDismiss()
+
+  // Screen customization
+  var container: ContainerComponent? { get set }
+  var splashScreen: Component? { get set }
+  var loadingScreen: Component? { get set }
+  var errorScreen: ErrorComponent? { get set }
+}
+```
+
+### PrimerPaymentMethodSelectionScope
+
+Scope for the payment method selection screen.
+
+```swift
+@MainActor
+public protocol PrimerPaymentMethodSelectionScope: AnyObject {
+  var state: AsyncStream<PrimerPaymentMethodSelectionState> { get }
+  var dismissalMechanism: [DismissalMechanism] { get }
+
+  func onPaymentMethodSelected(paymentMethod: CheckoutPaymentMethod)
+  func cancel()
+  func payWithVaultedPaymentMethod() async
+  func payWithVaultedPaymentMethodAndCvv(_ cvv: String) async
+  func updateCvvInput(_ cvv: String)
+  func showAllVaultedPaymentMethods()
+  func showOtherWaysToPay()
+
+  // Customization
+  var screen: PaymentMethodSelectionScreenComponent? { get set }
+  var paymentMethodItem: PaymentMethodItemComponent? { get set }
+  var categoryHeader: CategoryHeaderComponent? { get set }
+  var emptyStateView: Component? { get set }
+}
+```
+
+---
+
+## Payment Method Scopes
+
+### PrimerCardFormScope
+
+Comprehensive card form with field-level customization.
+
+```swift
+@MainActor
+public protocol PrimerCardFormScope: PrimerPaymentMethodScope where State == PrimerCardFormState {
+  var cardFormUIOptions: PrimerCardFormUIOptions? { get }
+  var selectCountry: PrimerSelectCountryScope { get }
+
+  // Field update methods
+  func updateCardNumber(_ cardNumber: String)
+  func updateCvv(_ cvv: String)
+  func updateExpiryDate(_ expiryDate: String)
+  func updateCardholderName(_ cardholderName: String)
+  func updatePostalCode(_ postalCode: String)
+  func updateCity(_ city: String)
+  func updateState(_ state: String)
+  func updateAddressLine1(_ addressLine1: String)
+  func updateAddressLine2(_ addressLine2: String)
+  func updatePhoneNumber(_ phoneNumber: String)
+  func updateFirstName(_ firstName: String)
+  func updateLastName(_ lastName: String)
+  func updateEmail(_ email: String)
+  func updateCountryCode(_ countryCode: String)
+  func updateSelectedCardNetwork(_ network: String)
+  func updateRetailOutlet(_ retailOutlet: String)
+  func updateOtpCode(_ otpCode: String)
+  func updateExpiryMonth(_ month: String)
+  func updateExpiryYear(_ year: String)
+
+  // Generic field access
+  func updateField(_ fieldType: PrimerInputElementType, value: String)
+  func getFieldValue(_ fieldType: PrimerInputElementType) -> String
+  func setFieldError(_ fieldType: PrimerInputElementType, message: String, errorCode: String?)
+  func clearFieldError(_ fieldType: PrimerInputElementType)
+  func getFieldError(_ fieldType: PrimerInputElementType) -> String?
+  func getFormConfiguration() -> CardFormConfiguration
+
+  // Field configuration (InputFieldConfig)
+  var cardNumberConfig: InputFieldConfig? { get set }
+  var expiryDateConfig: InputFieldConfig? { get set }
+  var cvvConfig: InputFieldConfig? { get set }
+  var cardholderNameConfig: InputFieldConfig? { get set }
+  var postalCodeConfig: InputFieldConfig? { get set }
+  var countryConfig: InputFieldConfig? { get set }
+  var cityConfig: InputFieldConfig? { get set }
+  var stateConfig: InputFieldConfig? { get set }
+  var addressLine1Config: InputFieldConfig? { get set }
+  var addressLine2Config: InputFieldConfig? { get set }
+  var phoneNumberConfig: InputFieldConfig? { get set }
+  var firstNameConfig: InputFieldConfig? { get set }
+  var lastNameConfig: InputFieldConfig? { get set }
+  var emailConfig: InputFieldConfig? { get set }
+  var retailOutletConfig: InputFieldConfig? { get set }
+  var otpCodeConfig: InputFieldConfig? { get set }
+
+  // Section customization
+  var title: String? { get set }
+  var screen: CardFormScreenComponent? { get set }
+  var cardInputSection: Component? { get set }
+  var billingAddressSection: Component? { get set }
+  var submitButton: Component? { get set }
+  var cobadgedCardsView: (([String], @escaping (String) -> Void) -> any View)? { get set }
+  var errorScreen: ErrorComponent? { get set }
+  var submitButtonText: String? { get set }
+  var showSubmitLoadingIndicator: Bool { get set }
+
+  // SDK field ViewBuilder methods
+  func PrimerCardNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerExpiryDateField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerCvvField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerCardholderNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerCountryField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerPostalCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerCityField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerStateField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerAddressLine1Field(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerAddressLine2Field(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerFirstNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerLastNameField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerEmailField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerPhoneNumberField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerRetailOutletField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func PrimerOtpCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView
+  func DefaultCardFormView(styling: PrimerFieldStyling?) -> AnyView
+}
+```
+
+### PrimerApplePayScope
+
+```swift
+@MainActor
+public protocol PrimerApplePayScope: PrimerPaymentMethodScope where State == PrimerApplePayState {
+  var state: AsyncStream<PrimerApplePayState> { get }
+
+  func PrimerApplePayButton(action: @escaping () -> Void) -> AnyView
+
+  var screen: ((_ scope: any PrimerApplePayScope) -> any View)? { get set }
+  var applePayButton: ((_ action: @escaping () -> Void) -> any View)? { get set }
+}
+```
+
+### PrimerPayPalScope
+
+```swift
+@MainActor
+public protocol PrimerPayPalScope: PrimerPaymentMethodScope where State == PrimerPayPalState {
+  var screen: PayPalScreenComponent? { get set }
+  var payButton: PayPalButtonComponent? { get set }
+  var submitButtonText: String? { get set }
+}
+```
+
+### PrimerKlarnaScope
+
+Multi-step flow: category selection -> authorization -> finalization.
+
+```swift
+@MainActor
+public protocol PrimerKlarnaScope: PrimerPaymentMethodScope where State == PrimerKlarnaState {
+  var paymentView: UIView? { get }
+
+  func selectPaymentCategory(_ categoryId: String)
+  func authorizePayment()
+  func finalizePayment()
+
+  var screen: KlarnaScreenComponent? { get set }
+  var authorizeButton: KlarnaButtonComponent? { get set }
+  var finalizeButton: KlarnaButtonComponent? { get set }
+}
+```
+
+### PrimerAchScope
+
+Multi-step flow: user details -> bank collection -> mandate acceptance.
+
+```swift
+@MainActor
+public protocol PrimerAchScope: PrimerPaymentMethodScope where State == PrimerAchState {
+  var bankCollectorViewController: UIViewController? { get }
+
+  func updateFirstName(_ value: String)
+  func updateLastName(_ value: String)
+  func updateEmailAddress(_ value: String)
+  func submitUserDetails()
+  func acceptMandate()
+  func declineMandate()
+
+  var screen: AchScreenComponent? { get set }
+  var userDetailsScreen: AchScreenComponent? { get set }
+  var mandateScreen: AchScreenComponent? { get set }
+  var submitButton: AchButtonComponent? { get set }
+}
+```
+
+### PrimerWebRedirectScope
+
+Web redirect payment methods (e.g., Twint). Redirects user to external page, then polls for result.
+
+```
+idle -> loading -> redirecting -> polling -> success | failure
+```
+
+```swift
+@MainActor
+public protocol PrimerWebRedirectScope: PrimerPaymentMethodScope where State == PrimerWebRedirectState {
+  var paymentMethodType: String { get }
+  var state: AsyncStream<PrimerWebRedirectState> { get }
+
+  // Customization
+  var screen: WebRedirectScreenComponent? { get set }
+  var payButton: WebRedirectButtonComponent? { get set }
+  var submitButtonText: String? { get set }
+}
+```
+
+### PrimerFormRedirectScope
+
+Form-based redirect payment methods (e.g., BLIK OTP code, MBWay phone number). Collects user input then completes payment in external app.
+
+```
+ready -> submitting -> awaitingExternalCompletion -> success | failure
+```
+
+```swift
+@MainActor
+public protocol PrimerFormRedirectScope: PrimerPaymentMethodScope where State == PrimerFormRedirectState {
+  var state: AsyncStream<PrimerFormRedirectState> { get }
+  var paymentMethodType: String { get }
+
+  func updateField(_ fieldType: PrimerFormFieldState.FieldType, value: String)
+
+  // Customization
+  var screen: FormRedirectScreenComponent? { get set }        // Replaces both form and pending screens
+  var formSection: FormRedirectFormSectionComponent? { get set }
+  var submitButton: FormRedirectButtonComponent? { get set }
+  var submitButtonText: String? { get set }
+}
+```
+
+### PrimerQRCodeScope
+
+QR code payment methods (e.g., PromptPay, Xfers). Displays a QR code and polls for completion. No user input needed.
+
+```
+loading -> displaying -> success | failure
+```
+
+```swift
+@MainActor
+public protocol PrimerQRCodeScope: PrimerPaymentMethodScope where State == PrimerQRCodeState {
+  var state: AsyncStream<PrimerQRCodeState> { get }
+  var screen: QRCodeScreenComponent? { get set }
+}
+```
+
+### PrimerSelectCountryScope
+
+```swift
+@MainActor
+public protocol PrimerSelectCountryScope {
+  var state: AsyncStream<PrimerSelectCountryState> { get }
+
+  func onCountrySelected(countryCode: String, countryName: String)
+  func cancel()
+  func onSearch(query: String)
+
+  var screen: ((_ scope: PrimerSelectCountryScope) -> AnyView)? { get set }
+  var searchBar: ((_ query: String, _ onQueryChange: @escaping (String) -> Void, _ placeholder: String) -> AnyView)? { get set }
+  var countryItem: CountryItemComponent? { get set }
+}
+```
+
+---
+
+## State Types
+
+### PrimerCheckoutState
+
+```
+initializing -> ready -> success | failure -> dismissed
+```
+
+```swift
+public enum PrimerCheckoutState {
+  case initializing
+  case ready(totalAmount: Int, currencyCode: String)
+  case success(PaymentResult)
+  case dismissed
+  case failure(PrimerError)
+}
+```
+
+### PrimerPaymentMethodSelectionState
+
+```swift
+public struct PrimerPaymentMethodSelectionState {
+  var paymentMethods: [CheckoutPaymentMethod]
+  var isLoading: Bool
+  var selectedPaymentMethod: CheckoutPaymentMethod?
+  var searchQuery: String
+  var filteredPaymentMethods: [CheckoutPaymentMethod]
+  var error: String?
+  var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod?
+  var isVaultPaymentLoading: Bool
+  var requiresCvvInput: Bool
+  var cvvInput: String
+  var isCvvValid: Bool
+  var cvvError: String?
+  var isPaymentMethodsExpanded: Bool
+}
+```
+
+### PrimerCardFormState
+
+```swift
+public struct PrimerCardFormState: Equatable {
+  var configuration: CardFormConfiguration
+  var data: FormData
+  var fieldErrors: [FieldError]
+  var isLoading: Bool
+  var isValid: Bool
+  var selectedCountry: PrimerCountry?
+  var selectedNetwork: PrimerCardNetwork?
+  var availableNetworks: [PrimerCardNetwork]
+  var surchargeAmountRaw: Int?
+  var surchargeAmount: String?
+  var displayFields: [PrimerInputElementType]
+
+  func hasError(for fieldType: PrimerInputElementType) -> Bool
+  func errorMessage(for fieldType: PrimerInputElementType) -> String?
+  mutating func setError(_ message: String, for fieldType: PrimerInputElementType, errorCode: String?)
+  mutating func clearError(for fieldType: PrimerInputElementType)
+}
+```
+
+### PrimerApplePayState
+
+```swift
+public struct PrimerApplePayState: Equatable {
+  var isLoading: Bool
+  var isAvailable: Bool
+  var availabilityError: String?
+  var buttonStyle: PKPaymentButtonStyle
+  var buttonType: PKPaymentButtonType
+  var cornerRadius: CGFloat
+
+  static var `default`: PrimerApplePayState
+  static func available(buttonStyle:buttonType:cornerRadius:) -> PrimerApplePayState
+  static func unavailable(error:) -> PrimerApplePayState
+  static var loading: PrimerApplePayState
+}
+```
+
+### PrimerKlarnaState
+
+```
+loading -> categorySelection -> viewReady -> authorizationStarted -> awaitingFinalization
+```
+
+```swift
+public struct PrimerKlarnaState: Equatable {
+  public enum Step: Equatable {
+    case loading
+    case categorySelection
+    case viewReady
+    case authorizationStarted
+    case awaitingFinalization
+  }
+
+  var step: Step
+  var categories: [KlarnaPaymentCategory]
+  var selectedCategoryId: String?
+}
+```
+
+### PrimerPayPalState
+
+```swift
+public struct PrimerPayPalState: Equatable {
+  public enum Step: Equatable {
+    case idle
+    case loading
+    case redirecting
+    case processing
+    case success
+    case failure(String)
+  }
+
+  var step: Step
+  var paymentMethod: CheckoutPaymentMethod?
+  var surchargeAmount: String?
+}
+```
+
+### PrimerAchState
+
+```
+loading -> userDetailsCollection -> bankAccountCollection -> mandateAcceptance -> processing
+```
+
+```swift
+public struct PrimerAchState: Equatable {
+  public enum Step: Equatable {
+    case loading
+    case userDetailsCollection
+    case bankAccountCollection
+    case mandateAcceptance
+    case processing
+  }
+
+  public struct UserDetails: Equatable {
+    let firstName: String
+    let lastName: String
+    let emailAddress: String
+  }
+
+  public struct FieldValidation: Equatable {
+    let firstNameError: String?
+    let lastNameError: String?
+    let emailError: String?
+    var hasErrors: Bool
+  }
+
+  var step: Step
+  var userDetails: UserDetails
+  var fieldValidation: FieldValidation?
+  var mandateText: String?
+  var isSubmitEnabled: Bool
+}
+```
+
+### PrimerWebRedirectState
+
+```
+idle -> loading -> redirecting -> polling -> success | failure
+```
+
+```swift
+public struct PrimerWebRedirectState: Equatable {
+  public enum Status: Equatable {
+    case idle
+    case loading
+    case redirecting
+    case polling
+    case success
+    case failure(String)
+  }
+
+  var status: Status
+  var paymentMethod: CheckoutPaymentMethod?
+  var surchargeAmount: String?
+}
+```
+
+### PrimerFormRedirectState
+
+```
+ready -> submitting -> awaitingExternalCompletion -> success | failure
+```
+
+```swift
+public struct PrimerFormRedirectState: Equatable {
+  public enum Status: Equatable {
+    case ready
+    case submitting
+    case awaitingExternalCompletion
+    case success
+    case failure(String)
+  }
+
+  var status: Status
+  var fields: [PrimerFormFieldState]
+  var isSubmitEnabled: Bool        // Computed: all fields non-empty and valid
+  var pendingMessage: String?
+  var surchargeAmount: String?
+
+  // Convenience accessors
+  var otpField: PrimerFormFieldState?    // First field with .otpCode type
+  var phoneField: PrimerFormFieldState?  // First field with .phoneNumber type
+  var isLoading: Bool              // status == .submitting
+  var isTerminal: Bool             // success or failure
+}
+```
+
+### PrimerFormFieldState
+
+```swift
+public struct PrimerFormFieldState: Equatable, Identifiable {
+  public enum FieldType: String, Equatable, Sendable {
+    case otpCode       // BLIK 6-digit code
+    case phoneNumber   // MBWay phone number
+  }
+
+  public enum KeyboardType: Equatable, Sendable {
+    case numberPad
+    case phonePad
+    case `default`
+  }
+
+  var id: String { fieldType.rawValue }
+  let fieldType: FieldType
+  var value: String
+  var isValid: Bool
+  var errorMessage: String?
+  let placeholder: String
+  let label: String
+  let helperText: String?
+  let keyboardType: KeyboardType
+  let maxLength: Int?              // nil = unlimited
+  var countryCodePrefix: String?   // Display prefix (e.g., "🇵🇹 +351")
+  var dialCode: String?            // Dial code (e.g., "+351")
+}
+```
+
+### PrimerQRCodeState
+
+```
+loading -> displaying -> success | failure
+```
+
+```swift
+public struct PrimerQRCodeState: Equatable {
+  public enum Status: Equatable {
+    case loading
+    case displaying
+    case success
+    case failure(String)
+  }
+
+  var status: Status
+  var paymentMethod: CheckoutPaymentMethod?
+  var qrCodeImageData: Data?       // PNG image data
+}
+```
+
+### PrimerSelectCountryState
+
+```swift
+public struct PrimerSelectCountryState: Equatable {
+  var countries: [PrimerCountry]
+  var filteredCountries: [PrimerCountry]
+  var searchQuery: String
+  var isLoading: Bool
+  var selectedCountry: PrimerCountry?
+}
+```
+
+---
+
+## Configuration
+
+### PrimerCheckoutTheme
+
+Design token overrides for the entire checkout UI.
+
+```swift
+public class PrimerCheckoutTheme {
+  public init(
+    colors: ColorOverrides? = nil,
+    radius: RadiusOverrides? = nil,
+    spacing: SpacingOverrides? = nil,
+    sizes: SizeOverrides? = nil,
+    typography: TypographyOverrides? = nil,
+    borderWidth: BorderWidthOverrides? = nil
+  )
+}
+```
+
+**Override types**: `ColorOverrides`, `RadiusOverrides`, `SpacingOverrides`, `SizeOverrides`, `TypographyOverrides`, `BorderWidthOverrides`. See `CheckoutComponentsTheme.swift` for all token names.
+
+### PrimerFieldStyling
+
+Per-field styling overrides. All properties are optional and fall back to design token defaults.
+
+```swift
+public struct PrimerFieldStyling {
+  // Typography
+  let fontName: String?           // Custom font family for input text
+  let fontSize: CGFloat?          // Font size for input text
+  let fontWeight: CGFloat?        // Font weight for input text
+  let labelFontName: String?      // Custom font family for labels
+  let labelFontSize: CGFloat?     // Font size for labels
+  let labelFontWeight: CGFloat?   // Font weight for labels
+
+  // Colors
+  let textColor: Color?           // Input text color
+  let labelColor: Color?          // Label text color
+  let backgroundColor: Color?     // Field background
+  let borderColor: Color?         // Default border color
+  let focusedBorderColor: Color?  // Border color when focused
+  let errorBorderColor: Color?    // Border color on error
+  let placeholderColor: Color?    // Placeholder text color
+
+  // Layout
+  let cornerRadius: CGFloat?      // Border corner radius
+  let borderWidth: CGFloat?       // Border stroke width
+  let padding: EdgeInsets?         // Inner content padding
+  let fieldHeight: CGFloat?       // Fixed field height
+}
+```
+
+### InputFieldConfig
+
+Partial customization or full component replacement for individual form fields.
+
+```swift
+public struct InputFieldConfig {
+  public init(
+    label: String? = nil,
+    placeholder: String? = nil,
+    styling: PrimerFieldStyling? = nil,
+    component: Component? = nil    // Full replacement — overrides all above
+  )
+}
+```
+
+---
+
+## Data Types
+
+### CheckoutPaymentMethod
+
+```swift
+public struct CheckoutPaymentMethod {
+  let id: String
+  let type: String                  // e.g., "PAYMENT_CARD", "PAYPAL"
+  let name: String                  // Display name
+  let icon: UIImage?
+  let metadata: [String: Any]?
+  let surcharge: Int?               // Minor units
+  let hasUnknownSurcharge: Bool
+  let formattedSurcharge: String?
+  let backgroundColor: UIColor?
+}
+```
+
+### PrimerCountry
+
+```swift
+public struct PrimerCountry: Equatable {
+  let code: String      // ISO 3166-1 alpha-2 (e.g., "US")
+  let name: String      // Localized name
+  let flag: String?     // Flag emoji
+  let dialCode: String? // Dialing code
+}
+```
+
+### FieldError
+
+```swift
+public struct FieldError: Equatable, Identifiable {
+  let id: UUID
+  let fieldType: PrimerInputElementType
+  let message: String
+  let errorCode: String?
+}
+```
+
+### CardFormConfiguration
+
+```swift
+public struct CardFormConfiguration: Equatable {
+  let cardFields: [PrimerInputElementType]
+  let billingFields: [PrimerInputElementType]
+  let requiresBillingAddress: Bool
+  var allFields: [PrimerInputElementType]
+}
+```
+
+### FormData
+
+```swift
+public struct FormData: Equatable {
+  subscript(fieldType: PrimerInputElementType) -> String { get set }
+  var dictionary: [PrimerInputElementType: String]
+}
+```
+
+### PresentationContext
+
+```swift
+public enum PresentationContext {
+  case direct               // Show cancel button
+  case fromPaymentSelection // Show back button
+}
+```
+
+### DismissalMechanism
+
+```swift
+public enum DismissalMechanism {
+  case gestures    // Swipe-down dismissal
+  case closeButton // Close/cancel button
+}
+```
+
+---
+
+## Type Aliases
+
+Component closures used for UI customization:
+
+| Alias | Signature |
+|---|---|
+| `Component` | `() -> any View` |
+| `ContainerComponent` | `(@escaping () -> any View) -> any View` |
+| `ErrorComponent` | `(String) -> any View` |
+| `PaymentMethodItemComponent` | `(CheckoutPaymentMethod) -> any View` |
+| `CountryItemComponent` | `(PrimerCountry, @escaping () -> Void) -> any View` |
+| `CategoryHeaderComponent` | `(String) -> any View` |
+| `PaymentMethodSelectionScreenComponent` | `(PrimerPaymentMethodSelectionScope) -> any View` |
+| `CardFormScreenComponent` | `(any PrimerCardFormScope) -> any View` |
+| `KlarnaScreenComponent` | `(any PrimerKlarnaScope) -> any View` |
+| `KlarnaButtonComponent` | `(any PrimerKlarnaScope) -> any View` |
+| `PayPalScreenComponent` | `(any PrimerPayPalScope) -> any View` |
+| `PayPalButtonComponent` | `(any PrimerPayPalScope) -> any View` |
+| `AchScreenComponent` | `(any PrimerAchScope) -> any View` |
+| `AchButtonComponent` | `(any PrimerAchScope) -> any View` |
+| `WebRedirectScreenComponent` | `(any PrimerWebRedirectScope) -> any View` |
+| `WebRedirectButtonComponent` | `(any PrimerWebRedirectScope) -> any View` |
+| `FormRedirectScreenComponent` | `(any PrimerFormRedirectScope) -> any View` |
+| `FormRedirectButtonComponent` | `(any PrimerFormRedirectScope) -> any View` |
+| `FormRedirectFormSectionComponent` | `(any PrimerFormRedirectScope) -> any View` |
+| `QRCodeScreenComponent` | `(any PrimerQRCodeScope) -> any View` |

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/CLAUDE.md
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/CLAUDE.md
@@ -1,0 +1,249 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in CheckoutComponents folder.
+
+## Overview
+
+CheckoutComponents is a modern, scope-based payment checkout framework for iOS 15+ that provides complete UI customization with exact Android API parity. It represents the newest integration approach in the Primer iOS SDK, using SwiftUI, async/await, and a hierarchical scope-based architecture.
+
+## Key Architecture Patterns
+
+### Scope-Based API
+
+CheckoutComponents uses a hierarchical scope pattern where each major component exposes a scope interface:
+
+- **`PrimerCheckoutScope`**: Main checkout lifecycle, navigation, and screen customization (Scope/PrimerCheckoutScope.swift:13)
+- **`PrimerPaymentMethodSelectionScope`**: Payment method grid and selection UI
+- **`PrimerCardFormScope`**: Comprehensive card form with field-level customization
+- **`PrimerPaymentMethodScope`**: Base protocol for all payment method implementations
+
+Each scope provides:
+- State observation via AsyncStream
+- UI component customization closures (ViewBuilder pattern)
+- SDK component access methods
+- Navigation and action methods
+
+### Dependency Injection
+
+CheckoutComponents uses a custom DI container framework (Internal/DI/Framework/):
+- Actor-based implementation for thread safety
+- Support for async/await resolution
+- Three retention policies: Transient, Singleton, Weak
+- Factory pattern support for parameterized object creation
+- Scoped containers for feature isolation
+
+**Registration**: ComposableContainer.swift:24 configures all dependencies
+**Resolution**: Manual resolution with explicit error handling using `DIContainer.current` or `DIContainer.currentSync`
+
+### Clean Architecture Layers
+
+CheckoutComponents follows Clean Architecture:
+```
+Internal/
+├── Domain/           # Business logic (Interactors, Models)
+├── Data/             # Repositories, Mappers
+├── Presentation/     # Scopes, ViewModels, UI Components
+├── Core/             # Validation, Services
+└── Navigation/       # CheckoutCoordinator, CheckoutNavigator
+```
+
+### Navigation System
+
+- **CheckoutNavigator**: State publisher for navigation events (Internal/Navigation/CheckoutNavigator.swift)
+- **CheckoutCoordinator**: Handles navigation stack management (Internal/Navigation/CheckoutCoordinator.swift:29)
+- **CheckoutRoute**: Enum defining all possible routes with navigation behaviors
+- State-driven navigation using AsyncStream
+
+### Payment Method Registry
+
+Dynamic payment method registration system:
+- Payment methods register themselves on startup (e.g., CardPaymentMethod.register())
+- Registry creates scopes dynamically via `PaymentMethodRegistry.shared.createScope()`
+- Supports three access patterns: type-safe metatype, enum-based, string identifier
+
+## Entry Points
+
+### UIKit Integration
+**PrimerCheckoutPresenter** (PrimerCheckoutPresenter.swift:64): Main UIKit entry point
+- `presentCheckout(clientToken:from:completion:)`: Present default UI
+- `presentCheckout(clientToken:from:primerSettings:primerTheme:scope:completion:)`: Present with scope-based customization
+- Acts as bridge between UIKit and SwiftUI implementation
+
+### SwiftUI Integration
+**PrimerCheckout** view: Direct SwiftUI integration for pure SwiftUI apps
+
+### Delegation, works only with UIKit Integration
+**PrimerCheckoutPresenterDelegate** protocol (PrimerCheckoutPresenter.swift:13):
+- `primerCheckoutPresenterDidCompleteWithSuccess(_:)`: Payment successful
+- `primerCheckoutPresenterDidFailWithError(_:)`: Payment failed
+- `primerCheckoutPresenterDidDismiss()`: Checkout dismissed
+- Optional 3DS lifecycle methods
+
+## State Management
+
+### Checkout State Flow
+```swift
+PrimerCheckoutState:
+.initializing → .ready → .success(PaymentResult) | .failure(PrimerError) → .dismissed
+```
+
+### Card Form State
+Structured state via `PrimerCardFormState` (Core/Data/PrimerCardFormState.swift):
+- Field-level validation with specific error codes
+- Co-badged card network detection and selection
+- Dynamic billing address field configuration
+- Surcharge information per network
+
+### AsyncStream Observation
+All scopes expose state as AsyncStream for reactive updates:
+```swift
+for await state in scope.state {
+    // Handle state changes
+}
+```
+
+## Customization Approaches
+
+### 1. Field-Level Customization via InputFieldConfig
+Customize individual fields with partial or full replacement via scope properties:
+```swift
+// Access card form scope and customize fields
+if let cardFormScope = checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self) {
+    cardFormScope.cardNumberConfig = InputFieldConfig(
+        label: "Card Number",
+        placeholder: "0000 0000 0000 0000",
+        styling: PrimerFieldStyling(borderColor: .blue)
+    )
+    cardFormScope.cvvConfig = InputFieldConfig(
+        component: { MyCustomCVVField() }
+    )
+}
+```
+
+### 2. Section-Level Customization
+Replace entire sections using scope section properties:
+```swift
+cardFormScope.cardInputSection = { scope in
+    AnyView(MyCustomCardDetailsSection(scope: scope))
+}
+```
+
+### 3. Full Screen Customization
+Replace the entire card form screen:
+```swift
+cardFormScope.screen = { scope in
+    AnyView(MyCustomCardFormScreen(scope: scope))
+}
+```
+
+### 4. Checkout-Level Screen Customization
+Customize checkout-level screens via scope properties:
+```swift
+// Custom splash screen (SDK initialization)
+checkoutScope.splashScreen = {
+    AnyView(MyCustomSplashScreen())
+}
+
+// Custom loading screen (payment processing) - matches Android's checkout.loading
+checkoutScope.loading = {
+    AnyView(MyCustomLoadingScreen())
+}
+
+// Custom error screen
+checkoutScope.errorScreen = { message in
+    AnyView(MyCustomErrorScreen(message: message))
+}
+```
+
+## Validation System
+
+### Validation Architecture
+- **ValidationService** (Internal/Core/Validation/ValidationService.swift): Core validation engine
+- **RulesFactory** (Internal/Core/Validation/RulesFactory.swift): Creates validation rules
+- **ValidationRule** protocol (Internal/Core/Validation/ValidationRule.swift): Individual rule implementations
+- **CardValidationRules** and **CommonValidationRules** (Internal/Core/Validation/Rules/)
+
+### Field Validation
+Each field state includes:
+- `value`: Current field value
+- `isValid`: Validation status
+- `error`: Specific FieldError if invalid
+- `isRequired`: Whether field is required
+- `isVisible`: Whether field should be shown
+
+## Testing Strategy
+
+### Test Structure
+Tests follow XCTest framework located in `/Tests/` directory:
+- Unit tests for domain logic (interactors, validators)
+- Integration tests for data layer (repositories)
+- UI tests via Debug App
+
+### Mock Container for Testing
+```swift
+let mockContainer = await DIContainer.createMockContainer()
+await DIContainer.withContainer(mockContainer) {
+    // Test with mock dependencies
+}
+```
+
+## Important Implementation Notes
+
+### Settings Integration
+CheckoutComponents integrates with PrimerSettings via:
+- **CheckoutComponentsSettingsService** (Internal/Services/CheckoutComponentsSettingsService.swift): Wraps PrimerSettings
+- **SettingsObserver** (Internal/Services/SettingsObserver.swift): Dynamic settings updates
+- Settings control screen visibility (init, success, error screens)
+- `is3DSSanityCheckEnabled` critical for production security
+
+### Presentation Context
+`PresentationContext` enum controls navigation behavior:
+- `.fromPaymentSelection`: Show back button (navigated from selection)
+- `.direct`: Show cancel button (directly presented)
+
+### 3DS Integration
+- Automatic 3DS handling via delegate callbacks
+- Sanity checks configurable via settings
+- Lifecycle callbacks: willPresent, didPresent, willDismiss, didComplete
+
+## Common Development Tasks
+
+### Adding a New Payment Method
+1. Create payment method class implementing `PrimerPaymentMethodScope`
+2. Implement required scope methods (start, submit, state observation)
+3. Register in `PaymentMethodRegistry`
+4. Add registration call in DefaultCheckoutScope.registerPaymentMethods()
+
+### Customizing UI Components
+Use the scope's customization closures:
+- For full control: Replace entire screens or sections
+- For styling: Use ViewBuilder methods with PrimerFieldStyling
+- For partial changes: Replace individual field closures
+
+### Debugging Navigation
+- Check CheckoutNavigator.navigationEvents AsyncStream
+- Verify CheckoutCoordinator.navigationStack state
+- Use `#if DEBUG` diagnostics in ComposableContainer.performHealthCheck()
+
+### DI Container Issues
+- Ensure `ComposableContainer.configure()` is called before use
+- Check container diagnostics: `await container.getDiagnostics()`
+- Verify registrations: `await container.performHealthCheck()`
+
+## Design Tokens
+
+CheckoutComponents uses a design token system (Internal/Tokens/):
+- **DesignTokens**: Light mode tokens
+- **DesignTokensDark**: Dark mode tokens
+- **DesignTokensManager**: Manages token access and theme switching
+- **PrimerFont**: Custom font support with fallbacks
+
+## Key Files Reference
+
+- Entry: PrimerCheckoutPresenter.swift, PrimerCheckout.swift
+- Scope interfaces: Scope/PrimerCheckoutScope.swift, Scope/PrimerCardFormScope.swift
+- Scope implementations: Internal/Presentation/Scope/DefaultCheckoutScope.swift
+- DI setup: Internal/DI/ComposableContainer.swift
+- Navigation: Internal/Navigation/CheckoutCoordinator.swift
+- Validation: Internal/Core/Validation/
+- Payment methods: PaymentMethods/Card/CardPaymentMethod.swift

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckout.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckout.swift
@@ -1,0 +1,319 @@
+//
+//  PrimerCheckout.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Pure SwiftUI implementation for CheckoutComponents SDK.
+///
+/// Example usage (minimal):
+/// ```swift
+/// PrimerCheckout(clientToken: "your_client_token")
+/// ```
+///
+/// With scope-based customization:
+/// ```swift
+/// PrimerCheckout(
+///     clientToken: "your_client_token",
+///     primerSettings: PrimerSettings(),
+///     primerTheme: PrimerCheckoutTheme(),
+///     scope: { checkoutScope in
+///         // Customize checkout screens
+///         checkoutScope.splashScreen = { CustomSplash() }
+///
+///         // Customize card form fields via InputFieldConfig
+///         if let cardFormScope = checkoutScope.getPaymentMethodScope(PrimerCardFormScope.self) as? DefaultCardFormScope {
+///             cardFormScope.cardNumberConfig = InputFieldConfig(placeholder: "Enter card number")
+///             cardFormScope.cvvConfig = InputFieldConfig(styling: PrimerFieldStyling(borderColor: .blue))
+///         }
+///     },
+///     onCompletion: { print("Checkout completed") }
+/// )
+/// ```
+@available(iOS 15.0, *)
+@MainActor
+public struct PrimerCheckout: View {
+
+  private let clientToken: String
+  private let settings: PrimerSettings
+  private let theme: PrimerCheckoutTheme
+  private let scope: ((PrimerCheckoutScope) -> Void)?
+  private let onCompletion: ((PrimerCheckoutState) -> Void)?
+  @StateObject private var navigator: CheckoutNavigator
+  private let presentationContext: PresentationContext
+  private let integrationType: CheckoutComponentsIntegrationType
+
+  /// Creates a PrimerCheckout view.
+  /// - Parameters:
+  ///   - clientToken: The client token obtained from your backend.
+  ///   - primerSettings: Configuration settings including payment options and UI preferences. Default: `PrimerSettings()`
+  ///   - primerTheme: Theme configuration for design tokens. Default: `PrimerCheckoutTheme()`
+  ///   - scope: Optional closure to configure the checkout scope with custom UI components.
+  ///   - onCompletion: Optional completion callback called when checkout completes with the final state (success, failure, or dismissed).
+  public init(
+    clientToken: String,
+    primerSettings: PrimerSettings = PrimerSettings(),
+    primerTheme: PrimerCheckoutTheme = PrimerCheckoutTheme(),
+    scope: ((PrimerCheckoutScope) -> Void)? = nil,
+    onCompletion: ((PrimerCheckoutState) -> Void)? = nil
+  ) {
+    self.clientToken = clientToken
+    settings = primerSettings
+    theme = primerTheme
+    self.scope = scope
+    self.onCompletion = onCompletion
+    _navigator = StateObject(wrappedValue: CheckoutNavigator())
+    presentationContext = .fromPaymentSelection
+    integrationType = .swiftUI
+  }
+
+  init(
+    clientToken: String,
+    primerSettings: PrimerSettings,
+    primerTheme: PrimerCheckoutTheme,
+    diContainer: DIContainer,
+    navigator: CheckoutNavigator,
+    presentationContext: PresentationContext,
+    integrationType: CheckoutComponentsIntegrationType,
+    scope: ((PrimerCheckoutScope) -> Void)? = nil,
+    onCompletion: ((PrimerCheckoutState) -> Void)? = nil
+  ) {
+    self.clientToken = clientToken
+    settings = primerSettings
+    theme = primerTheme
+    self.scope = scope
+    self.onCompletion = onCompletion
+    _navigator = StateObject(wrappedValue: navigator)
+    self.presentationContext = presentationContext
+    self.integrationType = integrationType
+  }
+
+  public var body: some View {
+    InternalCheckout(
+      clientToken: clientToken,
+      settings: settings,
+      theme: theme,
+      diContainer: DIContainer.shared,
+      navigator: navigator,
+      scope: scope,
+      presentationContext: presentationContext,
+      integrationType: integrationType,
+      onCompletion: onCompletion
+    )
+  }
+}
+
+// MARK: - Internal Implementation
+
+@available(iOS 15.0, *)
+@MainActor
+struct InternalCheckout: View, LogReporter {
+  private let clientToken: String
+  private let settings: PrimerSettings
+  private let theme: PrimerCheckoutTheme
+  private let diContainer: DIContainer
+  private let navigator: CheckoutNavigator
+  private let scope: ((PrimerCheckoutScope) -> Void)?
+  private let presentationContext: PresentationContext
+  private let integrationType: CheckoutComponentsIntegrationType
+  private let onCompletion: ((PrimerCheckoutState) -> Void)?
+
+  @State private var checkoutScope: DefaultCheckoutScope?
+  @State private var initializationState: InitializationState = .idle
+  @Environment(\.colorScheme) private var colorScheme
+
+  // Design tokens state for early theme application (splash screen)
+  @StateObject private var designTokensManager = DesignTokensManager()
+
+  private let sdkInitializer: CheckoutSDKInitializer
+
+  enum InitializationState {
+    case idle
+    case initializing
+    case retrying
+    case initialized
+    case failed(PrimerError)
+  }
+
+  init(
+    clientToken: String,
+    settings: PrimerSettings,
+    theme: PrimerCheckoutTheme,
+    diContainer: DIContainer,
+    navigator: CheckoutNavigator,
+    scope: ((PrimerCheckoutScope) -> Void)?,
+    presentationContext: PresentationContext,
+    integrationType: CheckoutComponentsIntegrationType,
+    onCompletion: ((PrimerCheckoutState) -> Void)?
+  ) {
+    self.clientToken = clientToken
+    self.settings = settings
+    self.theme = theme
+    self.diContainer = diContainer
+    self.navigator = navigator
+    self.scope = scope
+    self.presentationContext = presentationContext
+    self.integrationType = integrationType
+    self.onCompletion = onCompletion
+
+    sdkInitializer = CheckoutSDKInitializer(
+      clientToken: clientToken,
+      primerSettings: settings,
+      primerTheme: theme,
+      diContainer: diContainer,
+      navigator: navigator,
+      presentationContext: presentationContext
+    )
+  }
+
+  var body: some View {
+    VStack(spacing: 0) {
+      switch initializationState {
+      case .idle, .initializing:
+        splashContent
+      case .retrying:
+        loadingContent
+      case .initialized:
+        if let checkoutScope {
+          CheckoutScopeObserver(
+            scope: checkoutScope,
+            theme: theme,
+            onCompletion: onCompletion
+          )
+        } else {
+          splashContent
+        }
+      case let .failed(error):
+        errorContent(error: error)
+      }
+    }
+    .background(backgroundColor)
+    .environment(\.designTokens, designTokensManager.tokens)
+    .applyAppearanceMode(settings.uiOptions.appearanceMode)
+    .environment(\.layoutDirection, RTLSupport.layoutDirection)
+    .task {
+      await LoggingSessionContext.shared.recordInitStartTime()
+      await LoggingSessionContext.shared.initialize(
+        clientToken: clientToken, integrationType: integrationType
+      )
+      await setupDesignTokens()
+      await initializeSDK()
+    }
+    .onChange(of: colorScheme) { newColorScheme in
+      Task {
+        await loadDesignTokens(for: newColorScheme)
+      }
+    }
+    .onDisappear {
+      sdkInitializer.cleanup()
+    }
+  }
+
+  // MARK: - Design Token Management
+
+  /// Background color that uses theme override first, then loaded tokens, then system default.
+  /// This ensures the background color is correct from the first render.
+  private var backgroundColor: Color {
+    // Priority 1: Theme override (available immediately)
+    if let themeBackground = theme.colors?.primerColorBackground {
+      return themeBackground
+    }
+    // Priority 2: Loaded design tokens (available after async load)
+    if let tokens = designTokensManager.tokens {
+      return CheckoutColors.background(tokens: tokens)
+    }
+    // Priority 3: System default based on color scheme
+    return colorScheme == .dark ? Color(white: 0.11) : .white
+  }
+
+  private func setupDesignTokens() async {
+    designTokensManager.applyTheme(theme)
+    await loadDesignTokens(for: colorScheme)
+  }
+
+  private func loadDesignTokens(for colorScheme: ColorScheme) async {
+    do {
+      try await designTokensManager.fetchTokens(for: colorScheme)
+    } catch {
+      logger.error(message: "[InternalCheckout] Failed to load design tokens: \(error)")
+    }
+  }
+
+  // MARK: - Content Builders
+
+  @ViewBuilder
+  private var splashContent: some View {
+    if let customSplash = checkoutScope?.splashScreen {
+      AnyView(customSplash())
+    } else {
+      SplashScreen()
+    }
+  }
+
+  @ViewBuilder
+  private var loadingContent: some View {
+    if let customLoading = checkoutScope?.loadingScreen {
+      AnyView(customLoading())
+    } else {
+      DefaultLoadingScreen()
+    }
+  }
+
+  @ViewBuilder
+  private func errorContent(error: PrimerError) -> some View {
+    if let customError = checkoutScope?.errorScreen {
+      AnyView(customError(error.localizedDescription))
+    } else {
+      SDKInitializationErrorView(error: error) {
+        Task {
+          await initializeSDK(isRetry: true)
+        }
+      }
+    }
+  }
+
+  // MARK: - Private Methods
+
+  private func initializeSDK(isRetry: Bool = false) async {
+    switch initializationState {
+    case .idle, .failed: break
+    default: return
+    }
+
+    initializationState = isRetry ? .retrying : .initializing
+
+    do {
+      let result = try await sdkInitializer.initialize()
+      checkoutScope = result.checkoutScope
+
+      // Apply scope configuration if provided
+      if let scope, let checkoutScope {
+        scope(checkoutScope)
+      }
+
+      initializationState = .initialized
+    } catch {
+      let primerError = error as? PrimerError ?? PrimerError.underlyingErrors(errors: [error])
+      initializationState = .failed(primerError)
+    }
+  }
+}
+
+// MARK: - Appearance Mode Support
+
+@available(iOS 15.0, *)
+extension View {
+  @ViewBuilder
+  fileprivate func applyAppearanceMode(_ mode: PrimerAppearanceMode) -> some View {
+    switch mode {
+    case .system:
+      self
+    case .light:
+      preferredColorScheme(.light)
+    case .dark:
+      preferredColorScheme(.dark)
+    }
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
@@ -24,8 +24,7 @@ public protocol PrimerCheckoutPresenterDelegate: AnyObject {
     /// Called when 3DS challenge is about to be presented
     /// - Parameter paymentMethodTokenData: The payment method token data requiring 3DS
     func primerCheckoutPresenterWillPresent3DSChallenge(
-        _ paymentMethodTokenData: PrimerPaymentMethodTokenData
-    )
+        _ paymentMethodTokenData: PrimerPaymentMethodTokenData)
 
     /// Called when 3DS challenge UI is dismissed
     func primerCheckoutPresenterDidDismiss3DSChallenge()
@@ -208,8 +207,7 @@ extension PrimerCheckoutPresenterDelegate {
                 let maxHeight = context.maximumDetentValue
                 // Allow content to determine height, but cap at maximum
                 return min(
-                    max(contentHeight, SheetSizing.minimumHeight), maxHeight * SheetSizing.maximumScreenRatio
-                )
+                    max(contentHeight, SheetSizing.minimumHeight), maxHeight * SheetSizing.maximumScreenRatio)
             }
             sheet.detents = [customDetent, .large()]
             sheet.selectedDetentIdentifier = customDetent.identifier
@@ -375,8 +373,7 @@ extension PrimerCheckoutPresenter {
                 reason: "No presenting view controller found"
             )
 
-            PrimerDelegateProxy.primerDidFailWithError(error, data: nil) { _ in
-            }
+            shared.delegate?.primerCheckoutPresenterDidFailWithError(error)
             return
         }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
@@ -1,0 +1,448 @@
+//
+//  PrimerCheckoutPresenter.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Delegate protocol for CheckoutComponents result handling
+@available(iOS 15.0, *)
+public protocol PrimerCheckoutPresenterDelegate: AnyObject {
+    /// Called when payment is successful
+    /// - Parameter result: The payment result containing payment ID, status, and other details
+    func primerCheckoutPresenterDidCompleteWithSuccess(_ result: PaymentResult)
+
+    /// Called when payment fails
+    func primerCheckoutPresenterDidFailWithError(_ error: PrimerError)
+
+    /// Called when checkout is dismissed without completion
+    func primerCheckoutPresenterDidDismiss()
+
+    // MARK: - 3DS Delegate Methods (Optional with default implementations)
+
+    /// Called when 3DS challenge is about to be presented
+    /// - Parameter paymentMethodTokenData: The payment method token data requiring 3DS
+    func primerCheckoutPresenterWillPresent3DSChallenge(
+        _ paymentMethodTokenData: PrimerPaymentMethodTokenData
+    )
+
+    /// Called when 3DS challenge UI is dismissed
+    func primerCheckoutPresenterDidDismiss3DSChallenge()
+
+    /// Called when 3DS challenge completes (success or failure)
+    /// - Parameters:
+    ///   - success: Whether 3DS challenge was successful
+    ///   - resumeToken: The resume token if successful, nil if failed
+    ///   - error: The error if failed, nil if successful
+    func primerCheckoutPresenterDidComplete3DSChallenge(success: Bool, resumeToken: String?, error: Error?)
+}
+
+// MARK: - Optional 3DS Delegate Methods
+
+@available(iOS 15.0, *)
+extension PrimerCheckoutPresenterDelegate {
+    /// Override if you need 3DS challenge presentation callbacks
+    public func primerCheckoutPresenterWillPresent3DSChallenge(
+        _ paymentMethodTokenData: PrimerPaymentMethodTokenData
+    ) {
+    }
+
+    /// Override if you need 3DS challenge dismissal callbacks
+    public func primerCheckoutPresenterDidDismiss3DSChallenge() {
+    }
+
+    /// Override if you need 3DS challenge completion callbacks
+    public func primerCheckoutPresenterDidComplete3DSChallenge(
+        success: Bool, resumeToken: String?, error: Error?
+    ) {
+    }
+}
+
+/// UIKit entry point for CheckoutComponents SDK
+///
+/// This class provides UIKit-friendly APIs for presenting the CheckoutComponents UI from view controllers.
+/// It acts as a bridge between UIKit apps and the underlying SwiftUI implementation (PrimerCheckout).
+/// For pure SwiftUI apps, use PrimerCheckout directly instead of this class.
+@available(iOS 15.0, *)
+@MainActor
+@objc public final class PrimerCheckoutPresenter: NSObject {
+
+    // MARK: - Singleton
+
+    @objc public static let shared = PrimerCheckoutPresenter()
+
+    // MARK: - Properties
+
+    /// The currently active UIViewController hosting the SwiftUI checkout view
+    /// This will always be a PrimerSwiftUIBridgeViewController that wraps the PrimerCheckout SwiftUI view
+    private weak var activeCheckoutController: UIViewController?
+
+    /// Flag to prevent multiple simultaneous presentations
+    private var isPresentingCheckout = false
+
+    private let logger = PrimerLogging.shared.logger
+
+    public weak var delegate: PrimerCheckoutPresenterDelegate?
+
+    // MARK: - Private Init
+
+    override private init() {
+        super.init()
+    }
+
+    // MARK: - Public API
+
+    /// Present the CheckoutComponents UI
+    /// - Parameters:
+    ///   - clientToken: The client token for the session
+    ///   - viewController: The view controller to present from
+    ///   - completion: Optional completion handler
+    @objc public static func presentCheckout(
+        clientToken: String,
+        from viewController: UIViewController,
+        completion: (() -> Void)? = nil
+    ) {
+        presentCheckout(
+            clientToken: clientToken,
+            from: viewController,
+            primerSettings: PrimerSettings.current,
+            completion: completion
+        )
+    }
+
+    /// Present the CheckoutComponents UI
+    /// - Parameters:
+    ///   - clientToken: The client token for the session
+    ///   - viewController: The view controller to present from
+    ///   - primerSettings: Configuration settings to apply for this checkout session
+    ///   - completion: Optional completion handler
+    /// - Note: This method is not @objc compatible due to PrimerSettings parameter. For Objective-C, use the overload without settings parameter.
+    public static func presentCheckout(
+        clientToken: String,
+        from viewController: UIViewController,
+        primerSettings: PrimerSettings,
+        completion: (() -> Void)? = nil
+    ) {
+        shared.presentCheckout(
+            clientToken: clientToken,
+            from: viewController,
+            primerSettings: primerSettings,
+            primerTheme: PrimerCheckoutTheme(),
+            completion: completion
+        )
+    }
+
+    /// Present the CheckoutComponents UI with full configuration
+    /// - Parameters:
+    ///   - clientToken: The client token for the session
+    ///   - viewController: The view controller to present from
+    ///   - primerSettings: Configuration settings to apply for this checkout session
+    ///   - primerTheme: Theme configuration for design tokens
+    ///   - scope: Optional closure to configure the checkout scope with custom UI components
+    ///   - completion: Optional completion handler
+    public static func presentCheckout(
+        clientToken: String,
+        from viewController: UIViewController,
+        primerSettings: PrimerSettings,
+        primerTheme: PrimerCheckoutTheme,
+        scope: ((PrimerCheckoutScope) -> Void)? = nil,
+        completion: (() -> Void)? = nil
+    ) {
+        shared.presentCheckout(
+            clientToken: clientToken,
+            from: viewController,
+            primerSettings: primerSettings,
+            primerTheme: primerTheme,
+            scope: scope,
+            completion: completion
+        )
+    }
+
+    /// Dismiss the CheckoutComponents UI
+    /// - Parameters:
+    ///   - animated: Whether to animate the dismissal
+    ///   - completion: Optional completion handler
+    @objc public static func dismiss(
+        animated: Bool = true,
+        completion: (() -> Void)? = nil
+    ) {
+        shared.dismiss(animated: animated, completion: completion)
+    }
+
+    // MARK: - Instance Methods
+
+    // MARK: - Sheet Configuration
+
+    private enum SheetSizing {
+        static let minimumHeight: CGFloat = 200
+        static let maximumScreenRatio: CGFloat = 0.9
+    }
+
+    /// Configure sheet presentation for the bridge controller
+    /// - Parameters:
+    ///   - controller: The view controller to configure
+    ///   - settings: The settings to use for configuration
+    private func configureSheetPresentation(
+        for controller: UIViewController, settings: PrimerSettings
+    ) {
+        controller.modalPresentationStyle = .pageSheet
+
+        let dismissalMechanism = settings.uiOptions.dismissalMechanism
+
+        // isModalInPresentation = true DISABLES gestures (prevents accidental dismissal)
+        // isModalInPresentation = false ENABLES gestures (allows dismissal)
+        let gesturesEnabled = dismissalMechanism.contains(.gestures)
+        controller.isModalInPresentation = !gesturesEnabled
+
+        guard let sheet = controller.sheetPresentationController else { return }
+
+        if let primerBridge = controller as? PrimerSwiftUIBridgeViewController {
+            primerBridge.customSheetPresentationController = sheet
+        }
+
+        if #available(iOS 16.0, *) {
+            let customDetent = UISheetPresentationController.Detent.custom { [weak controller] context in
+                guard let controller else { return context.maximumDetentValue }
+                let contentHeight = controller.preferredContentSize.height
+                let maxHeight = context.maximumDetentValue
+                // Allow content to determine height, but cap at maximum
+                return min(
+                    max(contentHeight, SheetSizing.minimumHeight), maxHeight * SheetSizing.maximumScreenRatio
+                )
+            }
+            sheet.detents = [customDetent, .large()]
+            sheet.selectedDetentIdentifier = customDetent.identifier
+        } else {
+            // Fallback for iOS 15: use standard detents
+            sheet.detents = [.medium(), .large()]
+        }
+        // Show grabber when gestures are enabled, hide when disabled
+        sheet.prefersGrabberVisible = gesturesEnabled
+        sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+        sheet.largestUndimmedDetentIdentifier = .medium
+    }
+
+    /// Internal method for dismissing checkout (used by CheckoutCoordinator)
+    func dismissCheckout() {
+        dismissDirectly()
+    }
+
+    func handlePaymentSuccess(_ result: PaymentResult) {
+        logger.info(message: "Payment completed: \(result.paymentId)")
+
+        dismissDirectly { [weak self] in
+            if let delegate = self?.delegate {
+                delegate.primerCheckoutPresenterDidCompleteWithSuccess(result)
+            } else {
+                self?.logger.error(message: "No delegate set for payment success")
+            }
+        }
+    }
+
+    func handlePaymentFailure(_ error: PrimerError) {
+        logger.error(message: "Payment failed: \(error)")
+
+        dismissDirectly { [weak self] in
+            if let delegate = self?.delegate {
+                delegate.primerCheckoutPresenterDidFailWithError(error)
+            } else {
+                self?.logger.error(message: "No delegate set for payment failure")
+            }
+        }
+    }
+
+    func handleCheckoutDismiss() {
+        delegate?.primerCheckoutPresenterDidDismiss()
+    }
+
+    private func presentCheckout(
+        clientToken: String,
+        from viewController: UIViewController,
+        primerSettings: PrimerSettings,
+        primerTheme: PrimerCheckoutTheme,
+        scope: ((PrimerCheckoutScope) -> Void)? = nil,
+        completion: (() -> Void)?
+    ) {
+        guard !isPresentingCheckout else {
+            logger.debug(message: "Already presenting checkout")
+            completion?()
+            return
+        }
+
+        isPresentingCheckout = true
+
+        Task { @MainActor in
+            // SDK initialization is now handled automatically by PrimerCheckout
+            let bridgeController = PrimerSwiftUIBridgeViewController.createForCheckoutComponents(
+                clientToken: clientToken,
+                settings: primerSettings,
+                theme: primerTheme,
+                diContainer: DIContainer.shared,
+                navigator: CheckoutNavigator(),
+                presentationContext: .direct,
+                integrationType: .uiKit,
+                scope: scope,
+                onCompletion: { [weak self] state in
+                    switch state {
+                    case let .success(paymentResult):
+                        self?.handlePaymentSuccess(paymentResult)
+                    case let .failure(error):
+                        self?.handlePaymentFailure(error)
+                    default:
+                        self?.dismissDirectly()
+                        self?.handleCheckoutDismiss()
+                    }
+                }
+            )
+
+            activeCheckoutController = bridgeController
+
+            configureSheetPresentation(for: bridgeController, settings: primerSettings)
+
+            viewController.present(bridgeController, animated: true) { [weak self] in
+                self?.isPresentingCheckout = false
+                completion?()
+            }
+        }
+    }
+
+    // MARK: - Direct Dismissal
+
+    func dismissDirectly(completion: (() -> Void)? = nil) {
+        if let controller = activeCheckoutController {
+            controller.dismiss(animated: true) { [weak self] in
+                self?.activeCheckoutController = nil
+                completion?()
+            }
+        } else {
+            // No controller to dismiss, call completion immediately
+            completion?()
+        }
+    }
+
+    private func dismiss(animated: Bool, completion: (() -> Void)?) {
+        guard activeCheckoutController != nil else {
+            logger.debug(message: "No active checkout to dismiss")
+            completion?()
+            return
+        }
+
+        isPresentingCheckout = false
+
+        dismissDirectly { [weak self] in
+            self?.handleCheckoutDismiss()
+            completion?()
+        }
+    }
+
+}
+
+// MARK: - Convenience Methods
+
+@available(iOS 15.0, *)
+extension PrimerCheckoutPresenter {
+
+    /// Present checkout with automatic view controller detection
+    /// - Parameters:
+    ///   - clientToken: The client token for the session
+    ///   - completion: Optional completion handler
+    @objc public static func presentCheckout(
+        clientToken: String,
+        completion: (() -> Void)? = nil
+    ) {
+        presentCheckout(
+            clientToken: clientToken,
+            primerSettings: PrimerSettings.current,
+            completion: completion
+        )
+    }
+
+    /// Present checkout with automatic view controller detection and custom settings
+    /// - Parameters:
+    ///   - clientToken: The client token for the session
+    ///   - primerSettings: Configuration settings to apply for this checkout session
+    ///   - completion: Optional completion handler
+    /// - Note: This method is not @objc compatible due to PrimerSettings parameter. For Objective-C, use the method that takes a UIViewController.
+    public static func presentCheckout(
+        clientToken: String,
+        primerSettings: PrimerSettings,
+        completion: (() -> Void)? = nil
+    ) {
+        guard let viewController = shared.findPresentingViewController() else {
+            let error = PrimerError.unableToPresentPaymentMethod(
+                paymentMethodType: "CheckoutComponents",
+                reason: "No presenting view controller found"
+            )
+
+            PrimerDelegateProxy.primerDidFailWithError(error, data: nil) { _ in
+            }
+            return
+        }
+
+        presentCheckout(
+            clientToken: clientToken,
+            from: viewController,
+            primerSettings: primerSettings,
+            completion: completion
+        )
+    }
+
+}
+
+// MARK: - Integration Helpers
+
+@available(iOS 15.0, *)
+extension PrimerCheckoutPresenter {
+
+    @objc public static var isAvailable: Bool {
+        true  // Since we're already in an @available(iOS 15.0, *) context
+    }
+
+    @objc public static var isPresenting: Bool {
+        shared.isPresentingCheckout || shared.activeCheckoutController != nil
+    }
+
+    private func findPresentingViewController() -> UIViewController? {
+        guard
+            let windowScene = UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first(where: { $0.activationState == .foregroundActive }),
+            let rootViewController = windowScene.windows.first(where: { $0.isKeyWindow })?
+                .rootViewController
+        else {
+            return nil
+        }
+
+        return findTopViewController(from: rootViewController)
+    }
+
+    private func findTopViewController(from viewController: UIViewController) -> UIViewController {
+        if let presented = viewController.presentedViewController {
+            return findTopViewController(from: presented)
+        }
+
+        if let navigation = viewController as? UINavigationController,
+           let top = navigation.topViewController {
+            return findTopViewController(from: top)
+        }
+        if let tab = viewController as? UITabBarController,
+           let selected = tab.selectedViewController {
+            return findTopViewController(from: selected)
+        }
+
+        return viewController
+    }
+}
+
+// MARK: - Delegate Integration
+
+@available(iOS 15.0, *)
+extension PrimerCheckoutPresenter {
+
+    /// Set the Primer delegate (uses the shared Primer.delegate)
+    @objc public static var delegate: PrimerDelegate? {
+        get { Primer.shared.delegate }
+        set { Primer.shared.delegate = newValue }
+    }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/README.md
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/README.md
@@ -1,0 +1,890 @@
+# CheckoutComponents
+
+A modern, scope-based payment checkout framework for iOS 15+ that provides complete UI customization.
+
+## Overview
+
+CheckoutComponents is the newest payment integration approach in the Primer iOS SDK. It provides a type-safe, scope-based architecture that allows complete customization of every UI component while maintaining sensible defaults.
+
+### Key Features
+
+- 🎨 **Full UI Customization**: Replace any UI component while keeping others
+- 🔄 **Reactive State Management**: AsyncStream-based state observation
+- 💳 **Co-Badged Cards**: Automatic network detection with user selection and surcharge support
+- 🏠 **Dynamic Billing Address**: API-driven field configuration with smart visibility
+- 🔐 **Built-in 3DS**: Automatic 3D Secure handling with delegate callbacks
+- 📱 **SwiftUI Native**: Modern Swift with async/await and ViewBuilder patterns
+- 🎯 **Type-Safe API**: Structured state management with comprehensive field validation
+- 🧩 **Modular Architecture**: Mix and match SDK components with custom UI
+- 🚀 **Smart Navigation**: Context-aware presentation and dismissal
+
+## Requirements
+
+- iOS 15.0+
+- Swift 5.5+
+- Xcode 13.0+
+
+## Installation
+
+CheckoutComponents is included in the main PrimerSDK. Follow the standard [SDK installation guide](https://primer.io/docs/sdk/ios).
+
+## Quick Start
+
+### UIKit Integration
+
+```swift
+import PrimerSDK
+
+let settings = PrimerSettings(
+    debugOptions: PrimerDebugOptions(is3DSSanityCheckEnabled: false),
+    uiOptions: PrimerUIOptions(
+        appearanceMode: .dark
+    )
+)
+
+// Present default checkout UI
+PrimerCheckoutPresenter.presentCheckout(
+    with: clientToken,
+    from: viewController,
+    primerSettings: settings
+) {
+    // Optional completion
+}
+
+// Present with custom UI via scope configuration
+PrimerCheckoutPresenter.presentCheckout(
+    clientToken: clientToken,
+    from: viewController,
+    primerSettings: settings,
+    primerTheme: PrimerCheckoutTheme(),
+    scope: { checkoutScope in
+        // Customize screens using scope properties
+        checkoutScope.paymentMethodSelection.screen = { selectionScope in
+            AnyView(CustomPaymentSelectionView(scope: selectionScope))
+        }
+    }
+)
+
+// Present card form directly
+PrimerCheckoutPresenter.presentCardForm(
+    with: clientToken,
+    from: viewController
+)
+
+// Set delegate for callbacks
+PrimerCheckoutPresenter.delegate = self
+```
+
+### SwiftUI Integration
+
+```swift
+import SwiftUI
+import PrimerSDK
+
+struct ContentView: View {
+    var body: some View {
+        PrimerCheckout(
+            clientToken: "your_client_token",
+            primerSettings: PrimerSettings(),
+            scope: { checkoutScope in
+                // Customize screens using scope properties
+                checkoutScope.paymentMethodSelection.screen = { selectionScope in
+                    AnyView(CustomPaymentSelectionView(scope: selectionScope))
+                }
+            },
+            onCompletion: { result in
+                // Handle checkout result
+            }
+        )
+    }
+}
+```
+
+### Theme Customization
+
+CheckoutComponents supports separate theme configuration:
+
+```swift
+// Create a custom theme
+let customTheme = PrimerCheckoutTheme()
+customTheme.colorScheme.primaryColor = .purple
+customTheme.cornerRadius = 12
+
+// UIKit: Pass theme separately from settings
+PrimerCheckoutPresenter.presentCheckout(
+    with: clientToken,
+    from: self,
+    primerSettings: PrimerSettings(),
+    primerTheme: customTheme
+)
+
+// SwiftUI: Pass theme to PrimerCheckout
+PrimerCheckout(
+    clientToken: clientToken,
+    primerSettings: PrimerSettings(),
+    primerTheme: customTheme
+)
+
+// Theme overrides the theme in settings if both are provided
+let settings = PrimerSettings()
+settings.uiOptions.theme = defaultTheme
+
+PrimerCheckoutPresenter.presentCheckout(
+    with: clientToken,
+    from: self,
+    primerSettings: settings,
+    primerTheme: customTheme  // ← This takes precedence
+)
+```
+
+## Customization
+
+### Scope-Based Architecture
+
+CheckoutComponents uses a hierarchical scope-based API where each major component exposes a scope interface:
+
+- **`PrimerCheckoutScope`**: Main checkout lifecycle, navigation, and screen customization
+- **`PrimerPaymentMethodSelectionScope`**: Payment method grid and selection UI
+- **`PrimerCardFormScope`**: Comprehensive card form with field-level customization
+- **`PrimerPaymentMethodScope`**: Base protocol for all payment method implementations
+
+Each scope provides:
+- State observation via AsyncStream
+- UI component customization closures
+- SDK component access via ViewBuilder methods
+- Navigation and action methods
+
+### Customizing Individual Components
+
+Use `InputFieldConfig` to customize individual fields with partial or full replacement via scope properties:
+
+```swift
+// Access card form scope and customize fields
+if let cardFormScope = checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self) {
+    // Partial customization - change label/placeholder/styling
+    cardFormScope.cardNumberConfig = InputFieldConfig(
+        label: "Card Number",
+        placeholder: "0000 0000 0000 0000",
+        styling: PrimerFieldStyling(
+            backgroundColor: .gray.opacity(0.1),
+            cornerRadius: 12
+        )
+    )
+    // Full component replacement
+    cardFormScope.cvvConfig = InputFieldConfig(
+        component: { MyCustomCVVField() }
+    )
+}
+```
+
+### Using InputFieldConfig
+
+`InputFieldConfig` supports partial customization (label, placeholder, styling) or full component replacement:
+
+```swift
+// Partial customization - SDK renders default field with custom properties
+InputFieldConfig(
+    label: "Card Number",
+    placeholder: "Enter your card number",
+    styling: PrimerFieldStyling(
+        font: .system(size: 16),
+        textColor: .primary,
+        backgroundColor: .gray.opacity(0.05),
+        borderColor: .gray.opacity(0.3),
+        focusedBorderColor: .blue,
+        errorBorderColor: .red,
+        cornerRadius: 8,
+        borderWidth: 1,
+        padding: EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16),
+        fieldHeight: 56
+    )
+)
+
+// Full component replacement
+InputFieldConfig(
+    component: { MyCustomCardNumberField() }
+)
+```
+
+### Complete Custom UI
+
+Replace screens using scope-based `.screen` properties:
+
+```swift
+PrimerCheckoutPresenter.presentCheckout(
+    clientToken: clientToken,
+    from: viewController,
+    primerSettings: settings,
+    primerTheme: PrimerCheckoutTheme(),
+    scope: { checkoutScope in
+        // Replace the payment method selection screen
+        checkoutScope.paymentMethodSelection.screen = { selectionScope in
+            AnyView(CustomPaymentSelectionScreen(
+                scope: selectionScope,
+                checkoutScope: checkoutScope
+            ))
+        }
+
+        // Replace the card form screen
+        if let cardFormScope = checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self) {
+            cardFormScope.screen = { scope in
+                AnyView(CustomCardFormScreen(scope: scope))
+            }
+        }
+
+        // Replace lifecycle screens
+        checkoutScope.splashScreen = { AnyView(CustomSplashScreen()) }
+        checkoutScope.successScreen = { result in AnyView(CustomSuccessScreen(result: result)) }
+        checkoutScope.errorScreen = { error in AnyView(CustomErrorScreen(error: error)) }
+    }
+)
+```
+
+## Card Form Customization
+
+The card form scope provides comprehensive customization with:
+- Type-safe update methods for all fields
+- Field-level and section-level UI customization
+- Built-in validation and error handling
+- Dynamic field visibility based on configuration
+
+### Update Methods
+
+```swift
+// Access card form scope
+if let cardScope = checkoutScope.getPaymentMethodScope(for: .paymentCard) as? PrimerCardFormScope {
+    // Update card details
+    cardScope.updateCardNumber("4111 1111 1111 1111")
+    cardScope.updateExpiryDate("12/25")
+    cardScope.updateCvv("123")
+    cardScope.updateCardholderName("John Doe")
+    
+    // Update billing address
+    cardScope.updateFirstName("John")
+    cardScope.updateLastName("Doe")
+    cardScope.updateEmail("john@example.com")
+    cardScope.updatePhoneNumber("+1234567890")
+    cardScope.updateAddressLine1("123 Main St")
+    cardScope.updateAddressLine2("Apt 4B")
+    cardScope.updateCity("San Francisco")
+    cardScope.updateState("CA")
+    cardScope.updatePostalCode("94105")
+    cardScope.updateCountryCode("US")
+    
+    // Select card network for co-badged cards
+    cardScope.selectCardNetwork(.visa)
+    
+    // Submit the form
+    cardScope.submit()
+}
+```
+
+### Customizable Components
+
+CheckoutComponents provides three approaches for customization:
+
+#### 1. Field-Level Customization (Replace Individual Fields)
+
+```swift
+// Access card form scope and customize via InputFieldConfig
+if let cardFormScope = checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self) {
+    // Partial customization - SDK renders default field with custom properties
+    cardFormScope.cardNumberConfig = InputFieldConfig(
+        label: "Card Number",
+        placeholder: "0000 0000 0000 0000",
+        styling: customStyling
+    )
+    cardFormScope.expiryDateConfig = InputFieldConfig(
+        label: "Expiry",
+        styling: customStyling
+    )
+    cardFormScope.cvvConfig = InputFieldConfig(
+        label: "CVV",
+        styling: customStyling
+    )
+    // Full component replacement
+    cardFormScope.cardholderNameConfig = InputFieldConfig(
+        component: { CustomCardholderNameField() }
+    )
+}
+```
+
+#### 2. Section-Level Customization (Group Multiple Fields)
+
+```swift
+// Replace entire card details or billing address sections
+cardFormScope.cardInputSection = { scope in
+    AnyView(CustomCardSection(scope: scope))
+}
+cardFormScope.billingAddressSection = { scope in
+    AnyView(CustomBillingSection(scope: scope))
+}
+```
+
+#### 3. Full Screen Customization
+
+```swift
+// Replace entire card form screen
+cardFormScope.screen = { scope in
+    AnyView(
+        VStack(spacing: 16) {
+            // Access scope for state and actions
+            scope.PrimerCardNumberField(label: "Card Number", styling: nil)
+
+            HStack(spacing: 12) {
+                scope.PrimerExpiryDateField(label: "Expiry", styling: nil)
+                scope.PrimerCvvField(label: "CVV", styling: nil)
+            }
+
+            Button("Submit") {
+                scope.onSubmit()
+            }
+        }
+    )
+}
+```
+
+All customizable fields via InputFieldConfig:
+- Card fields: cardNumber, expiryDate, cvv, cardholderName, cardNetwork, retailOutlet, otpCode
+- Billing fields: firstName, lastName, email, phoneNumber, addressLine1, addressLine2, city, state, postalCode, countryCode
+
+## State Observation
+
+Observe real-time state changes using AsyncStream:
+
+### Checkout State
+
+```swift
+Task {
+    for await state in checkoutScope.state {
+        switch state {
+        case .initializing:
+            print("Loading payment methods...")
+        case .ready:
+            print("Payment methods loaded")
+        case .error(let error):
+            print("Error: \(error.localizedDescription)")
+        case .dismissed:
+            print("Checkout dismissed")
+        }
+    }
+}
+```
+
+### Card Form State
+
+The card form provides a structured state with comprehensive field information:
+
+```swift
+Task {
+    for await formState in cardScope.state {
+        // Overall form state
+        print("Form valid: \(formState.isValid)")
+        print("Submitting: \(formState.isSubmitting)")
+        print("Submit enabled: \(formState.isSubmitEnabled)")
+        
+        // Field-specific validation
+        if let error = formState.cardNumber.error {
+            print("Card number error: \(error.localizedDescription)")
+        }
+        
+        // Co-badged card information
+        if !formState.detectedCardNetworks.isEmpty {
+            print("Available networks: \(formState.detectedCardNetworks)")
+            print("Selected: \(formState.selectedCardNetwork ?? "None")")
+        }
+        
+        // Surcharge information
+        if let surcharge = formState.surcharge {
+            print("Surcharge: \(surcharge.amount) \(surcharge.currency)")
+        }
+        
+        // Dynamic field configuration
+        print("Cardholder name required: \(formState.configuration.isCardholderNameRequired)")
+        print("Billing fields: \(formState.configuration.billingAddressFields)")
+    }
+}
+```
+
+### Field State Structure
+
+Each field in the form state includes:
+```swift
+struct FieldState<T> {
+    let value: T?              // Current field value
+    let isValid: Bool          // Validation status
+    let error: FieldError?     // Specific error if invalid
+    let isRequired: Bool       // Whether field is required
+    let isVisible: Bool        // Whether field should be shown
+}
+```
+
+## Co-Badged Cards
+
+CheckoutComponents automatically detects and handles co-badged cards with network selection and surcharge support:
+
+```swift
+// Observe co-badged card state
+Task {
+    for await state in cardScope.state {
+        // Multiple networks detected
+        if state.availableNetworks.count > 1 {
+            print("Co-badged card detected: \(state.availableNetworks)")
+
+            // Get surcharge for selected network
+            if let surcharge = state.surchargeAmount {
+                print("Surcharge: \(surcharge)")
+            }
+        }
+    }
+}
+
+// Programmatically select network
+cardScope.updateSelectedCardNetwork("mastercard")
+
+// Customize network selector via scope closure
+cardScope.cobadgedCardsView = { availableNetworks, selectNetwork in
+    CustomNetworkPicker(
+        networks: availableNetworks,
+        onSelect: selectNetwork
+    )
+}
+
+// Or customize via InputFieldConfig on the scope
+cardScope.cardNetworkConfig = InputFieldConfig(
+    component: { MyCustomNetworkSelector() }
+)
+```
+
+## Billing Address
+
+Billing address fields are dynamically configured based on API response:
+
+```swift
+// Check which fields are required
+let formConfig = cardScope.getFormConfiguration()
+print("Required billing fields: \(formConfig.billingFields)")
+
+// Fields can include: firstName, lastName, email, phoneNumber,
+// addressLine1, addressLine2, city, state, postalCode, countryCode
+
+// Customize billing address fields via InputFieldConfig on scope
+cardFormScope.firstNameConfig = InputFieldConfig(label: "First Name", styling: customStyling)
+cardFormScope.lastNameConfig = InputFieldConfig(label: "Last Name", styling: customStyling)
+cardFormScope.emailConfig = InputFieldConfig(label: "Email", styling: customStyling)
+cardFormScope.countryCodeConfig = InputFieldConfig(label: "Country", styling: customStyling)
+
+// Or replace entire billing address section
+cardFormScope.billingAddressSection = { scope in
+    AnyView(CustomBillingAddressSection(scope: scope))
+}
+```
+
+## Payment Method Selection
+
+Customize the payment method selection screen:
+
+```swift
+// Access payment method selection scope
+if let selectionScope = checkoutScope.paymentMethodSelection {
+    // Replace entire selection screen
+    selectionScope.screen = { scope in
+        CustomPaymentMethodGrid(
+            methods: scope.state.paymentMethods,
+            onSelect: scope.onPaymentMethodSelected
+        )
+    }
+
+    // Or customize individual components
+    selectionScope.paymentMethodItem = { method in
+        CustomPaymentMethodCell(
+            method: method,
+            showSurcharge: method.surcharge != nil
+        )
+    }
+
+    // Custom category headers
+    selectionScope.categoryHeader = { category in
+        Text(category.displayName)
+            .font(.headline)
+            .padding(.vertical, 8)
+    }
+
+    // Empty state when no methods available
+    selectionScope.emptyStateView = {
+        VStack {
+            Image(systemName: "creditcard.slash")
+            Text("No payment methods available")
+        }
+    }
+}
+
+// Observe selection state
+Task {
+    for await state in selectionScope.state {
+        print("Available methods: \(state.paymentMethods.count)")
+        print("Categories: \(state.categories)")
+    }
+}
+```
+
+## Error Handling
+
+CheckoutComponents uses the PrimerCheckoutPresenterDelegate protocol:
+
+```swift
+extension ViewController: PrimerCheckoutPresenterDelegate {
+    func primerCheckoutPresenterDidCompletePayment(with data: PrimerCheckoutData) {
+        print("Payment successful: \(data.payment.id)")
+        // Handle successful payment
+    }
+    
+    func primerCheckoutPresenterDidFailWithError(_ error: PrimerError, data: PrimerCheckoutData?) -> PrimerErrorDecision {
+        switch error.errorCode {
+        case .paymentFailed:
+            // Allow retry
+            return .retry
+        case .userCancelled:
+            // Dismiss checkout
+            return .fail()
+        default:
+            // Show error message
+            return .fail(withMessage: error.localizedDescription)
+        }
+    }
+    
+    func primerCheckoutPresenterDidDismiss() {
+        print("Checkout dismissed")
+    }
+    
+    // 3DS handling
+    func primerCheckoutPresenterWillPresent3DS() {
+        print("3DS challenge will be presented")
+    }
+    
+    func primerCheckoutPresenterDidPresent3DS() {
+        print("3DS challenge presented")
+    }
+    
+    func primerCheckoutPresenterWillDismiss3DS() {
+        print("3DS challenge will be dismissed")
+    }
+    
+    func primerCheckoutPresenterDidComplete3DS(with result: ThreeDSResult) {
+        print("3DS completed: \(result)")
+    }
+}
+
+// Set the delegate
+PrimerCheckoutPresenter.delegate = self
+```
+
+## Advanced Features
+
+### 3D Secure
+
+3DS is handled automatically with delegate callbacks for tracking:
+
+```swift
+// Implement delegate methods for 3DS lifecycle
+extension ViewController: PrimerCheckoutPresenterDelegate {
+    func primerCheckoutPresenterWillPresent3DS() {
+        // Prepare UI for 3DS presentation
+    }
+    
+    func primerCheckoutPresenterDidComplete3DS(with result: ThreeDSResult) {
+        switch result {
+        case .success:
+            print("3DS authentication successful")
+        case .failure(let error):
+            print("3DS failed: \(error)")
+        case .cancelled:
+            print("3DS cancelled by user")
+        }
+    }
+}
+```
+
+### Dynamic Settings Updates
+
+For advanced use cases where settings need to be updated during an active checkout session, use the `updateSettings` API:
+
+```swift
+// Update settings mid-session (rare use case)
+let updatedSettings = PrimerSettings()
+updatedSettings.uiOptions.theme = darkModeTheme
+updatedSettings.uiOptions.isSuccessScreenEnabled = false
+
+await PrimerCheckoutPresenter.updateSettings(updatedSettings)
+```
+
+**When to use dynamic updates:**
+- Switching themes based on user preference during checkout
+- Enabling/disabling screens dynamically based on flow
+- Updating debug options for testing
+
+**Which settings can be updated mid-session:**
+- UI options (theme, screen visibility, dismissal mechanism)
+- Debug options (3DS sanity check)
+- Payment method options (Apple Pay configuration, URL schemes)
+
+**Important notes:**
+- This is a rare use case - most merchants should pass settings once at initialization
+- Settings changes take effect immediately for components that observe them
+- Not all settings changes make sense mid-session (e.g., changing fundamental payment configuration)
+- If no active checkout session exists, the update will fail gracefully with an error
+
+**Best practice:**
+```swift
+// ✅ Recommended: Set settings at initialization
+let settings = PrimerSettings()
+settings.uiOptions.theme = customTheme
+PrimerCheckoutPresenter.presentCheckout(with: clientToken, from: self, settings: settings)
+
+// ❌ Avoid unless necessary: Updating settings mid-session
+// Only use when you have a specific requirement to change settings after checkout has started
+```
+
+### Navigation and Presentation Context
+
+CheckoutComponents supports smart navigation based on presentation context:
+
+```swift
+// Direct presentation
+PrimerCheckoutPresenter.presentCardForm(
+    with: clientToken,
+    from: viewController
+)
+
+// The framework tracks presentation context
+// and adjusts navigation behavior accordingly:
+// - Back button shows when navigating from payment selection
+// - Cancel button shows for direct presentation
+```
+
+### Dynamic Payment Method Registration
+
+The framework supports dynamic payment method registration:
+
+```swift
+// Payment methods are registered automatically based on configuration
+// Each payment method type has its own scope implementation
+// Access dynamically via:
+let paymentMethodScope = checkoutScope.getPaymentMethodScope(for: paymentMethodType)
+```
+
+### Field Validation
+
+Comprehensive field validation with specific error codes:
+
+```swift
+enum FieldError {
+    case required
+    case invalidFormat
+    case invalidCardNumber
+    case invalidExpiryDate
+    case invalidCvv
+    case invalidEmail
+    case custom(String)
+}
+
+// Access field errors
+if let error = cardScope.state.cardNumber.error {
+    switch error {
+    case .invalidCardNumber:
+        showError("Please enter a valid card number")
+    case .required:
+        showError("Card number is required")
+    default:
+        showError(error.localizedDescription)
+    }
+}
+```
+
+### Surcharge Support
+
+Display payment method and network-specific surcharges:
+
+```swift
+// Payment method surcharge
+if let surcharge = paymentMethod.surcharge {
+    Text("+ \(surcharge.amount) \(surcharge.currency)")
+}
+
+// Network-specific surcharges for co-badged cards
+cardScope.state.detectedCardNetworks.forEach { network in
+    if let surcharge = cardScope.state.getNetworkSurcharge(for: network) {
+        print("\(network): +\(surcharge.formatted)")
+    }
+}
+```
+
+## Integration Examples
+
+### Basic Integration
+
+```swift
+// Simplest integration - default UI
+PrimerCheckoutPresenter.delegate = self
+PrimerCheckoutPresenter.presentCheckout(
+    with: clientToken,
+    from: viewController
+)
+```
+
+### Custom Card Form
+
+```swift
+PrimerCheckoutPresenter.presentCheckout(
+    clientToken: clientToken,
+    from: viewController,
+    primerSettings: settings,
+    primerTheme: PrimerCheckoutTheme(),
+    scope: { checkoutScope in
+        // Replace the card form screen with a custom implementation
+        if let cardFormScope = checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self) {
+            cardFormScope.screen = { scope in
+                AnyView(VStack(spacing: 20) {
+                    // Custom header
+                    CustomHeaderView()
+
+                    // Mix SDK and custom components
+                    scope.PrimerCardNumberField(
+                        label: "Card Number",
+                        styling: customStyling
+                    )
+
+                    HStack {
+                        scope.PrimerExpiryDateField(styling: customStyling)
+                        scope.PrimerCvvField(styling: customStyling)
+                    }
+
+                    // Custom billing section
+                    CustomBillingAddressView(scope: scope)
+
+                    // Submit button
+                    Button(action: { scope.onSubmit() }) {
+                        Text("Pay")
+                    }
+                })
+            }
+        }
+    }
+)
+```
+
+### Complete Custom Checkout
+
+```swift
+// Custom payment selection view that receives scope as parameter
+struct CustomPaymentSelectionView: View {
+    let scope: PrimerPaymentMethodSelectionScope
+    let checkoutScope: PrimerCheckoutScope
+
+    @State private var state = PrimerPaymentMethodSelectionState()
+
+    var body: some View {
+        NavigationView {
+            VStack {
+                if state.isLoading {
+                    ProgressView()
+                } else {
+                    PaymentMethodGrid(
+                        methods: state.paymentMethods,
+                        onSelect: { method in
+                            scope.onPaymentMethodSelected(paymentMethod: method)
+                        }
+                    )
+                }
+            }
+        }
+        .task {
+            for await newState in scope.state {
+                state = newState
+            }
+        }
+    }
+}
+
+// Present with scope-based customization
+PrimerCheckoutPresenter.presentCheckout(
+    clientToken: clientToken,
+    from: viewController,
+    primerSettings: settings,
+    primerTheme: PrimerCheckoutTheme(),
+    scope: { checkoutScope in
+        checkoutScope.paymentMethodSelection.screen = { selectionScope in
+            AnyView(CustomPaymentSelectionView(
+                scope: selectionScope,
+                checkoutScope: checkoutScope
+            ))
+        }
+    }
+)
+```
+
+## Best Practices
+
+1. **State Observation**: Use AsyncStream for reactive state updates
+   ```swift
+   Task {
+       for await state in scope.state {
+           updateUI(for: state)
+       }
+   }
+   ```
+
+2. **Error Handling**: Implement PrimerCheckoutPresenterDelegate for comprehensive error handling
+   ```swift
+   func primerCheckoutPresenterDidFailWithError(_ error: PrimerError, data: PrimerCheckoutData?) -> PrimerErrorDecision {
+       // Return .retry for recoverable errors
+       // Return .fail() for terminal errors
+   }
+   ```
+
+3. **Customization Strategy**: 
+   - Start with default UI
+   - Use SDK components with custom styling for quick customization
+   - Replace individual fields only when needed
+   - Build complete custom UI only for unique requirements
+
+4. **Performance**:
+   - Reuse scope references instead of repeatedly calling `getPaymentMethodScope`
+   - Batch state updates when possible
+   - Use structured state properties instead of parsing raw values
+
+5. **Testing Considerations**:
+   - Test with various card types including co-badged cards
+   - Verify dynamic field visibility with different configurations
+   - Test error states and recovery flows
+   - Validate 3DS flows with test cards
+
+6. **Accessibility**:
+   - Maintain VoiceOver support in custom components
+   - Use semantic colors that respect Dark Mode
+   - Provide clear error messages with actionable guidance
+   - Ensure touch targets meet minimum size requirements
+
+## Migration Guide
+
+For teams migrating from other Primer checkout solutions:
+
+1. **From Drop-In Checkout**: CheckoutComponents offers the same ease of integration with added customization options
+2. **From Headless Checkout**: Use the scope-based API for similar programmatic control with better type safety
+3. **From Raw API**: CheckoutComponents handles tokenization, 3DS, and validation automatically
+
+## API Reference
+
+For the full API reference, see [API_REFERENCE.md](API_REFERENCE.md).
+
+Key source files:
+- [PrimerCheckoutPresenter](PrimerCheckoutPresenter.swift) — UIKit entry point
+- [PrimerCheckout](PrimerCheckout.swift) — SwiftUI entry point
+- [PrimerCheckoutScope](Scope/PrimerCheckoutScope.swift)
+- [PrimerCardFormScope](Scope/PrimerCardFormScope.swift)
+- [PrimerPaymentMethodSelectionScope](Scope/PrimerPaymentMethodSelectionScope.swift)
+- [PrimerCardFormState](Core/Data/PrimerCardFormState.swift)
+
+## Support
+
+For support, please refer to the [Primer documentation](https://primer.io/docs) or contact support@primer.io.


### PR DESCRIPTION
## Summary
- Add `PrimerCheckout` — the main public entry point for creating and presenting checkout flows
- Add `PrimerCheckoutPresenter` — handles presentation logic, coordinator setup, and scope lifecycle
- Add Debug App integration with CheckoutComponents demos: `DefaultCheckoutDemo`, `CustomPaymentSelectionDemo`
- Add Debug App infrastructure: `CheckoutComponentsMenuViewController`, `CheckoutComponentsExamplesView`, `DemoRegistry`, `DemoProtocol`
- Add Debug App shared components: `DemoRow`, `ErrorView`, `LoadingView`, `NetworkingUtils`, `SimpleCountryPicker`
- Update existing Debug App files (`AppDelegate`, `SceneDelegate`, storyboard, project files) for CheckoutComponents navigation
- Add `API_REFERENCE.md` and `CLAUDE.md` documentation for CheckoutComponents

## Context
PR 15 of 16 in the CheckoutComponents feature split. Depends on [PR 14](https://github.com/primer-io/primer-sdk-ios/pull/1643) (UI layer).

[Notion tracker](https://www.notion.so/32fca65dc30e81dabf66f33e2b58c3a1)

## Test plan
- [ ] Build Debug App in Xcode and verify CheckoutComponents menu appears
- [ ] Run DefaultCheckoutDemo and verify end-to-end checkout flow
- [ ] Run CustomPaymentSelectionDemo and verify custom selection flow
- [ ] Verify `PrimerCheckout` public API initializes correctly
- [ ] Verify `PrimerCheckoutPresenter` manages scope lifecycle