### PR TITLE
feat: Implement PAY_NL_KAARTDIRECT in CheckoutComponents

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -111,6 +111,8 @@ extension PrimerPaymentMethodType {
       UIImage(primerResource: "giropay-icon")
     case .payNLIdeal:
       UIImage(primerResource: "ideal-icon-colored")
+    case .payNLKaartdirect:
+      ImageName.genericCard.image
     case .payNLPayconiq:
       UIImage(primerResource: "payconiq-icon-colored")
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -130,9 +130,15 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     FormRedirectPaymentMethod.register()
     QRCodePaymentMethod.registerAll([.xfersPayNow, .rapydPromptPay, .omisePromptPay])
 
+    // Payment methods that use the WebRedirect flow but whose backend `implementationType`
+    // is NATIVE_SDK instead of WEB_REDIRECT (e.g. due to custom drop-in buttons).
+    // Mirrors the WEB SDK's `mergeConfigWithLocalDefinitions` override.
+    let nativeSdkRedirectTypes: Set<String> = [
+      PrimerPaymentMethodType.payNLKaartdirect.rawValue
+    ]
     let webRedirectTypes = PrimerAPIConfigurationModule.apiConfiguration?
       .paymentMethods?
-      .filter { $0.implementationType == .webRedirect }
+      .filter { $0.implementationType == .webRedirect || nativeSdkRedirectTypes.contains($0.type) }
       .map(\.type) ?? []
     WebRedirectPaymentMethod.register(types: webRedirectTypes)
   }

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
@@ -73,6 +73,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
     case payNLBancontact                = "PAY_NL_BANCONTACT"
     case payNLGiropay                   = "PAY_NL_GIROPAY"
     case payNLIdeal                     = "PAY_NL_IDEAL"
+    case payNLKaartdirect                = "PAY_NL_KAARTDIRECT"
     case payNLPayconiq                  = "PAY_NL_PAYCONIQ"
     case paymentCard                    = "PAYMENT_CARD"
     case payPal                         = "PAYPAL"
@@ -146,6 +147,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
         case .payNLBancontact,
              .payNLGiropay,
              .payNLIdeal,
+             .payNLKaartdirect,
              .payNLPayconiq:
             "PAY_NL"
 

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -756,7 +756,8 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
             return nil
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
-        case .mollieGiftcard:
+        case .mollieGiftcard,
+             .payNLKaartdirect:
             return nil
         }
     }

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -247,6 +247,11 @@ final class PrimerPaymentMethodTypeIconTests: XCTestCase {
         XCTAssertNotNil(PrimerPaymentMethodType.payNLIdeal.icon)
     }
 
+    func test_icon_payNLKaartdirect_returnsGenericCardImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.payNLKaartdirect.icon)
+        XCTAssertEqual(PrimerPaymentMethodType.payNLKaartdirect.icon, ImageName.genericCard.image)
+    }
+
     func test_icon_payNLPayconiq_returnsNonNilImage() {
         XCTAssertNotNil(PrimerPaymentMethodType.payNLPayconiq.icon)
     }

--- a/Tests/Primer/CheckoutComponents/WebRedirect/KaartdirectRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/KaartdirectRegistrationTests.swift
@@ -72,10 +72,10 @@ final class KaartdirectRegistrationTests: XCTestCase {
     }
 
     func test_kaartdirect_createScope_returnsDefaultWebRedirectScope() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerWebRedirectDependencies()
-        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(
@@ -89,10 +89,10 @@ final class KaartdirectRegistrationTests: XCTestCase {
     }
 
     func test_kaartdirect_createScope_setsCorrectPaymentMethodType() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerWebRedirectDependencies()
-        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(
@@ -107,10 +107,10 @@ final class KaartdirectRegistrationTests: XCTestCase {
     }
 
     func test_kaartdirect_createScope_withMissingDependencies_throws() async throws {
-        // Given
-        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+        // Given — register after scope creation since init calls reset()
         let emptyContainer = Container()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
 
         // When/Then
         do {

--- a/Tests/Primer/CheckoutComponents/WebRedirect/KaartdirectRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/KaartdirectRegistrationTests.swift
@@ -1,0 +1,185 @@
+//
+//  KaartdirectRegistrationTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class KaartdirectRegistrationTests: XCTestCase {
+
+    private var container: Container!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try await ContainerTestHelpers.createTestContainer()
+        PaymentMethodRegistry.shared.reset()
+    }
+
+    override func tearDown() async throws {
+        await container.reset(ignoreDependencies: [Never.Type]())
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - PrimerPaymentMethodType Tests
+
+    func test_payNLKaartdirect_rawValue() {
+        XCTAssertEqual(PrimerPaymentMethodType.payNLKaartdirect.rawValue, "PAY_NL_KAARTDIRECT")
+    }
+
+    func test_payNLKaartdirect_provider() {
+        XCTAssertEqual(PrimerPaymentMethodType.payNLKaartdirect.provider, "PAY_NL")
+    }
+
+    func test_payNLKaartdirect_decodable() throws {
+        let data = Data("\"PAY_NL_KAARTDIRECT\"".utf8)
+        let decoded = try JSONDecoder().decode(PrimerPaymentMethodType.self, from: data)
+        XCTAssertEqual(decoded, .payNLKaartdirect)
+    }
+
+    func test_payNLKaartdirect_encodable() throws {
+        let encoded = try JSONEncoder().encode(PrimerPaymentMethodType.payNLKaartdirect)
+        let string = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(string, "\"PAY_NL_KAARTDIRECT\"")
+    }
+
+    func test_payNLKaartdirect_includedInAllCases() {
+        XCTAssertTrue(PrimerPaymentMethodType.allCases.contains(.payNLKaartdirect))
+    }
+
+    // MARK: - WebRedirect Registration Tests
+
+    func test_kaartdirect_registeredAsWebRedirect() {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertTrue(registered.contains(PrimerPaymentMethodType.payNLKaartdirect.rawValue))
+    }
+
+    func test_kaartdirect_notRegistered_whenNotIncluded() {
+        // Given
+        WebRedirectPaymentMethod.register(types: ["ADYEN_TWINT"])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertFalse(registered.contains(PrimerPaymentMethodType.payNLKaartdirect.rawValue))
+    }
+
+    func test_kaartdirect_createScope_returnsDefaultWebRedirectScope() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        XCTAssertTrue(scope is DefaultWebRedirectScope)
+    }
+
+    func test_kaartdirect_createScope_setsCorrectPaymentMethodType() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        let webRedirectScope = try XCTUnwrap(scope as? DefaultWebRedirectScope)
+        XCTAssertEqual(webRedirectScope.paymentMethodType, PrimerPaymentMethodType.payNLKaartdirect.rawValue)
+    }
+
+    func test_kaartdirect_createScope_withMissingDependencies_throws() async throws {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+        let emptyContainer = Container()
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When/Then
+        do {
+            _ = try await PaymentMethodRegistry.shared.createScope(
+                for: PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+                checkoutScope: checkoutScope,
+                diContainer: emptyContainer
+            )
+            XCTFail("Expected error when required dependency is missing")
+        } catch {
+            XCTAssertTrue(error is ContainerError || error is PrimerError)
+        }
+    }
+
+    func test_kaartdirect_registeredAlongsideOtherWebRedirectTypes() {
+        // Given
+        let types = [
+            "ADYEN_TWINT",
+            PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+            "ADYEN_SOFORT"
+        ]
+
+        // When
+        WebRedirectPaymentMethod.register(types: types)
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        for type in types {
+            XCTAssertTrue(registered.contains(type), "Expected \(type) to be registered")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func registerWebRedirectDependencies() async {
+        _ = try? await container.register(ProcessWebRedirectPaymentInteractor.self)
+            .asSingleton()
+            .with { _ in StubKaartdirectWebRedirectInteractor() }
+
+        _ = try? await container.register(PaymentMethodMapper.self)
+            .asSingleton()
+            .with { _ in StubKaartdirectPaymentMethodMapper() }
+
+        _ = try? await container.register(WebRedirectRepository.self)
+            .asSingleton()
+            .with { _ in MockWebRedirectRepository() }
+    }
+}
+
+// MARK: - Stubs
+
+@available(iOS 15.0, *)
+private final class StubKaartdirectWebRedirectInteractor: ProcessWebRedirectPaymentInteractor {
+    func execute(paymentMethodType: String) async throws -> PaymentResult {
+        PaymentResult(paymentId: "kaartdirect_payment_123", status: .success)
+    }
+}
+
+@available(iOS 15.0, *)
+private final class StubKaartdirectPaymentMethodMapper: PaymentMethodMapper {
+    func mapToPublic(_ internalMethod: InternalPaymentMethod) -> CheckoutPaymentMethod {
+        CheckoutPaymentMethod(
+            id: internalMethod.id,
+            type: internalMethod.type,
+            name: internalMethod.name
+        )
+    }
+
+    func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod] {
+        internalMethods.map { mapToPublic($0) }
+    }
+}


### PR DESCRIPTION
## Summary
- Register `PAY_NL_KAARTDIRECT` as a WebRedirect payment method in CheckoutComponents
- The backend returns `NATIVE_SDK` implementation type (due to custom drop-in button styling), but the actual flow is a standard redirect to Pay.nl's hosted gift card page
- Mirrors the WEB SDK approach (`mergeConfigWithLocalDefinitions`) by including known NATIVE_SDK redirect types during WebRedirect registration

## Changes
- Add `payNLKaartdirect` case to `PrimerPaymentMethodType` enum with `PAY_NL` provider mapping
- Register Kaartdirect alongside WebRedirect APMs in `DefaultCheckoutScope.registerPaymentMethods()`
- Add icon mapping (generic card, same as `MOLLIE_GIFTCARD`)
- Add exhaustive switch case in `UserInterfaceModule` for DropIn support
- Add `KaartdirectRegistrationTests` (11 tests covering enum, encoding, registration, scope creation)
- Add icon test in `PrimerPaymentMethodTypeImageNameTests`

## Jira
[ACC-7015](https://primerapi.atlassian.net/browse/ACC-7015)

## Test plan
- [x] All 11 Kaartdirect registration tests pass
- [x] All 63 WebRedirect + icon tests pass
- [x] Debug App builds successfully
- [ ] Manual test with client session containing PAY_NL_KAARTDIRECT

[ACC-7015]: https://primerapi.atlassian.net/browse/ACC-7015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ