### PR TITLE
refactor: Decouple checkout-level views from DefaultCheckoutScope [ACC-7172]

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/CheckoutScopeObserver.swift
@@ -8,16 +8,16 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct CheckoutScopeObserver: View, LogReporter {
-  private let scope: DefaultCheckoutScope
+  private let scope: any CheckoutScopeInternal
   private let theme: PrimerCheckoutTheme
   private let onCompletion: ((PrimerCheckoutState) -> Void)?
-  @State private var navigationState: DefaultCheckoutScope.NavigationState = .loading
+  @State private var navigationState: CheckoutNavigationState = .loading
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.bridgeController) private var bridgeController
   @StateObject private var designTokensManager = DesignTokensManager()
 
   init(
-    scope: DefaultCheckoutScope,
+    scope: any CheckoutScopeInternal,
     theme: PrimerCheckoutTheme = PrimerCheckoutTheme(),
     onCompletion: ((PrimerCheckoutState) -> Void)?
   ) {
@@ -42,12 +42,13 @@ struct CheckoutScopeObserver: View, LogReporter {
         .animation(.easeInOut(duration: 0.3), value: navigationState)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-    .environmentObject(scope)
     .environment(\.diContainer, DIContainer.currentSync)
     .environment(\.designTokens, designTokensManager.tokens)
     .environment(\.primerCheckoutScope, scope)
-    .onReceive(scope.$navigationState) { newState in
-      navigationState = newState
+    .task {
+      for await newState in scope.navigationStateStream {
+        navigationState = newState
+      }
     }
     .onAppear {
       Task {
@@ -120,10 +121,7 @@ struct CheckoutScopeObserver: View, LogReporter {
       selectedVaultedPaymentMethod: scope.selectedVaultedPaymentMethod,
       onSelect: { method in
         scope.setSelectedVaultedPaymentMethod(method)
-        if let selectionScope = scope.paymentMethodSelection
-          as? DefaultPaymentMethodSelectionScope {
-          selectionScope.collapsePaymentMethods()
-        }
+        scope.paymentMethodSelectionInternal.collapsePaymentMethods()
         scope.checkoutNavigator.navigateBack()
       },
       onBack: {
@@ -135,23 +133,14 @@ struct CheckoutScopeObserver: View, LogReporter {
     )
   }
 
-  @ViewBuilder
   private func makeDeleteConfirmationView(
     method: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
   ) -> some View {
-    if let selectionScope = scope.paymentMethodSelection as? DefaultPaymentMethodSelectionScope {
-      DeleteVaultedPaymentMethodConfirmationScreen(
-        vaultedPaymentMethod: method,
-        navigator: scope.checkoutNavigator,
-        scope: selectionScope
-      )
-    } else {
-      EmptyView().onAppear {
-        logger.error(
-          message: "Cannot cast paymentMethodSelection to DefaultPaymentMethodSelectionScope")
-        scope.checkoutNavigator.navigateBack()
-      }
-    }
+    DeleteVaultedPaymentMethodConfirmationScreen(
+      vaultedPaymentMethod: method,
+      navigator: scope.checkoutNavigator,
+      scope: scope.paymentMethodSelectionInternal
+    )
   }
 
   @ViewBuilder

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodComponents.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodComponents.swift
@@ -10,21 +10,16 @@ import SwiftUI
 @MainActor
 struct PaymentMethodScreen: View {
   let paymentMethodType: String
-  let checkoutScope: PrimerCheckoutScope
+  let checkoutScope: any CheckoutScopeInternal
 
   @ViewBuilder
   var body: some View {
-    // Truly generic dynamic view resolution via registry - NO hardcoded payment method checks!
-    // Each payment method registers its own view builder, making this fully extensible
     if let paymentMethodView = PaymentMethodRegistry.shared.getView(
       for: paymentMethodType,
       checkoutScope: checkoutScope
     ) {
-      // Payment method has a registered view implementation
       paymentMethodView
     } else {
-      // Payment method not registered or doesn't have view implementation yet
-      // Show placeholder that works for any payment method type
       AnyView(
         PaymentMethodPlaceholder(
           paymentMethodType: paymentMethodType,
@@ -39,7 +34,7 @@ struct PaymentMethodScreen: View {
 @MainActor
 struct PaymentMethodPlaceholder: View {
   let paymentMethodType: String
-  let checkoutScope: PrimerCheckoutScope
+  let checkoutScope: any CheckoutScopeInternal
 
   @Environment(\.designTokens) private var tokens
   @Environment(\.sizeCategory) private var sizeCategory  // Observes Dynamic Type changes
@@ -70,43 +65,23 @@ struct PaymentMethodPlaceholder: View {
 
   private var navigationBar: some View {
     HStack {
-      // Try to navigate back if we have access to the navigator, otherwise just show cancel
-      if let defaultScope = checkoutScope as? DefaultCheckoutScope {
-        Button(
-          action: {
-            defaultScope.checkoutNavigator.navigateBack()
-          },
-          label: {
-            HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
-              Image(systemName: RTLIcon.backChevron)
-                .font(PrimerFont.bodyMedium(tokens: tokens))
-              Text(CheckoutComponentsStrings.backButton)
-            }
-            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      Button(
+        action: checkoutScope.checkoutNavigator.navigateBack,
+        label: {
+          HStack(spacing: PrimerSpacing.xsmall(tokens: tokens)) {
+            Image(systemName: RTLIcon.backChevron)
+              .font(PrimerFont.bodyMedium(tokens: tokens))
+            Text(CheckoutComponentsStrings.backButton)
           }
-        )
-        .accessibility(
-          config: AccessibilityConfiguration(
-            identifier: AccessibilityIdentifiers.Common.backButton,
-            label: CheckoutComponentsStrings.a11yBack,
-            traits: [.isButton]
-          ))
-      } else {
-        // Fallback to cancel button if we can't access internal navigator
-        Button(
-          CheckoutComponentsStrings.cancelButton,
-          action: {
-            checkoutScope.onDismiss()
-          }
-        )
-        .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
-        .accessibility(
-          config: AccessibilityConfiguration(
-            identifier: AccessibilityIdentifiers.Common.closeButton,
-            label: CheckoutComponentsStrings.a11yCancel,
-            traits: [.isButton]
-          ))
-      }
+          .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        }
+      )
+      .accessibility(
+        config: AccessibilityConfiguration(
+          identifier: AccessibilityIdentifiers.Common.backButton,
+          label: CheckoutComponentsStrings.a11yBack,
+          traits: [.isButton]
+        ))
 
       Spacer()
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/CheckoutScopeInternal.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/CheckoutScopeInternal.swift
@@ -1,0 +1,32 @@
+//
+//  CheckoutScopeInternal.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+@available(iOS 15.0, *)
+@MainActor
+protocol CheckoutScopeInternal: PrimerCheckoutScope {
+  var paymentMethodSelectionInternal: any PaymentMethodSelectionScopeInternal { get }
+  var checkoutNavigator: CheckoutNavigator { get }
+
+  var navigationStateStream: AsyncStream<CheckoutNavigationState> { get }
+  var currentNavigationState: CheckoutNavigationState { get }
+  var currentState: PrimerCheckoutState { get }
+
+  var availablePaymentMethods: [InternalPaymentMethod] { get }
+  var vaultedPaymentMethods: [PrimerHeadlessUniversalCheckout.VaultedPaymentMethod] { get }
+  var selectedVaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod? { get }
+
+  var paymentMethodSelectionScreen: PaymentMethodSelectionScreenComponent? { get }
+  var successScreen: ((PaymentResult) -> AnyView)? { get }
+  var isInitScreenEnabled: Bool { get }
+  var isSuccessScreenEnabled: Bool { get }
+  var isErrorScreenEnabled: Bool { get }
+
+  func updateNavigationState(_ newState: CheckoutNavigationState)
+  func setSelectedVaultedPaymentMethod(_ method: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod?)
+  func retryPayment()
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -8,9 +8,7 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 @MainActor
-final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogReporter {
-
-  typealias NavigationState = CheckoutNavigationState
+final class DefaultCheckoutScope: CheckoutScopeInternal, ObservableObject, LogReporter {
 
   @Published private var internalState = PrimerCheckoutState.initializing
   @Published var navigationState = CheckoutNavigationState.loading
@@ -44,6 +42,23 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
 
   var currentState: PrimerCheckoutState { internalState }
 
+  var currentNavigationState: CheckoutNavigationState { navigationState }
+
+  var navigationStateStream: AsyncStream<CheckoutNavigationState> {
+    AsyncStream { continuation in
+      let task = Task { [self] in
+        for await value in $navigationState.values {
+          continuation.yield(value)
+        }
+        continuation.finish()
+      }
+
+      continuation.onTermination = { _ in
+        task.cancel()
+      }
+    }
+  }
+
   var checkoutNavigator: CheckoutNavigator { navigator }
 
   var availablePaymentMethods: [InternalPaymentMethod] = []
@@ -68,8 +83,11 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
 
   let presentationContext: PresentationContext
 
-  private var cachedPaymentMethodSelection: PrimerPaymentMethodSelectionScope?
-  var paymentMethodSelection: PrimerPaymentMethodSelectionScope {
+  private var cachedPaymentMethodSelection: (any PaymentMethodSelectionScopeInternal)?
+
+  var paymentMethodSelection: PrimerPaymentMethodSelectionScope { paymentMethodSelectionInternal }
+
+  var paymentMethodSelectionInternal: any PaymentMethodSelectionScopeInternal {
     if let cachedPaymentMethodSelection { return cachedPaymentMethodSelection }
     let scope = DefaultPaymentMethodSelectionScope(
       checkoutScope: self,
@@ -104,9 +122,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     self.presentationContext = presentationContext
 
     vaultManager.onSelectionChanged = { [weak self] _ in
-      if let selectionScope = self?.cachedPaymentMethodSelection as? DefaultPaymentMethodSelectionScope {
-        selectionScope.syncSelectedVaultedPaymentMethod()
-      }
+      self?.cachedPaymentMethodSelection?.syncSelectedVaultedPaymentMethod()
     }
 
     registerPaymentMethods()
@@ -245,7 +261,11 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     }
   }
 
-  func updateNavigationState(_ newState: NavigationState, syncToNavigator: Bool = true) {
+  func updateNavigationState(_ newState: CheckoutNavigationState) {
+    updateNavigationState(newState, syncToNavigator: true)
+  }
+
+  func updateNavigationState(_ newState: CheckoutNavigationState, syncToNavigator: Bool) {
     navigationState = newState
 
     announceScreenChange(for: newState)
@@ -277,7 +297,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     }
   }
 
-  private func announceScreenChange(for state: NavigationState) {
+  private func announceScreenChange(for state: CheckoutNavigationState) {
     guard let service = accessibilityAnnouncementService else { return }
 
     let message: String?
@@ -325,7 +345,7 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     navigationObservationTask = Task { @MainActor [weak self] in
       guard let self else { return }
       for await route in navigator.navigationEvents {
-        let newNavigationState: NavigationState
+        let newNavigationState: CheckoutNavigationState
         switch route {
         case .loading:
           newNavigationState = .loading

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultPaymentMethodSelectionScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultPaymentMethodSelectionScope.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 @MainActor
-final class DefaultPaymentMethodSelectionScope: PrimerPaymentMethodSelectionScope, ObservableObject,
+final class DefaultPaymentMethodSelectionScope: PaymentMethodSelectionScopeInternal, ObservableObject,
   LogReporter {
   // MARK: - Properties
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/PaymentMethodSelectionScopeInternal.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/PaymentMethodSelectionScopeInternal.swift
@@ -1,0 +1,15 @@
+//
+//  PaymentMethodSelectionScopeInternal.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+@MainActor
+protocol PaymentMethodSelectionScopeInternal: PrimerPaymentMethodSelectionScope {
+  func syncSelectedVaultedPaymentMethod()
+  func collapsePaymentMethods()
+  func deleteVaultedPaymentMethod(_ method: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod) async throws
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DeleteVaultedPaymentMethodConfirmationScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DeleteVaultedPaymentMethodConfirmationScreen.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct DeleteVaultedPaymentMethodConfirmationScreen: View, LogReporter {
   let vaultedPaymentMethod: PrimerHeadlessUniversalCheckout.VaultedPaymentMethod
   let navigator: CheckoutNavigator
-  let scope: DefaultPaymentMethodSelectionScope
+  let scope: any PaymentMethodSelectionScopeInternal
 
   @Environment(\.designTokens) private var tokens
 

--- a/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
@@ -459,6 +459,17 @@ final class DefaultCheckoutScopeBehaviorTests: XCTestCase {
         }
     }
 
+    func test_currentNavigationState_returnsLatestNavigationState() {
+        // Given
+        sut = makeSut()
+
+        // When
+        sut.updateNavigationState(.processing)
+
+        // Then
+        XCTAssertEqual(sut.currentNavigationState, .processing)
+    }
+
     func test_checkoutNavigator_returnsNavigator() {
         // Given
         sut = makeSut()
@@ -642,6 +653,52 @@ final class DefaultCheckoutScopeBehaviorTests: XCTestCase {
         } else {
             XCTFail("Expected initializing state, got \(state)")
         }
+    }
+
+    // MARK: - navigationStateStream Tests
+
+    func test_navigationStateStream_emitsInitialNavigationState() async throws {
+        // Given — disable init screen so the async init task cannot mutate the navigation state.
+        sut = makeSut(settings: PrimerSettings(uiOptions: PrimerUIOptions(isInitScreenEnabled: false)))
+
+        // When
+        let value = try await awaitFirst(sut.navigationStateStream)
+
+        // Then
+        XCTAssertEqual(value, .loading)
+    }
+
+    func test_navigationStateStream_emitsUpdatedNavigationStates() async throws {
+        // Given
+        sut = makeSut(settings: PrimerSettings(uiOptions: PrimerUIOptions(isInitScreenEnabled: false)))
+        let stream = sut.navigationStateStream
+        let waitTask = Task { try await awaitValue(stream, equalTo: .processing) }
+
+        // Allow the iteration task to subscribe before mutating.
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // When
+        sut.updateNavigationState(.processing)
+
+        // Then
+        let value = try await waitTask.value
+        XCTAssertEqual(value, .processing)
+    }
+
+    func test_navigationStateStream_consumerEarlyExit_terminatesCleanly() async {
+        // Given
+        sut = makeSut(settings: PrimerSettings(uiOptions: PrimerUIOptions(isInitScreenEnabled: false)))
+        var receivedCount = 0
+
+        // When — break after the first value to trigger the onTermination handler.
+        for await value in sut.navigationStateStream {
+            receivedCount += 1
+            XCTAssertEqual(value, .loading)
+            break
+        }
+
+        // Then
+        XCTAssertEqual(receivedCount, 1)
     }
 
     // MARK: - invokeBeforePaymentCreate Tests


### PR DESCRIPTION
# Description

[ACC-7172](https://primerapi.atlassian.net/browse/ACC-7172)

Follow-up to ACC-7135 (PR #1711). Removes 4 of the 5 remaining `as? Default*Scope` downcasts at the checkout level by introducing two narrow internal protocols. The 5th — `DefaultCheckoutScope.validated(from:)` — stays as the sanctioned public→internal boundary cast.

- Add `CheckoutScopeInternal` and `PaymentMethodSelectionScopeInternal`, internal protocols refining `PrimerCheckoutScope` / `PrimerPaymentMethodSelectionScope`. They expose only what internal views actually need: `checkoutNavigator`, `navigationStateStream`, cache access via `paymentMethodSelectionInternal`, and the three previously-downcast methods (`syncSelectedVaultedPaymentMethod`, `collapsePaymentMethods`, `deleteVaultedPaymentMethod`).
- `DefaultCheckoutScope` and `DefaultPaymentMethodSelectionScope` declare conformance to the new internal protocols (still satisfying the public ones transitively — no public API change).
- Retype `CheckoutScopeObserver`, `PaymentMethodComponents` (both `PaymentMethodScreen` and `PaymentMethodPlaceholder`), and `DeleteVaultedPaymentMethodConfirmationScreen` to accept the internal protocol types instead of the concrete `Default*Scope`.
- Replace the Combine `$navigationState` publisher with an `AsyncStream` to match the rest of the scope-observation patterns in the codebase.
- Drop the unused `.environmentObject(scope)` (verified zero `@EnvironmentObject DefaultCheckoutScope` consumers in CC sources or tests).
- Drop the now-unreachable `else` cancel-button fallback in `PaymentMethodPlaceholder` — `checkoutNavigator` is protocol-guaranteed so the downcast guard is gone.

No breaking changes. The public protocols `PrimerCheckoutScope` and `PrimerPaymentMethodSelectionScope` are unchanged.

# Manual Testing

- [ ] Checkout → tap a payment method → verify navigation works
- [ ] Pull-to-refresh on payment method list (vault sync path)
- [ ] Open a vaulted payment method → tap delete → confirm → verify deletion

# Contributor Checklist

- [ ] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable (no behavior change — existing tests cover the affected paths)
- [ ] I have added UI tests to new user flows, if applicable
- [ ] I have manually tested newly added UX
- [x] I have open a documentation PR, if applicable (N/A — no docs change)

[ACC-7172]: https://primerapi.atlassian.net/browse/ACC-7172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ