### PR TITLE
refactor: Run SwiftFormat on PrimerAPIClient

### DIFF
--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
@@ -40,8 +40,10 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         return true
     }
 
-    func fetchVaultedPaymentMethods(clientToken: DecodedJWTToken,
-                                    completion: @escaping APICompletion<Response.Body.VaultedPaymentMethods>) {
+    func fetchVaultedPaymentMethods(
+        clientToken: DecodedJWTToken,
+        completion: @escaping APICompletion<Response.Body.VaultedPaymentMethods>
+    ) {
         let endpoint = PrimerAPI.fetchVaultedPaymentMethods(clientToken: clientToken)
         networkService.request(endpoint) { (result: Result<Response.Body.VaultedPaymentMethods, Error>) in
             switch result {
@@ -68,9 +70,11 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         vaultedPaymentMethodAdditionalData: PrimerVaultedPaymentMethodAdditionalData?,
         completion: @escaping APICompletion<PrimerPaymentMethodTokenData>
     ) {
-        let endpoint = PrimerAPI.exchangePaymentMethodToken(clientToken: clientToken,
-                                                            vaultedPaymentMethodId: vaultedPaymentMethodId,
-                                                            vaultedPaymentMethodAdditionalData: vaultedPaymentMethodAdditionalData)
+        let endpoint = PrimerAPI.exchangePaymentMethodToken(
+            clientToken: clientToken,
+            vaultedPaymentMethodId: vaultedPaymentMethodId,
+            vaultedPaymentMethodAdditionalData: vaultedPaymentMethodAdditionalData
+        )
         execute(endpoint, completion: completion)
     }
 
@@ -112,9 +116,11 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         }
     }
 
-    func fetchConfiguration(clientToken: DecodedJWTToken,
-                            requestParameters: Request.URLParameters.Configuration?,
-                            completion: @escaping ConfigurationCompletion) {
+    func fetchConfiguration(
+        clientToken: DecodedJWTToken,
+        requestParameters: Request.URLParameters.Configuration?,
+        completion: @escaping ConfigurationCompletion
+    ) {
         let endpoint = PrimerAPI.fetchConfiguration(clientToken: clientToken, requestParameters: requestParameters)
         let retryConfig = RetryConfig(enabled: true)
         networkService.request(endpoint, retryConfig: retryConfig) { (result: Result<PrimerAPIConfiguration, Error>, headers) in
@@ -146,9 +152,11 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         }
     }
 
-    func createPayPalOrderSession(clientToken: DecodedJWTToken,
-                                  payPalCreateOrderRequest: Request.Body.PayPal.CreateOrder,
-                                  completion: @escaping APICompletion<Response.Body.PayPal.CreateOrder>) {
+    func createPayPalOrderSession(
+        clientToken: DecodedJWTToken,
+        payPalCreateOrderRequest: Request.Body.PayPal.CreateOrder,
+        completion: @escaping APICompletion<Response.Body.PayPal.CreateOrder>
+    ) {
         let endpoint = PrimerAPI.createPayPalOrderSession(clientToken: clientToken, payPalCreateOrderRequest: payPalCreateOrderRequest)
         execute(endpoint, completion: completion)
     }
@@ -165,11 +173,15 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func createPayPalBillingAgreementSession(clientToken: DecodedJWTToken,
-                                             payPalCreateBillingAgreementRequest: Request.Body.PayPal.CreateBillingAgreement,
-                                             completion: @escaping APICompletion<Response.Body.PayPal.CreateBillingAgreement>) {
-        let endpoint = PrimerAPI.createPayPalBillingAgreementSession(clientToken: clientToken,
-                                                                     payPalCreateBillingAgreementRequest: payPalCreateBillingAgreementRequest)
+    func createPayPalBillingAgreementSession(
+        clientToken: DecodedJWTToken,
+        payPalCreateBillingAgreementRequest: Request.Body.PayPal.CreateBillingAgreement,
+        completion: @escaping APICompletion<Response.Body.PayPal.CreateBillingAgreement>
+    ) {
+        let endpoint = PrimerAPI.createPayPalBillingAgreementSession(
+            clientToken: clientToken,
+            payPalCreateBillingAgreementRequest: payPalCreateBillingAgreementRequest
+        )
         execute(endpoint, completion: completion)
     }
 
@@ -185,11 +197,15 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func confirmPayPalBillingAgreement(clientToken: DecodedJWTToken,
-                                       payPalConfirmBillingAgreementRequest: Request.Body.PayPal.ConfirmBillingAgreement,
-                                       completion: @escaping APICompletion<Response.Body.PayPal.ConfirmBillingAgreement>) {
-        let endpoint = PrimerAPI.confirmPayPalBillingAgreement(clientToken: clientToken,
-                                                               payPalConfirmBillingAgreementRequest: payPalConfirmBillingAgreementRequest)
+    func confirmPayPalBillingAgreement(
+        clientToken: DecodedJWTToken,
+        payPalConfirmBillingAgreementRequest: Request.Body.PayPal.ConfirmBillingAgreement,
+        completion: @escaping APICompletion<Response.Body.PayPal.ConfirmBillingAgreement>
+    ) {
+        let endpoint = PrimerAPI.confirmPayPalBillingAgreement(
+            clientToken: clientToken,
+            payPalConfirmBillingAgreementRequest: payPalConfirmBillingAgreementRequest
+        )
         execute(endpoint, completion: completion)
     }
 
@@ -208,9 +224,12 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
     func createKlarnaPaymentSession(
         clientToken: DecodedJWTToken,
         klarnaCreatePaymentSessionAPIRequest: Request.Body.Klarna.CreatePaymentSession,
-        completion: @escaping APICompletion<Response.Body.Klarna.PaymentSession>) {
-        let endpoint = PrimerAPI.createKlarnaPaymentSession(clientToken: clientToken,
-                                                            klarnaCreatePaymentSessionAPIRequest: klarnaCreatePaymentSessionAPIRequest)
+        completion: @escaping APICompletion<Response.Body.Klarna.PaymentSession>
+    ) {
+        let endpoint = PrimerAPI.createKlarnaPaymentSession(
+            clientToken: clientToken,
+            klarnaCreatePaymentSessionAPIRequest: klarnaCreatePaymentSessionAPIRequest
+        )
         execute(endpoint, completion: completion)
     }
 
@@ -226,11 +245,15 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func createKlarnaCustomerToken(clientToken: DecodedJWTToken,
-                                   klarnaCreateCustomerTokenAPIRequest: Request.Body.Klarna.CreateCustomerToken,
-                                   completion: @escaping APICompletion<Response.Body.Klarna.CustomerToken>) {
-        let endpoint = PrimerAPI.createKlarnaCustomerToken(clientToken: clientToken,
-                                                           klarnaCreateCustomerTokenAPIRequest: klarnaCreateCustomerTokenAPIRequest)
+    func createKlarnaCustomerToken(
+        clientToken: DecodedJWTToken,
+        klarnaCreateCustomerTokenAPIRequest: Request.Body.Klarna.CreateCustomerToken,
+        completion: @escaping APICompletion<Response.Body.Klarna.CustomerToken>
+    ) {
+        let endpoint = PrimerAPI.createKlarnaCustomerToken(
+            clientToken: clientToken,
+            klarnaCreateCustomerTokenAPIRequest: klarnaCreateCustomerTokenAPIRequest
+        )
         execute(endpoint, completion: completion)
     }
 
@@ -246,11 +269,15 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func finalizeKlarnaPaymentSession(clientToken: DecodedJWTToken,
-                                      klarnaFinalizePaymentSessionRequest: Request.Body.Klarna.FinalizePaymentSession,
-                                      completion: @escaping APICompletion<Response.Body.Klarna.CustomerToken>) {
-        let endpoint = PrimerAPI.finalizeKlarnaPaymentSession(clientToken: clientToken,
-                                                              klarnaFinalizePaymentSessionRequest: klarnaFinalizePaymentSessionRequest)
+    func finalizeKlarnaPaymentSession(
+        clientToken: DecodedJWTToken,
+        klarnaFinalizePaymentSessionRequest: Request.Body.Klarna.FinalizePaymentSession,
+        completion: @escaping APICompletion<Response.Body.Klarna.CustomerToken>
+    ) {
+        let endpoint = PrimerAPI.finalizeKlarnaPaymentSession(
+            clientToken: clientToken,
+            klarnaFinalizePaymentSessionRequest: klarnaFinalizePaymentSessionRequest
+        )
         execute(endpoint, completion: completion)
     }
 
@@ -269,7 +296,8 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
     func listAdyenBanks(
         clientToken: DecodedJWTToken,
         request: Request.Body.Adyen.BanksList,
-        completion: @escaping APICompletion<BanksListSessionResponse>) {
+        completion: @escaping APICompletion<BanksListSessionResponse>
+    ) {
         let endpoint = PrimerAPI.listAdyenBanks(clientToken: clientToken, request: request)
         execute(endpoint, completion: completion)
     }
@@ -286,9 +314,11 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func listRetailOutlets(clientToken: DecodedJWTToken,
-                           paymentMethodId: String,
-                           completion: @escaping APICompletion<RetailOutletsList>) {
+    func listRetailOutlets(
+        clientToken: DecodedJWTToken,
+        paymentMethodId: String,
+        completion: @escaping APICompletion<RetailOutletsList>
+    ) {
         let endpoint = PrimerAPI.listRetailOutlets(clientToken: clientToken, paymentMethodId: paymentMethodId)
         execute(endpoint, completion: completion)
     }
@@ -313,7 +343,8 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
     ) {
         networkService.request(
             PrimerAPI.poll(clientToken: clientToken, url: url),
-            retryConfig: retryConfig) { (result: Result<PollingResponse, Error>, _) in
+            retryConfig: retryConfig
+        ) { (result: Result<PollingResponse, Error>, _) in
                 switch result {
                 case let .success(response): completion(.success(response))
                 case let .failure(error): completion(.failure(handled(error: error)))
@@ -333,9 +364,11 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func requestPrimerConfigurationWithActions(clientToken: DecodedJWTToken,
-                                               request: ClientSessionUpdateRequest,
-                                               completion: @escaping ConfigurationCompletion) {
+    func requestPrimerConfigurationWithActions(
+        clientToken: DecodedJWTToken,
+        request: ClientSessionUpdateRequest,
+        completion: @escaping ConfigurationCompletion
+    ) {
         let endpoint = PrimerAPI.requestPrimerConfigurationWithActions(clientToken: clientToken, request: request)
         networkService.request(endpoint) { (result: Result<PrimerAPIConfiguration, Error>, headers) in
             switch result {
@@ -365,10 +398,12 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         }
     }
 
-    func sendAnalyticsEvents(clientToken: DecodedJWTToken?,
-                             url: URL,
-                             body: [Analytics.Event]?,
-                             completion: @escaping APICompletion<Analytics.Service.Response>) {
+    func sendAnalyticsEvents(
+        clientToken: DecodedJWTToken?,
+        url: URL,
+        body: [Analytics.Event]?,
+        completion: @escaping APICompletion<Analytics.Service.Response>
+    ) {
         let endpoint = PrimerAPI.sendAnalyticsEvents(clientToken: clientToken, url: url, body: body)
         execute(endpoint, completion: completion)
     }
@@ -387,11 +422,15 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func fetchPayPalExternalPayerInfo(clientToken: DecodedJWTToken,
-                                      payPalExternalPayerInfoRequestBody: Request.Body.PayPal.PayerInfo,
-                                      completion: @escaping APICompletion<Response.Body.PayPal.PayerInfo>) {
-        let endpoint = PrimerAPI.fetchPayPalExternalPayerInfo(clientToken: clientToken,
-                                                              payPalExternalPayerInfoRequestBody: payPalExternalPayerInfoRequestBody)
+    func fetchPayPalExternalPayerInfo(
+        clientToken: DecodedJWTToken,
+        payPalExternalPayerInfoRequestBody: Request.Body.PayPal.PayerInfo,
+        completion: @escaping APICompletion<Response.Body.PayPal.PayerInfo>
+    ) {
+        let endpoint = PrimerAPI.fetchPayPalExternalPayerInfo(
+            clientToken: clientToken,
+            payPalExternalPayerInfoRequestBody: payPalExternalPayerInfoRequestBody
+        )
         execute(endpoint, completion: completion)
     }
 
@@ -407,8 +446,10 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func validateClientToken(request: Request.Body.ClientTokenValidation,
-                             completion: @escaping APICompletion<SuccessResponse>) {
+    func validateClientToken(
+        request: Request.Body.ClientTokenValidation,
+        completion: @escaping APICompletion<SuccessResponse>
+    ) {
         let endpoint = PrimerAPI.validateClientToken(request: request)
         execute(endpoint, completion: completion)
     }
@@ -421,9 +462,11 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func createPayment(clientToken: DecodedJWTToken,
-                       paymentRequestBody: Request.Body.Payment.Create,
-                       completion: @escaping APICompletion<Response.Body.Payment>) {
+    func createPayment(
+        clientToken: DecodedJWTToken,
+        paymentRequestBody: Request.Body.Payment.Create,
+        completion: @escaping APICompletion<Response.Body.Payment>
+    ) {
         let endpoint = PrimerAPI.createPayment(clientToken: clientToken, paymentRequest: paymentRequestBody)
         execute(endpoint, completion: completion)
     }
@@ -440,10 +483,12 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func resumePayment(clientToken: DecodedJWTToken,
-                       paymentId: String,
-                       paymentResumeRequest: Request.Body.Payment.Resume,
-                       completion: @escaping APICompletion<Response.Body.Payment>) {
+    func resumePayment(
+        clientToken: DecodedJWTToken,
+        paymentId: String,
+        paymentResumeRequest: Request.Body.Payment.Resume,
+        completion: @escaping APICompletion<Response.Body.Payment>
+    ) {
         let endpoint = PrimerAPI.resumePayment(clientToken: clientToken, paymentId: paymentId, paymentResumeRequest: paymentResumeRequest)
         execute(endpoint, completion: completion)
     }
@@ -462,10 +507,12 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func completePayment(clientToken: DecodedJWTToken,
-                         url: URL,
-                         paymentRequest: Request.Body.Payment.Complete,
-                         completion: @escaping APICompletion<Response.Body.Complete>) {
+    func completePayment(
+        clientToken: DecodedJWTToken,
+        url: URL,
+        paymentRequest: Request.Body.Payment.Complete,
+        completion: @escaping APICompletion<Response.Body.Complete>
+    ) {
         let endpoint = PrimerAPI.completePayment(clientToken: clientToken, url: url, paymentRequest: paymentRequest)
         execute(endpoint, completion: completion)
     }
@@ -508,9 +555,11 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func listCardNetworks(clientToken: DecodedJWTToken,
-                          bin: String,
-                          completion: @escaping APICompletion<Response.Body.Bin.Networks>) -> PrimerCancellable? {
+    func listCardNetworks(
+        clientToken: DecodedJWTToken,
+        bin: String,
+        completion: @escaping APICompletion<Response.Body.Bin.Networks>
+    ) -> PrimerCancellable? {
         let endpoint = PrimerAPI.listCardNetworks(clientToken: clientToken, bin: bin)
         return execute(endpoint) { (result: Result<Response.Body.Bin.Data, Error>) in
             completion(result.map { Response.Body.Bin.Networks(from: $0) })
@@ -542,9 +591,11 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func fetchNolSdkSecret(clientToken: DecodedJWTToken,
-                           paymentRequestBody: Request.Body.NolPay.NolPaySecretDataRequest,
-                           completion: @escaping APICompletion<Response.Body.NolPay.NolPaySecretDataResponse>) {
+    func fetchNolSdkSecret(
+        clientToken: DecodedJWTToken,
+        paymentRequestBody: Request.Body.NolPay.NolPaySecretDataRequest,
+        completion: @escaping APICompletion<Response.Body.NolPay.NolPaySecretDataResponse>
+    ) {
         let endpoint = PrimerAPI.getNolSdkSecret(clientToken: clientToken, request: paymentRequestBody)
         execute(endpoint, completion: completion)
     }
@@ -561,11 +612,15 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
-    func getPhoneMetadata(clientToken: DecodedJWTToken,
-                          paymentRequestBody: Request.Body.PhoneMetadata.PhoneMetadataDataRequest,
-                          completion: @escaping APICompletion<Response.Body.PhoneMetadata.PhoneMetadataDataResponse>) {
-        let endpoint = PrimerAPI.getPhoneMetadata(clientToken: clientToken,
-                                                  request: paymentRequestBody)
+    func getPhoneMetadata(
+        clientToken: DecodedJWTToken,
+        paymentRequestBody: Request.Body.PhoneMetadata.PhoneMetadataDataRequest,
+        completion: @escaping APICompletion<Response.Body.PhoneMetadata.PhoneMetadataDataResponse>
+    ) {
+        let endpoint = PrimerAPI.getPhoneMetadata(
+            clientToken: clientToken,
+            request: paymentRequestBody
+        )
         execute(endpoint, completion: completion)
     }
 


### PR DESCRIPTION
This prevents a needlessly large diff on an upcoming BDC PR