### PR TITLE
refactor: Decouple card form field views from DefaultCardFormScope [ACC-7135]

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Composite/CardDetailsView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Composite/CardDetailsView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct CardDetailsView: View {
-  let cardFormScope: any PrimerCardFormScope
+  let cardFormScope: any CardFormFieldScopeInternal
   @State private var cardNetwork: CardNetwork = .unknown
 
   @Environment(\.designTokens) private var tokens

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField+UIViewRepresentable.swift
@@ -18,7 +18,7 @@ struct AddressLineTextField: UIViewRepresentable, LogReporter {
   let inputType: PrimerInputElementType
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
-  let scope: (any PrimerCardFormScope)?
+  let scope: (any CardFormFieldScopeInternal)?
   let onAddressChange: ((String) -> Void)?
   let onValidationChange: ((Bool) -> Void)?
   let tokens: DesignTokens?
@@ -68,7 +68,7 @@ struct AddressLineTextField: UIViewRepresentable, LogReporter {
     @Binding private var isFocused: Bool
     private let isRequired: Bool
     private let inputType: PrimerInputElementType
-    private let scope: (any PrimerCardFormScope)?
+    private let scope: (any CardFormFieldScopeInternal)?
     private let onAddressChange: ((String) -> Void)?
     private let onValidationChange: ((Bool) -> Void)?
 
@@ -80,7 +80,7 @@ struct AddressLineTextField: UIViewRepresentable, LogReporter {
       isFocused: Binding<Bool>,
       isRequired: Bool,
       inputType: PrimerInputElementType,
-      scope: (any PrimerCardFormScope)?,
+      scope: (any CardFormFieldScopeInternal)?,
       onAddressChange: ((String) -> Void)?,
       onValidationChange: ((Bool) -> Void)?
     ) {
@@ -157,9 +157,7 @@ struct AddressLineTextField: UIViewRepresentable, LogReporter {
         isValid = true  // Optional fields are always valid while typing
       }
 
-      if let scope = scope as? DefaultCardFormScope {
-        scope.updateValidationStateIfNeeded(for: inputType, isValid: isValid)
-      }
+      scope?.updateValidationStateIfNeeded(for: inputType, isValid: isValid)
 
       return false
     }
@@ -174,10 +172,7 @@ struct AddressLineTextField: UIViewRepresentable, LogReporter {
         onValidationChange?(isValid)
 
         scope?.clearFieldError(inputType)
-
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationStateIfNeeded(for: inputType, isValid: isValid)
-        }
+        scope?.updateValidationStateIfNeeded(for: inputType, isValid: isValid)
         return
       }
 
@@ -205,14 +200,10 @@ struct AddressLineTextField: UIViewRepresentable, LogReporter {
       if let scope {
         if result.isValid {
           scope.clearFieldError(inputType)
-          if let scope = scope as? DefaultCardFormScope {
-            scope.updateValidationStateIfNeeded(for: inputType, isValid: true)
-          }
+          scope.updateValidationStateIfNeeded(for: inputType, isValid: true)
         } else if let message = result.errorMessage {
           scope.setFieldError(inputType, message: message, errorCode: result.errorCode)
-          if let scope = scope as? DefaultCardFormScope {
-            scope.updateValidationStateIfNeeded(for: inputType, isValid: false)
-          }
+          scope.updateValidationStateIfNeeded(for: inputType, isValid: false)
         }
       }
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField.swift
@@ -12,7 +12,7 @@ struct AddressLineInputField: View, LogReporter {
   let placeholder: String
   let isRequired: Bool
   let inputType: PrimerInputElementType
-  let scope: (any PrimerCardFormScope)?
+  let scope: (any CardFormFieldScopeInternal)?
   let onAddressChange: ((String) -> Void)?
   let onValidationChange: ((Bool) -> Void)?
   let styling: PrimerFieldStyling?
@@ -35,7 +35,7 @@ struct AddressLineInputField: View, LogReporter {
     placeholder: String,
     isRequired: Bool,
     inputType: PrimerInputElementType,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     styling: PrimerFieldStyling? = nil
   ) {
     self.label = label

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField+UIViewRepresentable.swift
@@ -137,7 +137,7 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
       } else {
         isValid = false
         errorMessage = nil
-        scope.updateValidationState(keyPath: \.cvv, isValid: false)
+        scope.updateValidationState(\.cvv, isValid: false)
       }
 
       return false
@@ -149,7 +149,7 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
       if trimmedCVV.isEmpty {
         isValid = false  // CVV is required
         errorMessage = nil  // Never show error message for empty fields
-        scope.updateValidationState(keyPath: \.cvv, isValid: false)
+        scope.updateValidationState(\.cvv, isValid: false)
         return
       }
 
@@ -162,12 +162,12 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.cvv)
-        scope.updateValidationState(keyPath: \.cvv, isValid: true)
+        scope.updateValidationState(\.cvv, isValid: true)
       } else {
         if let message = result.errorMessage {
           scope.setFieldError(.cvv, message: message, errorCode: result.errorCode)
         }
-        scope.updateValidationState(keyPath: \.cvv, isValid: false)
+        scope.updateValidationState(\.cvv, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField+UIViewRepresentable.swift
@@ -18,7 +18,7 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
   let cardNetwork: CardNetwork
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let tokens: DesignTokens?
 
   func makeUIView(context: Context) -> SecureTextField {
@@ -62,7 +62,7 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
     @Binding private var isValid: Bool
     @Binding private var errorMessage: String?
     @Binding private var isFocused: Bool
-    private let scope: any PrimerCardFormScope
+    private let scope: any CardFormFieldScopeInternal
 
     private var expectedCVVLength: Int {
       cardNetwork.validation?.code.length ?? 3
@@ -75,7 +75,7 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
       isValid: Binding<Bool>,
       errorMessage: Binding<String?>,
       isFocused: Binding<Bool>,
-      scope: any PrimerCardFormScope
+      scope: any CardFormFieldScopeInternal
     ) {
       self.validationService = validationService
       self.cardNetwork = cardNetwork
@@ -137,9 +137,7 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
       } else {
         isValid = false
         errorMessage = nil
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.cvv, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.cvv, isValid: false)
       }
 
       return false
@@ -151,9 +149,7 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
       if trimmedCVV.isEmpty {
         isValid = false  // CVV is required
         errorMessage = nil  // Never show error message for empty fields
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.cvv, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.cvv, isValid: false)
         return
       }
 
@@ -166,16 +162,12 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.cvv)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.cvv, isValid: true)
-        }
+        scope.updateValidationState(keyPath: \.cvv, isValid: true)
       } else {
         if let message = result.errorMessage {
           scope.setFieldError(.cvv, message: message, errorCode: result.errorCode)
         }
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.cvv, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.cvv, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CVVInputField: View, LogReporter {
   let label: String?
   let placeholder: String
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let cardNetwork: CardNetwork
   let styling: PrimerFieldStyling?
 
@@ -29,7 +29,7 @@ struct CVVInputField: View, LogReporter {
   init(
     label: String?,
     placeholder: String,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     cardNetwork: CardNetwork,
     styling: PrimerFieldStyling? = nil
   ) {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField+UIViewRepresentable.swift
@@ -15,7 +15,7 @@ struct CardNumberTextField: UIViewRepresentable, LogReporter {
   @Binding var errorMessage: String?
   @Binding var isFocused: Bool
 
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let placeholder: String
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
@@ -74,14 +74,14 @@ struct CardNumberTextField: UIViewRepresentable, LogReporter {
     @Binding private var isValid: Bool
     @Binding private var errorMessage: String?
     @Binding private var isFocused: Bool
-    private let scope: any PrimerCardFormScope
+    private let scope: any CardFormFieldScopeInternal
     private let validationService: ValidationService
     private var savedCursorPosition: Int = 0
     private var networkDetectionTimer: Timer?
     private var validationTimer: Timer?
 
     init(
-      scope: any PrimerCardFormScope,
+      scope: any CardFormFieldScopeInternal,
       validationService: ValidationService,
       cardNumber: Binding<String>,
       cardNetwork: Binding<CardNetwork>,

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CardNumberInputField: View, LogReporter {
   let label: String?
   let placeholder: String
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let selectedNetwork: CardNetwork?
   let availableNetworks: [CardNetwork]
   let styling: PrimerFieldStyling?
@@ -35,7 +35,7 @@ struct CardNumberInputField: View, LogReporter {
   init(
     label: String?,
     placeholder: String,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     selectedNetwork: CardNetwork? = nil,
     availableNetworks: [CardNetwork] = [],
     styling: PrimerFieldStyling? = nil

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField+UIViewRepresentable.swift
@@ -131,7 +131,7 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
 
       isValid = newText.count >= 2
 
-      scope.updateValidationState(keyPath: \.cardholderName, isValid: isValid)
+      scope.updateValidationState(\.cardholderName, isValid: isValid)
 
       return false
     }
@@ -143,7 +143,7 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
       if trimmedName.isEmpty {
         isValid = false  // Cardholder name is required
         errorMessage = nil  // Never show error message for empty fields
-        scope.updateValidationState(keyPath: \.cardholderName, isValid: false)
+        scope.updateValidationState(\.cardholderName, isValid: false)
         return
       }
 
@@ -157,12 +157,12 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.cardholderName)
-        scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
+        scope.updateValidationState(\.cardholderName, isValid: true)
       } else {
         if let message = result.errorMessage {
           scope.setFieldError(.cardholderName, message: message, errorCode: result.errorCode)
         }
-        scope.updateValidationState(keyPath: \.cardholderName, isValid: false)
+        scope.updateValidationState(\.cardholderName, isValid: false)
       }
 
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField+UIViewRepresentable.swift
@@ -16,7 +16,7 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
   let placeholder: String
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let tokens: DesignTokens?
 
   func makeUIView(context: Context) -> UITextField {
@@ -60,7 +60,7 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
     @Binding private var isValid: Bool
     @Binding private var errorMessage: String?
     @Binding private var isFocused: Bool
-    private let scope: any PrimerCardFormScope
+    private let scope: any CardFormFieldScopeInternal
 
     init(
       validationService: ValidationService,
@@ -68,7 +68,7 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
       isValid: Binding<Bool>,
       errorMessage: Binding<String?>,
       isFocused: Binding<Bool>,
-      scope: any PrimerCardFormScope
+      scope: any CardFormFieldScopeInternal
     ) {
       self.validationService = validationService
       _cardholderName = cardholderName
@@ -131,9 +131,7 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
 
       isValid = newText.count >= 2
 
-      if let scope = scope as? DefaultCardFormScope {
-        scope.updateValidationState(\.cardholderName, isValid: isValid)
-      }
+      scope.updateValidationState(keyPath: \.cardholderName, isValid: isValid)
 
       return false
     }
@@ -145,9 +143,7 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
       if trimmedName.isEmpty {
         isValid = false  // Cardholder name is required
         errorMessage = nil  // Never show error message for empty fields
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.cardholderName, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.cardholderName, isValid: false)
         return
       }
 
@@ -161,16 +157,12 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.cardholderName)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.cardholderName, isValid: true)
-        }
+        scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
       } else {
         if let message = result.errorMessage {
           scope.setFieldError(.cardholderName, message: message, errorCode: result.errorCode)
         }
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.cardholderName, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.cardholderName, isValid: false)
       }
 
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CardholderNameInputField: View, LogReporter {
   let label: String?
   let placeholder: String
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let styling: PrimerFieldStyling?
 
   // MARK: - Private Properties
@@ -28,7 +28,7 @@ struct CardholderNameInputField: View, LogReporter {
   init(
     label: String?,
     placeholder: String,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     styling: PrimerFieldStyling? = nil
   ) {
     self.label = label

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField+UIViewRepresentable.swift
@@ -17,7 +17,7 @@ struct CityTextField: UIViewRepresentable, LogReporter {
   let placeholder: String
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let tokens: DesignTokens?
 
   func makeUIView(context: Context) -> UITextField {
@@ -59,7 +59,7 @@ struct CityTextField: UIViewRepresentable, LogReporter {
     @Binding private var isValid: Bool
     @Binding private var errorMessage: String?
     @Binding private var isFocused: Bool
-    private let scope: any PrimerCardFormScope
+    private let scope: any CardFormFieldScopeInternal
 
     init(
       validationService: ValidationService,
@@ -67,7 +67,7 @@ struct CityTextField: UIViewRepresentable, LogReporter {
       isValid: Binding<Bool>,
       errorMessage: Binding<String?>,
       isFocused: Binding<Bool>,
-      scope: any PrimerCardFormScope
+      scope: any CardFormFieldScopeInternal
     ) {
       self.validationService = validationService
       _city = city
@@ -122,9 +122,7 @@ struct CityTextField: UIViewRepresentable, LogReporter {
       // Simple validation while typing (don't show errors until focus loss)
       isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-      if let scope = scope as? DefaultCardFormScope {
-        scope.updateValidationState(\.city, isValid: isValid)
-      }
+      scope.updateValidationState(keyPath: \.city, isValid: isValid)
 
       return false
     }
@@ -136,9 +134,7 @@ struct CityTextField: UIViewRepresentable, LogReporter {
       if trimmedCity.isEmpty {
         isValid = false  // City is required
         errorMessage = nil  // Never show error message for empty fields
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.city, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.city, isValid: false)
         return
       }
 
@@ -152,14 +148,10 @@ struct CityTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.city)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.city, isValid: true)
-        }
+        scope.updateValidationState(keyPath: \.city, isValid: true)
       } else if let message = result.errorMessage {
         scope.setFieldError(.city, message: message, errorCode: result.errorCode)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.city, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.city, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField+UIViewRepresentable.swift
@@ -122,7 +122,7 @@ struct CityTextField: UIViewRepresentable, LogReporter {
       // Simple validation while typing (don't show errors until focus loss)
       isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-      scope.updateValidationState(keyPath: \.city, isValid: isValid)
+      scope.updateValidationState(\.city, isValid: isValid)
 
       return false
     }
@@ -134,7 +134,7 @@ struct CityTextField: UIViewRepresentable, LogReporter {
       if trimmedCity.isEmpty {
         isValid = false  // City is required
         errorMessage = nil  // Never show error message for empty fields
-        scope.updateValidationState(keyPath: \.city, isValid: false)
+        scope.updateValidationState(\.city, isValid: false)
         return
       }
 
@@ -148,10 +148,10 @@ struct CityTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.city)
-        scope.updateValidationState(keyPath: \.city, isValid: true)
+        scope.updateValidationState(\.city, isValid: true)
       } else if let message = result.errorMessage {
         scope.setFieldError(.city, message: message, errorCode: result.errorCode)
-        scope.updateValidationState(keyPath: \.city, isValid: false)
+        scope.updateValidationState(\.city, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct CityInputField: View, LogReporter {
   let label: String?
   let placeholder: String
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let styling: PrimerFieldStyling?
 
   // MARK: - Private Properties
@@ -28,7 +28,7 @@ struct CityInputField: View, LogReporter {
   init(
     label: String?,
     placeholder: String,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     styling: PrimerFieldStyling? = nil
   ) {
     self.label = label

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
@@ -185,10 +185,10 @@ struct CountryInputField: View, LogReporter {
 
     if result.isValid {
       clearFieldError()
-      scope.updateValidationState(keyPath: \.countryCode, isValid: true)
+      scope.updateValidationState(\.countryCode, isValid: true)
     } else if let message = result.errorMessage {
       setFieldError(message: message, errorCode: result.errorCode)
-      scope.updateValidationState(keyPath: \.countryCode, isValid: false)
+      scope.updateValidationState(\.countryCode, isValid: false)
     }
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
@@ -185,10 +185,10 @@ struct CountryInputField: View, LogReporter {
 
     if result.isValid {
       clearFieldError()
-      scope.updateValidationState(\.countryCode, isValid: true)
+      scope.updateValidationState(keyPath: \.countryCode, isValid: true)
     } else if let message = result.errorMessage {
       setFieldError(message: message, errorCode: result.errorCode)
-      scope.updateValidationState(\.countryCode, isValid: false)
+      scope.updateValidationState(keyPath: \.countryCode, isValid: false)
     }
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField+UIViewRepresentable.swift
@@ -17,7 +17,7 @@ struct EmailTextField: UIViewRepresentable, LogReporter {
   let placeholder: String
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
-  let scope: (any PrimerCardFormScope)?
+  let scope: (any CardFormFieldScopeInternal)?
   let onEmailChange: ((String) -> Void)?
   let onValidationChange: ((Bool) -> Void)?
   let tokens: DesignTokens?
@@ -63,7 +63,7 @@ struct EmailTextField: UIViewRepresentable, LogReporter {
     @Binding private var isValid: Bool
     @Binding private var errorMessage: String?
     @Binding private var isFocused: Bool
-    private let scope: (any PrimerCardFormScope)?
+    private let scope: (any CardFormFieldScopeInternal)?
     private let onEmailChange: ((String) -> Void)?
     private let onValidationChange: ((Bool) -> Void)?
 
@@ -73,7 +73,7 @@ struct EmailTextField: UIViewRepresentable, LogReporter {
       isValid: Binding<Bool>,
       errorMessage: Binding<String?>,
       isFocused: Binding<Bool>,
-      scope: (any PrimerCardFormScope)?,
+      scope: (any CardFormFieldScopeInternal)?,
       onEmailChange: ((String) -> Void)?,
       onValidationChange: ((Bool) -> Void)?
     ) {
@@ -137,9 +137,7 @@ struct EmailTextField: UIViewRepresentable, LogReporter {
       isValid =
         !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && newText.contains("@")
 
-      if let scope = scope as? DefaultCardFormScope {
-        scope.updateValidationState(\.email, isValid: isValid)
-      }
+      scope?.updateValidationState(keyPath: \.email, isValid: isValid)
 
       return false
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField+UIViewRepresentable.swift
@@ -137,7 +137,7 @@ struct EmailTextField: UIViewRepresentable, LogReporter {
       isValid =
         !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && newText.contains("@")
 
-      scope?.updateValidationState(keyPath: \.email, isValid: isValid)
+      scope?.updateValidationState(\.email, isValid: isValid)
 
       return false
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField.swift
@@ -11,7 +11,7 @@ struct EmailInputField: View, LogReporter {
   let label: String?
   let placeholder: String
   let initialValue: String
-  let scope: (any PrimerCardFormScope)?
+  let scope: (any CardFormFieldScopeInternal)?
   let onEmailChange: ((String) -> Void)?
   let onValidationChange: ((Bool) -> Void)?
   let styling: PrimerFieldStyling?
@@ -31,7 +31,7 @@ struct EmailInputField: View, LogReporter {
   init(
     label: String?,
     placeholder: String,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     styling: PrimerFieldStyling? = nil
   ) {
     self.label = label

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField+UIViewRepresentable.swift
@@ -212,7 +212,7 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
       if trimmedExpiry.isEmpty {
         isValid = false  // Expiry date is required
         errorMessage = nil  // Never show error message for empty fields
-        scope.updateValidationState(keyPath: \.expiry, isValid: false)
+        scope.updateValidationState(\.expiry, isValid: false)
         return
       }
 
@@ -227,7 +227,7 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
             .expiryDate, message: CheckoutComponentsStrings.enterValidExpiryDate,
             errorCode: "invalid_format")
         }
-        scope.updateValidationState(keyPath: \.expiry, isValid: false)
+        scope.updateValidationState(\.expiry, isValid: false)
         return
       }
 
@@ -249,12 +249,12 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.expiryDate)
-        scope.updateValidationState(keyPath: \.expiry, isValid: true)
+        scope.updateValidationState(\.expiry, isValid: true)
       } else {
         if showErrors, let message = result.errorMessage {
           scope.setFieldError(.expiryDate, message: message, errorCode: result.errorCode)
         }
-        scope.updateValidationState(keyPath: \.expiry, isValid: false)
+        scope.updateValidationState(\.expiry, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField+UIViewRepresentable.swift
@@ -19,7 +19,7 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
   let placeholder: String
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let tokens: DesignTokens?
 
   func makeUIView(context: Context) -> UITextField {
@@ -65,7 +65,7 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
     @Binding private var isValid: Bool
     @Binding private var errorMessage: String?
     @Binding private var isFocused: Bool
-    private let scope: any PrimerCardFormScope
+    private let scope: any CardFormFieldScopeInternal
 
     init(
       validationService: ValidationService,
@@ -75,7 +75,7 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
       isValid: Binding<Bool>,
       errorMessage: Binding<String?>,
       isFocused: Binding<Bool>,
-      scope: any PrimerCardFormScope
+      scope: any CardFormFieldScopeInternal
     ) {
       self.validationService = validationService
       _expiryDate = expiryDate
@@ -212,9 +212,7 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
       if trimmedExpiry.isEmpty {
         isValid = false  // Expiry date is required
         errorMessage = nil  // Never show error message for empty fields
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.expiry, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.expiry, isValid: false)
         return
       }
 
@@ -229,9 +227,7 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
             .expiryDate, message: CheckoutComponentsStrings.enterValidExpiryDate,
             errorCode: "invalid_format")
         }
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.expiry, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.expiry, isValid: false)
         return
       }
 
@@ -253,16 +249,12 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.expiryDate)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.expiry, isValid: true)
-        }
+        scope.updateValidationState(keyPath: \.expiry, isValid: true)
       } else {
         if showErrors, let message = result.errorMessage {
           scope.setFieldError(.expiryDate, message: message, errorCode: result.errorCode)
         }
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.expiry, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.expiry, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ExpiryDateInputField: View, LogReporter {
   let label: String?
   let placeholder: String
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let styling: PrimerFieldStyling?
 
   // MARK: - Private Properties
@@ -30,7 +30,7 @@ struct ExpiryDateInputField: View, LogReporter {
   init(
     label: String?,
     placeholder: String,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     styling: PrimerFieldStyling? = nil
   ) {
     self.label = label

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField+UIViewRepresentable.swift
@@ -18,7 +18,7 @@ struct NameTextField: UIViewRepresentable, LogReporter {
   let inputType: PrimerInputElementType
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
-  let scope: (any PrimerCardFormScope)?
+  let scope: (any CardFormFieldScopeInternal)?
   let onNameChange: ((String) -> Void)?
   let onValidationChange: ((Bool) -> Void)?
   let tokens: DesignTokens?
@@ -66,7 +66,7 @@ struct NameTextField: UIViewRepresentable, LogReporter {
     @Binding private var errorMessage: String?
     @Binding private var isFocused: Bool
     private let inputType: PrimerInputElementType
-    private let scope: (any PrimerCardFormScope)?
+    private let scope: (any CardFormFieldScopeInternal)?
     private let onNameChange: ((String) -> Void)?
     private let onValidationChange: ((Bool) -> Void)?
 
@@ -77,7 +77,7 @@ struct NameTextField: UIViewRepresentable, LogReporter {
       errorMessage: Binding<String?>,
       isFocused: Binding<Bool>,
       inputType: PrimerInputElementType,
-      scope: (any PrimerCardFormScope)?,
+      scope: (any CardFormFieldScopeInternal)?,
       onNameChange: ((String) -> Void)?,
       onValidationChange: ((Bool) -> Void)?
     ) {
@@ -151,9 +151,7 @@ struct NameTextField: UIViewRepresentable, LogReporter {
       // Simple validation while typing (don't show errors until focus loss)
       isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-      if let scope = scope as? DefaultCardFormScope {
-        scope.updateValidationStateIfNeeded(for: inputType, isValid: isValid)
-      }
+      scope?.updateValidationStateIfNeeded(for: inputType, isValid: isValid)
 
       return false
     }
@@ -166,9 +164,7 @@ struct NameTextField: UIViewRepresentable, LogReporter {
         isValid = false  // Name fields are required
         errorMessage = nil  // Never show error message for empty fields
         onValidationChange?(false)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationStateIfNeeded(for: inputType, isValid: false)
-        }
+        scope?.updateValidationStateIfNeeded(for: inputType, isValid: false)
         return
       }
 
@@ -196,14 +192,10 @@ struct NameTextField: UIViewRepresentable, LogReporter {
       if let scope {
         if result.isValid {
           scope.clearFieldError(inputType)
-          if let scope = scope as? DefaultCardFormScope {
-            scope.updateValidationStateIfNeeded(for: inputType, isValid: true)
-          }
+          scope.updateValidationStateIfNeeded(for: inputType, isValid: true)
         } else if let message = result.errorMessage {
           scope.setFieldError(inputType, message: message, errorCode: result.errorCode)
-          if let scope = scope as? DefaultCardFormScope {
-            scope.updateValidationStateIfNeeded(for: inputType, isValid: false)
-          }
+          scope.updateValidationStateIfNeeded(for: inputType, isValid: false)
         }
       }
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField.swift
@@ -12,7 +12,7 @@ struct NameInputField: View, LogReporter {
   let placeholder: String
   let inputType: PrimerInputElementType
   let initialValue: String
-  let scope: (any PrimerCardFormScope)?
+  let scope: (any CardFormFieldScopeInternal)?
   let onNameChange: ((String) -> Void)?
   let onValidationChange: ((Bool) -> Void)?
   let styling: PrimerFieldStyling?
@@ -33,7 +33,7 @@ struct NameInputField: View, LogReporter {
     label: String?,
     placeholder: String,
     inputType: PrimerInputElementType,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     styling: PrimerFieldStyling? = nil
   ) {
     self.label = label

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField+UIViewRepresentable.swift
@@ -19,7 +19,7 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
   let keyboardType: UIKeyboardType
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let tokens: DesignTokens?
 
   func makeUIView(context: Context) -> UITextField {
@@ -73,7 +73,7 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
     @Binding private var errorMessage: String?
     @Binding private var isFocused: Bool
     private let countryCode: String?
-    private let scope: any PrimerCardFormScope
+    private let scope: any CardFormFieldScopeInternal
 
     init(
       validationService: ValidationService,
@@ -82,7 +82,7 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
       errorMessage: Binding<String?>,
       isFocused: Binding<Bool>,
       countryCode: String?,
-      scope: any PrimerCardFormScope
+      scope: any CardFormFieldScopeInternal
     ) {
       self.validationService = validationService
       _postalCode = postalCode
@@ -138,9 +138,7 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
       // Simple validation while typing (don't show errors until focus loss)
       isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-      if let scope = scope as? DefaultCardFormScope {
-        scope.updateValidationState(\.postalCode, isValid: isValid)
-      }
+      scope.updateValidationState(keyPath: \.postalCode, isValid: isValid)
 
       return false
     }
@@ -152,9 +150,7 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
       if trimmedPostalCode.isEmpty {
         isValid = false  // Postal code is required
         errorMessage = nil  // Never show error message for empty fields
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.postalCode, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.postalCode, isValid: false)
         return
       }
 
@@ -168,14 +164,10 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.postalCode)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.postalCode, isValid: true)
-        }
+        scope.updateValidationState(keyPath: \.postalCode, isValid: true)
       } else if let message = result.errorMessage {
         scope.setFieldError(.postalCode, message: message, errorCode: result.errorCode)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.postalCode, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.postalCode, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField+UIViewRepresentable.swift
@@ -138,7 +138,7 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
       // Simple validation while typing (don't show errors until focus loss)
       isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-      scope.updateValidationState(keyPath: \.postalCode, isValid: isValid)
+      scope.updateValidationState(\.postalCode, isValid: isValid)
 
       return false
     }
@@ -150,7 +150,7 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
       if trimmedPostalCode.isEmpty {
         isValid = false  // Postal code is required
         errorMessage = nil  // Never show error message for empty fields
-        scope.updateValidationState(keyPath: \.postalCode, isValid: false)
+        scope.updateValidationState(\.postalCode, isValid: false)
         return
       }
 
@@ -164,10 +164,10 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.postalCode)
-        scope.updateValidationState(keyPath: \.postalCode, isValid: true)
+        scope.updateValidationState(\.postalCode, isValid: true)
       } else if let message = result.errorMessage {
         scope.setFieldError(.postalCode, message: message, errorCode: result.errorCode)
-        scope.updateValidationState(keyPath: \.postalCode, isValid: false)
+        scope.updateValidationState(\.postalCode, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField.swift
@@ -12,7 +12,7 @@ struct PostalCodeInputField: View, LogReporter {
   let label: String?
   let placeholder: String
   let countryCode: String?
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let styling: PrimerFieldStyling?
 
   // MARK: - Private Properties
@@ -40,7 +40,7 @@ struct PostalCodeInputField: View, LogReporter {
     label: String?,
     placeholder: String,
     countryCode: String? = nil,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     styling: PrimerFieldStyling? = nil
   ) {
     self.label = label

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField+UIViewRepresentable.swift
@@ -122,7 +122,7 @@ struct StateTextField: UIViewRepresentable, LogReporter {
       // Simple validation while typing (don't show errors until focus loss)
       isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-      scope.updateValidationState(keyPath: \.state, isValid: isValid)
+      scope.updateValidationState(\.state, isValid: isValid)
 
       return false
     }
@@ -134,7 +134,7 @@ struct StateTextField: UIViewRepresentable, LogReporter {
       if trimmedState.isEmpty {
         isValid = false  // State is required
         errorMessage = nil  // Never show error message for empty fields
-        scope.updateValidationState(keyPath: \.state, isValid: false)
+        scope.updateValidationState(\.state, isValid: false)
         return
       }
 
@@ -148,10 +148,10 @@ struct StateTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.state)
-        scope.updateValidationState(keyPath: \.state, isValid: true)
+        scope.updateValidationState(\.state, isValid: true)
       } else if let message = result.errorMessage {
         scope.setFieldError(.state, message: message, errorCode: result.errorCode)
-        scope.updateValidationState(keyPath: \.state, isValid: false)
+        scope.updateValidationState(\.state, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField+UIViewRepresentable.swift
@@ -17,7 +17,7 @@ struct StateTextField: UIViewRepresentable, LogReporter {
   let placeholder: String
   let styling: PrimerFieldStyling?
   let validationService: ValidationService
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let tokens: DesignTokens?
 
   func makeUIView(context: Context) -> UITextField {
@@ -59,7 +59,7 @@ struct StateTextField: UIViewRepresentable, LogReporter {
     @Binding private var isValid: Bool
     @Binding private var errorMessage: String?
     @Binding private var isFocused: Bool
-    private let scope: any PrimerCardFormScope
+    private let scope: any CardFormFieldScopeInternal
 
     init(
       validationService: ValidationService,
@@ -67,7 +67,7 @@ struct StateTextField: UIViewRepresentable, LogReporter {
       isValid: Binding<Bool>,
       errorMessage: Binding<String?>,
       isFocused: Binding<Bool>,
-      scope: any PrimerCardFormScope
+      scope: any CardFormFieldScopeInternal
     ) {
       self.validationService = validationService
       _state = state
@@ -122,9 +122,7 @@ struct StateTextField: UIViewRepresentable, LogReporter {
       // Simple validation while typing (don't show errors until focus loss)
       isValid = !newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
 
-      if let scope = scope as? DefaultCardFormScope {
-        scope.updateValidationState(\.state, isValid: isValid)
-      }
+      scope.updateValidationState(keyPath: \.state, isValid: isValid)
 
       return false
     }
@@ -136,9 +134,7 @@ struct StateTextField: UIViewRepresentable, LogReporter {
       if trimmedState.isEmpty {
         isValid = false  // State is required
         errorMessage = nil  // Never show error message for empty fields
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.state, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.state, isValid: false)
         return
       }
 
@@ -152,14 +148,10 @@ struct StateTextField: UIViewRepresentable, LogReporter {
 
       if result.isValid {
         scope.clearFieldError(.state)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.state, isValid: true)
-        }
+        scope.updateValidationState(keyPath: \.state, isValid: true)
       } else if let message = result.errorMessage {
         scope.setFieldError(.state, message: message, errorCode: result.errorCode)
-        if let scope = scope as? DefaultCardFormScope {
-          scope.updateValidationState(\.state, isValid: false)
-        }
+        scope.updateValidationState(keyPath: \.state, isValid: false)
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct StateInputField: View, LogReporter {
   let label: String?
   let placeholder: String
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let styling: PrimerFieldStyling?
 
   // MARK: - Private Properties
@@ -28,7 +28,7 @@ struct StateInputField: View, LogReporter {
   init(
     label: String?,
     placeholder: String,
-    scope: any PrimerCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     styling: PrimerFieldStyling? = nil
   ) {
     self.label = label

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/CardFormFieldScopeInternal.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/CardFormFieldScopeInternal.swift
@@ -26,6 +26,6 @@ struct FieldValidationStates: Equatable {
 @available(iOS 15.0, *)
 @MainActor
 protocol CardFormFieldScopeInternal: PrimerCardFormScope {
-  func updateValidationState(keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool)
+  func updateValidationState(_ keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool)
   func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool)
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/CardFormFieldScopeInternal.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/CardFormFieldScopeInternal.swift
@@ -1,0 +1,31 @@
+//
+//  CardFormFieldScopeInternal.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+struct FieldValidationStates: Equatable {
+  var cardNumber: Bool = false
+  var cvv: Bool = false
+  var expiry: Bool = false
+  var cardholderName: Bool = false
+  var postalCode: Bool = false
+  var countryCode: Bool = false
+  var city: Bool = false
+  var state: Bool = false
+  var addressLine1: Bool = false
+  var addressLine2: Bool = false
+  var firstName: Bool = false
+  var lastName: Bool = false
+  var email: Bool = false
+  var phoneNumber: Bool = false
+}
+
+@available(iOS 15.0, *)
+@MainActor
+protocol CardFormFieldScopeInternal: PrimerCardFormScope {
+  func updateValidationState(keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool)
+  func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool)
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope+Validation.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope+Validation.swift
@@ -15,17 +15,17 @@ extension DefaultCardFormScope {
   /// The SDK uses this to track which fields are valid and determine overall form validity.
   ///
   /// ```swift
-  /// scope.updateValidationState(\.cvv, isValid: true)
-  /// scope.updateValidationState(\.cardNumber, isValid: false)
+  /// scope.updateValidationState(keyPath: \.cvv, isValid: true)
+  /// scope.updateValidationState(keyPath: \.cardNumber, isValid: false)
   /// ```
-  public func updateValidationState(_ field: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool) {
-    fieldValidationStates[keyPath: field] = isValid
+  func updateValidationState(keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool) {
+    fieldValidationStates[keyPath: keyPath] = isValid
     updateFieldValidationState()
   }
 
-  public func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool) {
+  func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool) {
     guard let keyPath = field.validationKeyPath else { return }
-    updateValidationState(keyPath, isValid: isValid)
+    updateValidationState(keyPath: keyPath, isValid: isValid)
   }
 }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope+Validation.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope+Validation.swift
@@ -15,17 +15,17 @@ extension DefaultCardFormScope {
   /// The SDK uses this to track which fields are valid and determine overall form validity.
   ///
   /// ```swift
-  /// scope.updateValidationState(keyPath: \.cvv, isValid: true)
-  /// scope.updateValidationState(keyPath: \.cardNumber, isValid: false)
+  /// scope.updateValidationState(\.cvv, isValid: true)
+  /// scope.updateValidationState(\.cardNumber, isValid: false)
   /// ```
-  func updateValidationState(keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool) {
+  func updateValidationState(_ keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool) {
     fieldValidationStates[keyPath: keyPath] = isValid
     updateFieldValidationState()
   }
 
   func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool) {
     guard let keyPath = field.validationKeyPath else { return }
-    updateValidationState(keyPath: keyPath, isValid: isValid)
+    updateValidationState(keyPath, isValid: isValid)
   }
 }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
@@ -6,26 +6,9 @@
 
 import SwiftUI
 
-struct FieldValidationStates: Equatable {
-  var cardNumber: Bool = false
-  var cvv: Bool = false
-  var expiry: Bool = false
-  var cardholderName: Bool = false
-  var postalCode: Bool = false
-  var countryCode: Bool = false
-  var city: Bool = false
-  var state: Bool = false
-  var addressLine1: Bool = false
-  var addressLine2: Bool = false
-  var firstName: Bool = false
-  var lastName: Bool = false
-  var email: Bool = false
-  var phoneNumber: Bool = false
-}
-
 @available(iOS 15.0, *)
 @MainActor
-final class DefaultCardFormScope: PrimerCardFormScope, ObservableObject, LogReporter {
+final class DefaultCardFormScope: CardFormFieldScopeInternal, ObservableObject, LogReporter {
 
   private(set) var presentationContext: PresentationContext = .fromPaymentSelection
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct CardFormScreen: View, LogReporter {
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
 
   @Environment(\.designTokens) private var tokens
   @Environment(\.bridgeController) private var bridgeController

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Views/CardFormFieldsView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Views/CardFormFieldsView.swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// - Dynamic billing address fields (based on configuration)
 @available(iOS 15.0, *)
 struct CardFormFieldsView: View {
-  let scope: any PrimerCardFormScope
+  let scope: any CardFormFieldScopeInternal
   let styling: PrimerFieldStyling?
 
   @Environment(\.designTokens) private var tokens

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
@@ -234,7 +234,7 @@
       log("updateCountryCode: \(countryCode)")
     }
 
-    func updateValidationState(keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool) {
+    func updateValidationState(_ keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool) {
       log("updateValidationState keyPath: \(keyPath), isValid: \(isValid)")
     }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
@@ -235,7 +235,7 @@
     }
 
     func updateValidationState(keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool) {
-      log("updateValidationState keyPath isValid: \(isValid)")
+      log("updateValidationState keyPath: \(keyPath), isValid: \(isValid)")
     }
 
     func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool) {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
@@ -11,7 +11,7 @@
   /// Mock implementation of PrimerCardFormScope for SwiftUI previews
   /// Provides configurable behavior and debug logging to help test different UI states
   @available(iOS 15.0, *)
-  public class MockCardFormScope: PrimerCardFormScope {
+  public class MockCardFormScope: CardFormFieldScopeInternal {
 
     // MARK: - Configuration Properties
 
@@ -234,12 +234,12 @@
       log("updateCountryCode: \(countryCode)")
     }
 
-    public func updateValidationState(
-      cardNumber: Bool, cvv: Bool, expiry: Bool, cardholderName: Bool
-    ) {
-      log(
-        "updateValidationState - cardNumber: \(cardNumber), cvv: \(cvv), expiry: \(expiry), cardholderName: \(cardholderName)"
-      )
+    func updateValidationState(keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool) {
+      log("updateValidationState keyPath isValid: \(isValid)")
+    }
+
+    func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool) {
+      log("updateValidationStateIfNeeded field: \(field), isValid: \(isValid)")
     }
 
     // MARK: - Structured State Support

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCardFormScope.swift
@@ -141,11 +141,6 @@ where State == PrimerCardFormState {
   func PrimerRetailOutletField(label: String?, styling: PrimerFieldStyling?) -> AnyView
   func PrimerOtpCodeField(label: String?, styling: PrimerFieldStyling?) -> AnyView
 
-  // MARK: - Validation State Communication
-
-  func updateValidationState(cardNumber: Bool, cvv: Bool, expiry: Bool, cardholderName: Bool)
-  func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool)
-
   // MARK: - Structured State Support
 
   func updateField(_ fieldType: PrimerInputElementType, value: String)
@@ -223,10 +218,6 @@ extension PrimerCardFormScope {
 
   public func getFormConfiguration() -> CardFormConfiguration {
     CardFormConfiguration.default
-  }
-
-  public func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool) {
-    // No-op default; overridden in DefaultCardFormScope
   }
 }
 

--- a/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
@@ -563,10 +563,10 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
-            scope.updateValidationState(keyPath: \.cvv, isValid: true)
-            scope.updateValidationState(keyPath: \.expiry, isValid: true)
-            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
 
             XCTAssertTrue(scope.structuredState.isValid)
         }
@@ -584,10 +584,10 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
-            scope.updateValidationState(keyPath: \.cvv, isValid: false)
-            scope.updateValidationState(keyPath: \.expiry, isValid: true)
-            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: false)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
 
             XCTAssertFalse(scope.structuredState.isValid)
         }
@@ -605,10 +605,10 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
-            scope.updateValidationState(keyPath: \.cvv, isValid: true)
-            scope.updateValidationState(keyPath: \.expiry, isValid: false)
-            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: false)
+            scope.updateValidationState(\.cardholderName, isValid: true)
 
             XCTAssertFalse(scope.structuredState.isValid)
         }
@@ -626,10 +626,10 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
-            scope.updateValidationState(keyPath: \.cvv, isValid: true)
-            scope.updateValidationState(keyPath: \.expiry, isValid: true)
-            scope.updateValidationState(keyPath: \.cardholderName, isValid: false)
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: false)
 
             XCTAssertFalse(scope.structuredState.isValid)
         }
@@ -647,21 +647,21 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
-            scope.updateValidationState(keyPath: \.cvv, isValid: true)
-            scope.updateValidationState(keyPath: \.expiry, isValid: true)
-            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
 
-            scope.updateValidationState(keyPath: \.postalCode, isValid: true)
-            scope.updateValidationState(keyPath: \.city, isValid: true)
-            scope.updateValidationState(keyPath: \.state, isValid: true)
-            scope.updateValidationState(keyPath: \.addressLine1, isValid: true)
-            scope.updateValidationState(keyPath: \.addressLine2, isValid: true)
-            scope.updateValidationState(keyPath: \.firstName, isValid: true)
-            scope.updateValidationState(keyPath: \.lastName, isValid: true)
-            scope.updateValidationState(keyPath: \.email, isValid: true)
-            scope.updateValidationState(keyPath: \.phoneNumber, isValid: true)
-            scope.updateValidationState(keyPath: \.countryCode, isValid: true)
+            scope.updateValidationState(\.postalCode, isValid: true)
+            scope.updateValidationState(\.city, isValid: true)
+            scope.updateValidationState(\.state, isValid: true)
+            scope.updateValidationState(\.addressLine1, isValid: true)
+            scope.updateValidationState(\.addressLine2, isValid: true)
+            scope.updateValidationState(\.firstName, isValid: true)
+            scope.updateValidationState(\.lastName, isValid: true)
+            scope.updateValidationState(\.email, isValid: true)
+            scope.updateValidationState(\.phoneNumber, isValid: true)
+            scope.updateValidationState(\.countryCode, isValid: true)
 
             XCTAssertTrue(scope.structuredState.isValid)
         }
@@ -1185,10 +1185,10 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
             scope.updateCardholderName("John Doe")
 
             // When
-            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
-            scope.updateValidationState(keyPath: \.cvv, isValid: true)
-            scope.updateValidationState(keyPath: \.expiry, isValid: true)
-            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
 
             // Then
             XCTAssertTrue(scope.fieldValidationStates.cardNumber)
@@ -1212,14 +1212,14 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
             scope.updateCardholderName("John Doe")
 
             // Set all valid first
-            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
-            scope.updateValidationState(keyPath: \.cvv, isValid: true)
-            scope.updateValidationState(keyPath: \.expiry, isValid: true)
-            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
+            scope.updateValidationState(\.cardNumber, isValid: true)
+            scope.updateValidationState(\.cvv, isValid: true)
+            scope.updateValidationState(\.expiry, isValid: true)
+            scope.updateValidationState(\.cardholderName, isValid: true)
             XCTAssertTrue(scope.structuredState.isValid)
 
             // When — invalidate one field
-            scope.updateValidationState(keyPath: \.cardNumber, isValid: false)
+            scope.updateValidationState(\.cardNumber, isValid: false)
 
             // Then
             XCTAssertFalse(scope.structuredState.isValid)

--- a/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
@@ -563,10 +563,10 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(\.cardNumber, isValid: true)
-            scope.updateValidationState(\.cvv, isValid: true)
-            scope.updateValidationState(\.expiry, isValid: true)
-            scope.updateValidationState(\.cardholderName, isValid: true)
+            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
+            scope.updateValidationState(keyPath: \.cvv, isValid: true)
+            scope.updateValidationState(keyPath: \.expiry, isValid: true)
+            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
 
             XCTAssertTrue(scope.structuredState.isValid)
         }
@@ -584,10 +584,10 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(\.cardNumber, isValid: true)
-            scope.updateValidationState(\.cvv, isValid: false)
-            scope.updateValidationState(\.expiry, isValid: true)
-            scope.updateValidationState(\.cardholderName, isValid: true)
+            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
+            scope.updateValidationState(keyPath: \.cvv, isValid: false)
+            scope.updateValidationState(keyPath: \.expiry, isValid: true)
+            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
 
             XCTAssertFalse(scope.structuredState.isValid)
         }
@@ -605,10 +605,10 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(\.cardNumber, isValid: true)
-            scope.updateValidationState(\.cvv, isValid: true)
-            scope.updateValidationState(\.expiry, isValid: false)
-            scope.updateValidationState(\.cardholderName, isValid: true)
+            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
+            scope.updateValidationState(keyPath: \.cvv, isValid: true)
+            scope.updateValidationState(keyPath: \.expiry, isValid: false)
+            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
 
             XCTAssertFalse(scope.structuredState.isValid)
         }
@@ -626,10 +626,10 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(\.cardNumber, isValid: true)
-            scope.updateValidationState(\.cvv, isValid: true)
-            scope.updateValidationState(\.expiry, isValid: true)
-            scope.updateValidationState(\.cardholderName, isValid: false)
+            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
+            scope.updateValidationState(keyPath: \.cvv, isValid: true)
+            scope.updateValidationState(keyPath: \.expiry, isValid: true)
+            scope.updateValidationState(keyPath: \.cardholderName, isValid: false)
 
             XCTAssertFalse(scope.structuredState.isValid)
         }
@@ -647,21 +647,21 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateExpiryDate("12/30")
             scope.updateCardholderName("John Doe")
 
-            scope.updateValidationState(\.cardNumber, isValid: true)
-            scope.updateValidationState(\.cvv, isValid: true)
-            scope.updateValidationState(\.expiry, isValid: true)
-            scope.updateValidationState(\.cardholderName, isValid: true)
+            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
+            scope.updateValidationState(keyPath: \.cvv, isValid: true)
+            scope.updateValidationState(keyPath: \.expiry, isValid: true)
+            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
 
-            scope.updateValidationState(\.postalCode, isValid: true)
-            scope.updateValidationState(\.city, isValid: true)
-            scope.updateValidationState(\.state, isValid: true)
-            scope.updateValidationState(\.addressLine1, isValid: true)
-            scope.updateValidationState(\.addressLine2, isValid: true)
-            scope.updateValidationState(\.firstName, isValid: true)
-            scope.updateValidationState(\.lastName, isValid: true)
-            scope.updateValidationState(\.email, isValid: true)
-            scope.updateValidationState(\.phoneNumber, isValid: true)
-            scope.updateValidationState(\.countryCode, isValid: true)
+            scope.updateValidationState(keyPath: \.postalCode, isValid: true)
+            scope.updateValidationState(keyPath: \.city, isValid: true)
+            scope.updateValidationState(keyPath: \.state, isValid: true)
+            scope.updateValidationState(keyPath: \.addressLine1, isValid: true)
+            scope.updateValidationState(keyPath: \.addressLine2, isValid: true)
+            scope.updateValidationState(keyPath: \.firstName, isValid: true)
+            scope.updateValidationState(keyPath: \.lastName, isValid: true)
+            scope.updateValidationState(keyPath: \.email, isValid: true)
+            scope.updateValidationState(keyPath: \.phoneNumber, isValid: true)
+            scope.updateValidationState(keyPath: \.countryCode, isValid: true)
 
             XCTAssertTrue(scope.structuredState.isValid)
         }
@@ -1185,10 +1185,10 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
             scope.updateCardholderName("John Doe")
 
             // When
-            scope.updateValidationState(\.cardNumber, isValid: true)
-            scope.updateValidationState(\.cvv, isValid: true)
-            scope.updateValidationState(\.expiry, isValid: true)
-            scope.updateValidationState(\.cardholderName, isValid: true)
+            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
+            scope.updateValidationState(keyPath: \.cvv, isValid: true)
+            scope.updateValidationState(keyPath: \.expiry, isValid: true)
+            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
 
             // Then
             XCTAssertTrue(scope.fieldValidationStates.cardNumber)
@@ -1212,14 +1212,14 @@ final class DefaultCardFormScopeValidationTests: XCTestCase {
             scope.updateCardholderName("John Doe")
 
             // Set all valid first
-            scope.updateValidationState(\.cardNumber, isValid: true)
-            scope.updateValidationState(\.cvv, isValid: true)
-            scope.updateValidationState(\.expiry, isValid: true)
-            scope.updateValidationState(\.cardholderName, isValid: true)
+            scope.updateValidationState(keyPath: \.cardNumber, isValid: true)
+            scope.updateValidationState(keyPath: \.cvv, isValid: true)
+            scope.updateValidationState(keyPath: \.expiry, isValid: true)
+            scope.updateValidationState(keyPath: \.cardholderName, isValid: true)
             XCTAssertTrue(scope.structuredState.isValid)
 
             // When — invalidate one field
-            scope.updateValidationState(\.cardNumber, isValid: false)
+            scope.updateValidationState(keyPath: \.cardNumber, isValid: false)
 
             // Then
             XCTAssertFalse(scope.structuredState.isValid)

--- a/Tests/Primer/CheckoutComponents/Scope/PrimerCardFormScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/PrimerCardFormScopeTests.swift
@@ -197,8 +197,6 @@ final class PrimerCardFormScopeTests: XCTestCase {
             AnyView(EmptyView())
         }
 
-        func updateValidationState(cardNumber: Bool, cvv: Bool, expiry: Bool, cardholderName: Bool) {}
-
         func DefaultCardFormView(styling: PrimerFieldStyling?) -> AnyView {
             AnyView(EmptyView())
         }


### PR DESCRIPTION
## Summary

Fixes [ACC-7135](https://primerapi.atlassian.net/browse/ACC-7135).

Introduces an internal protocol `CardFormFieldScopeInternal` that refines the public `PrimerCardFormScope` with the `FieldValidationStates`-keyed validation hook. Retypes the 9 card-form field components to accept the internal protocol and drops all **33** `as? DefaultCardFormScope` guards that previously silently skipped validation for any scope other than `DefaultCardFormScope` (notably `MockCardFormScope` used in `#Preview`s and tests).

Trims the public `PrimerCardFormScope` of two internal-only validation methods (`updateValidationState(cardNumber:cvv:expiry:cardholderName:)` and `updateValidationStateIfNeeded(for:isValid:)`) that were leftover plumbing from a pre-public-API iteration — neither was documented in `API_REFERENCE.md`. The first is demoted to an internal method on `DefaultCardFormScope`; the second moves onto the new internal protocol.

Also renames `updateValidationState(_ field:)` → `updateValidationState(keyPath:)` to match the Jira acceptance-criteria wording and make the parameter role explicit at call sites.

`FieldValidationStates` moves out of `DefaultCardFormScope.swift` into the new protocol file so it lives next to the protocol that keys on it (one-type-per-file).

## Test plan

- [x] `xcodebuild build` for Debug App succeeds
- [x] Full `UnitTestsTestPlan`: 2992 tests, 0 failures
- [x] `DefaultCardFormScopeTests` (57 tests) and `PrimerCardFormScopeTests` (10 tests) pass with the renamed `keyPath:` label and removed 4-arg protocol requirement
- [x] SwiftFormat / SwiftLint clean on changed files (only pre-existing violations remain)
- [ ] Manual Debug App smoke: launch CheckoutComponents → Card Form, type values, observe submit button enable/disable

## Follow-ups

Broader audit surfaced three more clusters of the same pattern outside ACC-7135's scope, filed in `Exp Sprint 2026.09`:

- **[ACC-7171](https://primerapi.atlassian.net/browse/ACC-7171)** — Finish CardFormScope decoupling (4 remaining downcasts in CardFormScreen/CardFormFieldsView + `PrimerCheckout.swift:27` doc-comment fix + retype `CountryInputField`, `BillingAddressView`)
- **[ACC-7172](https://primerapi.atlassian.net/browse/ACC-7172)** — Decouple checkout-level internals from `DefaultCheckoutScope`
- **[ACC-7173](https://primerapi.atlassian.net/browse/ACC-7173)** — Tighten `PaymentMethodProtocol.ScopeType` typealiases, 4 test-file downcasts, product decision on 5 questionable public members

[ACC-7135]: https://primerapi.atlassian.net/browse/ACC-7135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACC-7171]: https://primerapi.atlassian.net/browse/ACC-7171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ