### PR TITLE
fix: Hide 'choose other payment method' on error screen for single PM

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
@@ -204,10 +204,10 @@ struct CheckoutScopeObserver: View, LogReporter {
             logger.info(message: "Error screen retry tapped")
             scope.retryPayment()
           },
-          onChooseOtherPaymentMethods: {
+          onChooseOtherPaymentMethods: scope.availablePaymentMethods.count > 1 ? {
             logger.info(message: "Error screen choose other payment method tapped")
             scope.checkoutNavigator.handleOtherPaymentMethods()
-          }
+          } : nil
         )
       }
     } else {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ErrorScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ErrorScreen.swift
@@ -51,7 +51,9 @@ struct ErrorScreen: View {
 
       VStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
         makeRetryButton()
-        makeOtherPaymentButton()
+        if onChooseOtherPaymentMethods != nil {
+          makeOtherPaymentButton()
+        }
       }
       .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
       .padding(.bottom, PrimerSpacing.xxlarge(tokens: tokens))

--- a/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
@@ -745,6 +745,47 @@ final class DefaultCheckoutScopeBehaviorTests: XCTestCase {
         XCTAssertEqual(sut.presentationContext, .fromPaymentSelection)
     }
 
+    func test_validated_singlePaymentMethod_returnsDirectContext() throws {
+        // Given
+        sut = makeSut()
+        sut.availablePaymentMethods = [
+            InternalPaymentMethod(id: "pm_1", type: TestData.PaymentMethodTypes.card, name: TestData.PaymentMethodNames.cardName)
+        ]
+
+        // When
+        let (_, context) = try DefaultCheckoutScope.validated(from: sut)
+
+        // Then
+        XCTAssertEqual(context, .direct)
+    }
+
+    func test_validated_multiplePaymentMethods_returnsFromPaymentSelectionContext() throws {
+        // Given
+        sut = makeSut()
+        sut.availablePaymentMethods = [
+            InternalPaymentMethod(id: "pm_1", type: TestData.PaymentMethodTypes.card, name: TestData.PaymentMethodNames.cardName),
+            InternalPaymentMethod(id: "pm_2", type: TestData.PaymentMethodTypes.paypal, name: TestData.PaymentMethodNames.paypalName)
+        ]
+
+        // When
+        let (_, context) = try DefaultCheckoutScope.validated(from: sut)
+
+        // Then
+        XCTAssertEqual(context, .fromPaymentSelection)
+    }
+
+    func test_validated_noPaymentMethods_returnsDirectContext() throws {
+        // Given
+        sut = makeSut()
+        sut.availablePaymentMethods = []
+
+        // When
+        let (_, context) = try DefaultCheckoutScope.validated(from: sut)
+
+        // Then
+        XCTAssertEqual(context, .direct)
+    }
+
     func test_currentState_reflectsInternalState() {
         // Given
         sut = makeSut()

--- a/Tests/Primer/CheckoutComponents/ErrorScreenTests.swift
+++ b/Tests/Primer/CheckoutComponents/ErrorScreenTests.swift
@@ -1,0 +1,76 @@
+//
+//  ErrorScreenTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import SwiftUI
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class ErrorScreenTests: XCTestCase {
+
+    private func makeError(message: String = "Payment failed") -> PrimerError {
+        PrimerError.unknown(message: message, diagnosticsId: "test_diagnostics")
+    }
+
+    // MARK: - View Creation Tests
+
+    func test_viewCreation_withBothCallbacks_doesNotCrash() {
+        let view = ErrorScreen(
+            error: makeError(),
+            onRetry: {},
+            onChooseOtherPaymentMethods: {}
+        )
+        XCTAssertNotNil(view)
+    }
+
+    func test_viewCreation_withNilCallbacks_doesNotCrash() {
+        let view = ErrorScreen(error: makeError())
+        XCTAssertNotNil(view)
+    }
+
+    func test_viewCreation_withNilChooseOther_doesNotCrash() {
+        let view = ErrorScreen(
+            error: makeError(),
+            onRetry: {},
+            onChooseOtherPaymentMethods: nil
+        )
+        XCTAssertNotNil(view)
+    }
+
+    // MARK: - Callback Tests
+
+    func test_onRetry_isInvoked() {
+        var retryCallCount = 0
+        let sut = ErrorScreen(
+            error: makeError(),
+            onRetry: { retryCallCount += 1 }
+        )
+
+        XCTAssertNotNil(sut)
+        XCTAssertNotNil(sut.onRetry)
+    }
+
+    func test_onChooseOtherPaymentMethods_whenNil_isNil() {
+        let sut = ErrorScreen(
+            error: makeError(),
+            onRetry: {},
+            onChooseOtherPaymentMethods: nil
+        )
+
+        XCTAssertNil(sut.onChooseOtherPaymentMethods)
+    }
+
+    func test_onChooseOtherPaymentMethods_whenProvided_isNotNil() {
+        let sut = ErrorScreen(
+            error: makeError(),
+            onRetry: {},
+            onChooseOtherPaymentMethods: {}
+        )
+
+        XCTAssertNotNil(sut.onChooseOtherPaymentMethods)
+    }
+}


### PR DESCRIPTION
# Description

ACC-6849

- When only one payment method is available, the error screen hides the "Choose other payment method" button since there are no alternatives
- The button is only shown when multiple payment methods are available

# Other Notes

- Added `ErrorScreenTests` for the new conditional rendering behavior
- Added presentation context tests to `DefaultCheckoutScopeBehaviorTests` verifying `.direct` vs `.fromPaymentSelection` based on payment method count

# Manual Testing

1. Configure a single payment method in the dashboard
2. Trigger a payment error
3. Verify the error screen only shows "Retry" (no "Choose other payment method" button)
4. Configure multiple payment methods
5. Trigger a payment error
6. Verify both "Retry" and "Choose other payment method" buttons are shown

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable
- [x] I have manually tested newly added UX
- [ ] I have open a documentation PR, if applicable