### PR TITLE
fix: Reset DI container between CheckoutComponents tests

### DIFF
--- a/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
@@ -16,15 +16,17 @@ final class DefaultCheckoutScopeBehaviorTests: XCTestCase {
     private var sut: DefaultCheckoutScope!
     private var navigator: CheckoutNavigator!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         navigator = CheckoutNavigator(coordinator: CheckoutCoordinator())
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         sut = nil
         navigator = nil
-        super.tearDown()
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     private func makeSut(
@@ -197,19 +199,15 @@ final class DefaultCheckoutScopeBehaviorTests: XCTestCase {
         }
     }
 
-    func test_onDismiss_setsNavigationStateToDismissed() async throws {
-        // Given
-        sut = makeSut()
+    func test_onDismiss_setsNavigationStateToDismissed() {
+        // Given — disable the init screen so the async init task cannot overwrite `.dismissed` with `.loading`.
+        sut = makeSut(settings: PrimerSettings(uiOptions: PrimerUIOptions(isInitScreenEnabled: false)))
 
         // When
         sut.onDismiss()
 
-        // Wait for the Task to execute
-        try await Task.sleep(nanoseconds: 500_000_000)
-
-        // Then — onDismiss may set dismissed on state stream but not always on navigationState directly
-        let navState = sut.navigationState
-        XCTAssertTrue(navState == .dismissed || navState == .loading)
+        // Then — updateNavigationState(.dismissed) is synchronous, so the result is observable immediately.
+        XCTAssertEqual(sut.navigationState, .dismissed)
     }
 
     // MARK: - updateNavigationState Tests

--- a/Tests/Primer/CheckoutComponents/DefaultPaymentMethodSelectionScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultPaymentMethodSelectionScopeTests.swift
@@ -17,28 +17,19 @@ final class DefaultPaymentMethodSelectionScopeTests: XCTestCase {
     private var mockAnalytics: MockTrackingAnalyticsInteractor!
     private var sut: DefaultPaymentMethodSelectionScope!
 
-    override func setUp() {
-        super.setUp()
-        mockCheckoutScope = createCheckoutScope()
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
+        mockCheckoutScope = try await ContainerTestHelpers.createSettledCheckoutScope()
         mockAnalytics = MockTrackingAnalyticsInteractor()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         sut = nil
         mockAnalytics = nil
         mockCheckoutScope = nil
-        super.tearDown()
-    }
-
-    // MARK: - Helpers
-
-    private func createCheckoutScope() -> DefaultCheckoutScope {
-        DefaultCheckoutScope(
-            clientToken: TestData.Tokens.valid,
-            settings: PrimerSettings(),
-            diContainer: DIContainer.shared,
-            navigator: CheckoutNavigator()
-        )
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     private func makeSut() -> DefaultPaymentMethodSelectionScope {
@@ -615,26 +606,19 @@ final class DefaultPaymentMethodSelectionScopeAdditionalTests: XCTestCase {
     private var mockAnalytics: MockTrackingAnalyticsInteractor!
     private var sut: DefaultPaymentMethodSelectionScope!
 
-    override func setUp() {
-        super.setUp()
-        mockCheckoutScope = createCheckoutScope()
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
+        mockCheckoutScope = try await ContainerTestHelpers.createSettledCheckoutScope()
         mockAnalytics = MockTrackingAnalyticsInteractor()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         sut = nil
         mockAnalytics = nil
         mockCheckoutScope = nil
-        super.tearDown()
-    }
-
-    private func createCheckoutScope() -> DefaultCheckoutScope {
-        DefaultCheckoutScope(
-            clientToken: TestData.Tokens.valid,
-            settings: PrimerSettings(),
-            diContainer: DIContainer.shared,
-            navigator: CheckoutNavigator()
-        )
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     private func makeSut() -> DefaultPaymentMethodSelectionScope {
@@ -812,22 +796,19 @@ final class DefaultPaymentMethodSelectionScopeVaultTests: XCTestCase {
     private var mockAnalytics: MockTrackingAnalyticsInteractor!
     private var sut: DefaultPaymentMethodSelectionScope!
 
-    override func setUp() {
-        super.setUp()
-        mockCheckoutScope = DefaultCheckoutScope(
-            clientToken: TestData.Tokens.valid,
-            settings: PrimerSettings(),
-            diContainer: DIContainer.shared,
-            navigator: CheckoutNavigator()
-        )
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
+        mockCheckoutScope = try await ContainerTestHelpers.createSettledCheckoutScope()
         mockAnalytics = MockTrackingAnalyticsInteractor()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         sut = nil
         mockAnalytics = nil
         mockCheckoutScope = nil
-        super.tearDown()
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     private func makeSut() -> DefaultPaymentMethodSelectionScope {
@@ -912,6 +893,10 @@ final class DefaultPaymentMethodSelectionScopeVaultTests: XCTestCase {
         sut = makeSut()
         let method = makeVaultedPaymentMethod()
 
+        // Let the sut's init Task settle — it calls refreshVaultedPaymentMethods() once on startup.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        let fetchBaseline = mockRepo.fetchVaultedPaymentMethodsCallCount
+
         // When / Then
         do {
             try await sut.deleteVaultedPaymentMethod(method)
@@ -920,8 +905,8 @@ final class DefaultPaymentMethodSelectionScopeVaultTests: XCTestCase {
             XCTAssertTrue(error is TestError)
             // Delete was attempted
             XCTAssertEqual(mockRepo.deleteVaultedPaymentMethodCallCount, 1)
-            // Refresh should NOT have been called because delete threw
-            XCTAssertEqual(mockRepo.fetchVaultedPaymentMethodsCallCount, 0)
+            // Refresh should NOT have been triggered by the failed delete
+            XCTAssertEqual(mockRepo.fetchVaultedPaymentMethodsCallCount, fetchBaseline)
         }
     }
 
@@ -1372,7 +1357,7 @@ final class PaymentMethodSearchLogicTests: XCTestCase {
         // Given
         let methods = [
             CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
-            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal")
         ]
 
         // When / Then
@@ -1384,7 +1369,7 @@ final class PaymentMethodSearchLogicTests: XCTestCase {
         let methods = [
             CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
             CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
-            CheckoutPaymentMethod(id: "3", type: "KLARNA", name: "Klarna"),
+            CheckoutPaymentMethod(id: "3", type: "KLARNA", name: "Klarna")
         ]
 
         // When
@@ -1399,7 +1384,7 @@ final class PaymentMethodSearchLogicTests: XCTestCase {
         // Given
         let methods = [
             CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
-            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal")
         ]
 
         // When
@@ -1414,7 +1399,7 @@ final class PaymentMethodSearchLogicTests: XCTestCase {
         // Given
         let methods = [
             CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
-            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal")
         ]
 
         // When
@@ -1429,7 +1414,7 @@ final class PaymentMethodSearchLogicTests: XCTestCase {
         // Given
         let methods = [
             CheckoutPaymentMethod(id: "1", type: "CARD", name: "Visa Card"),
-            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal")
         ]
 
         // When
@@ -1444,7 +1429,7 @@ final class PaymentMethodSearchLogicTests: XCTestCase {
         // Given
         let methods = [
             CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Card"),
-            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal"),
+            CheckoutPaymentMethod(id: "2", type: "PAYPAL", name: "PayPal")
         ]
 
         // When / Then
@@ -1456,7 +1441,7 @@ final class PaymentMethodSearchLogicTests: XCTestCase {
         let methods = [
             CheckoutPaymentMethod(id: "1", type: "PAYMENT_CARD", name: "Visa Card"),
             CheckoutPaymentMethod(id: "2", type: "PAYMENT_CARD", name: "Mastercard"),
-            CheckoutPaymentMethod(id: "3", type: "PAYPAL", name: "PayPal"),
+            CheckoutPaymentMethod(id: "3", type: "PAYPAL", name: "PayPal")
         ]
 
         // When / Then

--- a/Tests/Primer/CheckoutComponents/FormRedirect/DefaultFormRedirectScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/FormRedirect/DefaultFormRedirectScopeTests.swift
@@ -17,14 +17,16 @@ final class DefaultFormRedirectScopeTests: XCTestCase {
 
     // MARK: - Setup / Teardown
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         mockInteractor = MockProcessFormRedirectPaymentInteractor()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockInteractor = nil
-        super.tearDown()
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     // MARK: - Field Configuration Tests

--- a/Tests/Primer/CheckoutComponents/FormRedirect/FormRedirectPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/FormRedirect/FormRedirectPaymentMethodTests.swift
@@ -16,6 +16,7 @@ final class FormRedirectPaymentMethodTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         container = try await ContainerTestHelpers.createTestContainer()
         PaymentMethodRegistry.shared.reset()
     }
@@ -23,6 +24,7 @@ final class FormRedirectPaymentMethodTests: XCTestCase {
     override func tearDown() async throws {
         await container.reset(ignoreDependencies: [Never.Type]())
         container = nil
+        await ContainerTestHelpers.resetSharedContainer()
         try await super.tearDown()
     }
 
@@ -439,7 +441,7 @@ final class FormRedirectPaymentMethodTests: XCTestCase {
                 id: "card-1",
                 type: PrimerPaymentMethodType.paymentCard.rawValue,
                 name: "Card"
-            ),
+            )
         ]
         return scope
     }

--- a/Tests/Primer/CheckoutComponents/InvokeBeforePaymentCreateTests.swift
+++ b/Tests/Primer/CheckoutComponents/InvokeBeforePaymentCreateTests.swift
@@ -11,16 +11,18 @@ import XCTest
 @MainActor
 final class InvokeBeforePaymentCreateTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         SDKSessionHelper.setUp()
         PrimerInternal.shared.currentIdempotencyKey = nil
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         PrimerInternal.shared.currentIdempotencyKey = nil
         SDKSessionHelper.tearDown()
-        super.tearDown()
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     // MARK: - onBeforePaymentCreate Property Tests

--- a/Tests/Primer/CheckoutComponents/Klarna/DefaultKlarnaScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Klarna/DefaultKlarnaScopeTests.swift
@@ -13,14 +13,16 @@ final class DefaultKlarnaScopeTests: XCTestCase {
 
     private var mockInteractor: MockProcessKlarnaPaymentInteractor!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         mockInteractor = MockProcessKlarnaPaymentInteractor()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockInteractor = nil
-        super.tearDown()
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     @MainActor
@@ -301,7 +303,7 @@ final class DefaultKlarnaScopeTests: XCTestCase {
         mockInteractor.paymentViewToReturn = UIView()
         mockInteractor.authorizationResultToReturn = .approved(authToken: KlarnaTestData.Constants.authToken)
         let tokenizeExpectation = expectation(description: "tokenize called")
-        mockInteractor.onTokenize = { authToken in
+        mockInteractor.onTokenize = { _ in
             tokenizeExpectation.fulfill()
             return KlarnaTestData.successPaymentResult
         }

--- a/Tests/Primer/CheckoutComponents/PayPal/DefaultPayPalScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/PayPal/DefaultPayPalScopeTests.swift
@@ -16,18 +16,20 @@ final class DefaultPayPalScopeTests: XCTestCase {
     private var sut: DefaultPayPalScope!
 
     @MainActor
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         mockCheckoutScope = createCheckoutScope()
         mockInteractor = MockProcessPayPalInteractor()
     }
 
     @MainActor
-    override func tearDown() {
+    override func tearDown() async throws {
         sut = nil
         mockInteractor = nil
         mockCheckoutScope = nil
-        super.tearDown()
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     // MARK: - Mock Types

--- a/Tests/Primer/CheckoutComponents/PaymentMethods/CardPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/PaymentMethods/CardPaymentMethodTests.swift
@@ -16,12 +16,14 @@ final class CardPaymentMethodTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         container = try await ContainerTestHelpers.createTestContainer()
     }
 
     override func tearDown() async throws {
         await container.reset(ignoreDependencies: [Never.Type]())
         container = nil
+        await ContainerTestHelpers.resetSharedContainer()
         try await super.tearDown()
     }
 

--- a/Tests/Primer/CheckoutComponents/PaymentMethods/PayPalPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/PaymentMethods/PayPalPaymentMethodTests.swift
@@ -16,12 +16,14 @@ final class PayPalPaymentMethodTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         container = try await ContainerTestHelpers.createTestContainer()
     }
 
     override func tearDown() async throws {
         await container.reset(ignoreDependencies: [Never.Type]())
         container = nil
+        await ContainerTestHelpers.resetSharedContainer()
         try await super.tearDown()
     }
 

--- a/Tests/Primer/CheckoutComponents/QRCode/DefaultQRCodeScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/QRCode/DefaultQRCodeScopeTests.swift
@@ -13,14 +13,16 @@ final class DefaultQRCodeScopeTests: XCTestCase {
 
     private var mockInteractor: MockProcessQRCodePaymentInteractor!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         mockInteractor = MockProcessQRCodePaymentInteractor()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockInteractor = nil
-        super.tearDown()
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     // MARK: - Full Success Flow

--- a/Tests/Primer/CheckoutComponents/QRCode/QRCodePaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/QRCode/QRCodePaymentMethodTests.swift
@@ -16,6 +16,7 @@ final class QRCodePaymentMethodTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         container = try await ContainerTestHelpers.createTestContainer()
         PaymentMethodRegistry.shared.reset()
     }
@@ -23,6 +24,7 @@ final class QRCodePaymentMethodTests: XCTestCase {
     override func tearDown() async throws {
         await container.reset(ignoreDependencies: [Never.Type]())
         container = nil
+        await ContainerTestHelpers.resetSharedContainer()
         try await super.tearDown()
     }
 
@@ -221,7 +223,7 @@ final class QRCodePaymentMethodTests: XCTestCase {
                 id: "card-1",
                 type: PrimerPaymentMethodType.paymentCard.rawValue,
                 name: "Card"
-            ),
+            )
         ]
         return scope
     }

--- a/Tests/Primer/CheckoutComponents/TestSupport/ContainerTestHelpers.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/ContainerTestHelpers.swift
@@ -32,6 +32,13 @@ enum ContainerTestHelpers {
         return container
     }
 
+    /// Clears `DIContainer.shared` so registrations and singleton instances from one test do not leak into the next.
+    /// Call in both `setUp` and `tearDown` of any test class that writes into `DIContainer.shared`.
+    @MainActor
+    static func resetSharedContainer() async {
+        await DIContainer.clearContainer()
+    }
+
     @MainActor
     static func createMockCheckoutScope() async -> DefaultCheckoutScope {
         let navigator = CheckoutNavigator(coordinator: CheckoutCoordinator())
@@ -45,5 +52,44 @@ enum ContainerTestHelpers {
             diContainer: DIContainer.shared,
             navigator: navigator
         )
+    }
+
+    /// Creates a `DefaultCheckoutScope` that has already finished its async init (state = `.ready` or `.failure`).
+    /// Use when a test depends on downstream code awaiting `checkoutScope.state` — without this, the scope may still
+    /// be in `.initializing` when the test asserts, causing flakes.
+    ///
+    /// Installs a fresh minimal test container as `DIContainer.shared` so the scope's init can actually run.
+    /// The test may later swap the container via `DIContainer.setContainer(_:)`; the scope's stored state survives.
+    @MainActor
+    static func createSettledCheckoutScope() async throws -> DefaultCheckoutScope {
+        let container = try await createTestContainer()
+        await DIContainer.setContainer(container)
+
+        let navigator = CheckoutNavigator(coordinator: CheckoutCoordinator())
+        let settings = PrimerSettings(
+            paymentHandling: .manual,
+            paymentMethodOptions: PrimerPaymentMethodOptions(),
+            uiOptions: PrimerUIOptions(isInitScreenEnabled: false)
+        )
+        let scope = DefaultCheckoutScope(
+            clientToken: TestData.Tokens.valid,
+            settings: settings,
+            diContainer: DIContainer.shared,
+            navigator: navigator
+        )
+
+        // Drain the state stream until the scope exits `.initializing`. Bounded by a generous timeout
+        // so a broken init doesn't hang the suite forever.
+        let deadline = Date().addingTimeInterval(5)
+        for await state in scope.state {
+            switch state {
+            case .initializing:
+                if Date() > deadline { return scope }
+                continue
+            default:
+                return scope
+            }
+        }
+        return scope
     }
 }

--- a/Tests/Primer/CheckoutComponents/WebRedirect/DefaultWebRedirectScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/DefaultWebRedirectScopeTests.swift
@@ -15,18 +15,20 @@ final class DefaultWebRedirectScopeTests: XCTestCase {
     private var mockRepository: MockWebRedirectRepository!
     private var mockAnalytics: MockTrackingAnalyticsInteractor!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         mockInteractor = MockProcessWebRedirectPaymentInteractor()
         mockRepository = MockWebRedirectRepository()
         mockAnalytics = MockTrackingAnalyticsInteractor()
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         mockInteractor = nil
         mockRepository = nil
         mockAnalytics = nil
-        super.tearDown()
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
     }
 
     // MARK: - Initialization Tests

--- a/Tests/Primer/CheckoutComponents/WebRedirect/WebRedirectPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/WebRedirectPaymentMethodTests.swift
@@ -16,6 +16,7 @@ final class WebRedirectPaymentMethodTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
         container = try await ContainerTestHelpers.createTestContainer()
         PaymentMethodRegistry.shared.reset()
     }
@@ -23,6 +24,7 @@ final class WebRedirectPaymentMethodTests: XCTestCase {
     override func tearDown() async throws {
         await container.reset(ignoreDependencies: [Never.Type]())
         container = nil
+        await ContainerTestHelpers.resetSharedContainer()
         try await super.tearDown()
     }
 
@@ -263,7 +265,7 @@ final class WebRedirectPaymentMethodTests: XCTestCase {
                 id: "card-1",
                 type: PrimerPaymentMethodType.paymentCard.rawValue,
                 name: "Card"
-            ),
+            )
         ]
         return scope
     }


### PR DESCRIPTION
## Summary

CheckoutComponents test classes write into the global `DIContainer.shared` but do not reset it between tests, so singleton registrations and resolution state leak across tests. Under varying test-run orderings this manifests as `circularDependency`, stale mock call counts, and tests asserting against state left by a previous class. Four open PRs have been repeatedly hitting this flake:

- #1685 (PAY_NL_KAARTDIRECT)
- #1686 (PAY_NL_PAYPAL)
- #1691 (ADYEN_AFFIRM)
- #1705 (ACC-7133 — DI error propagation)

Each run fails a *different* test (vault call-count assertions, `circularDependency(HeadlessRepository)`, `test_onDismiss_setsNavigationStateToDismissed`, etc.) — the hallmark of cross-test container-state leakage combined with async init races.

## Changes

- **`ContainerTestHelpers.resetSharedContainer()`** — new helper; called from `setUp` and `tearDown` of the 12 test files that use `DIContainer.shared`.
- **`ContainerTestHelpers.createSettledCheckoutScope()`** — new helper; creates a `DefaultCheckoutScope` with a pre-wired test container and returns only after its async init leaves `.initializing`. Used in the three `DefaultPaymentMethodSelectionScope*Tests` classes so downstream `loadPaymentMethods()` no longer awaits forever on a scope stuck in `.initializing`.
- **`test_onDismiss_setsNavigationStateToDismissed`** — race fix: build the SUT with `isInitScreenEnabled: false` so the async init task cannot overwrite `.dismissed` with `.loading`; drop the 500 ms sleep and the `|| == .loading` hedge — both `updateState` calls on the dismiss path are synchronous.
- **`test_deleteVaultedPaymentMethod_whenDeleteThrows_propagatesErrorWithoutRefresh`** — capture a post-init baseline of `fetchVaultedPaymentMethodsCallCount` and assert the failed delete did not increment it, rather than asserting the absolute count is zero (the settled scope now legitimately refreshes once during init).

No production code changes. 14 test files modified (+141 / −90).

## Test plan

- [x] Full local `PrimerSDKTests` test plan passes on first run
- [x] Targeted runs of previously flaky classes (`DefaultPaymentMethodSelectionScopeVaultTests`, `DefaultCheckoutScopeBehaviorTests`) pass
- [x] CI passes on first attempt
- [x] 2–3 rerun sanity checks that it stays green

## Notes

Branch intentionally omits the Jira prefix — this is test hygiene only, no Jira ticket. Once merged, rebase #1685/#1686/#1691/#1705 and their CI should stop flaking.