### PR TITLE
feat: Expose PrimerCardNetworkTraits for card network data access

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/AssetsManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/AssetsManager.swift
@@ -1,7 +1,7 @@
 //
 //  AssetsManager.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 import UIKit
@@ -36,11 +36,20 @@ extension PrimerHeadlessUniversalCheckout {
             return PrimerCardNetworkAsset(cardNetwork: cardNetwork, cardImage: cardImage)
         }
 
+        public static func getCardNetworkTraits(cardNetworkString: String?) -> PrimerCardNetworkTraits? {
+            guard let cardNetworkString else { return nil }
+            return Self.getCardNetworkTraits(for: CardNetwork(cardNetworkStr: cardNetworkString))
+        }
+
+        public static func getCardNetworkTraits(for cardNetwork: CardNetwork) -> PrimerCardNetworkTraits? {
+            cardNetwork.traits
+        }
+
         public static func getPaymentMethodAsset(for paymentMethodType: String) throws -> PrimerPaymentMethodAsset? {
             try verifyAPIConfig()
 
             guard let paymentMethod = PrimerAPIConfiguration.paymentMethodConfigs?
-                    .first(where: { $0.type == paymentMethodType })
+                .first(where: { $0.type == paymentMethodType })
             else {
                 return nil
             }
@@ -52,16 +61,18 @@ extension PrimerHeadlessUniversalCheckout {
             }
 
             guard let paymentMethodLogo = PrimerInternalAsset(
-                    colored: baseLogoImage.colored,
-                    light: baseLogoImage.light,
-                    dark: baseLogoImage.dark) else {
+                colored: baseLogoImage.colored,
+                light: baseLogoImage.light,
+                dark: baseLogoImage.dark
+            ) else {
                 return nil
             }
 
             guard let paymentMethodBackgroundColor = PrimerPaymentMethodBackgroundColor(
-                    coloredStr: baseBackgroundColor.coloredHex,
-                    lightStr: baseBackgroundColor.lightHex,
-                    darkStr: baseBackgroundColor.darkHex) else {
+                coloredStr: baseBackgroundColor.coloredHex,
+                lightStr: baseBackgroundColor.lightHex,
+                darkStr: baseBackgroundColor.darkHex
+            ) else {
                 return nil
             }
 
@@ -69,14 +80,15 @@ extension PrimerHeadlessUniversalCheckout {
                 paymentMethodType: paymentMethodType,
                 paymentMethodName: paymentMethod.name,
                 paymentMethodLogo: paymentMethodLogo,
-                paymentMethodBackgroundColor: paymentMethodBackgroundColor)
+                paymentMethodBackgroundColor: paymentMethodBackgroundColor
+            )
         }
 
         public static func getPaymentMethodAssets() throws -> [PrimerPaymentMethodAsset] {
             try verifyAPIConfig()
 
             let hucAvailablePaymentMethods = PrimerHeadlessUniversalCheckout.PaymentMethod.availablePaymentMethods
-                .compactMap({ $0.paymentMethodType })
+                .compactMap(\.paymentMethodType)
 
             var paymentMethodAssets: [PrimerPaymentMethodAsset] = []
 
@@ -90,17 +102,19 @@ extension PrimerHeadlessUniversalCheckout {
                 }
 
                 guard let paymentMethodLogo = PrimerInternalAsset(
-                        colored: baseLogoImage.colored,
-                        light: baseLogoImage.light,
-                        dark: baseLogoImage.dark)
+                    colored: baseLogoImage.colored,
+                    light: baseLogoImage.light,
+                    dark: baseLogoImage.dark
+                )
                 else {
                     continue
                 }
 
                 guard let paymentMethodBackgroundColor = PrimerPaymentMethodBackgroundColor(
-                        coloredStr: baseBackgroundColor.coloredHex,
-                        lightStr: baseBackgroundColor.lightHex,
-                        darkStr: baseBackgroundColor.darkHex)
+                    coloredStr: baseBackgroundColor.coloredHex,
+                    lightStr: baseBackgroundColor.lightHex,
+                    darkStr: baseBackgroundColor.darkHex
+                )
                 else {
                     continue
                 }
@@ -109,7 +123,8 @@ extension PrimerHeadlessUniversalCheckout {
                     paymentMethodType: paymentMethod.type,
                     paymentMethodName: paymentMethod.name,
                     paymentMethodLogo: paymentMethodLogo,
-                    paymentMethodBackgroundColor: paymentMethodBackgroundColor)
+                    paymentMethodBackgroundColor: paymentMethodBackgroundColor
+                )
 
                 paymentMethodAssets.append(paymentMethodAsset)
             }
@@ -130,7 +145,7 @@ public final class PrimerCardNetworkAsset {
     public let cardImage: UIImage?
 
     var displayName: String {
-        return cardNetwork.displayName
+        cardNetwork.displayName
     }
 
     init(cardNetwork: CardNetwork, cardImage: UIImage?) {

--- a/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/CardNetwork.swift
@@ -1,7 +1,7 @@
 //
 //  CardNetwork.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 // swiftlint:disable type_body_length
@@ -53,7 +53,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [15],
                 code: CardNetworkCode(
                     name: "CID",
-                    length: 4))
+                    length: 4
+                )
+            )
 
         case .bancontact, .cartesBancaires, .eftpos:
             return nil
@@ -66,7 +68,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [14, 16, 19],
                 code: CardNetworkCode(
                     name: "CVV",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .discover:
             return CardNetworkValidation(
@@ -76,7 +80,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [16, 19],
                 code: CardNetworkCode(
                     name: "CID",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .elo:
             return CardNetworkValidation(
@@ -112,7 +118,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [16],
                 code: CardNetworkCode(
                     name: "CVE",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .hiper:
             return CardNetworkValidation(
@@ -122,7 +130,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [16],
                 code: CardNetworkCode(
                     name: "CVC",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .hipercard:
             return CardNetworkValidation(
@@ -132,7 +142,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [16],
                 code: CardNetworkCode(
                     name: "CVC",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .jcb:
             return CardNetworkValidation(
@@ -142,7 +154,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [16, 17, 18, 19],
                 code: CardNetworkCode(
                     name: "CVV",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .masterCard:
             return CardNetworkValidation(
@@ -152,7 +166,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [16],
                 code: CardNetworkCode(
                     name: "CVC",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .maestro:
             return CardNetworkValidation(
@@ -171,7 +187,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [16, 17, 18, 19],
                 code: CardNetworkCode(
                     name: "CVC",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .mir:
             return CardNetworkValidation(
@@ -181,7 +199,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [16, 17, 18, 19],
                 code: CardNetworkCode(
                     name: "CVP2",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .visa:
             return CardNetworkValidation(
@@ -191,7 +211,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [16, 18, 19],
                 code: CardNetworkCode(
                     name: "CVV",
-                    length: 3))
+                    length: 3
+                )
+            )
 
         case .unionpay:
             return CardNetworkValidation(
@@ -227,7 +249,9 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
                 lengths: [14, 15, 16, 17, 18, 19],
                 code: CardNetworkCode(
                     name: "CVN",
-                    length: 3))
+                    length: 3
+                )
+            )
         case .unknown:
             return nil
         }
@@ -264,6 +288,19 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
         }
     }
 
+    public var traits: PrimerCardNetworkTraits? {
+        validation.map {
+            PrimerCardNetworkTraits(
+                cardNetwork: self,
+                displayName: $0.niceType,
+                panLengths: $0.lengths,
+                gapPattern: $0.gaps,
+                cvvLength: $0.code.length,
+                cvvLabel: $0.code.name
+            )
+        }
+    }
+
     var surcharge: Int? {
         guard let options = PrimerAPIConfigurationModule.apiConfiguration?.clientSession?.paymentMethod?.options,
               !options.isEmpty else { return nil }
@@ -277,8 +314,8 @@ public enum CardNetwork: String, Codable, CaseIterable, LogReporter {
             else { continue }
 
             guard let tmpNetwork = networks
-                    .filter({ $0["type"] as? String == self.rawValue.uppercased() })
-                    .first
+                .filter({ $0["type"] as? String == self.rawValue.uppercased() })
+                .first
             else { continue }
             guard let surcharge = tmpNetwork["surcharge"] as? Int else { continue }
             guard surcharge > 0 else { continue }

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerCardNetworkTraits.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerCardNetworkTraits.swift
@@ -1,0 +1,21 @@
+//
+//  PrimerCardNetworkTraits.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+/// Read-only traits of a card network — digit grouping, length constraints, and CVV configuration.
+///
+/// Access via ``CardNetwork/traits`` or
+/// ``PrimerHeadlessUniversalCheckout/AssetsManager/getCardNetworkTraits(for:)``. Returns `nil` for
+/// networks without known validation rules (e.g. `.bancontact`, `.cartesBancaires`, `.eftpos`, `.unknown`).
+public struct PrimerCardNetworkTraits {
+    public let cardNetwork: CardNetwork
+    public let displayName: String
+    public let panLengths: [Int]
+    public let gapPattern: [Int]
+    public let cvvLength: Int
+    public let cvvLabel: String
+}

--- a/Tests/Primer/Assets/AssetsManagerTests.swift
+++ b/Tests/Primer/Assets/AssetsManagerTests.swift
@@ -1,11 +1,11 @@
 //
 //  AssetsManagerTests.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import XCTest
 @testable import PrimerSDK
+import XCTest
 
 final class AssetsManagerTests: XCTestCase {
 
@@ -44,5 +44,30 @@ final class AssetsManagerTests: XCTestCase {
 
         XCTAssertEqual(AssetsManager.getCardNetworkAsset(cardNetworkString: "CARTES_BANCAIRES")?.cardNetwork, .cartesBancaires)
         XCTAssertNotNil(AssetsManager.getCardNetworkAsset(cardNetworkString: "CARTES_BANCAIRES")?.cardImage)
+    }
+
+    // MARK: - Card Network Traits
+
+    func testGetCardNetworkTraitsForNetworkWithValidation() throws {
+        let traits = try XCTUnwrap(AssetsManager.getCardNetworkTraits(for: .amex))
+        XCTAssertEqual(traits.cardNetwork, .amex)
+        XCTAssertEqual(traits.cvvLabel, "CID")
+        XCTAssertEqual(traits.cvvLength, 4)
+    }
+
+    func testGetCardNetworkTraitsForNetworkWithoutValidation() {
+        XCTAssertNil(AssetsManager.getCardNetworkTraits(for: .bancontact))
+        XCTAssertNil(AssetsManager.getCardNetworkTraits(for: .unknown))
+    }
+
+    func testGetCardNetworkTraitsForString() {
+        XCTAssertEqual(AssetsManager.getCardNetworkTraits(cardNetworkString: "VISA")?.cardNetwork, .visa)
+        XCTAssertEqual(AssetsManager.getCardNetworkTraits(cardNetworkString: "AMEX")?.cardNetwork, .amex)
+        XCTAssertEqual(AssetsManager.getCardNetworkTraits(cardNetworkString: "MASTERCARD")?.cardNetwork, .masterCard)
+    }
+
+    func testGetCardNetworkTraitsForNilOrUnknownString() {
+        XCTAssertNil(AssetsManager.getCardNetworkTraits(cardNetworkString: nil))
+        XCTAssertNil(AssetsManager.getCardNetworkTraits(cardNetworkString: "FOO"))
     }
 }

--- a/Tests/Primer/Data Models/CardNetworkTests.swift
+++ b/Tests/Primer/Data Models/CardNetworkTests.swift
@@ -1,11 +1,11 @@
 //
 //  CardNetworkTests.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import XCTest
 @testable import PrimerSDK
+import XCTest
 
 final class CardNetworkTests: XCTestCase {
 
@@ -80,5 +80,45 @@ final class CardNetworkTests: XCTestCase {
         SDKSessionHelper.setUp(paymentMethodOptions: nil)
 
         XCTAssertNil(CardNetwork.visa.surcharge)
+    }
+
+    // MARK: - Traits Tests
+
+    func testTraitsCoversAllCasesWithExpectedNilSet() {
+        let knownNil: Set<CardNetwork> = [.bancontact, .cartesBancaires, .eftpos, .unknown]
+        for network in CardNetwork.allCases {
+            if knownNil.contains(network) {
+                XCTAssertNil(network.traits, "\(network.rawValue) expected nil traits")
+            } else {
+                XCTAssertNotNil(network.traits, "\(network.rawValue) expected non-nil traits")
+            }
+        }
+    }
+
+    func testTraitsForAmex() throws {
+        let traits = try XCTUnwrap(CardNetwork.amex.traits)
+        XCTAssertEqual(traits.cardNetwork, .amex)
+        XCTAssertEqual(traits.displayName, "American Express")
+        XCTAssertEqual(traits.panLengths, [15])
+        XCTAssertEqual(traits.gapPattern, [4, 10])
+        XCTAssertEqual(traits.cvvLength, 4)
+        XCTAssertEqual(traits.cvvLabel, "CID")
+    }
+
+    func testTraitsForVisa() throws {
+        let traits = try XCTUnwrap(CardNetwork.visa.traits)
+        XCTAssertEqual(traits.cardNetwork, .visa)
+        XCTAssertEqual(traits.displayName, "Visa")
+        XCTAssertEqual(traits.panLengths, [16, 18, 19])
+        XCTAssertEqual(traits.gapPattern, [4, 8, 12])
+        XCTAssertEqual(traits.cvvLength, 3)
+        XCTAssertEqual(traits.cvvLabel, "CVV")
+    }
+
+    func testTraitsForMirAndEloPreserveCvvLabels() throws {
+        let mir = try XCTUnwrap(CardNetwork.mir.traits)
+        XCTAssertEqual(mir.cvvLabel, "CVP2")
+        let elo = try XCTUnwrap(CardNetwork.elo.traits)
+        XCTAssertEqual(elo.cvvLabel, "CVE")
     }
 }


### PR DESCRIPTION
# Description

ACC-7167

Exposes `PrimerCardNetworkTraits` as a public struct and accessor so the RN bridge (and merchants) can read per-network traits that were previously internal.

- `CardNetwork.traits: PrimerCardNetworkTraits?`
- `AssetsManager.getCardNetworkTraits(for:)` + `(cardNetworkString:)`
- Struct: `cardNetwork`, `displayName`, `panLengths`, `gapPattern`, `cvvLength`, `cvvLabel`
- Returns `nil` for networks without validation (bancontact, cartesBancaires, eftpos, unknown)

`CardNetworkValidation` stays internal.

# Manual Testing

Called through the RN iOS bridge. Amex returns `panLengths: [15]`, `gapPattern: [4, 10]`, `cvvLength: 4`, `cvvLabel: "CID"`.

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable
- [x] I have manually tested newly added UX
- [ ] I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ] I have verified that a suitable set of automated tests has been added
- [ ] I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ] I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ] If introducing a breaking change, I have communicated it internally
- [ ] Any related documentation PRs are ready to merge