### PR TITLE
feat: Implement PAY_NL_PAYPAL in CheckoutComponents

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -12,7 +12,7 @@ extension PrimerPaymentMethodType {
   /// Follows the same pattern as DropIn UI's TokenizationResponse.icon
   var defaultImageName: ImageName {
     switch self {
-    case .payPal, .primerTestPayPal: .paypal
+    case .payPal, .primerTestPayPal, .payNLPaypal: .paypal
     case .klarna, .primerTestKlarna, .adyenKlarna: .klarna
     case .paymentCard: .creditCard
     case .applePay: .appleIcon
@@ -113,6 +113,8 @@ extension PrimerPaymentMethodType {
       UIImage(primerResource: "ideal-icon-colored")
     case .payNLKaartdirect:
       ImageName.genericCard.image
+    case .payNLPaypal:
+      UIImage(primerResource: "paypal-icon-colored")
     case .payNLPayconiq:
       UIImage(primerResource: "payconiq-icon-colored")
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -134,7 +134,8 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     // is NATIVE_SDK instead of WEB_REDIRECT (e.g. due to custom drop-in buttons).
     // Mirrors the WEB SDK's `mergeConfigWithLocalDefinitions` override.
     let nativeSdkRedirectTypes: Set<String> = [
-      PrimerPaymentMethodType.payNLKaartdirect.rawValue
+      PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+      PrimerPaymentMethodType.payNLPaypal.rawValue
     ]
     let webRedirectTypes = PrimerAPIConfigurationModule.apiConfiguration?
       .paymentMethods?

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
@@ -75,6 +75,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
     case payNLIdeal                     = "PAY_NL_IDEAL"
     case payNLKaartdirect                = "PAY_NL_KAARTDIRECT"
     case payNLPayconiq                  = "PAY_NL_PAYCONIQ"
+    case payNLPaypal                    = "PAY_NL_PAYPAL"
     case paymentCard                    = "PAYMENT_CARD"
     case payPal                         = "PAYPAL"
     case primerTestKlarna               = "PRIMER_TEST_KLARNA"
@@ -148,7 +149,8 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
              .payNLGiropay,
              .payNLIdeal,
              .payNLKaartdirect,
-             .payNLPayconiq:
+             .payNLPayconiq,
+             .payNLPaypal:
             "PAY_NL"
 
         case .primerTestKlarna,

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -756,9 +756,7 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
             return nil
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
-        case .mollieGiftcard,
-             .payNLKaartdirect,
-             .payNLPaypal:
+        case .mollieGiftcard, .payNLKaartdirect, .payNLPaypal:
             return nil
         }
     }

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -757,7 +757,8 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
         case .mollieGiftcard,
-             .payNLKaartdirect:
+             .payNLKaartdirect,
+             .payNLPaypal:
             return nil
         }
     }

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -46,6 +46,10 @@ final class PrimerPaymentMethodTypeDefaultImageNameTests: XCTestCase {
         XCTAssertEqual(PrimerPaymentMethodType.googlePay.defaultImageName, .genericCard)
     }
 
+    func test_defaultImageName_payNLPaypal_returnsPaypalImage() {
+        XCTAssertEqual(PrimerPaymentMethodType.payNLPaypal.defaultImageName, .paypal)
+    }
+
     // MARK: - ACH Payment Methods
 
     func test_defaultImageName_goCardless_returnsAchBankImage() {
@@ -250,6 +254,11 @@ final class PrimerPaymentMethodTypeIconTests: XCTestCase {
     func test_icon_payNLKaartdirect_returnsGenericCardImage() {
         XCTAssertNotNil(PrimerPaymentMethodType.payNLKaartdirect.icon)
         XCTAssertEqual(PrimerPaymentMethodType.payNLKaartdirect.icon, ImageName.genericCard.image)
+    }
+
+    func test_icon_payNLPaypal_returnsPaypalIconImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.payNLPaypal.icon)
+        XCTAssertEqual(PrimerPaymentMethodType.payNLPaypal.icon, UIImage(primerResource: "paypal-icon-colored"))
     }
 
     func test_icon_payNLPayconiq_returnsNonNilImage() {

--- a/Tests/Primer/CheckoutComponents/WebRedirect/PayNLPaypalRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/PayNLPaypalRegistrationTests.swift
@@ -72,10 +72,10 @@ final class PayNLPaypalRegistrationTests: XCTestCase {
     }
 
     func test_payNLPaypal_createScope_returnsDefaultWebRedirectScope() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerWebRedirectDependencies()
-        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(
@@ -89,10 +89,10 @@ final class PayNLPaypalRegistrationTests: XCTestCase {
     }
 
     func test_payNLPaypal_createScope_setsCorrectPaymentMethodType() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerWebRedirectDependencies()
-        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(
@@ -107,10 +107,10 @@ final class PayNLPaypalRegistrationTests: XCTestCase {
     }
 
     func test_payNLPaypal_createScope_withMissingDependencies_throws() async throws {
-        // Given
-        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
+        // Given — register after scope creation since init calls reset()
         let emptyContainer = Container()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
 
         // When/Then
         do {

--- a/Tests/Primer/CheckoutComponents/WebRedirect/PayNLPaypalRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/PayNLPaypalRegistrationTests.swift
@@ -1,0 +1,186 @@
+//
+//  PayNLPaypalRegistrationTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class PayNLPaypalRegistrationTests: XCTestCase {
+
+    private var container: Container!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try await ContainerTestHelpers.createTestContainer()
+        PaymentMethodRegistry.shared.reset()
+    }
+
+    override func tearDown() async throws {
+        await container.reset(ignoreDependencies: [Never.Type]())
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - PrimerPaymentMethodType Tests
+
+    func test_payNLPaypal_rawValue() {
+        XCTAssertEqual(PrimerPaymentMethodType.payNLPaypal.rawValue, "PAY_NL_PAYPAL")
+    }
+
+    func test_payNLPaypal_provider() {
+        XCTAssertEqual(PrimerPaymentMethodType.payNLPaypal.provider, "PAY_NL")
+    }
+
+    func test_payNLPaypal_decodable() throws {
+        let data = Data("\"PAY_NL_PAYPAL\"".utf8)
+        let decoded = try JSONDecoder().decode(PrimerPaymentMethodType.self, from: data)
+        XCTAssertEqual(decoded, .payNLPaypal)
+    }
+
+    func test_payNLPaypal_encodable() throws {
+        let encoded = try JSONEncoder().encode(PrimerPaymentMethodType.payNLPaypal)
+        let string = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(string, "\"PAY_NL_PAYPAL\"")
+    }
+
+    func test_payNLPaypal_includedInAllCases() {
+        XCTAssertTrue(PrimerPaymentMethodType.allCases.contains(.payNLPaypal))
+    }
+
+    // MARK: - WebRedirect Registration Tests
+
+    func test_payNLPaypal_registeredAsWebRedirect() {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertTrue(registered.contains(PrimerPaymentMethodType.payNLPaypal.rawValue))
+    }
+
+    func test_payNLPaypal_notRegistered_whenNotIncluded() {
+        // Given
+        WebRedirectPaymentMethod.register(types: ["ADYEN_TWINT"])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertFalse(registered.contains(PrimerPaymentMethodType.payNLPaypal.rawValue))
+    }
+
+    func test_payNLPaypal_createScope_returnsDefaultWebRedirectScope() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.payNLPaypal.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        XCTAssertTrue(scope is DefaultWebRedirectScope)
+    }
+
+    func test_payNLPaypal_createScope_setsCorrectPaymentMethodType() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.payNLPaypal.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        let webRedirectScope = try XCTUnwrap(scope as? DefaultWebRedirectScope)
+        XCTAssertEqual(webRedirectScope.paymentMethodType, PrimerPaymentMethodType.payNLPaypal.rawValue)
+    }
+
+    func test_payNLPaypal_createScope_withMissingDependencies_throws() async throws {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLPaypal.rawValue])
+        let emptyContainer = Container()
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When/Then
+        do {
+            _ = try await PaymentMethodRegistry.shared.createScope(
+                for: PrimerPaymentMethodType.payNLPaypal.rawValue,
+                checkoutScope: checkoutScope,
+                diContainer: emptyContainer
+            )
+            XCTFail("Expected error when required dependency is missing")
+        } catch {
+            XCTAssertTrue(error is ContainerError || error is PrimerError)
+        }
+    }
+
+    func test_payNLPaypal_registeredAlongsideOtherWebRedirectTypes() {
+        // Given
+        let types = [
+            "ADYEN_TWINT",
+            PrimerPaymentMethodType.payNLPaypal.rawValue,
+            PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+            "ADYEN_SOFORT"
+        ]
+
+        // When
+        WebRedirectPaymentMethod.register(types: types)
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        for type in types {
+            XCTAssertTrue(registered.contains(type), "Expected \(type) to be registered")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func registerWebRedirectDependencies() async {
+        _ = try? await container.register(ProcessWebRedirectPaymentInteractor.self)
+            .asSingleton()
+            .with { _ in StubPayNLPaypalWebRedirectInteractor() }
+
+        _ = try? await container.register(PaymentMethodMapper.self)
+            .asSingleton()
+            .with { _ in StubPayNLPaypalPaymentMethodMapper() }
+
+        _ = try? await container.register(WebRedirectRepository.self)
+            .asSingleton()
+            .with { _ in MockWebRedirectRepository() }
+    }
+}
+
+// MARK: - Stubs
+
+@available(iOS 15.0, *)
+private final class StubPayNLPaypalWebRedirectInteractor: ProcessWebRedirectPaymentInteractor {
+    func execute(paymentMethodType: String) async throws -> PaymentResult {
+        PaymentResult(paymentId: "pay_nl_paypal_payment_123", status: .success)
+    }
+}
+
+@available(iOS 15.0, *)
+private final class StubPayNLPaypalPaymentMethodMapper: PaymentMethodMapper {
+    func mapToPublic(_ internalMethod: InternalPaymentMethod) -> CheckoutPaymentMethod {
+        CheckoutPaymentMethod(
+            id: internalMethod.id,
+            type: internalMethod.type,
+            name: internalMethod.name
+        )
+    }
+
+    func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod] {
+        internalMethods.map { mapToPublic($0) }
+    }
+}


### PR DESCRIPTION
## Summary
- Register `PAY_NL_PAYPAL` as a WebRedirect payment method in CheckoutComponents
- Add to `nativeSdkRedirectTypes` set (backend returns `NATIVE_SDK` but flow is a standard redirect to Pay.nl)
- Reuse existing PayPal icon assets (`paypal-icon-colored`) for the payment method button

## Context
Stacked on #1685 (Kaartdirect). Same pattern — Pay.nl payment method with `NATIVE_SDK` implementation type that should be treated as `WEB_REDIRECT`.

**Jira:** [ACC-7027](https://primerapi.atlassian.net/browse/ACC-7027)

## Changes
| File | Change |
|------|--------|
| `PrimerPaymentMethodType.swift` | Add `payNLPaypal` enum case + provider |
| `DefaultCheckoutScope.swift` | Add to `nativeSdkRedirectTypes` set |
| `PrimerPaymentMethodType+ImageName.swift` | Add `defaultImageName` (.paypal) + `icon` (paypal-icon-colored) |
| `UserInterfaceModule.swift` | Add to exhaustive switch (return nil) |
| `PayNLPaypalRegistrationTests.swift` | **New** — 11 registration tests |
| `PrimerPaymentMethodTypeImageNameTests.swift` | Add 2 image tests |

## Test plan
- [x] Build succeeds
- [x] All 13 new tests pass (11 registration + 2 image)
- [x] All existing tests pass
- [x] SwiftFormat + SwiftLint clean (no new violations)

[ACC-7027]: https://primerapi.atlassian.net/browse/ACC-7027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ