### PR TITLE
feat: Add MOLLIE_GIFTCARD payment method type

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -99,6 +99,8 @@ extension PrimerPaymentMethodType {
     // Mollie payment methods
     case .mollieBankcontact:
       UIImage(primerResource: "bancontact-card-logo-colored")
+    case .mollieGiftcard:
+      ImageName.genericCard.image
     case .mollieIdeal:
       UIImage(primerResource: "ideal-icon-colored")
 

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
@@ -66,6 +66,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
     case iPay88Card                     = "IPAY88_CARD"
     case klarna                         = "KLARNA"
     case mollieBankcontact              = "MOLLIE_BANCONTACT"
+    case mollieGiftcard                 = "MOLLIE_GIFTCARD"
     case mollieIdeal                    = "MOLLIE_IDEAL"
     case opennode                       = "OPENNODE"
     case payNLBancontact                = "PAY_NL_BANCONTACT"
@@ -136,6 +137,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
             "IPAY88"
 
         case .mollieBankcontact,
+             .mollieGiftcard,
              .mollieIdeal:
             "MOLLIE"
 

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -755,6 +755,8 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
             return nil
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
+        case .mollieGiftcard:
+            return nil
         }
     }
 

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -217,6 +217,10 @@ final class PrimerPaymentMethodTypeIconTests: XCTestCase {
         XCTAssertNotNil(PrimerPaymentMethodType.mollieBankcontact.icon)
     }
 
+    func test_icon_mollieGiftcard_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.mollieGiftcard.icon)
+    }
+
     func test_icon_mollieIdeal_returnsNonNilImage() {
         XCTAssertNotNil(PrimerPaymentMethodType.mollieIdeal.icon)
     }


### PR DESCRIPTION
## Summary
- Add `mollieGiftcard` case to `PrimerPaymentMethodType` enum with raw value `MOLLIE_GIFTCARD`
- Add provider mapping to `"MOLLIE"` group
- Add icon fallback in CheckoutComponents `PrimerPaymentMethodType+ImageName` extension
- Add exhaustive switch case in `UserInterfaceModule.displayMetadata`
- Add unit test for icon property

The actual payment flow is handled automatically by the existing WebRedirect infrastructure — when the backend returns this type with `implementationType: WEB_REDIRECT`, it gets dynamically registered and uses the generic redirect + polling flow.

## Jira
[ACC-7023](https://primerapi.atlassian.net/browse/ACC-7023)

## Test plan
- [x] `test_icon_mollieGiftcard_returnsNonNilImage` passes
- [ ] Verify MOLLIE_GIFTCARD appears in payment method selection when backend config includes it
- [ ] Verify redirect to Mollie's hosted gift card page works end-to-end

[ACC-7023]: https://primerapi.atlassian.net/browse/ACC-7023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ