### PR TITLE
feat: Add getClientSession() public getter on HUC (ACC-7236)

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/PrimerHeadlessUniversalCheckout.swift
@@ -165,6 +165,15 @@ public final class PrimerHeadlessUniversalCheckout: LogReporter {
         }
     }
 
+    /// Returns the current loaded client session, or `nil` if `start(...)` has not yet completed.
+    /// Reads synchronously from the in-memory configuration loaded during `start(...)`.
+    @objc public func getClientSession() -> PrimerClientSession? {
+        guard let apiConfiguration = PrimerAPIConfigurationModule.apiConfiguration else {
+            return nil
+        }
+        return PrimerClientSession(from: apiConfiguration)
+    }
+
     // MARK: - HELPERS
 
     private func continueValidateSession() async throws {
@@ -211,40 +220,40 @@ public final class PrimerHeadlessUniversalCheckout: LogReporter {
         var paymentMethods = PrimerAPIConfiguration.paymentMethodConfigs
 
         #if !canImport(PrimerKlarnaSDK)
-        if let klarnaIndex = paymentMethods?.firstIndex(where: { $0.type == PrimerPaymentMethodType.klarna.rawValue }) {
-            paymentMethods?.remove(at: klarnaIndex)
-            let message =
-                """
-Klarna configuration has been found but module 'PrimerKlarnaSDK' is missing. \
-Add `PrimerKlarnaSDK' in your project by adding \"pod 'PrimerKlarnaSDK'\" in your Podfile, \
-or by adding \"primer-klarna-sdk-ios\" in your Swift Package Manager
-"""
-            logger.warn(message: message)
-        }
+            if let klarnaIndex = paymentMethods?.firstIndex(where: { $0.type == PrimerPaymentMethodType.klarna.rawValue }) {
+                paymentMethods?.remove(at: klarnaIndex)
+                let message =
+                    """
+                    Klarna configuration has been found but module 'PrimerKlarnaSDK' is missing. \
+                    Add `PrimerKlarnaSDK' in your project by adding \"pod 'PrimerKlarnaSDK'\" in your Podfile, \
+                    or by adding \"primer-klarna-sdk-ios\" in your Swift Package Manager
+                    """
+                logger.warn(message: message)
+            }
         #endif
 
         #if !canImport(PrimerIPay88MYSDK)
-        if let iPay88ViewModelIndex = paymentMethods?.firstIndex(where: { $0.type == PrimerPaymentMethodType.iPay88Card.rawValue }) {
-            paymentMethods?.remove(at: iPay88ViewModelIndex)
-            let message =
-                """
-iPay88 configuration has been found but module 'PrimerIPay88SDK' is missing. \
-Add `PrimerIPay88SDK' in your project by adding \"pod 'PrimerIPay88SDK'\" in your Podfile.
-"""
-            logger.warn(message: message)
-        }
+            if let iPay88ViewModelIndex = paymentMethods?.firstIndex(where: { $0.type == PrimerPaymentMethodType.iPay88Card.rawValue }) {
+                paymentMethods?.remove(at: iPay88ViewModelIndex)
+                let message =
+                    """
+                    iPay88 configuration has been found but module 'PrimerIPay88SDK' is missing. \
+                    Add `PrimerIPay88SDK' in your project by adding \"pod 'PrimerIPay88SDK'\" in your Podfile.
+                    """
+                logger.warn(message: message)
+            }
         #endif
 
         #if !canImport(PrimerNolPaySDK)
-        if let nolPayViewModelIndex = paymentMethods?.firstIndex(where: { $0.type == PrimerPaymentMethodType.nolPay.rawValue }) {
-            paymentMethods?.remove(at: nolPayViewModelIndex)
-            let message =
-                """
-NolPay configuration has been found but module 'PrimerNolPaySDK' is missing. \
-Add `PrimerNolPaySDK' in your project by adding \"pod 'PrimerNolPaySDK'\" in your Podfile.
-"""
-            logger.warn(message: message)
-        }
+            if let nolPayViewModelIndex = paymentMethods?.firstIndex(where: { $0.type == PrimerPaymentMethodType.nolPay.rawValue }) {
+                paymentMethods?.remove(at: nolPayViewModelIndex)
+                let message =
+                    """
+                    NolPay configuration has been found but module 'PrimerNolPaySDK' is missing. \
+                    Add `PrimerNolPaySDK' in your project by adding \"pod 'PrimerNolPaySDK'\" in your Podfile.
+                    """
+                logger.warn(message: message)
+            }
         #endif
 
         return paymentMethods?.compactMap(\.type).filter({ !unsupportedPaymentMethodTypes.contains($0) })


### PR DESCRIPTION
# Description

ACC-7236

Adds `PrimerHeadlessUniversalCheckout.getClientSession() -> PrimerClientSession?` so callers can read the loaded session synchronously after `start(...)`. The RN bridge needs this to deliver an initial `onClientSessionUpdate` event to JS — the existing delegate only fires on subsequent updates, never at init, and adding an init-time fire would change behaviour for existing native merchants.

Returns `nil` before `start(...)` completes. Purely additive — no change to existing delegate timing or fields.

> Note: SwiftFormat reformatted `#if !canImport` blocks in this file on commit (master non-conformant with current `.swiftformat` config). The reformatting is whitespace-only; the meaningful change is the new method.

# Other Notes

- Other changes that are not specifically related to the intent of the PR

# Manual Testing

_Add manual testing notes here if applicable, otherwise remove this section_

# Screenshots

_If applicable, otherwise remove this section_

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge