### PR TITLE
feat: Implement NETS in CheckoutComponents

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -111,6 +111,8 @@ extension PrimerPaymentMethodType {
       UIImage(primerResource: "giropay-icon")
     case .payNLIdeal:
       UIImage(primerResource: "ideal-icon-colored")
+    case .payNLKaartdirect:
+      ImageName.genericCard.image
     case .payNLPayconiq:
       UIImage(primerResource: "payconiq-icon-colored")
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -103,6 +103,8 @@ extension PrimerPaymentMethodType {
       ImageName.genericCard.image
     case .mollieIdeal:
       UIImage(primerResource: "ideal-icon-colored")
+    case .nets:
+      ImageName.genericCard.image
 
     // Pay.nl payment methods
     case .payNLBancontact:

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -150,9 +150,15 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     FormRedirectPaymentMethod.register()
     QRCodePaymentMethod.registerAll([.xfersPayNow, .rapydPromptPay, .omisePromptPay])
 
+    // Payment methods that use the WebRedirect flow but whose backend `implementationType`
+    // is NATIVE_SDK instead of WEB_REDIRECT (e.g. due to custom drop-in buttons).
+    // Mirrors the WEB SDK's `mergeConfigWithLocalDefinitions` override.
+    let nativeSdkRedirectTypes: Set<String> = [
+      PrimerPaymentMethodType.payNLKaartdirect.rawValue
+    ]
     let webRedirectTypes = PrimerAPIConfigurationModule.apiConfiguration?
       .paymentMethods?
-      .filter { $0.implementationType == .webRedirect }
+      .filter { $0.implementationType == .webRedirect || nativeSdkRedirectTypes.contains($0.type) }
       .map(\.type) ?? []
     WebRedirectPaymentMethod.register(types: webRedirectTypes)
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -154,6 +154,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     // is NATIVE_SDK instead of WEB_REDIRECT (e.g. due to custom drop-in buttons).
     // Mirrors the WEB SDK's `mergeConfigWithLocalDefinitions` override.
     let nativeSdkRedirectTypes: Set<String> = [
+      PrimerPaymentMethodType.nets.rawValue,
       PrimerPaymentMethodType.payNLKaartdirect.rawValue
     ]
     let webRedirectTypes = PrimerAPIConfigurationModule.apiConfiguration?

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
@@ -69,6 +69,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
     case mollieBankcontact              = "MOLLIE_BANCONTACT"
     case mollieGiftcard                 = "MOLLIE_GIFTCARD"
     case mollieIdeal                    = "MOLLIE_IDEAL"
+    case nets                           = "NETS"
     case opennode                       = "OPENNODE"
     case payNLBancontact                = "PAY_NL_BANCONTACT"
     case payNLGiropay                   = "PAY_NL_GIROPAY"
@@ -123,6 +124,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
              .googlePay,
              .hoolah,
              .klarna,
+             .nets,
              .opennode,
              .paymentCard,
              .payPal,

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
@@ -73,6 +73,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
     case payNLBancontact                = "PAY_NL_BANCONTACT"
     case payNLGiropay                   = "PAY_NL_GIROPAY"
     case payNLIdeal                     = "PAY_NL_IDEAL"
+    case payNLKaartdirect                = "PAY_NL_KAARTDIRECT"
     case payNLPayconiq                  = "PAY_NL_PAYCONIQ"
     case paymentCard                    = "PAYMENT_CARD"
     case payPal                         = "PAYPAL"
@@ -146,6 +147,7 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
         case .payNLBancontact,
              .payNLGiropay,
              .payNLIdeal,
+             .payNLKaartdirect,
              .payNLPayconiq:
             "PAY_NL"
 

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -757,6 +757,7 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
         case .mollieGiftcard,
+             .nets,
              .payNLKaartdirect:
             return nil
         }

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -756,7 +756,8 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
             return nil
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
-        case .mollieGiftcard:
+        case .mollieGiftcard,
+             .payNLKaartdirect:
             return nil
         }
     }

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -756,9 +756,7 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
             return nil
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
-        case .mollieGiftcard,
-             .nets,
-             .payNLKaartdirect:
+        case .mollieGiftcard, .nets, .payNLKaartdirect:
             return nil
         }
     }

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -247,6 +247,11 @@ final class PrimerPaymentMethodTypeIconTests: XCTestCase {
         XCTAssertNotNil(PrimerPaymentMethodType.payNLIdeal.icon)
     }
 
+    func test_icon_payNLKaartdirect_returnsGenericCardImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.payNLKaartdirect.icon)
+        XCTAssertEqual(PrimerPaymentMethodType.payNLKaartdirect.icon, ImageName.genericCard.image)
+    }
+
     func test_icon_payNLPayconiq_returnsNonNilImage() {
         XCTAssertNotNil(PrimerPaymentMethodType.payNLPayconiq.icon)
     }

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -233,6 +233,11 @@ final class PrimerPaymentMethodTypeIconTests: XCTestCase {
         XCTAssertNotNil(PrimerPaymentMethodType.mollieIdeal.icon)
     }
 
+    func test_icon_nets_returnsGenericCardImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.nets.icon)
+        XCTAssertEqual(PrimerPaymentMethodType.nets.icon, ImageName.genericCard.image)
+    }
+
     // MARK: - Pay.nl Payment Methods
 
     func test_icon_payNLBancontact_returnsNonNilImage() {

--- a/Tests/Primer/CheckoutComponents/WebRedirect/KaartdirectRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/KaartdirectRegistrationTests.swift
@@ -72,10 +72,10 @@ final class KaartdirectRegistrationTests: XCTestCase {
     }
 
     func test_kaartdirect_createScope_returnsDefaultWebRedirectScope() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerWebRedirectDependencies()
-        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(
@@ -89,10 +89,10 @@ final class KaartdirectRegistrationTests: XCTestCase {
     }
 
     func test_kaartdirect_createScope_setsCorrectPaymentMethodType() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerWebRedirectDependencies()
-        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(
@@ -107,10 +107,10 @@ final class KaartdirectRegistrationTests: XCTestCase {
     }
 
     func test_kaartdirect_createScope_withMissingDependencies_throws() async throws {
-        // Given
-        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+        // Given — register after scope creation since init calls reset()
         let emptyContainer = Container()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
 
         // When/Then
         do {

--- a/Tests/Primer/CheckoutComponents/WebRedirect/KaartdirectRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/KaartdirectRegistrationTests.swift
@@ -1,0 +1,185 @@
+//
+//  KaartdirectRegistrationTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class KaartdirectRegistrationTests: XCTestCase {
+
+    private var container: Container!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try await ContainerTestHelpers.createTestContainer()
+        PaymentMethodRegistry.shared.reset()
+    }
+
+    override func tearDown() async throws {
+        await container.reset(ignoreDependencies: [Never.Type]())
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - PrimerPaymentMethodType Tests
+
+    func test_payNLKaartdirect_rawValue() {
+        XCTAssertEqual(PrimerPaymentMethodType.payNLKaartdirect.rawValue, "PAY_NL_KAARTDIRECT")
+    }
+
+    func test_payNLKaartdirect_provider() {
+        XCTAssertEqual(PrimerPaymentMethodType.payNLKaartdirect.provider, "PAY_NL")
+    }
+
+    func test_payNLKaartdirect_decodable() throws {
+        let data = Data("\"PAY_NL_KAARTDIRECT\"".utf8)
+        let decoded = try JSONDecoder().decode(PrimerPaymentMethodType.self, from: data)
+        XCTAssertEqual(decoded, .payNLKaartdirect)
+    }
+
+    func test_payNLKaartdirect_encodable() throws {
+        let encoded = try JSONEncoder().encode(PrimerPaymentMethodType.payNLKaartdirect)
+        let string = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(string, "\"PAY_NL_KAARTDIRECT\"")
+    }
+
+    func test_payNLKaartdirect_includedInAllCases() {
+        XCTAssertTrue(PrimerPaymentMethodType.allCases.contains(.payNLKaartdirect))
+    }
+
+    // MARK: - WebRedirect Registration Tests
+
+    func test_kaartdirect_registeredAsWebRedirect() {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertTrue(registered.contains(PrimerPaymentMethodType.payNLKaartdirect.rawValue))
+    }
+
+    func test_kaartdirect_notRegistered_whenNotIncluded() {
+        // Given
+        WebRedirectPaymentMethod.register(types: ["ADYEN_TWINT"])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertFalse(registered.contains(PrimerPaymentMethodType.payNLKaartdirect.rawValue))
+    }
+
+    func test_kaartdirect_createScope_returnsDefaultWebRedirectScope() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        XCTAssertTrue(scope is DefaultWebRedirectScope)
+    }
+
+    func test_kaartdirect_createScope_setsCorrectPaymentMethodType() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        let webRedirectScope = try XCTUnwrap(scope as? DefaultWebRedirectScope)
+        XCTAssertEqual(webRedirectScope.paymentMethodType, PrimerPaymentMethodType.payNLKaartdirect.rawValue)
+    }
+
+    func test_kaartdirect_createScope_withMissingDependencies_throws() async throws {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.payNLKaartdirect.rawValue])
+        let emptyContainer = Container()
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When/Then
+        do {
+            _ = try await PaymentMethodRegistry.shared.createScope(
+                for: PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+                checkoutScope: checkoutScope,
+                diContainer: emptyContainer
+            )
+            XCTFail("Expected error when required dependency is missing")
+        } catch {
+            XCTAssertTrue(error is ContainerError || error is PrimerError)
+        }
+    }
+
+    func test_kaartdirect_registeredAlongsideOtherWebRedirectTypes() {
+        // Given
+        let types = [
+            "ADYEN_TWINT",
+            PrimerPaymentMethodType.payNLKaartdirect.rawValue,
+            "ADYEN_SOFORT"
+        ]
+
+        // When
+        WebRedirectPaymentMethod.register(types: types)
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        for type in types {
+            XCTAssertTrue(registered.contains(type), "Expected \(type) to be registered")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func registerWebRedirectDependencies() async {
+        _ = try? await container.register(ProcessWebRedirectPaymentInteractor.self)
+            .asSingleton()
+            .with { _ in StubKaartdirectWebRedirectInteractor() }
+
+        _ = try? await container.register(PaymentMethodMapper.self)
+            .asSingleton()
+            .with { _ in StubKaartdirectPaymentMethodMapper() }
+
+        _ = try? await container.register(WebRedirectRepository.self)
+            .asSingleton()
+            .with { _ in MockWebRedirectRepository() }
+    }
+}
+
+// MARK: - Stubs
+
+@available(iOS 15.0, *)
+private final class StubKaartdirectWebRedirectInteractor: ProcessWebRedirectPaymentInteractor {
+    func execute(paymentMethodType: String) async throws -> PaymentResult {
+        PaymentResult(paymentId: "kaartdirect_payment_123", status: .success)
+    }
+}
+
+@available(iOS 15.0, *)
+private final class StubKaartdirectPaymentMethodMapper: PaymentMethodMapper {
+    func mapToPublic(_ internalMethod: InternalPaymentMethod) -> CheckoutPaymentMethod {
+        CheckoutPaymentMethod(
+            id: internalMethod.id,
+            type: internalMethod.type,
+            name: internalMethod.name
+        )
+    }
+
+    func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod] {
+        internalMethods.map { mapToPublic($0) }
+    }
+}

--- a/Tests/Primer/CheckoutComponents/WebRedirect/NetsRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/NetsRegistrationTests.swift
@@ -1,0 +1,185 @@
+//
+//  NetsRegistrationTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class NetsRegistrationTests: XCTestCase {
+
+    private var container: Container!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        container = try await ContainerTestHelpers.createTestContainer()
+        PaymentMethodRegistry.shared.reset()
+    }
+
+    override func tearDown() async throws {
+        await container.reset(ignoreDependencies: [Never.Type]())
+        container = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - PrimerPaymentMethodType Tests
+
+    func test_nets_rawValue() {
+        XCTAssertEqual(PrimerPaymentMethodType.nets.rawValue, "NETS")
+    }
+
+    func test_nets_provider() {
+        XCTAssertEqual(PrimerPaymentMethodType.nets.provider, "NETS")
+    }
+
+    func test_nets_decodable() throws {
+        let data = Data("\"NETS\"".utf8)
+        let decoded = try JSONDecoder().decode(PrimerPaymentMethodType.self, from: data)
+        XCTAssertEqual(decoded, .nets)
+    }
+
+    func test_nets_encodable() throws {
+        let encoded = try JSONEncoder().encode(PrimerPaymentMethodType.nets)
+        let string = String(data: encoded, encoding: .utf8)
+        XCTAssertEqual(string, "\"NETS\"")
+    }
+
+    func test_nets_includedInAllCases() {
+        XCTAssertTrue(PrimerPaymentMethodType.allCases.contains(.nets))
+    }
+
+    // MARK: - WebRedirect Registration Tests
+
+    func test_nets_registeredAsWebRedirect() {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.nets.rawValue])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertTrue(registered.contains(PrimerPaymentMethodType.nets.rawValue))
+    }
+
+    func test_nets_notRegistered_whenNotIncluded() {
+        // Given
+        WebRedirectPaymentMethod.register(types: ["ADYEN_TWINT"])
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        XCTAssertFalse(registered.contains(PrimerPaymentMethodType.nets.rawValue))
+    }
+
+    func test_nets_createScope_returnsDefaultWebRedirectScope() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.nets.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.nets.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        XCTAssertTrue(scope is DefaultWebRedirectScope)
+    }
+
+    func test_nets_createScope_setsCorrectPaymentMethodType() async throws {
+        // Given
+        await registerWebRedirectDependencies()
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.nets.rawValue])
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When
+        let scope = try await PaymentMethodRegistry.shared.createScope(
+            for: PrimerPaymentMethodType.nets.rawValue,
+            checkoutScope: checkoutScope,
+            diContainer: container
+        )
+
+        // Then
+        let webRedirectScope = try XCTUnwrap(scope as? DefaultWebRedirectScope)
+        XCTAssertEqual(webRedirectScope.paymentMethodType, PrimerPaymentMethodType.nets.rawValue)
+    }
+
+    func test_nets_createScope_withMissingDependencies_throws() async throws {
+        // Given
+        WebRedirectPaymentMethod.register(types: [PrimerPaymentMethodType.nets.rawValue])
+        let emptyContainer = Container()
+        let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+        // When/Then
+        do {
+            _ = try await PaymentMethodRegistry.shared.createScope(
+                for: PrimerPaymentMethodType.nets.rawValue,
+                checkoutScope: checkoutScope,
+                diContainer: emptyContainer
+            )
+            XCTFail("Expected error when required dependency is missing")
+        } catch {
+            XCTAssertTrue(error is ContainerError || error is PrimerError)
+        }
+    }
+
+    func test_nets_registeredAlongsideOtherWebRedirectTypes() {
+        // Given
+        let types = [
+            "ADYEN_TWINT",
+            PrimerPaymentMethodType.nets.rawValue,
+            PrimerPaymentMethodType.payNLKaartdirect.rawValue
+        ]
+
+        // When
+        WebRedirectPaymentMethod.register(types: types)
+
+        // Then
+        let registered = PaymentMethodRegistry.shared.registeredTypes
+        for type in types {
+            XCTAssertTrue(registered.contains(type), "Expected \(type) to be registered")
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func registerWebRedirectDependencies() async {
+        _ = try? await container.register(ProcessWebRedirectPaymentInteractor.self)
+            .asSingleton()
+            .with { _ in StubNetsWebRedirectInteractor() }
+
+        _ = try? await container.register(PaymentMethodMapper.self)
+            .asSingleton()
+            .with { _ in StubNetsPaymentMethodMapper() }
+
+        _ = try? await container.register(WebRedirectRepository.self)
+            .asSingleton()
+            .with { _ in MockWebRedirectRepository() }
+    }
+}
+
+// MARK: - Stubs
+
+@available(iOS 15.0, *)
+private final class StubNetsWebRedirectInteractor: ProcessWebRedirectPaymentInteractor {
+    func execute(paymentMethodType: String) async throws -> PaymentResult {
+        PaymentResult(paymentId: "nets_payment_123", status: .success)
+    }
+}
+
+@available(iOS 15.0, *)
+private final class StubNetsPaymentMethodMapper: PaymentMethodMapper {
+    func mapToPublic(_ internalMethod: InternalPaymentMethod) -> CheckoutPaymentMethod {
+        CheckoutPaymentMethod(
+            id: internalMethod.id,
+            type: internalMethod.type,
+            name: internalMethod.name
+        )
+    }
+
+    func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod] {
+        internalMethods.map { mapToPublic($0) }
+    }
+}


### PR DESCRIPTION
## Summary
- Register `NETS` (Nets Pay by Card) as a WebRedirect payment method in CheckoutComponents
- Backend returns `NATIVE_SDK` but WEB SDK confirms it's a standard popup redirect flow
- Added to `nativeSdkRedirectTypes` set (same pattern as Kaartdirect)
- New enum case `nets = "NETS"` with self-provider

**Jira:** [ACC-7024](https://primerapi.atlassian.net/browse/ACC-7024)

## Context
Stacked on #1685 (Kaartdirect). NETS is a Nordic card payment method where the user is redirected to a Nets-hosted page for card entry. The WEB SDK implements it as a simple `createPaymentMethod()` with a 830x745 popup — no custom UI needed.

## Changes
| File | Change |
|------|--------|
| `PrimerPaymentMethodType.swift` | Add `nets` enum case + provider (rawValue) |
| `DefaultCheckoutScope.swift` | Add to `nativeSdkRedirectTypes` set |
| `PrimerPaymentMethodType+ImageName.swift` | Add `icon` (genericCard fallback) |
| `UserInterfaceModule.swift` | Add to exhaustive switch (return nil) |
| `NetsRegistrationTests.swift` | **New** — 11 registration tests |
| `PrimerPaymentMethodTypeImageNameTests.swift` | Add icon test |

## Test plan
- [x] Build succeeds
- [x] All 12 new tests pass (11 registration + 1 image)
- [x] All existing tests pass
- [x] SwiftFormat + SwiftLint clean

[ACC-7024]: https://primerapi.atlassian.net/browse/ACC-7024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ