### PR TITLE
chore: pin iOS CI to specific Xcode and simulator versions

### DIFF
--- a/.github/actions/appetize-build/action.yml
+++ b/.github/actions/appetize-build/action.yml
@@ -60,9 +60,9 @@ runs:
   using: "composite"
   steps:
     - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd  # v1.6.0 
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
       with:
-        xcode-version: '16.4.0'
+        xcode-version: '26.2'
     - name: Install SSH key
       uses: shimataro/ssh-key-action@d4fffb50872869abe2d9a9098a6d9c5aa7d16be4 #v2.7.0
       with:
@@ -72,7 +72,7 @@ runs:
     - uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
       with:
         ssh-private-key: ${{ inputs.ssh-private-key }}
-    - uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4  # v1.255.0
+    - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64  # v1.299.0
       with:
         ruby-version: "3.2"
         bundler-cache: true

--- a/.github/actions/sdk-tests/action.yml
+++ b/.github/actions/sdk-tests/action.yml
@@ -43,9 +43,9 @@ runs:
   using: "composite"
   steps:
     - name: Select Xcode Version
-      uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
-        xcode-version: '16.4.0'
+        xcode-version: '26.2'
     - name: Install SSH key
       uses: shimataro/ssh-key-action@d4fffb50872869abe2d9a9098a6d9c5aa7d16be4 #v2.7.0
       with:
@@ -55,7 +55,7 @@ runs:
     - uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
       with:
         ssh-private-key: ${{ inputs.ssh-private-key }}
-    - uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4  # v1.255.0
+    - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64  # v1.299.0
       with:
         ruby-version: "3.2"
         bundler-cache: true

--- a/.github/workflows/build-test-upload.yml
+++ b/.github/workflows/build-test-upload.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   unit-tests-sdk-and-debug-app:
-    runs-on: macos-latest-large
+    runs-on: macos-26-xlarge
     timeout-minutes: 20
     name: "Unit Tests - SDK & Debug App"
     if: "!startsWith(github.head_ref, 'dependabot/')"
@@ -79,7 +79,7 @@ jobs:
 
   optional-sdk-tests:
     name: Optional SDK Tests
-    runs-on: macos-latest-large
+    runs-on: macos-26-xlarge
     needs: check-optional-tests
     if: needs.check-optional-tests.outputs.should-run-any == 'true'
     strategy:
@@ -121,7 +121,7 @@ jobs:
 
   spm-build:
     needs: unit-tests-sdk-and-debug-app
-    runs-on: macos-latest-large
+    runs-on: macos-26-xlarge
     timeout-minutes: 20
     name: "Build app with SPM Integration"
     steps:
@@ -132,7 +132,7 @@ jobs:
       - name: Select Xcode Version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: '16.4.0'
+          xcode-version: '26.2'
       - name: Install SSH key
         uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 #v2.8.1
         with:
@@ -164,7 +164,7 @@ jobs:
       - check-optional-tests
       - optional-sdk-tests
     name: SonarCloud
-    runs-on: macos-latest
+    runs-on: macos-26
     if: always() && !cancelled() && needs.unit-tests-sdk-and-debug-app.result == 'success' && (needs.check-optional-tests.outputs.should-run-any != 'true' || needs.optional-sdk-tests.result == 'success')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -207,7 +207,7 @@ jobs:
   build-and-upload-to-appetize:
     needs:
       - unit-tests-sdk-and-debug-app
-    runs-on: macos-latest-large
+    runs-on: macos-26-xlarge
     timeout-minutes: 45
     name: "Build and upload app to Appetize"
     steps:

--- a/.github/workflows/build-test-upload.yml
+++ b/.github/workflows/build-test-upload.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   unit-tests-sdk-and-debug-app:
-    runs-on: macos-26-xlarge
+    runs-on: macos-26-large
     timeout-minutes: 20
     name: "Unit Tests - SDK & Debug App"
     if: "!startsWith(github.head_ref, 'dependabot/')"
@@ -79,7 +79,7 @@ jobs:
 
   optional-sdk-tests:
     name: Optional SDK Tests
-    runs-on: macos-26-xlarge
+    runs-on: macos-26-large
     needs: check-optional-tests
     if: needs.check-optional-tests.outputs.should-run-any == 'true'
     strategy:
@@ -121,7 +121,7 @@ jobs:
 
   spm-build:
     needs: unit-tests-sdk-and-debug-app
-    runs-on: macos-26-xlarge
+    runs-on: macos-26-large
     timeout-minutes: 20
     name: "Build app with SPM Integration"
     steps:
@@ -207,7 +207,7 @@ jobs:
   build-and-upload-to-appetize:
     needs:
       - unit-tests-sdk-and-debug-app
-    runs-on: macos-26-xlarge
+    runs-on: macos-26-large
     timeout-minutes: 45
     name: "Build and upload app to Appetize"
     steps:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   SwiftFormat:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/pod_lint.yml
+++ b/.github/workflows/pod_lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pod-lint:
     if: ${{ github.event.pull_request.base.ref == 'master' }}
-    runs-on: macos-latest
+    runs-on: macos-26
     name: "Pod lint"
     strategy:
       fail-fast: false
@@ -25,7 +25,7 @@ jobs:
       - name: Select Xcode Version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
         with:
-            xcode-version: '16.4.0'
+            xcode-version: '26.2'
       - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64  # v1.299.0
         with:
           ruby-version: "3.2"

--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -34,7 +34,7 @@ jobs:
           bodyFile: "release.md"
   build-and-upload-to-appetize:
     if: github.head_ref == 'release/next' && github.event.pull_request.merged == true
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 20
     name: "Build and upload app to Appetize"
     steps:

--- a/.github/workflows/test-and-code-quality.yml
+++ b/.github/workflows/test-and-code-quality.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   sdk-unit-tests:
-    runs-on: macos-26-xlarge
+    runs-on: macos-26-large
     timeout-minutes: 20
     name: "SDK - Unit Tests"
     steps:
@@ -39,7 +39,7 @@ jobs:
 
   optional-sdk-tests:
     name: Optional SDK Tests
-    runs-on: macos-26-xlarge
+    runs-on: macos-26-large
     strategy:
       max-parallel: 3
       matrix:
@@ -75,7 +75,7 @@ jobs:
     needs:
       - sdk-unit-tests
       - optional-sdk-tests
-    runs-on: macos-26-xlarge
+    runs-on: macos-26-large
     name: SonarCloud
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-and-code-quality.yml
+++ b/.github/workflows/test-and-code-quality.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   sdk-unit-tests:
-    runs-on: macos-latest-large
+    runs-on: macos-26-xlarge
     timeout-minutes: 20
     name: "SDK - Unit Tests"
     steps:
@@ -39,7 +39,7 @@ jobs:
 
   optional-sdk-tests:
     name: Optional SDK Tests
-    runs-on: macos-latest-large
+    runs-on: macos-26-xlarge
     strategy:
       max-parallel: 3
       matrix:
@@ -75,7 +75,7 @@ jobs:
     needs:
       - sdk-unit-tests
       - optional-sdk-tests
-    runs-on: macos-latest-large
+    runs-on: macos-26-xlarge
     name: SonarCloud
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build-and-upload-to-appetize:
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 20
     name: "Build and upload app to Appetize"
     steps:
@@ -55,7 +55,7 @@ jobs:
           github-run-id: ${{ github.run_id }}
           stripe-publishable-key: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
   build-and-upload-to-firebase-and-lambdatest:
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 20
     name: "Distribute app to Firebase and LambdaTest"
     outputs:
@@ -74,7 +74,7 @@ jobs:
       - name: Select Xcode Version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
         with:
-          xcode-version: '16.4.0'
+          xcode-version: '26.2'
 
       - name: Install SSH key
         uses: shimataro/ssh-key-action@87a8f067114a8ce263df83e9ed5c849953548bc3 #v2.8.1

--- a/.github/workflows/xcode-versions-build.yml
+++ b/.github/workflows/xcode-versions-build.yml
@@ -11,15 +11,15 @@ on:
 jobs:
   build:
     name: "Build App"
-    runs-on: macos-latest
+    runs-on: macos-26
     strategy:
       max-parallel: 3
       matrix:
-        variant: 
+        variant:
           - cocoapods
           - spm
         xcode:
-          - '16.4.0'
+          - '26.2'
     steps:
       - name: Git - Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,7 +62,7 @@ jobs:
       - name: Build and archive app via SPM
         if: ${{ matrix.variant == 'spm' }}
         run: |
-          bundle exec fastlane test_sdk sim_version:18.5
+          bundle exec fastlane test_sdk sim_version:26.2
         env:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
@@ -86,7 +86,7 @@ jobs:
   success:
     name: Report Success
     needs: build
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Git - Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,7 +20,7 @@ spm_app_xcode_proj = "Debug App/Primer.io Debug App SPM.xcodeproj"
 
 info_plist_path = "Debug App/Info.plist"
 
-default_sim_version = "18.5"
+default_sim_version = "26.2"
 
 # Packages
 app_output_path = "/var/tmp/Primer.io_Debug_App.xcarchive/Products/Applications/Debug App.app"
@@ -59,14 +59,14 @@ platform :ios do
 
     run_tests(workspace: app_workspace,
               scheme: "PrimerSDKTests",
-              destination: "platform=iOS Simulator,name=iPhone 16",
+              destination: "platform=iOS Simulator,name=iPhone 17 Pro",
               xcargs: "EXCLUDED_ARCHS[sdk=iphonesimulator*]=arm64",
               skip_package_dependencies_resolution: true)
   end
 
   lane :ui_tests do
     run_tests(workspace: app_workspace,
-              devices: ["iPhone SE", "iPhone 16"])
+              devices: ["iPhone SE", "iPhone 17 Pro"])
   end
 
   lane :danger_check do
@@ -126,7 +126,7 @@ platform :ios do
       package_path: ".",
       scheme: "PrimerSDKTests",
       sdk: "iphonesimulator#{sim_version}",
-      destination: "OS=#{sim_version},name=iPhone 16",
+      destination: "OS=#{sim_version},name=iPhone 17 Pro",
       result_bundle: true,
       code_coverage: true,
       output_directory: Dir.pwd + "/test_output"
@@ -150,7 +150,7 @@ platform :ios do
       scheme: app_scheme,
       configuration: "Debug",
       sdk: "iphonesimulator#{sim_version}",
-      destination: "OS=#{sim_version},name=iPhone 16",
+      destination: "OS=#{sim_version},name=iPhone 17 Pro",
       result_bundle: true,
       code_coverage: true,
       clean: true,
@@ -167,7 +167,7 @@ platform :ios do
       package_path: ".",
       scheme: "PrimerSDKTests",
       sdk: "iphonesimulator#{sim_version}",
-      destination: "OS=#{sim_version},name=iPhone 16",
+      destination: "OS=#{sim_version},name=iPhone 17 Pro",
       result_bundle: true,
       code_coverage: true,
       output_directory: Dir.pwd + "/test_output"
@@ -177,7 +177,7 @@ platform :ios do
       package_path: ".",
       scheme: "DebugAppTests",
       sdk: "iphonesimulator#{sim_version}",
-      destination: "OS=#{sim_version},name=iPhone 16",
+      destination: "OS=#{sim_version},name=iPhone 17 Pro",
       result_bundle: true,
       code_coverage: true,
       output_directory: Dir.pwd + "/test_output"


### PR DESCRIPTION
# Description

[ACC-7057](https://primerapi.atlassian.net/browse/ACC-7057)

- Pin all iOS CI configuration to specific versions instead of using dynamic values (`macos-latest`, `macos-latest-large`)
- Xcode: `16.4.0` → `26.2`
- macOS runners: `macos-latest` → `macos-26`, `macos-latest-large` → `macos-26-xlarge`
- iOS Simulator: `18.5` → `26.2`, `iPhone 16` → `iPhone 17 Pro`
- Bump `setup-xcode` `v1.6.0` → `v1.7.0` and `ruby/setup-ruby` `v1.255.0` → `v1.299.0` in action files

# Contributor Checklist

- [ ] All status checks have passed prior to code review
- [ ] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable
- [ ] I have manually tested newly added UX
- [ ] I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ] I have verified that a suitable set of automated tests has been added
- [ ] I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ] I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ] If introducing a breaking change, I have communicated it internally
- [ ] Any related documentation PRs are ready to merge

[ACC-7057]: https://primerapi.atlassian.net/browse/ACC-7057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ