### PR TITLE
fix: Propagate critical DI registration failures in ComposableContainer

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
@@ -17,12 +17,14 @@ final class ComposableContainer: LogReporter {
     self.settings = settings
   }
 
-  func configure() async {
-    await registerInfrastructure()
-    await registerValidation()
+  func configure() async throws {
+    try await registerInfrastructure()
+    try await registerValidation()
     await registerInteractors()
     await registerPaymentInteractors()
-    await registerData()
+    try await registerData()
+
+    try await validateCriticalDependencies()
 
     await DIContainer.setContainer(container)
 
@@ -41,8 +43,22 @@ final class ComposableContainer: LogReporter {
 @available(iOS 15.0, *)
 extension ComposableContainer {
 
-  /// Guards registration-time errors (e.g. duplicate keys) without crashing.
-  /// Factory execution errors are thrown later at resolution time, not caught here.
+  /// Critical registrations — logs and rethrows so `configure()` fails loudly
+  /// and the SDK never publishes a partially-configured container.
+  fileprivate func criticalRegister<T>(
+    _ type: T.Type,
+    _ registration: () async throws -> Void
+  ) async throws {
+    do {
+      try await registration()
+    } catch {
+      logger.error(message: "Critical registration failed for \(type): \(error)")
+      throw error
+    }
+  }
+
+  /// Non-critical registrations — logs and swallows so a single optional
+  /// payment method failing to wire up does not block the rest of checkout.
   fileprivate func guardedRegister<T>(
     _ type: T.Type,
     _ registration: () async throws -> Void
@@ -60,15 +76,15 @@ extension ComposableContainer {
 @available(iOS 15.0, *)
 extension ComposableContainer {
 
-  fileprivate func registerInfrastructure() async {
+  fileprivate func registerInfrastructure() async throws {
     let settings = settings
-    await guardedRegister(PrimerSettings.self) {
+    try await criticalRegister(PrimerSettings.self) {
       _ = try await container.register(PrimerSettings.self)
         .asSingleton()
         .with { _ in settings }
     }
 
-    await guardedRegister(CheckoutComponentsAnalyticsServiceProtocol.self) {
+    try await criticalRegister(CheckoutComponentsAnalyticsServiceProtocol.self) {
       _ = try await container.register(CheckoutComponentsAnalyticsServiceProtocol.self)
         .asSingleton()
         .with { _ in
@@ -78,7 +94,7 @@ extension ComposableContainer {
         }
     }
 
-    await guardedRegister(CheckoutComponentsAnalyticsInteractorProtocol.self) {
+    try await criticalRegister(CheckoutComponentsAnalyticsInteractorProtocol.self) {
       _ = try await container.register(CheckoutComponentsAnalyticsInteractorProtocol.self)
         .asSingleton()
         .with { resolver in
@@ -94,15 +110,15 @@ extension ComposableContainer {
         .with { _ in DefaultAccessibilityAnnouncementService() }
     }
 
-    await guardedRegister(ConfigurationService.self) {
+    try await criticalRegister(ConfigurationService.self) {
       _ = try await container.register(ConfigurationService.self)
         .asSingleton()
         .with { _ in DefaultConfigurationService() }
     }
   }
 
-  fileprivate func registerValidation() async {
-    await guardedRegister(ValidationService.self) {
+  fileprivate func registerValidation() async throws {
+    try await criticalRegister(ValidationService.self) {
       _ = try await container.register(ValidationService.self)
         .asSingleton()
         .with { _ in
@@ -237,14 +253,14 @@ extension ComposableContainer {
     }
   }
 
-  fileprivate func registerData() async {
-    await guardedRegister(HeadlessRepository.self) {
+  fileprivate func registerData() async throws {
+    try await criticalRegister(HeadlessRepository.self) {
       _ = try await container.register(HeadlessRepository.self)
         .asSingleton()
         .with { _ in await HeadlessRepositoryImpl() }
     }
 
-    await guardedRegister(PaymentMethodMapper.self) {
+    try await criticalRegister(PaymentMethodMapper.self) {
       _ = try await container.register(PaymentMethodMapper.self)
         .asSingleton()
         .with { container in
@@ -294,6 +310,19 @@ extension ComposableContainer {
         .asTransient()
         .with { _ in QRCodeRepositoryImpl() }
     }
+  }
+
+  /// Runs in every build config. Resolving exercises the factory closures that
+  /// are deferred until resolution time, catching misconfiguration at init
+  /// instead of surfacing as a silent failure during payment.
+  fileprivate func validateCriticalDependencies() async throws {
+    _ = try await container.resolve(PrimerSettings.self)
+    _ = try await container.resolve(CheckoutComponentsAnalyticsServiceProtocol.self)
+    _ = try await container.resolve(CheckoutComponentsAnalyticsInteractorProtocol.self)
+    _ = try await container.resolve(ConfigurationService.self)
+    _ = try await container.resolve(ValidationService.self)
+    _ = try await container.resolve(HeadlessRepository.self)
+    _ = try await container.resolve(PaymentMethodMapper.self)
   }
 
   #if DEBUG

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/DI/ComposableContainer.swift
@@ -315,7 +315,7 @@ extension ComposableContainer {
   /// Runs in every build config. Resolving exercises the factory closures that
   /// are deferred until resolution time, catching misconfiguration at init
   /// instead of surfacing as a silent failure during payment.
-  fileprivate func validateCriticalDependencies() async throws {
+  private func validateCriticalDependencies() async throws {
     _ = try await container.resolve(PrimerSettings.self)
     _ = try await container.resolve(CheckoutComponentsAnalyticsServiceProtocol.self)
     _ = try await container.resolve(CheckoutComponentsAnalyticsInteractorProtocol.self)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/CheckoutSDKInitializer.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Services/CheckoutSDKInitializer.swift
@@ -61,7 +61,7 @@ final class CheckoutSDKInitializer {
     let composableContainer = ComposableContainer(
       settings: primerSettings
     )
-    await composableContainer.configure()
+    try await composableContainer.configure()
 
     // Resolve analytics interactor
     if let container = await DIContainer.current {

--- a/Tests/Primer/CheckoutComponents/DI/ComposableContainerTests.swift
+++ b/Tests/Primer/CheckoutComponents/DI/ComposableContainerTests.swift
@@ -1,0 +1,72 @@
+//
+//  ComposableContainerTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+
+@available(iOS 15.0, *)
+final class ComposableContainerTests: XCTestCase {
+
+    private var savedContainer: ContainerProtocol?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        savedContainer = await DIContainer.current
+        await DIContainer.clearContainer()
+    }
+
+    override func tearDown() async throws {
+        if let savedContainer {
+            await DIContainer.setContainer(savedContainer)
+        } else {
+            await DIContainer.clearContainer()
+        }
+        try await super.tearDown()
+    }
+
+    // MARK: - Happy Path
+
+    func test_configure_withValidSettings_doesNotThrow() async throws {
+        let sut = ComposableContainer(settings: PrimerSettings())
+
+        try await sut.configure()
+
+        let current = await DIContainer.current
+        XCTAssertNotNil(current, "Container should be published only after successful configuration")
+    }
+
+    // MARK: - Critical Dependency Validation
+
+    func test_configure_registersAllCriticalDependencies_resolvable() async throws {
+        let sut = ComposableContainer(settings: PrimerSettings())
+
+        try await sut.configure()
+
+        guard let container = await DIContainer.current else {
+            XCTFail("Container should be published after configure")
+            return
+        }
+
+        // Each critical dependency must be resolvable post-configure; if any
+        // factory threw during validation, configure() would have failed.
+        _ = try await container.resolve(PrimerSettings.self)
+        _ = try await container.resolve(CheckoutComponentsAnalyticsServiceProtocol.self)
+        _ = try await container.resolve(CheckoutComponentsAnalyticsInteractorProtocol.self)
+        _ = try await container.resolve(ConfigurationService.self)
+        _ = try await container.resolve(ValidationService.self)
+        _ = try await container.resolve(HeadlessRepository.self)
+        _ = try await container.resolve(PaymentMethodMapper.self)
+    }
+
+    // MARK: - Container Publishing Ordering
+
+    func test_configure_beforeCall_doesNotPublishContainer() async {
+        _ = ComposableContainer(settings: PrimerSettings())
+
+        let current = await DIContainer.current
+        XCTAssertNil(current, "Container should not be published until configure() runs")
+    }
+}

--- a/Tests/Primer/CheckoutComponents/DI/PrimerSettingsDIIntegrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/DI/PrimerSettingsDIIntegrationTests.swift
@@ -39,7 +39,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
         let composableContainer = ComposableContainer(settings: customSettings)
 
         // When: Configure the container
-        await composableContainer.configure()
+        try await composableContainer.configure()
         guard let container = await DIContainer.current else {
             XCTFail("DIContainer.current should not be nil after configuration")
             return
@@ -58,7 +58,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
         let composableContainer = ComposableContainer(settings: settings)
 
         // When: Configure container and resolve twice
-        await composableContainer.configure()
+        try await composableContainer.configure()
         guard let container = await DIContainer.current else {
             XCTFail("DIContainer.current should not be nil")
             return
@@ -78,7 +78,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
         let composableContainer = ComposableContainer(settings: defaultSettings)
 
         // When: Configure and resolve
-        await composableContainer.configure()
+        try await composableContainer.configure()
         guard let container = await DIContainer.current else {
             XCTFail("DIContainer.current should not be nil")
             return
@@ -105,7 +105,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
         let composableContainer = ComposableContainer(settings: settings)
 
         // When: Configure and resolve
-        await composableContainer.configure()
+        try await composableContainer.configure()
         guard let container = await DIContainer.current else {
             XCTFail("DIContainer.current should not be nil")
             return
@@ -127,7 +127,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
         // Given: Mutable settings
         let settings = PrimerSettings()
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("DIContainer.current should not be nil")
@@ -155,7 +155,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
         let composableContainer = ComposableContainer(settings: settings)
 
         // When: Configure and resolve
-        await composableContainer.configure()
+        try await composableContainer.configure()
         guard let container = await DIContainer.current else {
             XCTFail("DIContainer.current should not be nil")
             return
@@ -180,7 +180,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
         let composableContainer = ComposableContainer(settings: settings)
 
         // When: Configure and resolve
-        await composableContainer.configure()
+        try await composableContainer.configure()
         guard let container = await DIContainer.current else {
             XCTFail("DIContainer.current should not be nil")
             return
@@ -199,7 +199,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
         // Given: Configured container
         let settings = PrimerSettings()
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         // Await before assertion to avoid async autoclosure issue
         let currentContainer = await DIContainer.current
@@ -217,7 +217,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
         // Given: First configuration
         let settings1 = PrimerSettings(paymentHandling: .auto)
         let container1 = ComposableContainer(settings: settings1)
-        await container1.configure()
+        try await container1.configure()
 
         let resolved1 = try await DIContainer.current?.resolve(PrimerSettings.self)
         XCTAssertEqual(resolved1?.paymentHandling, .auto)
@@ -227,7 +227,7 @@ final class PrimerSettingsDIIntegrationTests: XCTestCase {
 
         let settings2 = PrimerSettings(paymentHandling: .manual)
         let container2 = ComposableContainer(settings: settings2)
-        await container2.configure()
+        try await container2.configure()
 
         // Then: New settings should be resolved
         let resolved2 = try await DIContainer.current?.resolve(PrimerSettings.self)

--- a/Tests/Primer/CheckoutComponents/DI/PrimerSettingsIntegrationTests.swift
+++ b/Tests/Primer/CheckoutComponents/DI/PrimerSettingsIntegrationTests.swift
@@ -57,7 +57,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
 
         // When: Configure container with these settings
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -90,7 +90,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
         // Given: Configured container
         let settings = PrimerSettings(paymentHandling: .auto)
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -129,7 +129,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
         )
 
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -173,7 +173,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
         )
 
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -199,7 +199,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
         let settings = PrimerSettings(localeData: localeData)
 
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -220,7 +220,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
         let settings = PrimerSettings(localeData: localeData)
 
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -241,7 +241,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
         // Given: Initial configuration
         let settings1 = PrimerSettings(paymentHandling: .auto)
         let container1 = ComposableContainer(settings: settings1)
-        await container1.configure()
+        try await container1.configure()
 
         let initialResolve = try await DIContainer.current?.resolve(PrimerSettings.self)
         XCTAssertEqual(initialResolve?.paymentHandling, .auto)
@@ -249,7 +249,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
         // When: Reconfigure container (without clearing)
         let settings2 = PrimerSettings(paymentHandling: .manual)
         let container2 = ComposableContainer(settings: settings2)
-        await container2.configure()
+        try await container2.configure()
 
         let afterResolve = try await DIContainer.current?.resolve(PrimerSettings.self)
 
@@ -261,7 +261,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
         // Given: Configured container
         let settings = PrimerSettings()
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         // Await before assertion to avoid async autoclosure issue
         let currentContainer = await DIContainer.current
@@ -294,7 +294,7 @@ final class PrimerSettingsIntegrationTests: XCTestCase {
         // Given: Default settings (no customization)
         let settings = PrimerSettings()
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")

--- a/Tests/Primer/CheckoutComponents/Data/HeadlessRepositorySettingsTests.swift
+++ b/Tests/Primer/CheckoutComponents/Data/HeadlessRepositorySettingsTests.swift
@@ -25,7 +25,7 @@ final class HeadlessRepositorySettingsTests: XCTestCase {
         // Given: Configured DI container with settings
         let settings = PrimerSettings(paymentHandling: .manual)
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -47,7 +47,7 @@ final class HeadlessRepositorySettingsTests: XCTestCase {
             apiVersion: .V2_4
         )
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -79,7 +79,7 @@ final class HeadlessRepositorySettingsTests: XCTestCase {
         // Given: Settings without explicit payment handling (uses default)
         let settings = PrimerSettings()
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -100,7 +100,7 @@ final class HeadlessRepositorySettingsTests: XCTestCase {
             )
         )
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -119,7 +119,7 @@ final class HeadlessRepositorySettingsTests: XCTestCase {
         // Given: First container with auto mode
         let settings1 = PrimerSettings(paymentHandling: .auto)
         let container1 = ComposableContainer(settings: settings1)
-        await container1.configure()
+        try await container1.configure()
 
         let resolved1 = try await DIContainer.current?.resolve(PrimerSettings.self)
         XCTAssertEqual(resolved1?.paymentHandling, .auto)
@@ -129,7 +129,7 @@ final class HeadlessRepositorySettingsTests: XCTestCase {
 
         let settings2 = PrimerSettings(paymentHandling: .manual)
         let container2 = ComposableContainer(settings: settings2)
-        await container2.configure()
+        try await container2.configure()
 
         let resolved2 = try await DIContainer.current?.resolve(PrimerSettings.self)
 
@@ -142,7 +142,7 @@ final class HeadlessRepositorySettingsTests: XCTestCase {
         // Given: Settings without explicit API version
         let settings = PrimerSettings()
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")
@@ -159,7 +159,7 @@ final class HeadlessRepositorySettingsTests: XCTestCase {
         // Given: Settings without explicit caching configuration
         let settings = PrimerSettings()
         let composableContainer = ComposableContainer(settings: settings)
-        await composableContainer.configure()
+        try await composableContainer.configure()
 
         guard let container = await DIContainer.current else {
             XCTFail("Container should be configured")


### PR DESCRIPTION
# Description

ACC-7133

`ComposableContainer.configure()` previously wrapped every registration in a `guardedRegister` that swallowed and logged all errors, and the only validation (`performHealthCheck()`) was gated behind `#if DEBUG` with no throwing behavior. That meant a broken container could be published successfully in release builds, and downstream `try?` resolves would fail silently — surfacing as confusing "nothing happens" bugs at payment time instead of a clear error at init.

**What changed:**

- `configure()` is now `async throws` and its single production caller (`CheckoutSDKInitializer.initialize()`, already `throws`) propagates the error naturally.
- Registration helpers split by intent:
  - `criticalRegister` — logs and **rethrows**, used for `PrimerSettings`, analytics service + interactor, `ConfigurationService`, `ValidationService`, `HeadlessRepository`, `PaymentMethodMapper`.
  - `guardedRegister` — keeps the existing log-and-swallow behavior for optional per-payment-method wiring so a single APM failing doesn't block checkout.
- New `validateCriticalDependencies()` runs in **every** build config after registration and resolves each critical type. This triggers the factory closures (which otherwise only run at resolve time) so misconfiguration surfaces immediately.
- `DIContainer.setContainer(...)` now runs **after** validation, so a partially-configured container is never published globally.
- The DEBUG-only `performHealthCheck()` diagnostic logging is unchanged.

**Not a breaking change** — `configure()` is not part of the public merchant API; the only caller was already in a throwing context.

# Manual Testing

Covered by existing + new automated tests. The failure path delegates to `Container.resolve(...)`, which is already extensively covered by `ContainerErrorTests` and `DIContainerTests`.

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable
- [x] I have manually tested newly added UX
- [ ] I have open a documentation PR, if applicable