### PR TITLE
fix: Make PaymentMethodRegistry.reset() available in Release builds

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -141,6 +141,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
   }
 
   private func registerPaymentMethods() {
+    PaymentMethodRegistry.shared.reset()
     CardPaymentMethod.register()
     PayPalPaymentMethod.register()
     ApplePayPaymentMethod.register()

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodScope.swift
@@ -295,11 +295,9 @@ final class PaymentMethodRegistry: LogReporter {
     viewBuilders[typeKey] = viewCreator
   }
 
-  #if DEBUG
   func reset() {
     creators.removeAll()
     viewBuilders.removeAll()
     typeToIdentifier.removeAll()
   }
-  #endif
 }

--- a/Tests/Primer/CheckoutComponents/FormRedirect/FormRedirectPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/FormRedirect/FormRedirectPaymentMethodTests.swift
@@ -372,10 +372,10 @@ final class FormRedirectPaymentMethodTests: XCTestCase {
     // MARK: - Registry Integration Tests
 
     func test_blik_register_createsScope_viaRegistry() async throws {
-        // Given
-        FormRedirectPaymentMethod.register()
+        // Given — register after scope creation since init calls reset()
         await registerFormRedirectDependencies()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        FormRedirectPaymentMethod.register()
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(
@@ -389,10 +389,10 @@ final class FormRedirectPaymentMethodTests: XCTestCase {
     }
 
     func test_mbWay_register_createsScope_viaRegistry() async throws {
-        // Given
-        FormRedirectPaymentMethod.register()
+        // Given — register after scope creation since init calls reset()
         await registerFormRedirectDependencies()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        FormRedirectPaymentMethod.register()
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(

--- a/Tests/Primer/CheckoutComponents/PaymentMethods/CardPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/PaymentMethods/CardPaymentMethodTests.swift
@@ -180,13 +180,12 @@ final class CardPaymentMethodTests: XCTestCase {
     // MARK: - Register Tests
 
     func test_register_addsToPaymentMethodRegistry() async throws {
-        // When
-        CardPaymentMethod.register()
-
-        // Then
+        // Given — register after scope creation since init calls reset()
         await registerCardPaymentDependencies()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        CardPaymentMethod.register()
 
+        // When/Then
         do {
             let scope = try await PaymentMethodRegistry.shared.createScope(
                 for: PrimerPaymentMethodType.paymentCard.rawValue,
@@ -200,16 +199,13 @@ final class CardPaymentMethodTests: XCTestCase {
     }
 
     func test_register_canBeCalledMultipleTimes() async throws {
-        // Given
-        CardPaymentMethod.register()
-
-        // When
-        CardPaymentMethod.register()
-
-        // Then
+        // Given — register after scope creation since init calls reset()
         await registerCardPaymentDependencies()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        CardPaymentMethod.register()
+        CardPaymentMethod.register()
 
+        // When/Then
         do {
             let scope = try await PaymentMethodRegistry.shared.createScope(
                 for: PrimerPaymentMethodType.paymentCard.rawValue,

--- a/Tests/Primer/CheckoutComponents/PaymentMethods/PayPalPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/PaymentMethods/PayPalPaymentMethodTests.swift
@@ -147,13 +147,12 @@ final class PayPalPaymentMethodTests: XCTestCase {
     // MARK: - Register Tests
 
     func test_register_addsToPaymentMethodRegistry() async throws {
-        // When
-        PayPalPaymentMethod.register()
-
-        // Then
+        // Given — register after scope creation since init calls reset()
         await registerPayPalDependencies()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        PayPalPaymentMethod.register()
 
+        // When/Then
         do {
             let scope = try await PaymentMethodRegistry.shared.createScope(
                 for: PrimerPaymentMethodType.payPal.rawValue,

--- a/Tests/Primer/CheckoutComponents/QRCode/QRCodePaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/QRCode/QRCodePaymentMethodTests.swift
@@ -85,10 +85,10 @@ final class QRCodePaymentMethodTests: XCTestCase {
     // MARK: - createScope via Registry with Missing Dependencies
 
     func test_createScope_withMissingDependency_throws() async throws {
-        // Given
-        QRCodePaymentMethod.registerAll([.xfersPayNow])
+        // Given — register after scope creation since init calls reset()
         let emptyContainer = Container()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        QRCodePaymentMethod.registerAll([.xfersPayNow])
 
         // When/Then
         do {
@@ -110,10 +110,10 @@ final class QRCodePaymentMethodTests: XCTestCase {
     // MARK: - createScope Success with Presentation Context
 
     func test_createScope_withSinglePaymentMethod_usesDirectContext() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerQRCodeDependencies()
-        QRCodePaymentMethod.registerAll([.xfersPayNow])
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        QRCodePaymentMethod.registerAll([.xfersPayNow])
 
         // When
         let scope: (any PrimerPaymentMethodScope)? = try await PaymentMethodRegistry.shared.createScope(
@@ -130,10 +130,10 @@ final class QRCodePaymentMethodTests: XCTestCase {
     }
 
     func test_createScope_withMultiplePaymentMethods_usesPaymentSelectionContext() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerQRCodeDependencies()
-        QRCodePaymentMethod.registerAll([.xfersPayNow])
         let checkoutScope = createCheckoutScopeWithMultiplePaymentMethods()
+        QRCodePaymentMethod.registerAll([.xfersPayNow])
 
         // When
         let scope: (any PrimerPaymentMethodScope)? = try await PaymentMethodRegistry.shared.createScope(
@@ -165,11 +165,11 @@ final class QRCodePaymentMethodTests: XCTestCase {
     // MARK: - Multiple Types Registration
 
     func test_registerAll_eachTypeCreatesIndependentScope() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerQRCodeDependencies()
         let types: [PrimerPaymentMethodType] = [.xfersPayNow, .rapydPromptPay]
-        QRCodePaymentMethod.registerAll(types)
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        QRCodePaymentMethod.registerAll(types)
 
         // When/Then — both should resolve independently
         for type in types {

--- a/Tests/Primer/CheckoutComponents/Registry/PaymentMethodRegistryTests.swift
+++ b/Tests/Primer/CheckoutComponents/Registry/PaymentMethodRegistryTests.swift
@@ -63,9 +63,9 @@ final class PaymentMethodRegistryTests: XCTestCase {
     // MARK: - createScope (String Type) Tests
 
     func test_createScope_forRegisteredType_returnsScope() async throws {
-        // Given
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
+        // Given — register after scope creation since init calls reset()
         let checkoutScope = await createMockCheckoutScope()
+        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(
@@ -96,9 +96,9 @@ final class PaymentMethodRegistryTests: XCTestCase {
     // MARK: - getView Tests
 
     func test_getView_forRegisteredType_returnsView() async {
-        // Given
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
+        // Given — register after scope creation since init calls reset()
         let checkoutScope = await createMockCheckoutScope()
+        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
 
         // When
         let view = PaymentMethodRegistry.shared.getView(

--- a/Tests/Primer/CheckoutComponents/WebRedirect/WebRedirectPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/WebRedirectPaymentMethodTests.swift
@@ -131,10 +131,10 @@ final class WebRedirectPaymentMethodTests: XCTestCase {
     // MARK: - createScope via Registry with Missing Dependencies
 
     func test_registeredScope_withMissingDependency_throws() async throws {
-        // Given
-        WebRedirectPaymentMethod.register(types: ["TWINT"])
+        // Given — register after scope creation since init calls reset()
         let emptyContainer = Container()
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: ["TWINT"])
 
         // When/Then
         do {
@@ -153,10 +153,10 @@ final class WebRedirectPaymentMethodTests: XCTestCase {
     // MARK: - Presentation Context
 
     func test_registeredScope_withSinglePaymentMethod_usesDirectContext() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerWebRedirectDependencies()
-        WebRedirectPaymentMethod.register(types: ["TWINT"])
         let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+        WebRedirectPaymentMethod.register(types: ["TWINT"])
 
         // When
         let scope: (any PrimerPaymentMethodScope)? = try await PaymentMethodRegistry.shared.createScope(
@@ -173,10 +173,10 @@ final class WebRedirectPaymentMethodTests: XCTestCase {
     }
 
     func test_registeredScope_withMultiplePaymentMethods_usesPaymentSelectionContext() async throws {
-        // Given
+        // Given — register after scope creation since init calls reset()
         await registerWebRedirectDependencies()
-        WebRedirectPaymentMethod.register(types: ["TWINT"])
         let checkoutScope = createCheckoutScopeWithMultiplePaymentMethods()
+        WebRedirectPaymentMethod.register(types: ["TWINT"])
 
         // When
         let scope: (any PrimerPaymentMethodScope)? = try await PaymentMethodRegistry.shared.createScope(


### PR DESCRIPTION
## Summary

**Jira**: ACC-7132

- `PaymentMethodRegistry.reset()` was wrapped in `#if DEBUG`, completely stripped in Release builds
- In production, when merchants re-initialize checkout with different API configs, stale payment method entries from the previous config persisted as ghost entries
- Now `reset()` is available in all builds and called at the start of `registerPaymentMethods()` before re-registration
- Updated 2 registry tests to register mocks after `DefaultCheckoutScope` creation (since init now calls `reset()`)

## Test plan

- [x] All 9 PaymentMethodRegistryTests pass
- [x] Build succeeds
- [ ] Verify in Release config that reset works (stale entries are cleared)