### PR TITLE
fix: Replace selectCountry getter side effect with lazy var

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
@@ -390,15 +390,7 @@ final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, LogRepo
     checkoutScope?.onDismiss()
   }
 
-  private var _selectCountry: DefaultSelectCountryScope?
-  var selectCountry: PrimerSelectCountryScope {
-    if let existing = _selectCountry {
-      return existing
-    }
-    let scope = DefaultSelectCountryScope(cardFormScope: self)
-    _selectCountry = scope
-    return scope
-  }
+  lazy var selectCountry: PrimerSelectCountryScope = DefaultSelectCountryScope(cardFormScope: self)
 
   private func updateCardData() {
     let cardData = PrimerCardData(


### PR DESCRIPTION
## Summary

**Jira**: ACC-7136

- The `selectCountry` computed property in `DefaultCardFormScope` was lazily creating and caching a `DefaultSelectCountryScope` on first access, mutating `_selectCountry` — a side effect in a getter
- Replaced with idiomatic `lazy var` for identical behavior (single allocation, same instance on repeat access) without the hidden mutation
- 1 line replaces 8 lines

## Test plan

- [x] All 57 DefaultCardFormScopeTests pass (including `test_selectCountry_returnsScope` and `test_selectCountry_returnsSameInstance`)
- [x] Build succeeds