### PR TITLE
fix: Pass correct paymentMethodType to QRCode interactor

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
@@ -226,15 +226,14 @@ extension ComposableContainer {
         }
     }
 
-    await guardedRegister(ProcessQRCodePaymentInteractor.self) {
-      _ = try await container.register(ProcessQRCodePaymentInteractor.self)
-        .asTransient()
-        .with { resolver in
-          ProcessQRCodePaymentInteractorImpl(
-            repository: try await resolver.resolve(QRCodeRepository.self),
-            paymentMethodType: ""
-          )
-        }
+    await guardedRegister(QRCodePaymentInteractorFactory.self) {
+      try await container.registerFactory(
+        QRCodePaymentInteractorFactory.self
+      ) { resolver in
+        QRCodePaymentInteractorFactory(
+          repository: try await resolver.resolve(QRCodeRepository.self)
+        )
+      }
     }
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/QRCodePaymentInteractorFactory.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/QRCodePaymentInteractorFactory.swift
@@ -1,0 +1,21 @@
+//
+//  QRCodePaymentInteractorFactory.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@available(iOS 15.0, *)
+struct QRCodePaymentInteractorFactory: Factory, @unchecked Sendable {
+  typealias Product = ProcessQRCodePaymentInteractor
+  typealias Params = String
+
+  private let repository: QRCodeRepository
+
+  init(repository: QRCodeRepository) {
+    self.repository = repository
+  }
+
+  func create(with paymentMethodType: String) async throws -> ProcessQRCodePaymentInteractor {
+    ProcessQRCodePaymentInteractorImpl(repository: repository, paymentMethodType: paymentMethodType)
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/QRCodePaymentInteractorFactory.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Interactors/QRCodePaymentInteractorFactory.swift
@@ -5,10 +5,7 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 @available(iOS 15.0, *)
-struct QRCodePaymentInteractorFactory: Factory, @unchecked Sendable {
-  typealias Product = ProcessQRCodePaymentInteractor
-  typealias Params = String
-
+struct QRCodePaymentInteractorFactory: Factory {
   private let repository: QRCodeRepository
 
   init(repository: QRCodeRepository) {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/QRCode/QRCodePaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/QRCode/QRCodePaymentMethod.swift
@@ -41,7 +41,8 @@ enum QRCodePaymentMethod {
         CheckoutComponentsAnalyticsInteractorProtocol.self
       )
 
-      let interactor = try await diContainer.resolve(ProcessQRCodePaymentInteractor.self)
+      let factory = try await diContainer.resolve(QRCodePaymentInteractorFactory.self)
+      let interactor = try await factory.create(with: paymentMethodType)
 
       return DefaultQRCodeScope(
         checkoutScope: defaultCheckoutScope,

--- a/Tests/Primer/CheckoutComponents/QRCode/QRCodePaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/QRCode/QRCodePaymentMethodTests.swift
@@ -189,14 +189,13 @@ final class QRCodePaymentMethodTests: XCTestCase {
             .asSingleton()
             .with { _ in StubQRCodeRepository() }
 
-        _ = try? await container.register(ProcessQRCodePaymentInteractor.self)
-            .asTransient()
-            .with { resolver in
-                ProcessQRCodePaymentInteractorImpl(
-                    repository: try await resolver.resolve(QRCodeRepository.self),
-                    paymentMethodType: ""
-                )
-            }
+        try? await container.registerFactory(
+            QRCodePaymentInteractorFactory.self
+        ) { resolver in
+            QRCodePaymentInteractorFactory(
+                repository: try await resolver.resolve(QRCodeRepository.self)
+            )
+        }
     }
 
     private func createCheckoutScopeWithMultiplePaymentMethods() -> DefaultCheckoutScope {


### PR DESCRIPTION
## Summary

**Jira**: ACC-7131

- The QRCode interactor was registered in DI with `paymentMethodType: ""`, causing all QR code payments (PromptPay, Xfers PayNow) to send an empty string to the backend
- Introduces `QRCodePaymentInteractorFactory` using the existing `Factory<Product, Params>` protocol so the correct payment method type is passed at scope-creation time
- This is the first usage of the Factory pattern in CheckoutComponents, leveraging the existing DI framework infrastructure

## Test plan

- [x] All 22 QRCode-related tests pass (QRCodePaymentMethodTests, ProcessQRCodePaymentInteractorTests, DefaultQRCodeScopeTests)
- [x] Build succeeds
- [ ] Manual: test with a real QR code payment method (e.g., PromptPay) to verify correct type is sent