### PR TITLE
feat: Implement ADYEN_AFFIRM billing address redirect in CheckoutComponents

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Accessibility/Domain/AccessibilityIdentifiers.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Accessibility/Domain/AccessibilityIdentifiers.swift
@@ -159,6 +159,18 @@ enum AccessibilityIdentifiers {
     static let cancelButton = "checkout_components_web_redirect_cancel_button"
   }
 
+  enum BillingAddressRedirect {
+    static let screen = "checkout_components_billing_address_redirect_screen"
+    static let countryCodeField = "checkout_components_billing_address_redirect_country_code_field"
+    static let addressLine1Field = "checkout_components_billing_address_redirect_address_line1_field"
+    static let addressLine2Field = "checkout_components_billing_address_redirect_address_line2_field"
+    static let postalCodeField = "checkout_components_billing_address_redirect_postal_code_field"
+    static let cityField = "checkout_components_billing_address_redirect_city_field"
+    static let stateField = "checkout_components_billing_address_redirect_state_field"
+    static let submitButton = "checkout_components_billing_address_redirect_submit_button"
+    static let backButton = "checkout_components_billing_address_redirect_back_button"
+  }
+
   enum FormRedirect {
     static let screen = "checkout_components_form_redirect_screen"
     static let otpField = "checkout_components_form_redirect_otp_field"

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Extensions/PrimerPaymentMethodType+ImageName.swift
@@ -51,6 +51,8 @@ extension PrimerPaymentMethodType {
       UIImage(primerResource: "coinbase-icon-colored")
 
     // Adyen payment methods
+    case .adyenAffirm:
+      ImageName.genericCard.image
     case .adyenAlipay:
       UIImage(primerResource: "alipay-icon-colored")
     case .adyenBlik:

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultBillingAddressRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultBillingAddressRedirectScope.swift
@@ -1,0 +1,276 @@
+//
+//  DefaultBillingAddressRedirectScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultBillingAddressRedirectScope: PrimerBillingAddressRedirectScope, ObservableObject, LogReporter {
+
+  let paymentMethodType: String
+
+  private(set) var presentationContext: PresentationContext
+
+  var dismissalMechanism: [DismissalMechanism] {
+    checkoutScope?.dismissalMechanism ?? []
+  }
+
+  var state: AsyncStream<PrimerBillingAddressRedirectState> {
+    AsyncStream { continuation in
+      let task = Task { @MainActor in
+        for await _ in $internalState.values {
+          continuation.yield(internalState)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
+  var screen: BillingAddressRedirectScreenComponent?
+  var submitButton: BillingAddressRedirectButtonComponent?
+  var submitButtonText: String?
+
+  private weak var checkoutScope: DefaultCheckoutScope?
+  private let processWebRedirectInteractor: ProcessWebRedirectPaymentInteractor
+  private let validationService: ValidationService
+  private let accessibilityService: AccessibilityAnnouncementService?
+  private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol?
+  private let repository: WebRedirectRepository?
+
+  @Published private var internalState: PrimerBillingAddressRedirectState
+
+  private var hasStarted = false
+
+  init(
+    paymentMethodType: String,
+    checkoutScope: DefaultCheckoutScope,
+    presentationContext: PresentationContext = .fromPaymentSelection,
+    processWebRedirectInteractor: ProcessWebRedirectPaymentInteractor,
+    validationService: ValidationService = DefaultValidationService(),
+    accessibilityService: AccessibilityAnnouncementService? = nil,
+    analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol? = nil,
+    repository: WebRedirectRepository? = nil,
+    paymentMethod: CheckoutPaymentMethod? = nil,
+    surchargeAmount: String? = nil
+  ) {
+    self.paymentMethodType = paymentMethodType
+    self.checkoutScope = checkoutScope
+    self.presentationContext = presentationContext
+    self.processWebRedirectInteractor = processWebRedirectInteractor
+    self.validationService = validationService
+    self.accessibilityService = accessibilityService
+    self.analyticsInteractor = analyticsInteractor
+    self.repository = repository
+    internalState = PrimerBillingAddressRedirectState(
+      status: .ready,
+      paymentMethod: paymentMethod,
+      surchargeAmount: surchargeAmount
+    )
+  }
+
+  // MARK: - Lifecycle
+
+  func start() {
+    guard !hasStarted else { return }
+    hasStarted = true
+    logger.debug(message: "Billing address redirect scope started for \(paymentMethodType)")
+
+    Task {
+      try? await ClientSessionActionsModule().selectPaymentMethodIfNeeded(paymentMethodType, cardNetwork: nil)
+    }
+  }
+
+  func submit() {
+    guard internalState.isFormValid else {
+      logger.warn(message: "Submit called but billing address form is not valid")
+      validateAllFields()
+      return
+    }
+
+    Task {
+      await performPayment()
+    }
+  }
+
+  func cancel() {
+    repository?.cancelPolling(paymentMethodType: paymentMethodType)
+    internalState.status = .ready
+    checkoutScope?.onDismiss()
+  }
+
+  func onBack() {
+    if presentationContext.shouldShowBackButton {
+      checkoutScope?.checkoutNavigator.navigateBack()
+    }
+  }
+
+  // MARK: - Field Updates
+
+  func updateCountryCode(_ value: String) {
+    internalState.countryCode = value
+    validateField(.countryCode, value: value)
+    revalidateFormValidity()
+  }
+
+  func updateAddressLine1(_ value: String) {
+    internalState.addressLine1 = value
+    validateField(.addressLine1, value: value)
+    revalidateFormValidity()
+  }
+
+  func updateAddressLine2(_ value: String) {
+    internalState.addressLine2 = value
+    // addressLine2 is optional — clear any existing error
+    internalState.errors.removeValue(forKey: .addressLine2)
+    revalidateFormValidity()
+  }
+
+  func updatePostalCode(_ value: String) {
+    internalState.postalCode = value
+    validateField(.postalCode, value: value)
+    revalidateFormValidity()
+  }
+
+  func updateCity(_ value: String) {
+    internalState.city = value
+    validateField(.city, value: value)
+    revalidateFormValidity()
+  }
+
+  func updateState(_ value: String) {
+    internalState.state = value
+    validateField(.state, value: value)
+    revalidateFormValidity()
+  }
+
+  // MARK: - Validation
+
+  private func validateField(_ fieldType: PrimerInputElementType, value: String) {
+    let result = validationService.validateField(type: fieldType, value: value)
+
+    if result.isValid {
+      internalState.errors.removeValue(forKey: fieldType)
+    } else if let message = result.errorMessage {
+      internalState.errors[fieldType] = FieldError(
+        fieldType: fieldType,
+        message: message,
+        errorCode: result.errorCode
+      )
+    }
+  }
+
+  private func validateAllFields() {
+    let requiredFields: [(PrimerInputElementType, String)] = [
+      (.countryCode, internalState.countryCode),
+      (.addressLine1, internalState.addressLine1),
+      (.postalCode, internalState.postalCode),
+      (.city, internalState.city),
+      (.state, internalState.state)
+    ]
+
+    for (fieldType, value) in requiredFields {
+      validateField(fieldType, value: value)
+    }
+
+    revalidateFormValidity()
+  }
+
+  private func revalidateFormValidity() {
+    let requiredFieldsNonEmpty =
+      !internalState.countryCode.isEmpty &&
+      !internalState.addressLine1.isEmpty &&
+      !internalState.postalCode.isEmpty &&
+      !internalState.city.isEmpty &&
+      !internalState.state.isEmpty
+
+    let noErrors = internalState.errors.isEmpty
+
+    internalState.isFormValid = requiredFieldsNonEmpty && noErrors
+  }
+
+  // MARK: - Payment Flow
+
+  private func performPayment() async {
+    guard let checkoutScope else { return }
+
+    internalState.status = .submitting
+    checkoutScope.startProcessing()
+
+    await analyticsInteractor?.trackEvent(
+      .paymentSubmitted,
+      metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+    )
+
+    do {
+      try await checkoutScope.invokeBeforePaymentCreate(
+        paymentMethodType: paymentMethodType
+      )
+
+      // Send billing address to backend before redirect
+      let billingAddress = createBillingAddress()
+      if let billingAddress {
+        try await ClientSessionActionsModule
+          .updateBillingAddressViaClientSessionActionWithAddressIfNeeded(billingAddress)
+      }
+
+      await analyticsInteractor?.trackEvent(
+        .paymentProcessingStarted,
+        metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+      )
+
+      internalState.status = .redirecting
+
+      let result = try await processWebRedirectInteractor.execute(
+        paymentMethodType: paymentMethodType
+      )
+
+      checkoutScope.startProcessing()
+      internalState.status = .polling
+
+      await analyticsInteractor?.trackEvent(
+        .paymentRedirectToThirdParty,
+        metadata: .payment(PaymentEvent(paymentMethod: paymentMethodType))
+      )
+
+      internalState.status = .success
+      checkoutScope.handlePaymentSuccess(result)
+
+    } catch {
+      checkoutScope.startProcessing()
+
+      let errorMessage = (error as? PrimerError)?.localizedDescription ?? error.localizedDescription
+      internalState.status = .failure(errorMessage)
+
+      let primerError = error as? PrimerError ?? PrimerError.unknown(message: error.localizedDescription)
+      checkoutScope.handlePaymentError(primerError)
+    }
+  }
+
+  private func createBillingAddress() -> ClientSession.Address? {
+    guard !internalState.addressLine1.isEmpty else { return nil }
+
+    return ClientSession.Address(
+      firstName: nil,
+      lastName: nil,
+      addressLine1: internalState.addressLine1.nilIfEmpty,
+      addressLine2: internalState.addressLine2.nilIfEmpty,
+      city: internalState.city.nilIfEmpty,
+      postalCode: internalState.postalCode.nilIfEmpty,
+      state: internalState.state.nilIfEmpty,
+      countryCode: internalState.countryCode.nilIfEmpty.flatMap { CountryCode(rawValue: $0) }
+    )
+  }
+}
+
+private extension String {
+  var nilIfEmpty: String? {
+    isEmpty ? nil : self
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -131,9 +131,13 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     BillingAddressRedirectPaymentMethod.register()
     QRCodePaymentMethod.registerAll([.xfersPayNow, .rapydPromptPay, .omisePromptPay])
 
+    // Payment methods with dedicated scopes that override the generic WebRedirect registration.
+    let dedicatedScopeTypes: Set<String> = [
+      PrimerPaymentMethodType.adyenAffirm.rawValue
+    ]
     let webRedirectTypes = PrimerAPIConfigurationModule.apiConfiguration?
       .paymentMethods?
-      .filter { $0.implementationType == .webRedirect }
+      .filter { $0.implementationType == .webRedirect && !dedicatedScopeTypes.contains($0.type) }
       .map(\.type) ?? []
     WebRedirectPaymentMethod.register(types: webRedirectTypes)
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -128,6 +128,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     AdyenKlarnaPaymentMethod.register()
     AchPaymentMethod.register()
     FormRedirectPaymentMethod.register()
+    BillingAddressRedirectPaymentMethod.register()
     QRCodePaymentMethod.registerAll([.xfersPayNow, .rapydPromptPay, .omisePromptPay])
 
     let webRedirectTypes = PrimerAPIConfigurationModule.apiConfiguration?

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -131,13 +131,9 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     BillingAddressRedirectPaymentMethod.register()
     QRCodePaymentMethod.registerAll([.xfersPayNow, .rapydPromptPay, .omisePromptPay])
 
-    // Payment methods with dedicated scopes that override the generic WebRedirect registration.
-    let dedicatedScopeTypes: Set<String> = [
-      PrimerPaymentMethodType.adyenAffirm.rawValue
-    ]
     let webRedirectTypes = PrimerAPIConfigurationModule.apiConfiguration?
       .paymentMethods?
-      .filter { $0.implementationType == .webRedirect && !dedicatedScopeTypes.contains($0.type) }
+      .filter { $0.implementationType == .webRedirect }
       .map(\.type) ?? []
     WebRedirectPaymentMethod.register(types: webRedirectTypes)
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -1,0 +1,295 @@
+//
+//  BillingAddressRedirectScreen.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct BillingAddressRedirectScreen: View {
+
+  let scope: any PrimerBillingAddressRedirectScope
+
+  @Environment(\.designTokens) private var tokens
+  @Environment(\.diContainer) private var container
+  @State private var billingState = PrimerBillingAddressRedirectState()
+  @State private var validationService: ValidationService?
+
+  // MARK: - Local field state for text fields
+
+  @State private var countryCode = ""
+  @State private var addressLine1 = ""
+  @State private var addressLine2 = ""
+  @State private var postalCode = ""
+  @State private var city = ""
+  @State private var state = ""
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: PrimerSpacing.xxlarge(tokens: tokens)) {
+        makeHeaderSection()
+        makeBillingAddressForm()
+        makeSubmitButtonSection()
+      }
+      .padding(.horizontal, PrimerSpacing.large(tokens: tokens))
+      .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+    }
+    .frame(maxWidth: UIScreen.main.bounds.width)
+    .navigationBarHidden(true)
+    .background(CheckoutColors.background(tokens: tokens))
+    .accessibilityIdentifier(AccessibilityIdentifiers.BillingAddressRedirect.screen)
+    .task {
+      for await newState in scope.state {
+        billingState = newState
+      }
+    }
+    .onAppear { resolveValidationService() }
+  }
+
+  // MARK: - Header
+
+  private func makeHeaderSection() -> some View {
+    VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
+      HStack {
+        if scope.presentationContext.shouldShowBackButton {
+          Button(action: scope.onBack) {
+            HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+              Image(systemName: RTLIcon.backChevron)
+                .font(PrimerFont.bodyMedium(tokens: tokens))
+              Text(CheckoutComponentsStrings.backButton)
+            }
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          }
+          .accessibility(config: AccessibilityConfiguration(
+            identifier: AccessibilityIdentifiers.BillingAddressRedirect.backButton,
+            label: CheckoutComponentsStrings.a11yBack,
+            traits: [.isButton]
+          ))
+        }
+
+        Spacer()
+
+        if scope.dismissalMechanism.contains(.closeButton) {
+          Button(CheckoutComponentsStrings.cancelButton, action: scope.cancel)
+            .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        }
+      }
+
+      Text(paymentMethodDisplayName)
+        .font(PrimerFont.titleXLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityAddTraits(.isHeader)
+
+      if let surcharge = billingState.surchargeAmount {
+        Text(surcharge)
+          .font(PrimerFont.bodySmall(tokens: tokens))
+          .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+      }
+    }
+  }
+
+  // MARK: - Billing Address Form
+
+  private func makeBillingAddressForm() -> some View {
+    VStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+      makeCountryField()
+      makeTextField(
+        label: CheckoutComponentsStrings.addressLine1Label,
+        placeholder: CheckoutComponentsStrings.addressLine1Placeholder,
+        text: $addressLine1,
+        fieldType: .addressLine1,
+        identifier: AccessibilityIdentifiers.BillingAddressRedirect.addressLine1Field,
+        onUpdate: scope.updateAddressLine1
+      )
+      makeTextField(
+        label: CheckoutComponentsStrings.addressLine2Label,
+        placeholder: CheckoutComponentsStrings.addressLine2Placeholder,
+        text: $addressLine2,
+        fieldType: .addressLine2,
+        identifier: AccessibilityIdentifiers.BillingAddressRedirect.addressLine2Field,
+        onUpdate: scope.updateAddressLine2
+      )
+      HStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
+        makeTextField(
+          label: CheckoutComponentsStrings.postalCodeLabel,
+          placeholder: CheckoutComponentsStrings.postalCodePlaceholder,
+          text: $postalCode,
+          fieldType: .postalCode,
+          identifier: AccessibilityIdentifiers.BillingAddressRedirect.postalCodeField,
+          onUpdate: scope.updatePostalCode
+        )
+        makeTextField(
+          label: CheckoutComponentsStrings.cityLabel,
+          placeholder: CheckoutComponentsStrings.cityPlaceholder,
+          text: $city,
+          fieldType: .city,
+          identifier: AccessibilityIdentifiers.BillingAddressRedirect.cityField,
+          onUpdate: scope.updateCity
+        )
+      }
+      makeTextField(
+        label: CheckoutComponentsStrings.stateLabel,
+        placeholder: CheckoutComponentsStrings.statePlaceholder,
+        text: $state,
+        fieldType: .state,
+        identifier: AccessibilityIdentifiers.BillingAddressRedirect.stateField,
+        onUpdate: scope.updateState
+      )
+    }
+  }
+
+  private func makeCountryField() -> some View {
+    VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+      Text(CheckoutComponentsStrings.countryLabel)
+        .font(PrimerFont.bodySmall(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+
+      Menu {
+        ForEach(CountryCode.allCases, id: \.self) { country in
+          Button {
+            countryCode = country.rawValue
+            scope.updateCountryCode(country.rawValue)
+          } label: {
+            Text("\(country.flag) \(country.country)")
+          }
+        }
+      } label: {
+        HStack {
+          if let selected = CountryCode(rawValue: countryCode) {
+            Text("\(selected.flag ?? "") \(selected.country)")
+              .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+          } else {
+            Text(CheckoutComponentsStrings.countrySelectorPlaceholder)
+              .foregroundColor(CheckoutColors.textPlaceholder(tokens: tokens))
+          }
+          Spacer()
+          Image(systemName: "chevron.down")
+            .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+        }
+        .font(PrimerFont.bodyLarge(tokens: tokens))
+        .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+        .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
+        .background(CheckoutColors.background(tokens: tokens))
+        .overlay(
+          RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+            .stroke(fieldBorderColor(for: .countryCode), lineWidth: PrimerBorderWidth.standard)
+        )
+      }
+      .accessibilityIdentifier(AccessibilityIdentifiers.BillingAddressRedirect.countryCodeField)
+
+      if let error = billingState.errors[.countryCode] {
+        Text(error.message)
+          .font(PrimerFont.bodySmall(tokens: tokens))
+          .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
+      }
+    }
+  }
+
+  private func makeTextField(
+    label: String,
+    placeholder: String,
+    text: Binding<String>,
+    fieldType: PrimerInputElementType,
+    identifier: String,
+    onUpdate: @escaping (String) -> Void
+  ) -> some View {
+    VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+      Text(label)
+        .font(PrimerFont.bodySmall(tokens: tokens))
+        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
+
+      TextField(placeholder, text: text)
+        .font(PrimerFont.bodyLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
+        .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
+        .background(CheckoutColors.background(tokens: tokens))
+        .overlay(
+          RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
+            .stroke(fieldBorderColor(for: fieldType), lineWidth: PrimerBorderWidth.standard)
+        )
+        .autocapitalization(.words)
+        .disableAutocorrection(true)
+        .accessibilityIdentifier(identifier)
+        .onChange(of: text.wrappedValue) { newValue in
+          onUpdate(newValue)
+        }
+
+      if let error = billingState.errors[fieldType] {
+        Text(error.message)
+          .font(PrimerFont.bodySmall(tokens: tokens))
+          .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
+      }
+    }
+  }
+
+  private func fieldBorderColor(for fieldType: PrimerInputElementType) -> Color {
+    billingState.errors[fieldType] != nil
+      ? CheckoutColors.textNegative(tokens: tokens)
+      : CheckoutColors.borderDefault(tokens: tokens)
+  }
+
+  // MARK: - Submit Button
+
+  @ViewBuilder
+  private func makeSubmitButtonSection() -> some View {
+    if let customButton = scope.submitButton {
+      AnyView(customButton(scope))
+    } else {
+      Button(action: scope.submit) {
+        makeSubmitButtonContent()
+      }
+      .disabled(isButtonDisabled)
+    }
+  }
+
+  private func makeSubmitButtonContent() -> some View {
+    let isLoading = [.submitting, .redirecting, .polling].contains(billingState.status)
+
+    return HStack {
+      if isLoading {
+        ProgressView()
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.white(tokens: tokens)))
+          .scaleEffect(PrimerScale.small)
+      } else {
+        Text(submitButtonText)
+      }
+    }
+    .font(PrimerFont.body(tokens: tokens))
+    .foregroundColor(CheckoutColors.white(tokens: tokens))
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, PrimerSpacing.large(tokens: tokens))
+    .background(submitButtonBackground)
+    .cornerRadius(PrimerRadius.small(tokens: tokens))
+    .accessibility(config: AccessibilityConfiguration(
+      identifier: AccessibilityIdentifiers.BillingAddressRedirect.submitButton,
+      label: submitButtonText,
+      traits: [.isButton]
+    ))
+  }
+
+  private var submitButtonText: String {
+    scope.submitButtonText ?? CheckoutComponentsStrings.webRedirectButtonContinue(paymentMethodDisplayName)
+  }
+
+  private var submitButtonBackground: Color {
+    isButtonDisabled
+      ? CheckoutColors.gray300(tokens: tokens)
+      : CheckoutColors.textPrimary(tokens: tokens)
+  }
+
+  private var isButtonDisabled: Bool {
+    !billingState.isFormValid || [.submitting, .redirecting, .polling].contains(billingState.status)
+  }
+
+  private var paymentMethodDisplayName: String {
+    billingState.paymentMethod?.name ?? scope.paymentMethodType
+  }
+
+  private func resolveValidationService() {
+    guard let container else { return }
+    validationService = try? container.resolveSync(ValidationService.self)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/BillingAddressRedirect/BillingAddressRedirectPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/BillingAddressRedirect/BillingAddressRedirectPaymentMethod.swift
@@ -1,0 +1,66 @@
+//
+//  BillingAddressRedirectPaymentMethod.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+enum BillingAddressRedirectPaymentMethod {
+
+  @MainActor
+  static func register() {
+    PaymentMethodRegistry.shared.register(
+      paymentMethodType: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      scopeCreator: createScope(for:checkoutScope:container:),
+      viewCreator: createView(for:checkoutScope:)
+    )
+  }
+
+  @MainActor
+  private static func createScope(
+    for paymentMethodType: String,
+    checkoutScope: any PrimerCheckoutScope,
+    container: any ContainerProtocol
+  ) async throws -> DefaultBillingAddressRedirectScope {
+    let (defaultCheckoutScope, paymentMethodContext) = try DefaultCheckoutScope.validated(from: checkoutScope)
+
+    let mapper = try? await container.resolve(PaymentMethodMapper.self)
+    let paymentMethod: CheckoutPaymentMethod? = defaultCheckoutScope.availablePaymentMethods
+      .first { $0.type == paymentMethodType }
+      .flatMap { mapper?.mapToPublic($0) }
+
+    let processWebRedirectInteractor = try await container.resolve(ProcessWebRedirectPaymentInteractor.self)
+    let validationService = (try? await container.resolve(ValidationService.self)) ?? DefaultValidationService()
+    let accessibilityService = try? await container.resolve(AccessibilityAnnouncementService.self)
+    let analyticsInteractor = try? await container.resolve(CheckoutComponentsAnalyticsInteractorProtocol.self)
+    let repository = try? await container.resolve(WebRedirectRepository.self)
+
+    return DefaultBillingAddressRedirectScope(
+      paymentMethodType: paymentMethodType,
+      checkoutScope: defaultCheckoutScope,
+      presentationContext: paymentMethodContext,
+      processWebRedirectInteractor: processWebRedirectInteractor,
+      validationService: validationService,
+      accessibilityService: accessibilityService,
+      analyticsInteractor: analyticsInteractor,
+      repository: repository,
+      paymentMethod: paymentMethod,
+      surchargeAmount: paymentMethod?.formattedSurcharge
+    )
+  }
+
+  @MainActor
+  private static func createView(
+    for paymentMethodType: String,
+    checkoutScope: any PrimerCheckoutScope
+  ) -> AnyView? {
+    guard let billingScope: DefaultBillingAddressRedirectScope = checkoutScope.getPaymentMethodScope(for: paymentMethodType) else {
+      return nil
+    }
+
+    return billingScope.screen.map { AnyView($0(billingScope)) }
+      ?? AnyView(BillingAddressRedirectScreen(scope: billingScope))
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/BillingAddressRedirect/PrimerBillingAddressRedirectState.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/BillingAddressRedirect/PrimerBillingAddressRedirectState.swift
@@ -1,0 +1,59 @@
+//
+//  PrimerBillingAddressRedirectState.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+/// Billing address redirect flow:
+/// `ready` -> `submitting` -> `redirecting` -> `polling` -> `success` | `failure`
+@available(iOS 15.0, *)
+public struct PrimerBillingAddressRedirectState: Equatable, @unchecked Sendable {
+
+  /// When switching on this enum, always include a `default` case to handle future additions.
+  public enum Status: Equatable {
+    case ready
+    case submitting
+    case redirecting
+    case polling
+    case success
+    case failure(String)
+  }
+
+  public internal(set) var status: Status
+  public internal(set) var paymentMethod: CheckoutPaymentMethod?
+  public internal(set) var surchargeAmount: String?
+
+  // MARK: - Billing Address Fields
+
+  public internal(set) var countryCode: String
+  public internal(set) var addressLine1: String
+  public internal(set) var addressLine2: String
+  public internal(set) var postalCode: String
+  public internal(set) var city: String
+  public internal(set) var state: String
+
+  // MARK: - Validation
+
+  public internal(set) var errors: [PrimerInputElementType: FieldError]
+  public internal(set) var isFormValid: Bool
+
+  public init(
+    status: Status = .ready,
+    paymentMethod: CheckoutPaymentMethod? = nil,
+    surchargeAmount: String? = nil
+  ) {
+    self.status = status
+    self.paymentMethod = paymentMethod
+    self.surchargeAmount = surchargeAmount
+    countryCode = ""
+    addressLine1 = ""
+    addressLine2 = ""
+    postalCode = ""
+    city = ""
+    state = ""
+    errors = [:]
+    isFormValid = false
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerBillingAddressRedirectScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerBillingAddressRedirectScope.swift
@@ -1,0 +1,67 @@
+//
+//  PrimerBillingAddressRedirectScope.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+/// Type alias for billing address redirect screen customization component.
+@available(iOS 15.0, *)
+public typealias BillingAddressRedirectScreenComponent = (any PrimerBillingAddressRedirectScope) -> any View
+
+/// Type alias for billing address redirect button customization component.
+@available(iOS 15.0, *)
+public typealias BillingAddressRedirectButtonComponent = (any PrimerBillingAddressRedirectScope) -> any View
+
+/// Scope protocol for payment methods that require a billing address form before redirect (e.g., Affirm).
+///
+/// Provides billing address field management, state observation, and UI customization
+/// for payment methods that collect a billing address before redirecting to an external
+/// page to complete payment.
+///
+/// ## State Flow
+/// ```
+/// ready → submitting → redirecting → polling → success | failure
+/// ```
+///
+/// ## Usage
+/// ```swift
+/// if let affirmScope = checkoutScope.getPaymentMethodScope(
+///   PrimerBillingAddressRedirectScope.self
+/// ) {
+///   affirmScope.updateCountryCode("US")
+///   affirmScope.updateAddressLine1("123 Main St")
+///   affirmScope.updateCity("San Francisco")
+///   affirmScope.updateState("CA")
+///   affirmScope.updatePostalCode("94105")
+///
+///   for await state in affirmScope.state {
+///     if state.isFormValid {
+///       affirmScope.submit()
+///     }
+///   }
+/// }
+/// ```
+@available(iOS 15.0, *)
+@MainActor
+public protocol PrimerBillingAddressRedirectScope: PrimerPaymentMethodScope
+where State == PrimerBillingAddressRedirectState {
+
+  var paymentMethodType: String { get }
+
+  // MARK: - Billing Address Fields
+
+  func updateCountryCode(_ value: String)
+  func updateAddressLine1(_ value: String)
+  func updateAddressLine2(_ value: String)
+  func updatePostalCode(_ value: String)
+  func updateCity(_ value: String)
+  func updateState(_ value: String)
+
+  // MARK: - Screen-Level Customization
+
+  var screen: BillingAddressRedirectScreenComponent? { get set }
+  var submitButton: BillingAddressRedirectButtonComponent? { get set }
+  var submitButtonText: String? { get set }
+}

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethodType.swift
@@ -36,6 +36,7 @@ import Foundation
 /// - Note: **v3.0 breaking change**: This enum is now `public`. All cases are part of the
 ///   public API contract — no cases can be removed or renamed without a breaking change.
 public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, Hashable {
+    case adyenAffirm                    = "ADYEN_AFFIRM"
     case adyenAlipay                    = "ADYEN_ALIPAY"
     case adyenBlik                      = "ADYEN_BLIK"
     case adyenBancontactCard            = "ADYEN_BANCONTACT_CARD"
@@ -96,7 +97,8 @@ public enum PrimerPaymentMethodType: String, Codable, CaseIterable, Equatable, H
 
     var provider: String {
         switch self {
-        case .adyenAlipay,
+        case .adyenAffirm,
+             .adyenAlipay,
              .adyenBlik,
              .adyenBancontactCard,
              .adyenDotPay,

--- a/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
+++ b/Sources/PrimerSDK/Classes/Modules/UserInterfaceModule.swift
@@ -756,7 +756,7 @@ final class UserInterfaceModule: NSObject, UserInterfaceModuleProtocol {
             return nil
         case .fintechtureSmartTransfer, .fintechtureImmediateTransfer:
             return nil
-        case .mollieGiftcard:
+        case .adyenAffirm, .mollieGiftcard:
             return nil
         }
     }

--- a/Tests/Primer/CheckoutComponents/BillingAddressRedirect/AffirmRegistrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/BillingAddressRedirect/AffirmRegistrationTests.swift
@@ -1,0 +1,154 @@
+//
+//  AffirmRegistrationTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class AffirmRegistrationTests: XCTestCase {
+
+  private var container: Container!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    container = try await ContainerTestHelpers.createTestContainer()
+    PaymentMethodRegistry.shared.reset()
+  }
+
+  override func tearDown() async throws {
+    await container.reset(ignoreDependencies: [Never.Type]())
+    container = nil
+    try await super.tearDown()
+  }
+
+  // MARK: - PrimerPaymentMethodType Tests
+
+  func test_adyenAffirm_rawValue() {
+    XCTAssertEqual(PrimerPaymentMethodType.adyenAffirm.rawValue, "ADYEN_AFFIRM")
+  }
+
+  func test_adyenAffirm_provider() {
+    XCTAssertEqual(PrimerPaymentMethodType.adyenAffirm.provider, "ADYEN")
+  }
+
+  func test_adyenAffirm_decodable() throws {
+    let data = Data("\"ADYEN_AFFIRM\"".utf8)
+    let decoded = try JSONDecoder().decode(PrimerPaymentMethodType.self, from: data)
+    XCTAssertEqual(decoded, .adyenAffirm)
+  }
+
+  func test_adyenAffirm_encodable() throws {
+    let encoded = try JSONEncoder().encode(PrimerPaymentMethodType.adyenAffirm)
+    let string = String(data: encoded, encoding: .utf8)
+    XCTAssertEqual(string, "\"ADYEN_AFFIRM\"")
+  }
+
+  func test_adyenAffirm_includedInAllCases() {
+    XCTAssertTrue(PrimerPaymentMethodType.allCases.contains(.adyenAffirm))
+  }
+
+  // MARK: - Registration Tests
+
+  func test_affirm_registeredAsBillingAddressRedirect() {
+    // Given
+    BillingAddressRedirectPaymentMethod.register()
+
+    // Then
+    let registered = PaymentMethodRegistry.shared.registeredTypes
+    XCTAssertTrue(registered.contains(PrimerPaymentMethodType.adyenAffirm.rawValue))
+  }
+
+  func test_affirm_createScope_returnsDefaultBillingAddressRedirectScope() async throws {
+    // Given
+    await registerDependencies()
+    BillingAddressRedirectPaymentMethod.register()
+    let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+    // When
+    let scope = try await PaymentMethodRegistry.shared.createScope(
+      for: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      checkoutScope: checkoutScope,
+      diContainer: container
+    )
+
+    // Then
+    XCTAssertTrue(scope is DefaultBillingAddressRedirectScope)
+  }
+
+  func test_affirm_createScope_setsCorrectPaymentMethodType() async throws {
+    // Given
+    await registerDependencies()
+    BillingAddressRedirectPaymentMethod.register()
+    let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+    // When
+    let scope = try await PaymentMethodRegistry.shared.createScope(
+      for: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      checkoutScope: checkoutScope,
+      diContainer: container
+    )
+
+    // Then
+    let billingScope = try XCTUnwrap(scope as? DefaultBillingAddressRedirectScope)
+    XCTAssertEqual(billingScope.paymentMethodType, PrimerPaymentMethodType.adyenAffirm.rawValue)
+  }
+
+  func test_affirm_createScope_withMissingDependencies_throws() async throws {
+    // Given
+    BillingAddressRedirectPaymentMethod.register()
+    let emptyContainer = Container()
+    let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+
+    // When/Then
+    do {
+      _ = try await PaymentMethodRegistry.shared.createScope(
+        for: PrimerPaymentMethodType.adyenAffirm.rawValue,
+        checkoutScope: checkoutScope,
+        diContainer: emptyContainer
+      )
+      XCTFail("Expected error when required dependency is missing")
+    } catch {
+      XCTAssertTrue(error is ContainerError || error is PrimerError)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func registerDependencies() async {
+    _ = try? await container.register(ProcessWebRedirectPaymentInteractor.self)
+      .asSingleton()
+      .with { _ in StubAffirmWebRedirectInteractor() }
+
+    _ = try? await container.register(PaymentMethodMapper.self)
+      .asSingleton()
+      .with { _ in StubAffirmPaymentMethodMapper() }
+
+    _ = try? await container.register(WebRedirectRepository.self)
+      .asSingleton()
+      .with { _ in MockWebRedirectRepository() }
+  }
+}
+
+// MARK: - Stubs
+
+@available(iOS 15.0, *)
+private final class StubAffirmWebRedirectInteractor: ProcessWebRedirectPaymentInteractor {
+  func execute(paymentMethodType: String) async throws -> PaymentResult {
+    PaymentResult(paymentId: "affirm_payment_123", status: .success)
+  }
+}
+
+@available(iOS 15.0, *)
+private final class StubAffirmPaymentMethodMapper: PaymentMethodMapper {
+  func mapToPublic(_ internalMethod: InternalPaymentMethod) -> CheckoutPaymentMethod {
+    CheckoutPaymentMethod(id: internalMethod.id, type: internalMethod.type, name: internalMethod.name)
+  }
+
+  func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod] {
+    internalMethods.map { mapToPublic($0) }
+  }
+}

--- a/Tests/Primer/CheckoutComponents/BillingAddressRedirect/DefaultBillingAddressRedirectScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/BillingAddressRedirect/DefaultBillingAddressRedirectScopeTests.swift
@@ -194,6 +194,201 @@ final class DefaultBillingAddressRedirectScopeTests: XCTestCase {
     XCTAssertEqual(sut.paymentMethodType, "ADYEN_AFFIRM")
   }
 
+  // MARK: - Start Tests
+
+  func test_start_doesNotCrash() async throws {
+    sut.start()
+    try await Task.sleep(nanoseconds: 100_000_000)
+    XCTAssertEqual(sut.paymentMethodType, PrimerPaymentMethodType.adyenAffirm.rawValue)
+  }
+
+  func test_start_calledTwice_isIdempotent() async throws {
+    sut.start()
+    sut.start()
+    try await Task.sleep(nanoseconds: 100_000_000)
+    let state = await collectFirstState()
+    XCTAssertEqual(state.status, .ready)
+  }
+
+  // MARK: - Cancel Tests
+
+  func test_cancel_setsStatusToReady() async throws {
+    sut.cancel()
+    try await Task.sleep(nanoseconds: 50_000_000)
+    let state = await collectFirstState()
+    XCTAssertEqual(state.status, .ready)
+  }
+
+  func test_cancel_withNilRepository_doesNotCrash() {
+    sut.cancel()
+  }
+
+  // MARK: - onBack Tests
+
+  func test_onBack_fromPaymentSelection_navigatesBack() async {
+    let coordinator = CheckoutCoordinator()
+    coordinator.navigate(to: .paymentMethodSelection)
+    coordinator.navigate(to: .paymentMethod(PrimerPaymentMethodType.adyenAffirm.rawValue, .fromPaymentSelection))
+    let navigator = CheckoutNavigator(coordinator: coordinator)
+    let checkoutScope = DefaultCheckoutScope(
+      clientToken: TestData.Tokens.valid,
+      settings: PrimerSettings(paymentHandling: .manual, paymentMethodOptions: PrimerPaymentMethodOptions()),
+      diContainer: DIContainer.shared,
+      navigator: navigator,
+      presentationContext: .fromPaymentSelection
+    )
+    let scope = DefaultBillingAddressRedirectScope(
+      paymentMethodType: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      checkoutScope: checkoutScope,
+      presentationContext: .fromPaymentSelection,
+      processWebRedirectInteractor: mockInteractor
+    )
+
+    scope.onBack()
+
+    XCTAssertEqual(coordinator.currentRoute, .paymentMethodSelection)
+  }
+
+  func test_onBack_directContext_doesNotNavigate() async {
+    let coordinator = CheckoutCoordinator()
+    coordinator.navigate(to: .paymentMethod(PrimerPaymentMethodType.adyenAffirm.rawValue, .direct))
+    let navigator = CheckoutNavigator(coordinator: coordinator)
+    let checkoutScope = DefaultCheckoutScope(
+      clientToken: TestData.Tokens.valid,
+      settings: PrimerSettings(paymentHandling: .manual, paymentMethodOptions: PrimerPaymentMethodOptions()),
+      diContainer: DIContainer.shared,
+      navigator: navigator,
+      presentationContext: .direct
+    )
+    let initialStackCount = coordinator.navigationStack.count
+    let scope = DefaultBillingAddressRedirectScope(
+      paymentMethodType: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      checkoutScope: checkoutScope,
+      presentationContext: .direct,
+      processWebRedirectInteractor: mockInteractor
+    )
+
+    scope.onBack()
+
+    XCTAssertEqual(coordinator.navigationStack.count, initialStackCount)
+  }
+
+  // MARK: - dismissalMechanism Tests
+
+  func test_dismissalMechanism_reflectsCheckoutScope() async {
+    let mechanism = sut.dismissalMechanism
+    XCTAssertNotNil(mechanism)
+  }
+
+  // MARK: - presentationContext Tests
+
+  func test_presentationContext_defaultIsFromPaymentSelection() {
+    XCTAssertEqual(sut.presentationContext, .fromPaymentSelection)
+  }
+
+  func test_presentationContext_directIsPreserved() async {
+    let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+    let scope = DefaultBillingAddressRedirectScope(
+      paymentMethodType: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      checkoutScope: checkoutScope,
+      presentationContext: .direct,
+      processWebRedirectInteractor: mockInteractor
+    )
+    XCTAssertEqual(scope.presentationContext, .direct)
+  }
+
+  // MARK: - Init Tests
+
+  func test_init_withPaymentMethod_populatesState() async {
+    let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+    let paymentMethod = CheckoutPaymentMethod(
+      id: "affirm_id",
+      type: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      name: "Affirm"
+    )
+    let scope = DefaultBillingAddressRedirectScope(
+      paymentMethodType: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      checkoutScope: checkoutScope,
+      processWebRedirectInteractor: mockInteractor,
+      paymentMethod: paymentMethod
+    )
+
+    let state = await firstState(from: scope)
+    XCTAssertEqual(state.paymentMethod?.id, "affirm_id")
+    XCTAssertEqual(state.paymentMethod?.type, PrimerPaymentMethodType.adyenAffirm.rawValue)
+  }
+
+  func test_init_withSurchargeAmount_populatesState() async {
+    let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+    let scope = DefaultBillingAddressRedirectScope(
+      paymentMethodType: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      checkoutScope: checkoutScope,
+      processWebRedirectInteractor: mockInteractor,
+      surchargeAmount: "$2.50"
+    )
+
+    let state = await firstState(from: scope)
+    XCTAssertEqual(state.surchargeAmount, "$2.50")
+  }
+
+  // MARK: - Validation Edge Cases
+
+  func test_updateAddressLine2_withExistingError_clearsError() async {
+    // addressLine2 is optional and always clears errors regardless of input
+    sut.updateAddressLine2("Apt 4B")
+    sut.updateAddressLine2("")
+
+    let state = await collectFirstState()
+    XCTAssertNil(state.errors[.addressLine2])
+  }
+
+  func test_updateField_thenEmpty_keepsFormInvalid() async {
+    sut.updateCountryCode("US")
+    sut.updateCountryCode("")
+
+    let state = await collectFirstState()
+    XCTAssertFalse(state.isFormValid)
+  }
+
+  func test_submit_withInvalidForm_triggersValidationOnAllFields() async throws {
+    sut.submit()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    let state = await collectFirstState()
+    XCTAssertFalse(state.isFormValid)
+    XCTAssertEqual(mockInteractor.executeCallCount, 0)
+  }
+
+  // MARK: - Submit / performPayment Tests
+
+  func test_submit_withValidForm_transitionsOutOfReady() async throws {
+    fillValidForm()
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    sut.submit()
+
+    let finalState = try await awaitValue(sut.state, matching: { $0.status != .ready })
+    XCTAssertNotEqual(finalState.status, .ready)
+  }
+
+  func test_submit_whenInteractorThrows_eventuallyFails() async throws {
+    mockInteractor.errorToThrow = PrimerError.unknown(message: "boom")
+    fillValidForm()
+    try await Task.sleep(nanoseconds: 50_000_000)
+
+    sut.submit()
+
+    let state = try await awaitValue(sut.state, matching: {
+      if case .failure = $0.status { return true }
+      return false
+    })
+    if case .failure = state.status {
+      // Expected
+    } else {
+      XCTFail("Expected failure status")
+    }
+  }
+
   // MARK: - Helpers
 
   private func fillValidForm() {
@@ -205,8 +400,12 @@ final class DefaultBillingAddressRedirectScopeTests: XCTestCase {
   }
 
   private func collectFirstState() async -> PrimerBillingAddressRedirectState {
+    await firstState(from: sut)
+  }
+
+  private func firstState(from scope: DefaultBillingAddressRedirectScope) async -> PrimerBillingAddressRedirectState {
     var collectedState = PrimerBillingAddressRedirectState()
-    for await state in sut.state {
+    for await state in scope.state {
       collectedState = state
       break
     }
@@ -221,7 +420,7 @@ private final class MockBillingAddressWebRedirectInteractor: ProcessWebRedirectP
 
   private(set) var executeCallCount = 0
   private(set) var lastPaymentMethodType: String?
-  var resultToReturn: PaymentResult = PaymentResult(paymentId: "test_123", status: .success)
+  var resultToReturn = PaymentResult(paymentId: "test_123", status: .success)
   var errorToThrow: Error?
 
   func execute(paymentMethodType: String) async throws -> PaymentResult {

--- a/Tests/Primer/CheckoutComponents/BillingAddressRedirect/DefaultBillingAddressRedirectScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/BillingAddressRedirect/DefaultBillingAddressRedirectScopeTests.swift
@@ -1,0 +1,233 @@
+//
+//  DefaultBillingAddressRedirectScopeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultBillingAddressRedirectScopeTests: XCTestCase {
+
+  private var sut: DefaultBillingAddressRedirectScope!
+  private var mockInteractor: MockBillingAddressWebRedirectInteractor!
+
+  override func setUp() async throws {
+    try await super.setUp()
+    mockInteractor = MockBillingAddressWebRedirectInteractor()
+    let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+    sut = DefaultBillingAddressRedirectScope(
+      paymentMethodType: PrimerPaymentMethodType.adyenAffirm.rawValue,
+      checkoutScope: checkoutScope,
+      processWebRedirectInteractor: mockInteractor
+    )
+  }
+
+  override func tearDown() async throws {
+    sut = nil
+    mockInteractor = nil
+    try await super.tearDown()
+  }
+
+  // MARK: - Field Update Tests
+
+  func test_updateCountryCode_updatesState() async {
+    // When
+    sut.updateCountryCode("US")
+
+    // Then
+    let state = await collectFirstState()
+    XCTAssertEqual(state.countryCode, "US")
+  }
+
+  func test_updateAddressLine1_updatesState() async {
+    // When
+    sut.updateAddressLine1("123 Main St")
+
+    // Then
+    let state = await collectFirstState()
+    XCTAssertEqual(state.addressLine1, "123 Main St")
+  }
+
+  func test_updateAddressLine2_updatesState() async {
+    // When
+    sut.updateAddressLine2("Apt 4B")
+
+    // Then
+    let state = await collectFirstState()
+    XCTAssertEqual(state.addressLine2, "Apt 4B")
+  }
+
+  func test_updatePostalCode_updatesState() async {
+    // When
+    sut.updatePostalCode("94105")
+
+    // Then
+    let state = await collectFirstState()
+    XCTAssertEqual(state.postalCode, "94105")
+  }
+
+  func test_updateCity_updatesState() async {
+    // When
+    sut.updateCity("San Francisco")
+
+    // Then
+    let state = await collectFirstState()
+    XCTAssertEqual(state.city, "San Francisco")
+  }
+
+  func test_updateState_updatesState() async {
+    // When
+    sut.updateState("CA")
+
+    // Then
+    let state = await collectFirstState()
+    XCTAssertEqual(state.state, "CA")
+  }
+
+  // MARK: - Form Validity Tests
+
+  func test_formValidity_allRequiredFieldsFilled_isValid() async {
+    // When
+    fillValidForm()
+
+    // Then
+    let state = await collectFirstState()
+    XCTAssertTrue(state.isFormValid)
+  }
+
+  func test_formValidity_missingCountryCode_isInvalid() async {
+    // Given
+    sut.updateAddressLine1("123 Main St")
+    sut.updatePostalCode("94105")
+    sut.updateCity("San Francisco")
+    sut.updateState("CA")
+
+    // Then
+    let state = await collectFirstState()
+    XCTAssertFalse(state.isFormValid)
+  }
+
+  func test_formValidity_missingAddressLine1_isInvalid() async {
+    // Given
+    sut.updateCountryCode("US")
+    sut.updatePostalCode("94105")
+    sut.updateCity("San Francisco")
+    sut.updateState("CA")
+
+    // Then
+    let state = await collectFirstState()
+    XCTAssertFalse(state.isFormValid)
+  }
+
+  func test_formValidity_addressLine2Optional_stillValid() async {
+    // Given — fill all required fields but NOT addressLine2
+    fillValidForm()
+
+    // Then — should still be valid
+    let state = await collectFirstState()
+    XCTAssertTrue(state.isFormValid)
+    XCTAssertEqual(state.addressLine2, "")
+  }
+
+  func test_formValidity_emptyForm_isInvalid() async {
+    // Then
+    let state = await collectFirstState()
+    XCTAssertFalse(state.isFormValid)
+  }
+
+  // MARK: - Initial State Tests
+
+  func test_initialState_statusIsReady() async {
+    let state = await collectFirstState()
+    XCTAssertEqual(state.status, .ready)
+  }
+
+  func test_initialState_formIsInvalid() async {
+    let state = await collectFirstState()
+    XCTAssertFalse(state.isFormValid)
+  }
+
+  func test_initialState_allFieldsEmpty() async {
+    let state = await collectFirstState()
+    XCTAssertTrue(state.countryCode.isEmpty)
+    XCTAssertTrue(state.addressLine1.isEmpty)
+    XCTAssertTrue(state.addressLine2.isEmpty)
+    XCTAssertTrue(state.postalCode.isEmpty)
+    XCTAssertTrue(state.city.isEmpty)
+    XCTAssertTrue(state.state.isEmpty)
+  }
+
+  func test_initialState_noErrors() async {
+    let state = await collectFirstState()
+    XCTAssertTrue(state.errors.isEmpty)
+  }
+
+  // MARK: - Submit Guard Tests
+
+  func test_submit_withInvalidForm_doesNotCallInteractor() async throws {
+    // Given — form is empty (invalid)
+
+    // When
+    sut.submit()
+    try await Task.sleep(nanoseconds: 100_000_000)
+
+    // Then
+    XCTAssertEqual(mockInteractor.executeCallCount, 0)
+  }
+
+  func test_submit_withValidForm_isAccepted() async {
+    // Given
+    fillValidForm()
+    let state = await collectFirstState()
+
+    // Then — form should be valid, which means submit() would proceed
+    XCTAssertTrue(state.isFormValid)
+    XCTAssertEqual(state.status, .ready)
+  }
+
+  // MARK: - Payment Method Type
+
+  func test_paymentMethodType_isAdyenAffirm() {
+    XCTAssertEqual(sut.paymentMethodType, "ADYEN_AFFIRM")
+  }
+
+  // MARK: - Helpers
+
+  private func fillValidForm() {
+    sut.updateCountryCode("US")
+    sut.updateAddressLine1("123 Main St")
+    sut.updatePostalCode("94105")
+    sut.updateCity("San Francisco")
+    sut.updateState("CA")
+  }
+
+  private func collectFirstState() async -> PrimerBillingAddressRedirectState {
+    var collectedState = PrimerBillingAddressRedirectState()
+    for await state in sut.state {
+      collectedState = state
+      break
+    }
+    return collectedState
+  }
+}
+
+// MARK: - Mock Interactor
+
+@available(iOS 15.0, *)
+private final class MockBillingAddressWebRedirectInteractor: ProcessWebRedirectPaymentInteractor {
+
+  private(set) var executeCallCount = 0
+  private(set) var lastPaymentMethodType: String?
+  var resultToReturn: PaymentResult = PaymentResult(paymentId: "test_123", status: .success)
+  var errorToThrow: Error?
+
+  func execute(paymentMethodType: String) async throws -> PaymentResult {
+    executeCallCount += 1
+    lastPaymentMethodType = paymentMethodType
+    if let error = errorToThrow { throw error }
+    return resultToReturn
+  }
+}

--- a/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerPaymentMethodTypeImageNameTests.swift
@@ -125,6 +125,11 @@ final class PrimerPaymentMethodTypeIconTests: XCTestCase {
 
     // MARK: - Adyen Payment Methods
 
+    func test_icon_adyenAffirm_returnsGenericCardImage() {
+        XCTAssertNotNil(PrimerPaymentMethodType.adyenAffirm.icon)
+        XCTAssertEqual(PrimerPaymentMethodType.adyenAffirm.icon, ImageName.genericCard.image)
+    }
+
     func test_icon_adyenAlipay_returnsNonNilImage() {
         XCTAssertNotNil(PrimerPaymentMethodType.adyenAlipay.icon)
     }


### PR DESCRIPTION
## Summary

Implements `ADYEN_AFFIRM` (Affirm via Adyen) in CheckoutComponents by introducing a new **BillingAddressRedirect** scope type.

**Jira:** [ACC-7025](https://primerapi.atlassian.net/browse/ACC-7025)

## Why a new scope type?

Affirm is a BNPL payment method that requires **billing address collection before redirect**. This doesn't fit existing scopes:
- **WebRedirect** has no form — it's just a button + redirect
- **FormRedirect** handles OTP/phone input (BLIK, MBWay) — different field types and validation

The WEB SDK confirms this: `BillingAddressScene.tsx` collects country, address, postal code, city, state BEFORE tokenization. Without the address, Affirm rejects the payment.

## Why not reuse the card form's BillingAddressView?

The card form's billing address UI components (`BillingAddressView`, `CountryInputField`, `CityInputField`, etc.) are tightly coupled to `PrimerCardFormScope` / `DefaultCardFormScope`:
- `CountryInputField` accesses `scope.$structuredState`, `scope.selectCountry` (navigation), `scope.clearFieldError()`, `scope.updateValidationState()` — all `DefaultCardFormScope`-specific
- Other field components accept `any PrimerCardFormScope` and pass it through to inner TextField components

Extracting a shared protocol would require refactoring 7+ existing components and their tests. Instead, the `BillingAddressRedirectScreen` creates its own SwiftUI text fields with the **same validation rules** (`AddressRule`, `CityRule`, `StateRule`, `PostalCodeRule` from `CommonValidationRules.swift`). The business logic is fully reused; only the view layer is separate.

## Registration order concern

`ADYEN_AFFIRM` has `implementationType: WEB_REDIRECT` in the backend. Without a filter, the dynamic `WebRedirectPaymentMethod.register(types:)` would overwrite our dedicated registration (registry uses last-write-wins). The `dedicatedScopeTypes` set excludes Affirm from WebRedirect auto-registration.

**Note:** This filter modifies the same `webRedirectTypes` line as PR #1685 (Kaartdirect's `nativeSdkRedirectTypes`). When both merge, the combined filter should be:
```swift
.filter { ($0.implementationType == .webRedirect || nativeSdkRedirectTypes.contains($0.type))
          && !dedicatedScopeTypes.contains($0.type) }
```

## What's reused vs new

**Reused from existing code:**
- Validation rules: `AddressRule`, `CityRule`, `StateRule`, `PostalCodeRule` (`CommonValidationRules.swift`)
- `ValidationService` + `RulesFactory`
- `ClientSessionActionsModule.updateBillingAddressViaClientSessionActionWithAddressIfNeeded()` for billing address submission
- `ProcessWebRedirectPaymentInteractor` for the redirect flow after form submission
- Design tokens, checkout colors, accessibility patterns

**New:**
- `PrimerBillingAddressRedirectScope` — public scope protocol (same pattern as `PrimerWebRedirectScope`, `PrimerFormRedirectScope`)
- `PrimerBillingAddressRedirectState` — state with billing fields, validation errors, form validity
- `DefaultBillingAddressRedirectScope` — manages field updates, validation, billing address submission, then redirect
- `BillingAddressRedirectScreen` — billing address form (country picker + 5 text fields + submit button)
- `BillingAddressRedirectPaymentMethod` — payment method registration for `ADYEN_AFFIRM`

## State flow

```
ready → (user fills form) → submitting → redirecting → polling → success | failure
```

## Required billing address fields (from WEB SDK)

| Field | Required |
|-------|----------|
| Country Code | Yes |
| Address Line 1 | Yes |
| Address Line 2 | No |
| Postal Code | Yes |
| City | Yes |
| State | Yes |

## Changes

### New files (7)
| File | Purpose |
|------|---------|
| `Scope/PrimerBillingAddressRedirectScope.swift` | Public scope protocol + type aliases |
| `PaymentMethods/BillingAddressRedirect/PrimerBillingAddressRedirectState.swift` | Public state |
| `PaymentMethods/BillingAddressRedirect/BillingAddressRedirectPaymentMethod.swift` | Registration |
| `Internal/.../DefaultBillingAddressRedirectScope.swift` | Scope implementation |
| `Internal/.../BillingAddressRedirectScreen.swift` | Screen view |
| `Tests/.../AffirmRegistrationTests.swift` | 9 registration tests |
| `Tests/.../DefaultBillingAddressRedirectScopeTests.swift` | 18 scope tests |

### Modified files (6)
| File | Change |
|------|--------|
| `PrimerPaymentMethodType.swift` | Add `adyenAffirm` case + ADYEN provider |
| `PrimerPaymentMethodType+ImageName.swift` | Add icon (genericCard fallback) |
| `UserInterfaceModule.swift` | Add to exhaustive switch |
| `DefaultCheckoutScope.swift` | Register scope + exclude from WebRedirect auto-registration |
| `AccessibilityIdentifiers.swift` | Add `BillingAddressRedirect` identifiers |
| `PrimerPaymentMethodTypeImageNameTests.swift` | Add icon test |

## Test plan
- [x] Build succeeds
- [x] 28 new tests pass (9 registration + 18 scope + 1 icon)
- [x] All existing tests unaffected
- [x] SwiftFormat + SwiftLint clean
- [ ] E2E test with client session containing ADYEN_AFFIRM (needs Adyen account with Affirm enabled)

[ACC-7025]: https://primerapi.atlassian.net/browse/ACC-7025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ