### PR TITLE
chore: Add ability to send generic events

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEventProtocol.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsEventProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  AnalyticsEventProtocol.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+protocol AnalyticsEvent: Sendable {
+    var analyticsUrl: String? { get }
+    var localId: String { get }
+    var createdAt: Int { get }
+}
+
+extension Analytics.Event: AnalyticsEvent {}

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
@@ -10,10 +10,10 @@
 import Foundation
 
 protocol AnalyticsServiceProtocol: Actor {
-    func record(events: [Analytics.Event]) async throws
-    func fire(events: [Analytics.Event])
-    func record(event: Analytics.Event) async throws
-    func fire(event: Analytics.Event)
+    func record(events: [any AnalyticsEvent]) async throws
+    func fire(events: [any AnalyticsEvent])
+    func record(event: any AnalyticsEvent) async throws
+    func fire(event: any AnalyticsEvent)
 }
 
 extension Analytics {
@@ -25,10 +25,12 @@ extension Analytics {
         static let maximumBatchSize: UInt = 100
 
         static var shared = {
-            Service(sdkLogsUrl: Service.defaultSdkLogsUrl,
-                    batchSize: Service.maximumBatchSize,
-                    storage: Analytics.storage,
-                    apiClient: Analytics.apiClient ?? PrimerAPIClient())
+            Service(
+                sdkLogsUrl: Service.defaultSdkLogsUrl,
+                batchSize: Service.maximumBatchSize,
+                storage: Analytics.storage,
+                apiClient: Analytics.apiClient ?? PrimerAPIClient()
+            )
         }()
 
         let sdkLogsUrl: URL
@@ -43,27 +45,30 @@ extension Analytics {
 
         private var isSyncing: Bool = false
 
-        init(sdkLogsUrl: URL,
-             batchSize: UInt,
-             storage: Storage,
-             apiClient: PrimerAPIClientAnalyticsProtocol) {
+        init(
+            sdkLogsUrl: URL,
+            batchSize: UInt,
+            storage: Storage,
+            apiClient: PrimerAPIClientAnalyticsProtocol
+        ) {
             self.sdkLogsUrl = sdkLogsUrl
             self.batchSize = batchSize
             self.storage = storage
             self.apiClient = apiClient
         }
 
-        func record(events: [Analytics.Event]) async throws {
-            let storedEvents: [Analytics.Event] = storage.loadEvents()
+        func record(events: [any AnalyticsEvent]) async throws {
+            let events = events.map(StoredEvent.init)
+            let storedEvents = storage.loadEvents()
             let storedEventsIds = storedEvents.map(\.localId)
-            var eventsToAppend: [Analytics.Event] = []
+            var eventsToAppend: [StoredEvent] = []
 
             for event in events {
                 if storedEventsIds.contains(event.localId) { continue }
                 eventsToAppend.append(event)
             }
 
-            var combinedEvents: [Analytics.Event] = eventsToAppend.sorted(by: { $0.createdAt > $1.createdAt })
+            var combinedEvents: [StoredEvent] = eventsToAppend.sorted(by: { $0.createdAt > $1.createdAt })
             combinedEvents.append(contentsOf: storedEvents)
 
             logger.debug(message: "📚 Analytics: Recording \(events.count) events (new total: \(combinedEvents.count))")
@@ -100,17 +105,17 @@ extension Analytics {
             }
         }
 
-        func fire(events: [Analytics.Event]) {
+        func fire(events: [any AnalyticsEvent]) {
             Task {
                 try? await self.record(events: events)
             }
         }
 
-        func record(event: Analytics.Event) async throws {
+        func record(event: any AnalyticsEvent) async throws {
             try await record(events: [event])
         }
 
-        func fire(event: Analytics.Event) {
+        func fire(event: any AnalyticsEvent) {
             Task {
                 try? await self.record(events: [event])
             }
@@ -126,7 +131,7 @@ extension Analytics {
             }
         }
 
-        private func sync(events: [Analytics.Event], isFlush: Bool = false) async throws {
+        private func sync(events: [StoredEvent], isFlush: Bool = false) async throws {
             let syncType = isFlush ? "flush" : "sync"
             guard !events.isEmpty else { return logger.warn(message: "📚 Analytics: Attempted to \(syncType) but had no events")}
 
@@ -152,16 +157,20 @@ extension Analytics {
             storage.deleteAnalyticsFile()
         }
 
-        private func sendSdkLogEvents(events: [Analytics.Event]) async throws {
-            let sdkLogEvents = events.filter { $0.analyticsUrl == nil }
-            let sdkLogEventsBatches = sdkLogEvents.toBatches(of: batchSize)
+        private func sendSdkLogEvents(events: [StoredEvent]) async throws {
+            let (sdkEvents, rawEvents) = events
+                .filter { $0.analyticsUrl == nil }
+                .partitioned()
 
-            for batch in sdkLogEventsBatches {
+            for batch in sdkEvents.toBatches(of: batchSize) {
                 try await sendEvents(batch, to: sdkLogsUrl)
+            }
+            if !rawEvents.isEmpty {
+                try await sendRawEvents(rawEvents, to: sdkLogsUrl)
             }
         }
 
-        private func sendSdkAnalyticsEvents(events: [Analytics.Event]) async throws {
+        private func sendSdkAnalyticsEvents(events: [StoredEvent]) async throws {
             let events = events.filter { $0.analyticsUrl != nil }
             let urls = Set(events.compactMap(\.analyticsUrl).compactMap(URL.init))
             let eventSets = urls.map { url in
@@ -178,10 +187,13 @@ extension Analytics {
             }
         }
 
-        private func sendSdkAnalyticsEvents(url: URL, events: [Analytics.Event]) async throws {
-            let batches = events.toBatches(of: batchSize)
-            for batch in batches {
+        private func sendSdkAnalyticsEvents(url: URL, events: [StoredEvent]) async throws {
+            let (sdkEvents, rawEvents) = events.partitioned()
+            for batch in sdkEvents.toBatches(of: batchSize) {
                 try await sendEvents(batch, to: url)
+            }
+            if !rawEvents.isEmpty {
+                try await sendRawEvents(rawEvents, to: url)
             }
         }
 
@@ -218,7 +230,7 @@ extension Analytics {
                     let messageContent = "\(events.count) events on URL \(url.absoluteString)"
                     switch result {
                     case .success:
-                        self.storage.delete(events)
+                        self.storage.delete(events.map(StoredEvent.sdk))
                         self.logger.debug(message: "📚 Analytics: Finished sending \(messageContent)")
                         completion(nil)
                     case let .failure(err):
@@ -242,6 +254,13 @@ extension Analytics {
             }
         }
 
+        private func sendRawEvents(_ events: [RawAnalyticsEvent], to url: URL) async throws {
+            guard !events.isEmpty else { return }
+            let data = try JSONEncoder().encode(events.map(\.payload))
+            _ = try await apiClient.sendRawAnalyticsEvents(url: url, body: data)
+            storage.delete(events.map(StoredEvent.raw))
+        }
+
         private func handleFailedEvents(forUrl url: URL) {
             self.eventSendFailureCount += 1
             if eventSendFailureCount >= 3 {
@@ -262,6 +281,22 @@ extension Analytics {
 }
 
 extension Analytics.Service {
+    static func record(event: any AnalyticsEvent) async throws {
+        try await shared.record(event: event)
+    }
+
+    static func fire(event: any AnalyticsEvent) {
+        Task { await shared.fire(event: event) }
+    }
+
+    static func record(events: [any AnalyticsEvent]) async throws {
+        try await shared.record(events: events)
+    }
+
+    static func fire(events: [any AnalyticsEvent]) {
+        Task { await shared.fire(events: events) }
+    }
+
     static func record(event: Analytics.Event) async throws {
         try await shared.record(event: event)
     }

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsStorage.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsStorage.swift
@@ -6,16 +6,18 @@
 
 import Foundation
 
-private let analyticsFileURL: URL = FileManager.default.urls(for: .documentDirectory,
-                                                             in: .userDomainMask)[0].appendingPathComponent("analytics")
+private let analyticsFileURL: URL = FileManager.default.urls(
+    for: .documentDirectory,
+    in: .userDomainMask
+)[0].appendingPathComponent("analytics")
 
 protocol AnalyticsStorage: Sendable {
 
-    func loadEvents() -> [Analytics.Event]
+    func loadEvents() -> [StoredEvent]
 
-    func save(_ events: [Analytics.Event]) throws
+    func save(_ events: [StoredEvent]) throws
 
-    func delete(_ events: [Analytics.Event])
+    func delete(_ events: [StoredEvent])
 
     func delete(eventsWithUrl url: URL)
 
@@ -36,14 +38,14 @@ extension Analytics {
             self.fileURL = fileURL
         }
 
-        func loadEvents() -> [Analytics.Event] {
+        func loadEvents() -> [StoredEvent] {
             do {
                 guard FileManager.default.fileExists(atPath: fileURL.path) else {
                     return []
                 }
 
                 let eventsData = try Data(contentsOf: fileURL)
-                let events = try JSONDecoder().decode([Analytics.Event].self, from: eventsData)
+                let events = try JSONDecoder().decode([StoredEvent].self, from: eventsData)
                 let sortedEvents = events.sorted(by: { $0.createdAt > $1.createdAt })
                 return sortedEvents
 
@@ -54,7 +56,7 @@ extension Analytics {
             }
         }
 
-        func save(_ events: [Analytics.Event]) throws {
+        func save(_ events: [StoredEvent]) throws {
             do {
                 let eventsData = try JSONEncoder().encode(events)
                 try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -65,7 +67,7 @@ extension Analytics {
             }
         }
 
-        func delete(_ events: [Analytics.Event]) {
+        func delete(_ events: [StoredEvent]) {
             guard !events.isEmpty else {
                 logger.warn(message: "📚 Analytics: tried to delete events but array was empty ...")
                 return

--- a/Sources/PrimerSDK/Classes/Core/Analytics/RawAnalyticsEvent.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/RawAnalyticsEvent.swift
@@ -1,0 +1,26 @@
+//
+//  RawAnalyticsEvent.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+import PrimerFoundation
+
+struct RawAnalyticsEvent: AnalyticsEvent, Codable {
+    let analyticsUrl: String?
+    let localId: String
+    let createdAt: Int
+    let payload: CodableValue
+
+    init(analyticsUrl: String? = nil, payload: CodableValue) {
+        self.analyticsUrl = analyticsUrl
+        self.localId = String.randomString(length: 32)
+        self.createdAt = Date().millisecondsSince1970
+        self.payload = payload
+    }
+}
+
+extension RawAnalyticsEvent: Equatable {
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.localId == rhs.localId }
+}

--- a/Sources/PrimerSDK/Classes/Core/Analytics/StoredEvent.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/StoredEvent.swift
@@ -1,0 +1,92 @@
+//
+//  StoredEvent.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+enum StoredEvent: Codable {
+    case sdk(Analytics.Event)
+    case raw(RawAnalyticsEvent)
+    
+    var analyticsUrl: String? {
+        switch self {
+        case let .sdk(event): event.analyticsUrl
+        case let .raw(event): event.analyticsUrl
+        }
+    }
+    
+    var localId: String {
+        switch self {
+        case let .sdk(event): event.localId
+        case let .raw(event): event.localId
+        }
+    }
+    
+    var createdAt: Int {
+        switch self {
+        case let .sdk(event): event.createdAt
+        case let .raw(event): event.createdAt
+        }
+    }
+    
+    init(_ event: any AnalyticsEvent) {
+        if let sdkEvent = event as? Analytics.Event {
+            self = .sdk(sdkEvent)
+        } else if let rawEvent = event as? RawAnalyticsEvent {
+            self = .raw(rawEvent)
+        } else {
+            fatalError("Unknown AnalyticsEvent type: \(type(of: event))")
+        }
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decodeIfPresent(Kind.self, forKey: .kind) ?? .sdk
+        switch kind {
+        case .sdk: self = .sdk(try Analytics.Event(from: decoder))
+        case .raw: self = .raw(try RawAnalyticsEvent(from: decoder))
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .sdk(event):
+            try container.encode(Kind.sdk, forKey: .kind)
+            try event.encode(to: encoder)
+        case let .raw(event):
+            try container.encode(Kind.raw, forKey: .kind)
+            try event.encode(to: encoder)
+        }
+    }
+}
+
+extension StoredEvent: Equatable {
+    static func == (lhs: StoredEvent, rhs: StoredEvent) -> Bool {
+        lhs.localId == rhs.localId
+    }
+}
+
+private extension StoredEvent {
+    private enum CodingKeys: String, CodingKey {
+        case kind
+    }
+    
+    private enum Kind: String, Codable {
+        case sdk, raw
+    }
+}
+
+extension Array where Element == StoredEvent {
+    func partitioned() -> (sdk: [Analytics.Event], raw: [RawAnalyticsEvent]) {
+        var sdk: [Analytics.Event] = []
+        var raw: [RawAnalyticsEvent] = []
+        for event in self {
+            switch event {
+            case let .sdk(e): sdk.append(e)
+            case let .raw(e): raw.append(e)
+            }
+        }
+        return (sdk, raw)
+    }
+}

--- a/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Services/API/Primer/PrimerAPI.swift
@@ -34,6 +34,7 @@ enum PrimerAPI: Endpoint, Equatable {
              (.continue3DSRemoteAuth, .continue3DSRemoteAuth),
              (.poll, .poll),
              (.sendAnalyticsEvents, .sendAnalyticsEvents),
+             (.sendRawAnalyticsEvents, .sendRawAnalyticsEvents),
              (.createPayment, .createPayment),
              (.validateClientToken, .validateClientToken),
              (.getNolSdkSecret, .getNolSdkSecret),
@@ -45,18 +46,26 @@ enum PrimerAPI: Endpoint, Equatable {
     }
 
     case redirect(clientToken: DecodedJWTToken, url: URL)
-    case exchangePaymentMethodToken(clientToken: DecodedJWTToken,
-                                    vaultedPaymentMethodId: String,
-                                    vaultedPaymentMethodAdditionalData: PrimerVaultedPaymentMethodAdditionalData?)
+    case exchangePaymentMethodToken(
+        clientToken: DecodedJWTToken,
+        vaultedPaymentMethodId: String,
+        vaultedPaymentMethodAdditionalData: PrimerVaultedPaymentMethodAdditionalData?
+    )
     case fetchConfiguration(clientToken: DecodedJWTToken, requestParameters: Request.URLParameters.Configuration?)
     case fetchVaultedPaymentMethods(clientToken: DecodedJWTToken)
     case deleteVaultedPaymentMethod(clientToken: DecodedJWTToken, id: String)
-    case createPayPalOrderSession(clientToken: DecodedJWTToken,
-                                  payPalCreateOrderRequest: Request.Body.PayPal.CreateOrder)
-    case createPayPalBillingAgreementSession(clientToken: DecodedJWTToken,
-                                             payPalCreateBillingAgreementRequest: Request.Body.PayPal.CreateBillingAgreement)
-    case confirmPayPalBillingAgreement(clientToken: DecodedJWTToken,
-                                       payPalConfirmBillingAgreementRequest: Request.Body.PayPal.ConfirmBillingAgreement)
+    case createPayPalOrderSession(
+        clientToken: DecodedJWTToken,
+        payPalCreateOrderRequest: Request.Body.PayPal.CreateOrder
+    )
+    case createPayPalBillingAgreementSession(
+        clientToken: DecodedJWTToken,
+        payPalCreateBillingAgreementRequest: Request.Body.PayPal.CreateBillingAgreement
+    )
+    case confirmPayPalBillingAgreement(
+        clientToken: DecodedJWTToken,
+        payPalConfirmBillingAgreementRequest: Request.Body.PayPal.ConfirmBillingAgreement
+    )
     case createKlarnaPaymentSession(clientToken: DecodedJWTToken, klarnaCreatePaymentSessionAPIRequest: Request.Body.Klarna.CreatePaymentSession)
     case createKlarnaCustomerToken(clientToken: DecodedJWTToken, klarnaCreateCustomerTokenAPIRequest: Request.Body.Klarna.CreateCustomerToken)
     case finalizeKlarnaPaymentSession(clientToken: DecodedJWTToken, klarnaFinalizePaymentSessionRequest: Request.Body.Klarna.FinalizePaymentSession)
@@ -67,15 +76,18 @@ enum PrimerAPI: Endpoint, Equatable {
     case requestPrimerConfigurationWithActions(clientToken: DecodedJWTToken, request: ClientSessionUpdateRequest)
 
     // 3DS
-    case begin3DSRemoteAuth(clientToken: DecodedJWTToken,
-                            paymentMethodTokenData: PrimerPaymentMethodTokenData,
-                            threeDSecureBeginAuthRequest: ThreeDS.BeginAuthRequest)
+    case begin3DSRemoteAuth(
+        clientToken: DecodedJWTToken,
+        paymentMethodTokenData: PrimerPaymentMethodTokenData,
+        threeDSecureBeginAuthRequest: ThreeDS.BeginAuthRequest
+    )
     case continue3DSRemoteAuth(clientToken: DecodedJWTToken, threeDSTokenId: String, continueInfo: ThreeDS.ContinueInfo)
 
     // Generic
     case poll(clientToken: DecodedJWTToken?, url: String)
 
     case sendAnalyticsEvents(clientToken: DecodedJWTToken?, url: URL, body: [Analytics.Event]?)
+    case sendRawAnalyticsEvents(clientToken: DecodedJWTToken?, url: URL, body: Data)
 
     case fetchPayPalExternalPayerInfo(clientToken: DecodedJWTToken, payPalExternalPayerInfoRequestBody: Request.Body.PayPal.PayerInfo)
 
@@ -167,7 +179,8 @@ extension PrimerAPI {
                 tmpHeaders["Primer-Client-Token"] = token
             }
 
-        case let .sendAnalyticsEvents(clientToken, _, _):
+        case let .sendAnalyticsEvents(clientToken, _, _),
+             let .sendRawAnalyticsEvents(clientToken, _, _):
             if let token = clientToken?.accessToken {
                 tmpHeaders["Primer-Client-Token"] = token
             }
@@ -211,6 +224,7 @@ extension PrimerAPI {
              .listRetailOutlets,
              .poll,
              .sendAnalyticsEvents,
+             .sendRawAnalyticsEvents,
              .fetchPayPalExternalPayerInfo,
              .testFinalizePolling,
              .getNolSdkSecret,
@@ -260,7 +274,8 @@ extension PrimerAPI {
             return baseURL
         case let .poll(_, url):
             return url
-        case let .sendAnalyticsEvents(_, url, _):
+        case let .sendAnalyticsEvents(_, url, _),
+             let .sendRawAnalyticsEvents(_, url, _):
             return url.absoluteString
         case let .validateClientToken(request):
             return request.clientToken.decodedJWTToken?.pciUrl
@@ -309,7 +324,8 @@ extension PrimerAPI {
             return "/client-session/actions"
         case .poll:
             return ""
-        case .sendAnalyticsEvents:
+        case .sendAnalyticsEvents,
+             .sendRawAnalyticsEvents:
             return ""
         case .fetchPayPalExternalPayerInfo:
             return "/paypal/orders"
@@ -358,6 +374,7 @@ extension PrimerAPI {
              .continue3DSRemoteAuth,
              .listAdyenBanks,
              .sendAnalyticsEvents,
+             .sendRawAnalyticsEvents,
              .fetchPayPalExternalPayerInfo,
              .validateClientToken,
              .createPayment,
@@ -424,6 +441,8 @@ extension PrimerAPI {
             }
         case let .sendAnalyticsEvents(_, _, body):
             return try? JSONEncoder().encode(body)
+        case let .sendRawAnalyticsEvents(_, _, body):
+            return body
         case let .fetchPayPalExternalPayerInfo(_, payPalExternalPayerInfoRequestBody):
             return try? JSONEncoder().encode(payPalExternalPayerInfoRequestBody)
         case let .validateClientToken(clientTokenToValidate):
@@ -481,7 +500,8 @@ extension PrimerAPI {
 
         // No explicit timeout
         case .poll,
-             .sendAnalyticsEvents:
+             .sendAnalyticsEvents,
+             .sendRawAnalyticsEvents:
             return nil
         }
     }

--- a/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/PrimerAPIClient.swift
@@ -422,6 +422,17 @@ final class PrimerAPIClient: PrimerAPIClientProtocol {
         )
     }
 
+    func sendRawAnalyticsEvents(url: URL, body: Data) async throws -> Analytics.Service.Response {
+        let clientToken = PrimerAPIConfigurationModule.clientToken?.decodedJWTToken
+        return try await networkService.request(
+            .sendRawAnalyticsEvents(
+                clientToken: clientToken,
+                url: url,
+                body: body
+            )
+        )
+    }
+
     func fetchPayPalExternalPayerInfo(
         clientToken: DecodedJWTToken,
         payPalExternalPayerInfoRequestBody: Request.Body.PayPal.PayerInfo,

--- a/Sources/PrimerSDK/Classes/Services/Network/Protocols/PrimerAPIClientAnalyticsProtocol.swift
+++ b/Sources/PrimerSDK/Classes/Services/Network/Protocols/PrimerAPIClientAnalyticsProtocol.swift
@@ -10,13 +10,18 @@ protocol PrimerAPIClientAnalyticsProtocol: Sendable {
 
     typealias ResponseHandler = (_ result: Result<Analytics.Service.Response, Error>) -> Void
 
-    func sendAnalyticsEvents(clientToken: DecodedJWTToken?,
-                             url: URL,
-                             body: [Analytics.Event]?,
-                             completion: @escaping ResponseHandler)
+    func sendAnalyticsEvents(
+        clientToken: DecodedJWTToken?,
+        url: URL,
+        body: [Analytics.Event]?,
+        completion: @escaping ResponseHandler
+    )
 
-    func sendAnalyticsEvents(clientToken: DecodedJWTToken?,
-                             url: URL,
-                             body: [Analytics.Event]?) async throws -> Analytics.Service.Response
+    func sendAnalyticsEvents(
+        clientToken: DecodedJWTToken?,
+        url: URL,
+        body: [Analytics.Event]?
+    ) async throws -> Analytics.Service.Response
 
+    func sendRawAnalyticsEvents(url: URL, body: Data) async throws -> Analytics.Service.Response
 }

--- a/Tests/Primer/Analytics/AnalyticsStorageTests.swift
+++ b/Tests/Primer/Analytics/AnalyticsStorageTests.swift
@@ -1,11 +1,11 @@
 //
 //  AnalyticsStorageTests.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import XCTest
 @testable import PrimerSDK
+import XCTest
 
 final class AnalyticsStorageTests: XCTestCase {
 
@@ -13,10 +13,10 @@ final class AnalyticsStorageTests: XCTestCase {
 
     let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("analytics")
 
-    let events = [
-        Analytics.Event.message(message: "Test #1", messageType: .other, severity: .info),
-        Analytics.Event.message(message: "Test #2", messageType: .other, severity: .info),
-        Analytics.Event.message(message: "Test #3", messageType: .other, severity: .info)
+    let events: [StoredEvent] = [
+        .sdk(.message(message: "Test #1", messageType: .other, severity: .info)),
+        .sdk(.message(message: "Test #2", messageType: .other, severity: .info)),
+        .sdk(.message(message: "Test #3", messageType: .other, severity: .info))
     ]
 
     override func setUpWithError() throws {
@@ -95,6 +95,12 @@ final class AnalyticsStorageTests: XCTestCase {
 }
 
 extension Analytics.Event: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(localId)
+    }
+}
+
+extension StoredEvent: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(localId)
     }

--- a/Tests/Primer/Network/Services/NetworkingReportingServiceTests.swift
+++ b/Tests/Primer/Network/Services/NetworkingReportingServiceTests.swift
@@ -1,11 +1,11 @@
 //
 //  NetworkingReportingServiceTests.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import XCTest
 @testable import PrimerSDK
+import XCTest
 
 final class NetworkingReportingServiceTests: XCTestCase {
 
@@ -25,26 +25,30 @@ final class NetworkingReportingServiceTests: XCTestCase {
     func testRequestStartEventSent() throws {
         let expectation = XCTestExpectation(description: "Request start event sent")
 
-        let endpoint = PrimerAPI.fetchConfiguration(clientToken: Mocks.decodedJWTToken,
-                                                    requestParameters: nil)
+        let endpoint = PrimerAPI.fetchConfiguration(
+            clientToken: Mocks.decodedJWTToken,
+            requestParameters: nil
+        )
         let request = try DefaultNetworkRequestFactory().request(for: endpoint, identifier: nil)
-
 
         // Assert
         analyticsService.onRecord = { events in
+            let event = events.first as? Analytics.Event
             XCTAssertEqual(events.count, 1)
-            XCTAssertEqual(events.first?.eventType, .networkCall)
-            XCTAssertNil(events.first?.analyticsUrl)
-            XCTAssertTrue(events.first?.properties is NetworkCallEventProperties)
+            XCTAssertEqual(event?.eventType, .networkCall)
+            XCTAssertNil(event?.analyticsUrl)
+            XCTAssertTrue(event?.properties is NetworkCallEventProperties)
 
-            let properties = events.first?.properties as! NetworkCallEventProperties
+            let properties = event?.properties as! NetworkCallEventProperties
             XCTAssertEqual(properties.callType, .requestStart)
             expectation.fulfill()
         }
 
-        networkReportingService.report(eventType: .requestStart(identifier: "id",
-                                                                endpoint: endpoint,
-                                                                request: request))
+        networkReportingService.report(eventType: .requestStart(
+            identifier: "id",
+            endpoint: endpoint,
+            request: request
+        ))
 
         wait(for: [expectation], timeout: 1)
     }
@@ -52,26 +56,30 @@ final class NetworkingReportingServiceTests: XCTestCase {
     func testRequestEndEventSent() throws {
         let expectation = XCTestExpectation(description: "Request end event sent")
 
-        let endpoint = PrimerAPI.fetchConfiguration(clientToken: Mocks.decodedJWTToken,
-                                                    requestParameters: nil)
+        let endpoint = PrimerAPI.fetchConfiguration(
+            clientToken: Mocks.decodedJWTToken,
+            requestParameters: nil
+        )
         let responseMetadata = ResponseMetadataModel(responseUrl: nil, statusCode: 0, headers: nil)
 
         analyticsService.onRecord = { events in
+            let event = events.first as? Analytics.Event
             XCTAssertEqual(events.count, 1)
-            XCTAssertEqual(events.first?.eventType, .networkCall)
-            XCTAssertNil(events.first?.analyticsUrl)
-            XCTAssertTrue(events.first?.properties is NetworkCallEventProperties)
+            XCTAssertEqual(event?.eventType, .networkCall)
+            XCTAssertNil(event?.analyticsUrl)
+            XCTAssertTrue(event?.properties is NetworkCallEventProperties)
 
-            let properties = events.first?.properties as! NetworkCallEventProperties
+            let properties = event?.properties as! NetworkCallEventProperties
             XCTAssertEqual(properties.callType, .requestEnd)
             expectation.fulfill()
         }
 
-        networkReportingService.report(eventType: .requestEnd(identifier: "id",
-                                                              endpoint: endpoint,
-                                                              response: responseMetadata,
-                                                              duration: 1000))
-
+        networkReportingService.report(eventType: .requestEnd(
+            identifier: "id",
+            endpoint: endpoint,
+            response: responseMetadata,
+            duration: 1000
+        ))
 
         wait(for: [expectation], timeout: 1)
     }
@@ -79,16 +87,19 @@ final class NetworkingReportingServiceTests: XCTestCase {
     func testNetworkConnectivityEventSent() throws {
         let expectation = XCTestExpectation(description: "Network connectivity event sent")
 
-        let endpoint = PrimerAPI.fetchConfiguration(clientToken: Mocks.decodedJWTToken,
-                                                    requestParameters: nil)
+        let endpoint = PrimerAPI.fetchConfiguration(
+            clientToken: Mocks.decodedJWTToken,
+            requestParameters: nil
+        )
 
         analyticsService.onRecord = { events in
+            let event = events.first as? Analytics.Event
             XCTAssertEqual(events.count, 1)
-            XCTAssertEqual(events.first?.eventType, .networkConnectivity)
-            XCTAssertNil(events.first?.analyticsUrl)
-            XCTAssertTrue(events.first?.properties is NetworkConnectivityEventProperties)
+            XCTAssertEqual(event?.eventType, .networkConnectivity)
+            XCTAssertNil(event?.analyticsUrl)
+            XCTAssertTrue(event?.properties is NetworkConnectivityEventProperties)
 
-            let properties = events.first?.properties as! NetworkConnectivityEventProperties
+            let properties = event?.properties as! NetworkConnectivityEventProperties
             XCTAssertEqual(properties.networkType, .wifi)
             expectation.fulfill()
         }

--- a/Tests/Utilities/Mocks/Analytics/MockAnalyticsStorage.swift
+++ b/Tests/Utilities/Mocks/Analytics/MockAnalyticsStorage.swift
@@ -1,26 +1,26 @@
 //
 //  MockAnalyticsStorage.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import XCTest
 @testable import PrimerSDK
+import XCTest
 
 class MockAnalyticsStorage: Analytics.Storage {
 
-    var events: [Analytics.Event] = []
+    var events: [StoredEvent] = []
 
-    func loadEvents() -> [Analytics.Event] {
-        return events
+    func loadEvents() -> [StoredEvent] {
+        events
     }
 
-    func save(_ events: [Analytics.Event]) throws {
+    func save(_ events: [StoredEvent]) throws {
         self.events = events
     }
 
-    func delete(_ eventsToDelete: [Analytics.Event]) {
-        let idsToDelete = eventsToDelete.map { $0.localId }
+    func delete(_ eventsToDelete: [StoredEvent]) {
+        let idsToDelete = eventsToDelete.map(\.localId)
         self.events = self.events.filter { event in
             !idsToDelete.contains(event.localId)
         }

--- a/Tests/Utilities/Mocks/Analytics/MockPrimerAPIAnalyticsClient.swift
+++ b/Tests/Utilities/Mocks/Analytics/MockPrimerAPIAnalyticsClient.swift
@@ -1,11 +1,11 @@
 //
 //  MockPrimerAPIAnalyticsClient.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import XCTest
 @testable import PrimerSDK
+import XCTest
 
 class MockPrimerAPIAnalyticsClient: PrimerAPIClientAnalyticsProtocol {
 
@@ -37,6 +37,14 @@ class MockPrimerAPIAnalyticsClient: PrimerAPIClientAnalyticsProtocol {
         self.onSendAnalyticsEvent?(body)
         if shouldSucceed {
             return .init(id: nil, result: nil)
+        } else {
+            throw PrimerError.unknown()
+        }
+    }
+
+    func sendRawAnalyticsEvents(url: URL, body: Data) async throws -> Analytics.Service.Response {
+        if shouldSucceed {
+            return Analytics.Service.Response(id: nil, result: nil)
         } else {
             throw PrimerError.unknown()
         }

--- a/Tests/Utilities/Mocks/Services/MockAPIClient.swift
+++ b/Tests/Utilities/Mocks/Services/MockAPIClient.swift
@@ -73,9 +73,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
         throw NSError(domain: "MockPrimerAPIClient", code: 1, userInfo: nil)
     }
 
-    func fetchConfiguration(clientToken: PrimerSDK.DecodedJWTToken,
-                            requestParameters: PrimerSDK.Request.URLParameters.Configuration?,
-                            completion: @escaping PrimerSDK.ConfigurationCompletion) {
+    func fetchConfiguration(
+        clientToken: PrimerSDK.DecodedJWTToken,
+        requestParameters: PrimerSDK.Request.URLParameters.Configuration?,
+        completion: @escaping PrimerSDK.ConfigurationCompletion
+    ) {
         guard let result = fetchConfigurationResult,
               result.0 != nil || result.1 != nil
         else {
@@ -773,8 +775,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
         }
     }
 
-    func sendAnalyticsEvents(clientToken: PrimerSDK.DecodedJWTToken?,
-                             url: URL, body: [PrimerSDK.Analytics.Event]?) async throws -> Analytics.Service.Response {
+    func sendAnalyticsEvents(
+        clientToken: PrimerSDK.DecodedJWTToken?,
+        url: URL,
+        body: [PrimerSDK.Analytics.Event]?
+    ) async throws -> Analytics.Service.Response {
         guard let result = sendAnalyticsEventsResult,
               result.0 != nil || result.1 != nil
         else {
@@ -788,6 +793,10 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
         if let successResult = result.0 { return successResult }
         XCTAssert(false, "Set 'sendAnalyticsResult' on your MockPrimerAPIClient")
         throw NSError(domain: "MockPrimerAPIClient", code: 1, userInfo: nil)
+    }
+
+    func sendRawAnalyticsEvents(url: URL, body: Data) async throws -> Analytics.Service.Response {
+        Analytics.Service.Response(id: nil, result: nil)
     }
 
     // Payment
@@ -897,8 +906,11 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
         if let errorResult = result.1 { throw errorResult }
     }
 
-    func listCardNetworks(clientToken: DecodedJWTToken, bin: String,
-                          completion: @escaping (Result<Response.Body.Bin.Networks, Error>) -> Void) -> PrimerCancellable? {
+    func listCardNetworks(
+        clientToken: DecodedJWTToken,
+        bin: String,
+        completion: @escaping (Result<Response.Body.Bin.Networks, Error>) -> Void
+    ) -> PrimerCancellable? {
         guard let result = listCardNetworksResult, result.0 != nil || result.1 != nil else {
             XCTFail("Set 'listCardNetworksResult' on your MockPrimerAPIClient")
             return nil
@@ -942,12 +954,20 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
             return Response.Body.Bin.Data(
                 firstDigits: String(bin.prefix(6)),
                 binData: successResult.networks.map {
-                    .init(displayName: nil, network: $0.value,
-                          issuerCountryCode: nil, issuerName: nil,
-                          accountFundingType: nil, prepaidReloadableIndicator: nil,
-                          productUsageType: nil, productCode: nil,
-                          productName: nil, issuerCurrencyCode: nil,
-                          regionalRestriction: nil, accountNumberType: nil)
+                    .init(
+                        displayName: nil,
+                        network: $0.value,
+                        issuerCountryCode: nil,
+                        issuerName: nil,
+                        accountFundingType: nil,
+                        prepaidReloadableIndicator: nil,
+                        productUsageType: nil,
+                        productCode: nil,
+                        productName: nil,
+                        issuerCurrencyCode: nil,
+                        regionalRestriction: nil,
+                        accountNumberType: nil
+                    )
                 }
             )
         }
@@ -1403,18 +1423,20 @@ extension MockPrimerAPIClient {
         static let mockBinNetworks = Response.Body.Bin.Networks(networks: [.init(value: "MOCK_NETWORK")])
         static let mockBinData = Response.Body.Bin.Data(
             firstDigits: "123456",
-            binData: [.init(displayName: "Mock Network",
-                            network: "MOCK_NETWORK",
-                            issuerCountryCode: nil,
-                            issuerName: nil,
-                            accountFundingType: nil,
-                            prepaidReloadableIndicator: nil,
-                            productUsageType: nil,
-                            productCode: nil,
-                            productName: nil,
-                            issuerCurrencyCode: nil,
-                            regionalRestriction: nil,
-                            accountNumberType: nil)]
+            binData: [.init(
+                displayName: "Mock Network",
+                network: "MOCK_NETWORK",
+                issuerCountryCode: nil,
+                issuerName: nil,
+                accountFundingType: nil,
+                prepaidReloadableIndicator: nil,
+                productUsageType: nil,
+                productCode: nil,
+                productName: nil,
+                issuerCurrencyCode: nil,
+                regionalRestriction: nil,
+                accountNumberType: nil
+            )]
         )
         static let mockPhoneMetadataResponse = Response.Body.PhoneMetadata.PhoneMetadataDataResponse(
             isValid: true,

--- a/Tests/Utilities/Mocks/Services/MockAnalyticsService.swift
+++ b/Tests/Utilities/Mocks/Services/MockAnalyticsService.swift
@@ -7,25 +7,25 @@
 @testable import PrimerSDK
 
 final actor MockAnalyticsService: AnalyticsServiceProtocol {
-    private var eventsStorage: [Analytics.Event] = []
-    nonisolated(unsafe) var onRecord: (([Analytics.Event]) -> Void)?
+    private var eventsStorage: [any AnalyticsEvent] = []
+    nonisolated(unsafe) var onRecord: (([any AnalyticsEvent]) -> Void)?
 
-    func record(events: [Analytics.Event]) async throws {
+    func record(events: [any AnalyticsEvent]) async throws {
         eventsStorage.append(contentsOf: events)
         onRecord?(events)
     }
 
-    func fire(events: [Analytics.Event]) {
+    func fire(events: [any AnalyticsEvent]) {
         eventsStorage.append(contentsOf: events)
         onRecord?(events)
     }
 
-    func record(event: Analytics.Event) async throws {
+    func record(event: any AnalyticsEvent) async throws {
         eventsStorage.append(contentsOf: [event])
         onRecord?([event])
     }
 
-    func fire(event: PrimerSDK.Analytics.Event) {
+    func fire(event: any AnalyticsEvent) {
         eventsStorage.append(contentsOf: [event])
         onRecord?([event])
     }


### PR DESCRIPTION
As part of the BDC spec, the SDK needs to be able to handle arbitrary events not known at compile time. This PR implements that functionality 