### PR TITLE
feat: Add setBillingAddress public API on RawDataManager (ACC-6916)

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/RawDataManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/Payment Method Managers/RawDataManager.swift
@@ -17,22 +17,32 @@ import SafariServices
 public protocol PrimerHeadlessUniversalCheckoutRawDataManagerDelegate {
 
     @available(*, deprecated, message: "Use _:didReceiveCardMetadata:forState: instead")
-    @objc optional func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              metadataDidChange metadata: [String: Any]?)
+    @objc optional func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        metadataDidChange metadata: [String: Any]?
+    )
 
-    @objc optional func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              dataIsValid isValid: Bool,
-                              errors: [Error]?)
+    @objc optional func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        dataIsValid isValid: Bool,
+        errors: [Error]?
+    )
 
-    @objc optional func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              willFetchMetadataForState state: PrimerValidationState)
+    @objc optional func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        willFetchMetadataForState state: PrimerValidationState
+    )
 
-    @objc optional func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              didReceiveMetadata metadata: PrimerPaymentMethodMetadata,
-                              forState state: PrimerValidationState)
+    @objc optional func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        didReceiveMetadata metadata: PrimerPaymentMethodMetadata,
+        forState state: PrimerValidationState
+    )
 
-    @objc optional func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              didReceiveBinData binData: PrimerBinData)
+    @objc optional func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        didReceiveBinData binData: PrimerBinData
+    )
 }
 
 protocol PrimerRawDataTokenizationBuilderProtocol {
@@ -100,9 +110,11 @@ extension PrimerHeadlessUniversalCheckout {
         /// The `isUsedInDropIn` flag enables support for Drop-In integration flow,
         /// expanding the utility of RawDataManager to both Headless and Drop-In use cases.
         /// When set to true, it configures the RawDataManager to behave as a Drop-In integration.
-        public required init(paymentMethodType: String,
-                             delegate: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate? = nil,
-                             isUsedInDropIn: Bool = false) throws {
+        public required init(
+            paymentMethodType: String,
+            delegate: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate? = nil,
+            isUsedInDropIn: Bool = false
+        ) throws {
             if isUsedInDropIn {
                 PrimerInternal.shared.sdkIntegrationType = .dropIn
             } else {
@@ -244,9 +256,59 @@ extension PrimerHeadlessUniversalCheckout {
                     }
                 } catch {
                     let delegate = PrimerHeadlessUniversalCheckout.current.delegate
-                    delegate?.primerHeadlessUniversalCheckoutDidFail?(withError: error,
-                                                                      checkoutData: self.paymentCheckoutData)
+                    delegate?.primerHeadlessUniversalCheckoutDidFail?(
+                        withError: error,
+                        checkoutData: self.paymentCheckoutData
+                    )
                 }
+            }
+        }
+
+        /// Dispatches the billing address as a client-session action.
+        ///
+        /// Must be awaited before calling ``submit()`` — tokenization reads billing from the server-side
+        /// client session. Safe to call repeatedly; the server accepts repeat dispatches idempotently.
+        ///
+        /// - Parameter address: The billing address to dispatch. Must have at least one non-empty field.
+        ///   If `countryCode` is set, it must be a valid `CountryCode` raw value.
+        /// - Throws: ``PrimerValidationError/invalidRawData`` when the address has no non-empty fields
+        ///   or when `countryCode` is not a valid `CountryCode`. Also propagates any error from the
+        ///   underlying client-session update (network, decoding, server validation).
+        public func setBillingAddress(_ address: PrimerAddress) async throws {
+            Analytics.Service.fire(event: Analytics.Event.sdk(
+                name: "\(Self.self).\(#function)",
+                params: [
+                    "category": "RAW_DATA",
+                    "intent": PrimerInternal.shared.intent?.rawValue ?? "null",
+                    "paymentMethodType": paymentMethodType
+                ]
+            ))
+
+            try validate(billingAddress: address)
+
+            let clientSessionAddress = ClientSession.Address(from: address)
+            try await ClientSessionActionsModule
+                .updateBillingAddressViaClientSessionActionWithAddressIfNeeded(clientSessionAddress)
+        }
+
+        private func validate(billingAddress address: PrimerAddress) throws {
+            let hasAnyField = [
+                address.firstName,
+                address.lastName,
+                address.addressLine1,
+                address.addressLine2,
+                address.city,
+                address.state,
+                address.postalCode,
+                address.countryCode
+            ].contains { $0?.isEmpty == false }
+
+            guard hasAnyField else {
+                throw PrimerValidationError.invalidRawData()
+            }
+
+            if let code = address.countryCode, !code.isEmpty, CountryCode(rawValue: code) == nil {
+                throw PrimerValidationError.invalidRawData()
             }
         }
 
@@ -432,8 +494,10 @@ extension PrimerHeadlessUniversalCheckout {
             return nil
         }
 
-        private func handleDecodedClientTokenIfNeeded(_ decodedJWTToken: DecodedJWTToken,
-                                                      paymentMethodTokenData: PrimerPaymentMethodTokenData) async throws -> String? {
+        private func handleDecodedClientTokenIfNeeded(
+            _ decodedJWTToken: DecodedJWTToken,
+            paymentMethodTokenData: PrimerPaymentMethodTokenData
+        ) async throws -> String? {
             if decodedJWTToken.intent == RequiredActionName.threeDSAuthentication.rawValue {
                 return try await handle3DSAuthenticationForDecodedClientToken(decodedJWTToken, paymentMethodTokenData: paymentMethodTokenData)
             } else if decodedJWTToken.intent == RequiredActionName.processor3DS.rawValue {
@@ -447,8 +511,10 @@ extension PrimerHeadlessUniversalCheckout {
             }
         }
 
-        private func handle3DSAuthenticationForDecodedClientToken(_ decodedJWTToken: DecodedJWTToken,
-                                                                  paymentMethodTokenData: PrimerPaymentMethodTokenData) async throws -> String? {
+        private func handle3DSAuthenticationForDecodedClientToken(
+            _ decodedJWTToken: DecodedJWTToken,
+            paymentMethodTokenData: PrimerPaymentMethodTokenData
+        ) async throws -> String? {
             try await ThreeDSService().perform3DS(
                 paymentMethodTokenData: paymentMethodTokenData,
                 sdkDismissed: nil
@@ -574,9 +640,11 @@ extension PrimerHeadlessUniversalCheckout {
                 }
 
                 let formatter = DateFormatter().withExpirationDisplayDateFormat()
-                additionalInfo = XenditCheckoutVoucherAdditionalInfo(expiresAt: formatter.string(from: decodedExpiresAt),
-                                                                     couponCode: decodedVoucherReference,
-                                                                     retailerName: selectedRetailerName)
+                additionalInfo = XenditCheckoutVoucherAdditionalInfo(
+                    expiresAt: formatter.string(from: decodedExpiresAt),
+                    couponCode: decodedVoucherReference,
+                    retailerName: selectedRetailerName
+                )
                 paymentCheckoutData?.additionalInfo = additionalInfo
 
             default:
@@ -638,8 +706,10 @@ extension PrimerHeadlessUniversalCheckout {
         }
 
         private func handleResumePaymentEvent(_ resumePaymentId: String, resumeToken: String) async throws -> Response.Body.Payment {
-            try await createResumePaymentService.resumePaymentWithPaymentId(resumePaymentId,
-                                                                            paymentResumeRequest: Request.Body.Payment.Resume(token: resumeToken))
+            try await createResumePaymentService.resumePaymentWithPaymentId(
+                resumePaymentId,
+                paymentResumeRequest: Request.Body.Payment.Resume(token: resumeToken)
+            )
         }
 
         @MainActor
@@ -662,17 +732,17 @@ extension PrimerHeadlessUniversalCheckout {
                 }
 
                 #if DEBUG
-                if TEST {
-                    // This ensures that the presentation completion is correctly handled in headless unit tests
-                    guard !UIApplication.shared.windows.isEmpty else {
-                        DispatchQueue.main.async {
-                            guard !didResume else { return }
-                            didResume = true
-                            continuation.resume()
+                    if TEST {
+                        // This ensures that the presentation completion is correctly handled in headless unit tests
+                        guard !UIApplication.shared.windows.isEmpty else {
+                            DispatchQueue.main.async {
+                                guard !didResume else { return }
+                                didResume = true
+                                continuation.resume()
+                            }
+                            return
                         }
-                        return
                     }
-                }
                 #endif
 
                 Task { @MainActor in

--- a/Sources/PrimerSDK/Classes/Data Models/ClientSession+PrimerAddress.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ClientSession+PrimerAddress.swift
@@ -1,0 +1,22 @@
+//
+//  ClientSession+PrimerAddress.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+extension ClientSession.Address {
+    init(from primerAddress: PrimerAddress) {
+        self.init(
+            firstName: primerAddress.firstName,
+            lastName: primerAddress.lastName,
+            addressLine1: primerAddress.addressLine1,
+            addressLine2: primerAddress.addressLine2,
+            city: primerAddress.city,
+            postalCode: primerAddress.postalCode,
+            state: primerAddress.state,
+            countryCode: primerAddress.countryCode.flatMap { CountryCode(rawValue: $0) }
+        )
+    }
+}

--- a/Tests/Primer/Managers/RawDataManagerTests.swift
+++ b/Tests/Primer/Managers/RawDataManagerTests.swift
@@ -1,11 +1,11 @@
 //
 //  RawDataManagerTests.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import XCTest
 @testable import PrimerSDK
+import XCTest
 
 final class RawDataManagerTests: XCTestCase {
 
@@ -68,10 +68,12 @@ final class RawDataManagerTests: XCTestCase {
             XCTFail("Failed with error: \(error.localizedDescription)")
         }
 
-        sut.rawData = PrimerCardData(cardNumber: "4111 1111 1111 1111",
-                                     expiryDate: "03/2030",
-                                     cvv: "123",
-                                     cardholderName: "John Appleseed")
+        sut.rawData = PrimerCardData(
+            cardNumber: "4111 1111 1111 1111",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Appleseed"
+        )
 
         sut.submit()
 
@@ -124,10 +126,12 @@ final class RawDataManagerTests: XCTestCase {
             XCTFail("Failed with error: \(error.localizedDescription)")
         }
 
-        sut.rawData = PrimerCardData(cardNumber: "4111 1111 1111 1111",
-                                     expiryDate: "03/2030",
-                                     cvv: "123",
-                                     cardholderName: "John Appleseed")
+        sut.rawData = PrimerCardData(
+            cardNumber: "4111 1111 1111 1111",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Appleseed"
+        )
 
         sut.submit()
 
@@ -150,10 +154,12 @@ final class RawDataManagerTests: XCTestCase {
             expectDidFail.fulfill()
         }
 
-        sut.rawData = PrimerCardData(cardNumber: "4111 1111 1111 1111",
-                                     expiryDate: "03/2030",
-                                     cvv: "123",
-                                     cardholderName: "John Appleseed")
+        sut.rawData = PrimerCardData(
+            cardNumber: "4111 1111 1111 1111",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Appleseed"
+        )
 
         sut.submit()
 
@@ -165,7 +171,7 @@ final class RawDataManagerTests: XCTestCase {
         let expectDidFail = self.expectation(description: "Did fail")
         headlessCheckoutDelegate.onDidFail = { error in
             switch error {
-            case PrimerError.invalidValue(let key, let value, _, _):
+            case let PrimerError.invalidValue(key, value, _, _):
                 XCTAssertEqual(key, "rawData")
                 XCTAssertNil(value)
                 XCTAssertFalse(self.sut.isDataValid)
@@ -178,8 +184,10 @@ final class RawDataManagerTests: XCTestCase {
         let expectDidValidate = self.expectation(description: "Did validate")
         rawDataManagerDelegate.onDataIsValid = { _, isValid, errors in
             XCTAssertFalse(isValid)
-            XCTAssertTrue(errors!.first!.localizedDescription.starts(
-                with: "[invalid-value] Invalid value 'nil' for key 'rawData' ")
+            XCTAssertTrue(
+                errors!.first!.localizedDescription.starts(
+                    with: "[invalid-value] Invalid value 'nil' for key 'rawData' "
+                )
             )
             expectDidValidate.fulfill()
         }
@@ -203,10 +211,12 @@ final class RawDataManagerTests: XCTestCase {
         }
 
         // Act
-        sut.rawData = PrimerCardData(cardNumber: "4111111111111111",
-                                     expiryDate: "03/2030",
-                                     cvv: "123",
-                                     cardholderName: "Test Name")
+        sut.rawData = PrimerCardData(
+            cardNumber: "4111111111111111",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "Test Name"
+        )
 
         // Assert
         waitForExpectations(timeout: 3.0)
@@ -230,118 +240,241 @@ final class RawDataManagerTests: XCTestCase {
                 expectFirstValidation.fulfill()
             }
             // Only after setting data the second time and not having fulfilled second expectation yet
-            else if validationCount > 1 && !fulfilledSecond {
+            else if validationCount > 1, !fulfilledSecond {
                 fulfilledSecond = true
                 expectSecondValidation.fulfill()
             }
         }
 
         // Act - First set valid data
-        sut.rawData = PrimerCardData(cardNumber: "4111111111111111",
-                                     expiryDate: "03/2030",
-                                     cvv: "123",
-                                     cardholderName: "Test Name")
+        sut.rawData = PrimerCardData(
+            cardNumber: "4111111111111111",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "Test Name"
+        )
 
         // Wait for first validation
         wait(for: [expectFirstValidation], timeout: 3.0)
 
         // Act - Then set identical data to ensure delegate is still called
-        sut.rawData = PrimerCardData(cardNumber: "4111111111111111",
-                                     expiryDate: "03/2030",
-                                     cvv: "123",
-                                     cardholderName: "Test Name")
+        sut.rawData = PrimerCardData(
+            cardNumber: "4111111111111111",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "Test Name"
+        )
 
         // Assert
         wait(for: [expectSecondValidation], timeout: 3.0)
         XCTAssertTrue(validationCount > 1, "Delegate should be notified at least twice")
     }
-    
+
+    // MARK: setBillingAddress
+
+    func testSetBillingAddressDispatchesClientSessionAction() async throws {
+        let apiClient = MockPrimerAPIClient()
+        PrimerAPIConfigurationModule.apiClient = apiClient
+        apiClient.fetchConfigurationWithActionsResult = (PrimerAPIConfiguration.current, nil)
+
+        let address = PrimerAddress(
+            firstName: "John",
+            lastName: "Appleseed",
+            addressLine1: "1 Infinite Loop",
+            addressLine2: nil,
+            postalCode: "95014",
+            city: "Cupertino",
+            state: "CA",
+            countryCode: "US"
+        )
+
+        try await sut.setBillingAddress(address)
+    }
+
+    func testSetBillingAddressThrowsOnEmptyAddress() async {
+        let address = PrimerAddress(
+            firstName: nil,
+            lastName: nil,
+            addressLine1: nil,
+            addressLine2: nil,
+            postalCode: nil,
+            city: nil,
+            state: nil,
+            countryCode: nil
+        )
+
+        do {
+            try await sut.setBillingAddress(address)
+            XCTFail("Expected setBillingAddress to throw on empty address")
+        } catch let error as PrimerValidationError {
+            if case .invalidRawData = error {
+                // pass
+            } else {
+                XCTFail("Expected .invalidRawData, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected PrimerValidationError, got \(error)")
+        }
+    }
+
+    func testSetBillingAddressThrowsOnInvalidCountryCode() async {
+        let address = PrimerAddress(
+            firstName: nil,
+            lastName: nil,
+            addressLine1: nil,
+            addressLine2: nil,
+            postalCode: "95014",
+            city: nil,
+            state: nil,
+            countryCode: "USA" // invalid — expected "US"
+        )
+
+        do {
+            try await sut.setBillingAddress(address)
+            XCTFail("Expected setBillingAddress to throw on invalid countryCode")
+        } catch let error as PrimerValidationError {
+            if case .invalidRawData = error {
+                // pass
+            } else {
+                XCTFail("Expected .invalidRawData, got \(error)")
+            }
+        } catch {
+            XCTFail("Expected PrimerValidationError, got \(error)")
+        }
+    }
+
+    func testClientSessionAddressInitFromPrimerAddressMapsFields() {
+        let primerAddress = PrimerAddress(
+            firstName: "John",
+            lastName: "Appleseed",
+            addressLine1: "1 Infinite Loop",
+            addressLine2: "Building 2",
+            postalCode: "95014",
+            city: "Cupertino",
+            state: "CA",
+            countryCode: "US"
+        )
+
+        let address = ClientSession.Address(from: primerAddress)
+
+        XCTAssertEqual(address.firstName, "John")
+        XCTAssertEqual(address.lastName, "Appleseed")
+        XCTAssertEqual(address.addressLine1, "1 Infinite Loop")
+        XCTAssertEqual(address.addressLine2, "Building 2")
+        XCTAssertEqual(address.city, "Cupertino")
+        XCTAssertEqual(address.postalCode, "95014")
+        XCTAssertEqual(address.state, "CA")
+        XCTAssertEqual(address.countryCode, .us)
+    }
+
     // MARK: Helpers
 
     var tokenizationResponseBody: Response.Body.Tokenization {
-        .init(analyticsId: "analytics_id",
-              id: "id",
-              isVaulted: false,
-              isAlreadyVaulted: false,
-              paymentInstrumentType: .offSession,
-              paymentMethodType: Mocks.Static.Strings.webRedirectPaymentMethodType,
-              paymentInstrumentData: nil,
-              threeDSecureAuthentication: nil,
-              token: "token",
-              tokenType: .singleUse,
-              vaultData: nil)
+        .init(
+            analyticsId: "analytics_id",
+            id: "id",
+            isVaulted: false,
+            isAlreadyVaulted: false,
+            paymentInstrumentType: .offSession,
+            paymentMethodType: Mocks.Static.Strings.webRedirectPaymentMethodType,
+            paymentInstrumentData: nil,
+            threeDSecureAuthentication: nil,
+            token: "token",
+            tokenType: .singleUse,
+            vaultData: nil
+        )
     }
 
     var paymentResponseBody: Response.Body.Payment {
-        return .init(id: "id",
-                     paymentId: "payment_id",
-                     amount: 123,
-                     currencyCode: "GBP",
-                     customer: .init(firstName: "first_name",
-                                     lastName: "last_name",
-                                     emailAddress: "email_address",
-                                     mobileNumber: "+44(0)7891234567",
-                                     billingAddress: .init(firstName: "billing_first_name",
-                                                           lastName: "billing_last_name",
-                                                           addressLine1: "billing_line_1",
-                                                           addressLine2: "billing_line_2",
-                                                           city: "billing_city",
-                                                           state: "billing_state",
-                                                           countryCode: "billing_country_code",
-                                                           postalCode: "billing_postal_code"),
-                                     shippingAddress: .init(firstName: "shipping_first_name",
-                                                            lastName: "shipping_last_name",
-                                                            addressLine1: "shipping_line_1",
-                                                            addressLine2: "shipping_line_2",
-                                                            city: "shipping_city",
-                                                            state: "shipping_state",
-                                                            countryCode: "shipping_country_code",
-                                                            postalCode: "shipping_postal_code")),
-                     customerId: "customer_id",
-                     orderId: "order_id",
-                     status: .success)
+        .init(
+            id: "id",
+            paymentId: "payment_id",
+            amount: 123,
+            currencyCode: "GBP",
+            customer: .init(
+                firstName: "first_name",
+                lastName: "last_name",
+                emailAddress: "email_address",
+                mobileNumber: "+44(0)7891234567",
+                billingAddress: .init(
+                    firstName: "billing_first_name",
+                    lastName: "billing_last_name",
+                    addressLine1: "billing_line_1",
+                    addressLine2: "billing_line_2",
+                    city: "billing_city",
+                    state: "billing_state",
+                    countryCode: "billing_country_code",
+                    postalCode: "billing_postal_code"
+                ),
+                shippingAddress: .init(
+                    firstName: "shipping_first_name",
+                    lastName: "shipping_last_name",
+                    addressLine1: "shipping_line_1",
+                    addressLine2: "shipping_line_2",
+                    city: "shipping_city",
+                    state: "shipping_state",
+                    countryCode: "shipping_country_code",
+                    postalCode: "shipping_postal_code"
+                )
+            ),
+            customerId: "customer_id",
+            orderId: "order_id",
+            status: .success
+        )
     }
 
     var paymentResponseBodyWithRedirectAction: Response.Body.Payment {
-        return .init(id: "id",
-                     paymentId: "payment_id",
-                     amount: 123,
-                     currencyCode: "GBP",
-                     customer: .init(firstName: "first_name",
-                                     lastName: "last_name",
-                                     emailAddress: "email_address",
-                                     mobileNumber: "+44(0)7891234567",
-                                     billingAddress: .init(firstName: "billing_first_name",
-                                                           lastName: "billing_last_name",
-                                                           addressLine1: "billing_line_1",
-                                                           addressLine2: "billing_line_2",
-                                                           city: "billing_city",
-                                                           state: "billing_state",
-                                                           countryCode: "billing_country_code",
-                                                           postalCode: "billing_postal_code"),
-                                     shippingAddress: .init(firstName: "shipping_first_name",
-                                                            lastName: "shipping_last_name",
-                                                            addressLine1: "shipping_line_1",
-                                                            addressLine2: "shipping_line_2",
-                                                            city: "shipping_city",
-                                                            state: "shipping_state",
-                                                            countryCode: "shipping_country_code",
-                                                            postalCode: "shipping_postal_code")),
-                     customerId: "customer_id",
-                     orderId: "order_id",
-                     requiredAction: .init(clientToken: MockAppState.mockClientTokenWithRedirect,
-                                           name: .checkout,
-                                           description: "description"),
-                     status: .success)
+        .init(
+            id: "id",
+            paymentId: "payment_id",
+            amount: 123,
+            currencyCode: "GBP",
+            customer: .init(
+                firstName: "first_name",
+                lastName: "last_name",
+                emailAddress: "email_address",
+                mobileNumber: "+44(0)7891234567",
+                billingAddress: .init(
+                    firstName: "billing_first_name",
+                    lastName: "billing_last_name",
+                    addressLine1: "billing_line_1",
+                    addressLine2: "billing_line_2",
+                    city: "billing_city",
+                    state: "billing_state",
+                    countryCode: "billing_country_code",
+                    postalCode: "billing_postal_code"
+                ),
+                shippingAddress: .init(
+                    firstName: "shipping_first_name",
+                    lastName: "shipping_last_name",
+                    addressLine1: "shipping_line_1",
+                    addressLine2: "shipping_line_2",
+                    city: "shipping_city",
+                    state: "shipping_state",
+                    countryCode: "shipping_country_code",
+                    postalCode: "shipping_postal_code"
+                )
+            ),
+            customerId: "customer_id",
+            orderId: "order_id",
+            requiredAction: .init(
+                clientToken: MockAppState.mockClientTokenWithRedirect,
+                name: .checkout,
+                description: "description"
+            ),
+            status: .success
+        )
     }
 
     var paymentResponseAfterResume: Response.Body.Payment {
-        .init(id: "id",
-              paymentId: "payment_id",
-              amount: 1234,
-              currencyCode: "GBP",
-              customerId: "customer_id",
-              orderId: "order_id",
-              status: .success)
+        .init(
+            id: "id",
+            paymentId: "payment_id",
+            amount: 1234,
+            currencyCode: "GBP",
+            customerId: "customer_id",
+            orderId: "order_id",
+            status: .success
+        )
     }
 }


### PR DESCRIPTION
# Description

[ACC-7169](https://primerapi.atlassian.net/browse/ACC-7169)

Adds `setBillingAddress(_:)` on `PrimerHeadlessUniversalCheckout.RawDataManager` so headless consumers (RN) can dispatch a billing address before tokenization. Wraps the existing internal `ClientSessionActionsModule.updateBillingAddressViaClientSessionActionWithAddressIfNeeded(_:)`.

```swift
public func setBillingAddress(_ address: PrimerAddress) async throws
```

Throws `PrimerValidationError.invalidRawData()` for empty addresses or invalid `countryCode`.

Additive, no breaking changes.

# Manual Testing

- Valid address → `primerClientSessionDidUpdate` fires with the new values, no errors.
- Empty `PrimerAddress` → throws, no network call.
- Invalid `countryCode` (e.g. `"USA"`) → throws, no network call.

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

[ACC-7169]: https://primerapi.atlassian.net/browse/ACC-7169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ