### PR TITLE
feat: Implement ADYEN_SWISH in CheckoutComponents

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -77,6 +77,8 @@ extension PrimerPaymentMethodType {
       UIImage(primerResource: "payshop-icon-colored")
     case .adyenSofort, .primerTestSofort:
       UIImage(primerResource: "sofort-icon-colored")
+    case .adyenSwish:
+      UIImage(primerResource: "swish-logo-colored")
     case .adyenTrustly:
       UIImage(primerResource: "trustly-icon-colored")
     case .adyenTwint:

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
@@ -50,6 +50,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
     case adyenPayTrail                  = "ADYEN_PAYTRAIL"
     case adyenPayshop                   = "ADYEN_PAYSHOP"
     case adyenSofort                    = "ADYEN_SOFORT"
+    case adyenSwish                     = "ADYEN_SWISH"
     case adyenTrustly                   = "ADYEN_TRUSTLY"
     case adyenTwint                     = "ADYEN_TWINT"
     case adyenVipps                     = "ADYEN_VIPPS"
@@ -109,6 +110,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
              .adyenMultibanco,
              .adyenPayTrail,
              .adyenSofort,
+             .adyenSwish,
              .adyenPayshop,
              .adyenTrustly,
              .adyenTwint,

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -756,7 +756,8 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
             return nil
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
-        case .mollieGiftcard:
+        case .adyenSwish,
+             .mollieGiftcard:
             return nil
         }
     }

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -181,6 +181,11 @@ final class PrimerPaymentMethodTypeIconTests: XCTestCase {
         XCTAssertNotNil(PrimerPaymentMethodType.primerTestSofort.icon)
     }
 
+    func test_icon_adyenSwish_returnsNonNilImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenSwish.icon)
+        XCTAssertEqual(PrimerPaymentMethodType.adyenSwish.icon, UIImage(primerResource: "swish-logo-colored"))
+    }
+
     func test_icon_adyenTrustly_returnsNonNilImage() {
         XCTAssertNotNil(PrimerPaymentMethodType.adyenTrustly.icon)
     }

--- a/Tests/Primer/CheckoutComponents/WebRedirect/SwishRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/SwishRegistrationTests.swift
@@ -1,0 +1,185 @@
+//
+//  SwishRegistrationTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class SwishRegistrationTests: XCTestCase {
+
+    private var container: Container!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try await ContainerTestHelpers.createTestContainer()
+        PaymentMethodRegistry.shared.reset()
+    }
+
+    override func tearDown() async throws {
+        await container.reset(ignoreDependencies: [Never.Type]())
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - PrimerPaymentMethodType Tests
+
+    func test_adyenSwish_rawValue() {
+        XCTAssertEqual(PrimerPaymentMethodType.adyenSwish.rawValue, "ADYEN_SWISH")
+    }
+
+    func test_adyenSwish_provider() {
+        XCTAssertEqual(PrimerPaymentMethodType.adyenSwish.provider, "ADYEN")
+    }
+
+    func test_adyenSwish_decodable() throws {
+        let data = Data("\"ADYEN_SWISH\"".utf8)
+        let decoded = try JSONDecoder().decode(PrimerPaymentMethodType.self, from: data)
+        XCTAssertEqual(decoded, .adyenSwish)
+    }
+
+    func test_adyenSwish_encodable() throws {
+        let encoded = try JSONEncoder().encode(PrimerPaymentMethodType.adyenSwish)
+        let string = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(string, "\"ADYEN_SWISH\"")
+    }
+
+    func test_adyenSwish_includedInAllCases() {
+        XCTAssertTrue(PrimerPaymentMethodType.allCases.contains(.adyenSwish))
+    }
+
+    // MARK: - WebRedirect Registration Tests
+
+    func test_swish_registeredAsWebRedirect() {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.adyenSwish.rawValue])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertTrue(registered.contains(PrimerPaymentMethodType.adyenSwish.rawValue))
+    }
+
+    func test_swish_notRegistered_whenNotIncluded() {
+        // Given
+        WebRedirectPaymentMethod.register(types: ["ADYEN_TWINT"])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertFalse(registered.contains(PrimerPaymentMethodType.adyenSwish.rawValue))
+    }
+
+    func test_swish_createScope_returnsDefaultWebRedirectScope() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.adyenSwish.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.adyenSwish.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        XCTAssertTrue(scope is DefaultWebRedirectScope)
+    }
+
+    func test_swish_createScope_setsCorrectPaymentMethodType() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.adyenSwish.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.adyenSwish.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        let webRedirectScope = try XCTUnwrap(scope as? DefaultWebRedirectScope)
+        XCTAssertEqual(webRedirectScope.paymentMethodType, PrimerPaymentMethodType.adyenSwish.rawValue)
+    }
+
+    func test_swish_createScope_withMissingDependencies_throws() async throws {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.adyenSwish.rawValue])
+        let emptyContainer = Container()
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When/Then
+        do {
+            _ = try await PaymentMethodRegistry.shared.createScope(
+                for: PrimerPaymentMethodType.adyenSwish.rawValue,
+                checkoutScope: checkoutScope,
+                diContainer: emptyContainer
+            )
+            XCTFail("Expected error when required dependency is missing")
+        } catch {
+            XCTAssertTrue(error is ContainerError || error is PrimerError)
+        }
+    }
+
+    func test_swish_registeredAlongsideOtherWebRedirectTypes() {
+        // Given
+        let types = [
+            "ADYEN_TWINT",
+            PrimerPaymentMethodType.adyenSwish.rawValue,
+            "ADYEN_SOFORT"
+        ]
+
+        // When
+        WebRedirectPaymentMethod.register(types: types)
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        for type in types {
+            XCTAssertTrue(registered.contains(type), "Expected \(type) to be registered")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func registerWebRedirectDependencies() async {
+        _ = try? await container.register(ProcessWebRedirectPaymentInteractor.self)
+            .asSingleton()
+            .with { _ in StubSwishWebRedirectInteractor() }
+
+        _ = try? await container.register(PaymentMethodMapper.self)
+            .asSingleton()
+            .with { _ in StubSwishPaymentMethodMapper() }
+
+        _ = try? await container.register(WebRedirectRepository.self)
+            .asSingleton()
+            .with { _ in MockWebRedirectRepository() }
+    }
+}
+
+// MARK: - Stubs
+
+@available(iOS 15.0, *)
+private final class StubSwishWebRedirectInteractor: ProcessWebRedirectPaymentInteractor {
+    func execute(paymentMethodType: String) async throws -> PaymentResult {
+        PaymentResult(paymentId: "swish_payment_123", status: .success)
+    }
+}
+
+@available(iOS 15.0, *)
+private final class StubSwishPaymentMethodMapper: PaymentMethodMapper {
+    func mapToPublic(_ internalMethod: InternalPaymentMethod) -> CheckoutPaymentMethod {
+        CheckoutPaymentMethod(
+            id: internalMethod.id,
+            type: internalMethod.type,
+            name: internalMethod.name
+        )
+    }
+
+    func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod] {
+        internalMethods.map { mapToPublic($0) }
+    }
+}


### PR DESCRIPTION
## Summary
- Register `ADYEN_SWISH` (Swish) as a WebRedirect payment method
- Backend sends `WEB_REDIRECT` on mobile via `mobile-override-implementation-type`, so it auto-registers with the existing filter
- Uses `swish-logo-colored` icon asset (already in bundle)

**Jira:** [ACC-7019](https://primerapi.atlassian.net/browse/ACC-7019)

## Changes
| File | Change |
|------|--------|
| `PrimerPaymentMethodType.swift` | Add `adyenSwish` enum case + provider |
| `PrimerPaymentMethodType+ImageName.swift` | Add `icon` (swish-logo-colored) |
| `UserInterfaceModule.swift` | Add to exhaustive switch (return nil) |
| `SwishRegistrationTests.swift` | **New** — 11 registration tests |
| `PrimerPaymentMethodTypeImageNameTests.swift` | Add icon test |

## Test plan
- [x] Build succeeds
- [x] All 12 new tests pass (11 registration + 1 image)
- [x] All existing tests pass
- [x] SwiftFormat + SwiftLint clean

[ACC-7019]: https://primerapi.atlassian.net/browse/ACC-7019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ