### PR TITLE
feat: Implement ADYEN_BANCONTACT_PAYCONIQ in CheckoutComponents

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -57,6 +57,8 @@ extension PrimerPaymentMethodType {
       UIImage(primerResource: "blik-icon-colored")
     case .adyenBancontactCard:
       UIImage(primerResource: "bancontact-card-logo-colored")
+    case .adyenBancontactPayconiq:
+      UIImage(primerResource: "payconiq-logo-colored")
     case .adyenDotPay:
       UIImage(primerResource: "dotpay-icon-colored")
     case .adyenGiropay:

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
@@ -39,6 +39,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
     case adyenAlipay                    = "ADYEN_ALIPAY"
     case adyenBlik                      = "ADYEN_BLIK"
     case adyenBancontactCard            = "ADYEN_BANCONTACT_CARD"
+    case adyenBancontactPayconiq        = "ADYEN_BANCONTACT_PAYCONIQ"
     case adyenDotPay                    = "ADYEN_DOTPAY"
     case adyenGiropay                   = "ADYEN_GIROPAY"
     case adyenIDeal                     = "ADYEN_IDEAL"
@@ -99,6 +100,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
         case .adyenAlipay,
              .adyenBlik,
              .adyenBancontactCard,
+             .adyenBancontactPayconiq,
              .adyenDotPay,
              .adyenGiropay,
              .adyenIDeal,

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -756,7 +756,8 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
             return nil
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
-        case .mollieGiftcard:
+        case .adyenBancontactPayconiq,
+             .mollieGiftcard:
             return nil
         }
     }

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -137,6 +137,11 @@ final class PrimerPaymentMethodTypeIconTests: XCTestCase {
         XCTAssertNotNil(PrimerPaymentMethodType.adyenBancontactCard.icon)
     }
 
+    func test_icon_adyenBancontactPayconiq_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenBancontactPayconiq.icon)
+        XCTAssertEqual(PrimerPaymentMethodType.adyenBancontactPayconiq.icon, UIImage(primerResource: "payconiq-logo-colored"))
+    }
+
     func test_icon_adyenDotPay_returnsNonNilImage() {
         XCTAssertNotNil(PrimerPaymentMethodType.adyenDotPay.icon)
     }

--- a/Tests/Primer/CheckoutComponents/WebRedirect/BancontactPayconiqRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/BancontactPayconiqRegistrationTests.swift
@@ -1,0 +1,185 @@
+//
+//  BancontactPayconiqRegistrationTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class BancontactPayconiqRegistrationTests: XCTestCase {
+
+    private var container: Container!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try await ContainerTestHelpers.createTestContainer()
+        PaymentMethodRegistry.shared.reset()
+    }
+
+    override func tearDown() async throws {
+        await container.reset(ignoreDependencies: [Never.Type]())
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - PrimerPaymentMethodType Tests
+
+    func test_adyenBancontactPayconiq_rawValue() {
+        XCTAssertEqual(PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue, "ADYEN_BANCONTACT_PAYCONIQ")
+    }
+
+    func test_adyenBancontactPayconiq_provider() {
+        XCTAssertEqual(PrimerPaymentMethodType.adyenBancontactPayconiq.provider, "ADYEN")
+    }
+
+    func test_adyenBancontactPayconiq_decodable() throws {
+        let data = Data("\"ADYEN_BANCONTACT_PAYCONIQ\"".utf8)
+        let decoded = try JSONDecoder().decode(PrimerPaymentMethodType.self, from: data)
+        XCTAssertEqual(decoded, .adyenBancontactPayconiq)
+    }
+
+    func test_adyenBancontactPayconiq_encodable() throws {
+        let encoded = try JSONEncoder().encode(PrimerPaymentMethodType.adyenBancontactPayconiq)
+        let string = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(string, "\"ADYEN_BANCONTACT_PAYCONIQ\"")
+    }
+
+    func test_adyenBancontactPayconiq_includedInAllCases() {
+        XCTAssertTrue(PrimerPaymentMethodType.allCases.contains(.adyenBancontactPayconiq))
+    }
+
+    // MARK: - WebRedirect Registration Tests
+
+    func test_bancontactPayconiq_registeredAsWebRedirect() {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertTrue(registered.contains(PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue))
+    }
+
+    func test_bancontactPayconiq_notRegistered_whenNotIncluded() {
+        // Given
+        WebRedirectPaymentMethod.register(types: ["ADYEN_TWINT"])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertFalse(registered.contains(PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue))
+    }
+
+    func test_bancontactPayconiq_createScope_returnsDefaultWebRedirectScope() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        XCTAssertTrue(scope is DefaultWebRedirectScope)
+    }
+
+    func test_bancontactPayconiq_createScope_setsCorrectPaymentMethodType() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        let webRedirectScope = try XCTUnwrap(scope as? DefaultWebRedirectScope)
+        XCTAssertEqual(webRedirectScope.paymentMethodType, PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue)
+    }
+
+    func test_bancontactPayconiq_createScope_withMissingDependencies_throws() async throws {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue])
+        let emptyContainer = Container()
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When/Then
+        do {
+            _ = try await PaymentMethodRegistry.shared.createScope(
+                for: PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue,
+                checkoutScope: checkoutScope,
+                diContainer: emptyContainer
+            )
+            XCTFail("Expected error when required dependency is missing")
+        } catch {
+            XCTAssertTrue(error is ContainerError || error is PrimerError)
+        }
+    }
+
+    func test_bancontactPayconiq_registeredAlongsideOtherWebRedirectTypes() {
+        // Given
+        let types = [
+            "ADYEN_TWINT",
+            PrimerPaymentMethodType.adyenBancontactPayconiq.rawValue,
+            "ADYEN_SOFORT"
+        ]
+
+        // When
+        WebRedirectPaymentMethod.register(types: types)
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        for type in types {
+            XCTAssertTrue(registered.contains(type), "Expected \(type) to be registered")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func registerWebRedirectDependencies() async {
+        _ = try? await container.register(ProcessWebRedirectPaymentInteractor.self)
+            .asSingleton()
+            .with { _ in StubBancontactPayconiqWebRedirectInteractor() }
+
+        _ = try? await container.register(PaymentMethodMapper.self)
+            .asSingleton()
+            .with { _ in StubBancontactPayconiqPaymentMethodMapper() }
+
+        _ = try? await container.register(WebRedirectRepository.self)
+            .asSingleton()
+            .with { _ in MockWebRedirectRepository() }
+    }
+}
+
+// MARK: - Stubs
+
+@available(iOS 15.0, *)
+private final class StubBancontactPayconiqWebRedirectInteractor: ProcessWebRedirectPaymentInteractor {
+    func execute(paymentMethodType: String) async throws -> PaymentResult {
+        PaymentResult(paymentId: "bancontact_payconiq_payment_123", status: .success)
+    }
+}
+
+@available(iOS 15.0, *)
+private final class StubBancontactPayconiqPaymentMethodMapper: PaymentMethodMapper {
+    func mapToPublic(_ internalMethod: InternalPaymentMethod) -> CheckoutPaymentMethod {
+        CheckoutPaymentMethod(
+            id: internalMethod.id,
+            type: internalMethod.type,
+            name: internalMethod.name
+        )
+    }
+
+    func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod] {
+        internalMethods.map { mapToPublic($0) }
+    }
+}


### PR DESCRIPTION
## Summary
- Register `ADYEN_BANCONTACT_PAYCONIQ` (Payconiq by Bancontact) as a WebRedirect payment method
- Backend sends `WEB_REDIRECT` on mobile via `mobile-override-implementation-type`, so it auto-registers with the existing filter
- Uses `payconiq-logo-colored` icon asset (already in bundle)

**Jira:** [ACC-7018](https://primerapi.atlassian.net/browse/ACC-7018)

## Changes
| File | Change |
|------|--------|
| `PrimerPaymentMethodType.swift` | Add `adyenBancontactPayconiq` enum case + provider |
| `PrimerPaymentMethodType+ImageName.swift` | Add `icon` (payconiq-logo-colored) |
| `UserInterfaceModule.swift` | Add to exhaustive switch (return nil) |
| `BancontactPayconiqRegistrationTests.swift` | **New** — 11 registration tests |
| `PrimerPaymentMethodTypeImageNameTests.swift` | Add icon test |

## Test plan
- [x] Build succeeds
- [x] All 12 new tests pass (11 registration + 1 image)
- [x] All existing tests pass
- [x] SwiftFormat + SwiftLint clean

[ACC-7018]: https://primerapi.atlassian.net/browse/ACC-7018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ