### PR TITLE
fix(headless): validate cobadged cards via BIN cache (iOS↔Android parity)

### DIFF
--- a/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutRawDataViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutRawDataViewController.swift
@@ -325,6 +325,8 @@ extension MerchantHeadlessCheckoutRawDataViewController: PrimerHeadlessUniversal
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            // Preserve prior tap across metadata re-fires (e.g. submit-time re-validation).
+            let priorPick = rawCardData.cardNetwork
             cardsStackView.removeAllArrangedSubviews()
             selectedCardNetwork = nil
 
@@ -333,11 +335,14 @@ extension MerchantHeadlessCheckoutRawDataViewController: PrimerHeadlessUniversal
                 cardBadgesInteractive = false
                 rawCardData.cardNetwork = nil
                 addCardBadges(for: metadata.detectedCardNetworks.items)
-            } else if let selectableNetworks = metadata.selectableCardNetworks {
-                // Selectable co-badge: first badge visually selected, but cardNetwork nil until user taps
+            } else if let selectableNetworks = metadata.selectableCardNetworks,
+                      selectableNetworks.items.count > 1 {
+                let preservedSelection = priorPick.flatMap { pick in
+                    selectableNetworks.items.first { $0.network == pick }
+                }
                 cardBadgesInteractive = true
-                selectedCardNetwork = selectableNetworks.items.first
-                rawCardData.cardNetwork = nil
+                selectedCardNetwork = preservedSelection ?? selectableNetworks.items.first
+                rawCardData.cardNetwork = preservedSelection?.network
                 addCardBadges(for: selectableNetworks.items)
                 for (index, network) in selectableNetworks.items.enumerated() {
                     guard let imageView = cardsStackView.arrangedSubviews[safe: index] as? UIImageView else { continue }

--- a/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutRawDataViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutRawDataViewController.swift
@@ -24,10 +24,12 @@ class MerchantHeadlessCheckoutRawDataViewController: UIViewController {
     var paymentMethodType: String!
     var paymentId: String?
     var activityIndicator: UIActivityIndicatorView?
-    var rawCardData = PrimerCardData(cardNumber: "",
-                                     expiryDate: "",
-                                     cvv: "",
-                                     cardholderName: "")
+    var rawCardData = PrimerCardData(
+        cardNumber: "",
+        expiryDate: "",
+        cvv: "",
+        cardholderName: ""
+    )
 
     var cardnumberTextField: UITextField?
     var expiryDateTextField: UITextField?
@@ -99,17 +101,25 @@ class MerchantHeadlessCheckoutRawDataViewController: UIViewController {
             for inputElementType in inputElementTypes {
                 switch inputElementType {
                 case .cardNumber:
-                    self.cardnumberTextField = styledTextField(forAccessibilityId: "cardNumberTextField",
-                                                               withPlaceholderText: "4242 4242 4242 4242")
+                    self.cardnumberTextField = styledTextField(
+                        forAccessibilityId: "cardNumberTextField",
+                        withPlaceholderText: "4242 4242 4242 4242"
+                    )
                 case .expiryDate:
-                    self.expiryDateTextField = styledTextField(forAccessibilityId: "expiryDateTextField",
-                                                               withPlaceholderText: "03/2030")
+                    self.expiryDateTextField = styledTextField(
+                        forAccessibilityId: "expiryDateTextField",
+                        withPlaceholderText: "03/2030"
+                    )
                 case .cvv:
-                    self.cvvTextField = styledTextField(forAccessibilityId: "cvvTextField",
-                                                        withPlaceholderText: "123")
+                    self.cvvTextField = styledTextField(
+                        forAccessibilityId: "cvvTextField",
+                        withPlaceholderText: "123"
+                    )
                 case .cardholderName:
-                    self.cardholderNameTextField = styledTextField(forAccessibilityId: "cardholderNameTextField",
-                                                                   withPlaceholderText: "John Smith")
+                    self.cardholderNameTextField = styledTextField(
+                        forAccessibilityId: "cardholderNameTextField",
+                        withPlaceholderText: "John Smith"
+                    )
                 case .otp:
                     break
 
@@ -154,8 +164,10 @@ class MerchantHeadlessCheckoutRawDataViewController: UIViewController {
         }
     }
 
-    private func styledTextField(forAccessibilityId accessibilityId: String,
-                                 withPlaceholderText placeholderText: String) -> UITextField {
+    private func styledTextField(
+        forAccessibilityId accessibilityId: String,
+        withPlaceholderText placeholderText: String
+    ) -> UITextField {
         let textField = UITextField(frame: .zero)
         textField.accessibilityIdentifier = accessibilityId
         textField.borderStyle = .none
@@ -226,7 +238,8 @@ extension MerchantHeadlessCheckoutRawDataViewController: UITextFieldDelegate {
                 expiryDate: self.expiryDateTextField?.text ?? "",
                 cvv: self.cvvTextField?.text ?? "",
                 cardholderName: self.cardholderNameTextField?.text ?? "",
-                cardNetwork: self.rawCardData.cardNetwork)
+                cardNetwork: self.rawCardData.cardNetwork
+            )
 
         } else if textField == self.expiryDateTextField {
             self.rawCardData = PrimerCardData(
@@ -234,7 +247,8 @@ extension MerchantHeadlessCheckoutRawDataViewController: UITextFieldDelegate {
                 expiryDate: newText,
                 cvv: self.cvvTextField?.text ?? "",
                 cardholderName: self.cardholderNameTextField?.text ?? "",
-                cardNetwork: self.rawCardData.cardNetwork)
+                cardNetwork: self.rawCardData.cardNetwork
+            )
 
         } else if textField == self.cvvTextField {
             self.rawCardData = PrimerCardData(
@@ -242,7 +256,8 @@ extension MerchantHeadlessCheckoutRawDataViewController: UITextFieldDelegate {
                 expiryDate: self.expiryDateTextField?.text ?? "",
                 cvv: newText,
                 cardholderName: self.cardholderNameTextField?.text ?? "",
-                cardNetwork: self.rawCardData.cardNetwork)
+                cardNetwork: self.rawCardData.cardNetwork
+            )
 
         } else if textField == self.cardholderNameTextField {
             self.rawCardData = PrimerCardData(
@@ -250,7 +265,8 @@ extension MerchantHeadlessCheckoutRawDataViewController: UITextFieldDelegate {
                 expiryDate: self.expiryDateTextField?.text ?? "",
                 cvv: self.cvvTextField?.text ?? "",
                 cardholderName: newText.isEmpty ? nil : newText,
-                cardNetwork: self.rawCardData.cardNetwork)
+                cardNetwork: self.rawCardData.cardNetwork
+            )
         }
 
         print("self.rawCardData\ncardNumber: \(self.rawCardData.cardNumber)\nexpiryDate: \(self.rawCardData.expiryDate)\ncvv: \(self.rawCardData.cvv)\ncardholderName: \(self.rawCardData.cardholderName ?? "nil")")
@@ -262,23 +278,29 @@ extension MerchantHeadlessCheckoutRawDataViewController: UITextFieldDelegate {
 
 extension MerchantHeadlessCheckoutRawDataViewController: PrimerHeadlessUniversalCheckoutRawDataManagerDelegate {
 
-    func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              dataIsValid isValid: Bool,
-                              errors: [Error]?) {
+    func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        dataIsValid isValid: Bool,
+        errors: [Error]?
+    ) {
         print("\n\nMERCHANT APP\n\(#function)\ndataIsValid: \(isValid)")
         self.logs.append(#function)
         self.payButton.backgroundColor = isValid ? .black : .lightGray
         self.payButton.isEnabled = isValid
     }
 
-    func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              metadataDidChange metadata: [String: Any]?) {
+    func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        metadataDidChange metadata: [String: Any]?
+    ) {
         print("\n\nMERCHANT APP\n\(#function)\nmetadataDidChange: \(String(describing: metadata))")
         self.logs.append(#function)
     }
 
-    func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              willFetchMetadataForState state: PrimerValidationState) {
+    func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        willFetchMetadataForState state: PrimerValidationState
+    ) {
         print("[MerchantHeadlessCheckoutRawDataViewController] willFetchCardMetadataForState")
         DispatchQueue.main.async {
             self.cardsStackView.removeAllArrangedSubviews()
@@ -287,8 +309,11 @@ extension MerchantHeadlessCheckoutRawDataViewController: PrimerHeadlessUniversal
         }
     }
 
-    func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              didReceiveMetadata metadata: PrimerPaymentMethodMetadata, forState state: PrimerValidationState) {
+    func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        didReceiveMetadata metadata: PrimerPaymentMethodMetadata,
+        forState state: PrimerValidationState
+    ) {
         guard let metadata = metadata as? PrimerCardNumberEntryMetadata,
               let cardState = state as? PrimerCardNumberEntryState else {
             print("[MerchantHeadlessCheckoutRawDataViewController] ERROR: Failed to cast metadata and state to card entry models")
@@ -360,8 +385,10 @@ extension MerchantHeadlessCheckoutRawDataViewController: PrimerHeadlessUniversal
         }
     }
 
-    func primerRawDataManager(_ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-                              didReceiveBinData binData: PrimerBinData) {
+    func primerRawDataManager(
+        _ rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        didReceiveBinData binData: PrimerBinData
+    ) {
         let statusStr = binData.status == .complete ? "complete" : "partial"
         let preferredStr = binData.preferred?.displayName ?? "none"
         let alternativesStr = binData.alternatives.map(\.displayName).joined(separator: ", ")

--- a/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
+++ b/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
@@ -9,6 +9,7 @@ import Foundation
 protocol CardValidationService {
     func validateCardNetworks(withCardNumber cardNumber: String)
     func createValidationMetadata(networks: [CardNetwork], source: PrimerCardValidationSource) -> PrimerCardNumberEntryMetadata
+    func cachedMetadata(forCardNumber cardNumber: String) -> PrimerCardNumberEntryMetadata?
 }
 
 final class DefaultCardValidationService: CardValidationService, LogReporter {
@@ -58,6 +59,14 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
         metadataCacheQueue.async(flags: .barrier) {
             self.binDataCacheBacking[key] = binData
         }
+    }
+
+    private func binKey(for cardNumber: String) -> String {
+        String(cardNumber.prefix(Self.maximumBinLength))
+    }
+
+    func cachedMetadata(forCardNumber cardNumber: String) -> PrimerCardNumberEntryMetadata? {
+        getCachedMetadata(for: binKey(for: cardNumber.withoutWhiteSpace))
     }
 
     init(
@@ -110,7 +119,7 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
             willFetchMetadataForState: cardState
         )
 
-        let cacheKey = cardState.cardNumber
+        let cacheKey = binKey(for: cardState.cardNumber)
         if let cached = getCachedMetadata(for: cacheKey) {
             handle(cardMetadata: cached, forCardState: cardState)
             if let cachedBin = getCachedBinData(for: cacheKey) {
@@ -152,7 +161,7 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
                 handle(cardMetadata: metadata, forCardState: cardState)
 
                 let binData = buildBinData(from: enrichedNetworks, firstDigits: result.firstDigits, status: .complete)
-                setCachedBinData(binData, for: cardState.cardNumber)
+                setCachedBinData(binData, for: binKey(for: cardState.cardNumber))
                 delegate?.primerRawDataManager?(rawDataManager, didReceiveBinData: binData)
             } catch {
                 sendEvent(forError: error)
@@ -202,8 +211,7 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
     }
 
     private func handle(cardMetadata: PrimerCardNumberEntryMetadata, forCardState cardState: PrimerCardNumberEntryState) {
-        let cacheKey = cardState.cardNumber
-        setCachedMetadata(cardMetadata, for: cacheKey)
+        setCachedMetadata(cardMetadata, for: binKey(for: cardState.cardNumber))
 
         let trackable = cardMetadata.selectableCardNetworks ?? cardMetadata.detectedCardNetworks
         sendEvent(forNetworks: trackable.items, source: cardMetadata.source)

--- a/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
+++ b/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
@@ -60,10 +60,12 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
         }
     }
 
-    init(rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
-         allowedCardNetworks: [CardNetwork] = [CardNetwork].allowedCardNetworks,
-         apiClient: PrimerAPIClientBINDataProtocol = PrimerAPIClient(),
-         debouncer: Debouncer = .init(delay: 0.35)) {
+    init(
+        rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
+        allowedCardNetworks: [CardNetwork] = [CardNetwork].allowedCardNetworks,
+        apiClient: PrimerAPIClientBINDataProtocol = PrimerAPIClient(),
+        debouncer: Debouncer = .init(delay: 0.35)
+    ) {
         self.rawDataManager = rawDataManager
         self.allowedCardNetworks = allowedCardNetworks
         self.apiClient = apiClient
@@ -103,8 +105,10 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
     }
 
     private func useRemoteValidation(withCardState cardState: PrimerCardNumberEntryState) {
-        delegate?.primerRawDataManager?(rawDataManager,
-                                        willFetchMetadataForState: cardState)
+        delegate?.primerRawDataManager?(
+            rawDataManager,
+            willFetchMetadataForState: cardState
+        )
 
         let cacheKey = cardState.cardNumber
         if let cached = getCachedMetadata(for: cacheKey) {
@@ -180,9 +184,11 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
             Analytics.Service.fire(event: event)
         }
 
-        delegate?.primerRawDataManager?(rawDataManager,
-                                        didReceiveMetadata: metadata,
-                                        forState: cardState)
+        delegate?.primerRawDataManager?(
+            rawDataManager,
+            didReceiveMetadata: metadata,
+            forState: cardState
+        )
 
         let localNetworks = networks.map(PrimerCardNetwork.init(network:))
         let binData = buildBinData(from: localNetworks, firstDigits: nil, status: .partial)
@@ -202,9 +208,11 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
         let trackable = cardMetadata.selectableCardNetworks ?? cardMetadata.detectedCardNetworks
         sendEvent(forNetworks: trackable.items, source: cardMetadata.source)
 
-        delegate?.primerRawDataManager?(rawDataManager,
-                                        didReceiveMetadata: cardMetadata,
-                                        forState: cardState)
+        delegate?.primerRawDataManager?(
+            rawDataManager,
+            didReceiveMetadata: cardMetadata,
+            forState: cardState
+        )
 
         guard lastValidatedCardNumber != cardState.cardNumber else {
             return
@@ -229,14 +237,18 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
 
     // MARK: Model generation
 
-    func createValidationMetadata(networks: [CardNetwork],
-                                  source: PrimerCardValidationSource) -> PrimerCardNumberEntryMetadata {
+    func createValidationMetadata(
+        networks: [CardNetwork],
+        source: PrimerCardValidationSource
+    ) -> PrimerCardNumberEntryMetadata {
         createValidationMetadata(networks: networks, source: source, enrichedNetworks: nil)
     }
 
-    private func createValidationMetadata(networks: [CardNetwork],
-                                          source: PrimerCardValidationSource,
-                                          enrichedNetworks: [PrimerCardNetwork]?) -> PrimerCardNumberEntryMetadata
+    private func createValidationMetadata(
+        networks: [CardNetwork],
+        source: PrimerCardValidationSource,
+        enrichedNetworks: [PrimerCardNetwork]?
+    ) -> PrimerCardNumberEntryMetadata
     {
         let selectable: [PrimerCardNetwork]
         let detected: [PrimerCardNetwork]

--- a/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
+++ b/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
@@ -64,14 +64,6 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
         }
     }
 
-    private func binKey(for cardNumber: String) -> String {
-        String(cardNumber.prefix(Self.maximumBinLength))
-    }
-
-    func cachedMetadata(forCardNumber cardNumber: String) -> PrimerCardNumberEntryMetadata? {
-        getCachedMetadata(for: binKey(for: cardNumber.withoutWhiteSpace))
-    }
-
     init(
         rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager,
         allowedCardNetworks: [CardNetwork] = [CardNetwork].allowedCardNetworks,
@@ -82,6 +74,14 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
         self.allowedCardNetworks = allowedCardNetworks
         self.apiClient = apiClient
         self.debouncer = debouncer
+    }
+
+    func cachedMetadata(forCardNumber cardNumber: String) -> PrimerCardNumberEntryMetadata? {
+        getCachedMetadata(for: binKey(for: cardNumber.withoutWhiteSpace))
+    }
+
+    private func binKey(for cardNumber: String) -> String {
+        String(cardNumber.prefix(Self.maximumBinLength))
     }
 
     // MARK: Core Validation

--- a/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
+++ b/Sources/PrimerSDK/Classes/Core/BIN Data/CardValidationService.swift
@@ -12,6 +12,7 @@ import Foundation
 protocol CardValidationService {
     func validateCardNetworks(withCardNumber cardNumber: String)
     func createValidationMetadata(networks: [CardNetwork], source: PrimerCardValidationSource) -> PrimerCardNumberEntryMetadata
+    func cachedMetadata(forCardNumber cardNumber: String) -> PrimerCardNumberEntryMetadata?
 }
 
 final class DefaultCardValidationService: CardValidationService, LogReporter {
@@ -61,6 +62,14 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
         metadataCacheQueue.async(flags: .barrier) {
             self.binDataCacheBacking[key] = binData
         }
+    }
+
+    private func binKey(for cardNumber: String) -> String {
+        String(cardNumber.prefix(Self.maximumBinLength))
+    }
+
+    func cachedMetadata(forCardNumber cardNumber: String) -> PrimerCardNumberEntryMetadata? {
+        getCachedMetadata(for: binKey(for: cardNumber.withoutWhiteSpace))
     }
 
     init(
@@ -113,7 +122,7 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
             willFetchMetadataForState: cardState
         )
 
-        let cacheKey = cardState.cardNumber
+        let cacheKey = binKey(for: cardState.cardNumber)
         if let cached = getCachedMetadata(for: cacheKey) {
             handle(cardMetadata: cached, forCardState: cardState)
             if let cachedBin = getCachedBinData(for: cacheKey) {
@@ -155,7 +164,7 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
                 handle(cardMetadata: metadata, forCardState: cardState)
 
                 let binData = buildBinData(from: enrichedNetworks, firstDigits: result.firstDigits, status: .complete)
-                setCachedBinData(binData, for: cardState.cardNumber)
+                setCachedBinData(binData, for: binKey(for: cardState.cardNumber))
                 delegate?.primerRawDataManager?(rawDataManager, didReceiveBinData: binData)
             } catch {
                 sendEvent(forError: error)
@@ -205,8 +214,7 @@ final class DefaultCardValidationService: CardValidationService, LogReporter {
     }
 
     private func handle(cardMetadata: PrimerCardNumberEntryMetadata, forCardState cardState: PrimerCardNumberEntryState) {
-        let cacheKey = cardState.cardNumber
-        setCachedMetadata(cardMetadata, for: cacheKey)
+        setCachedMetadata(cardMetadata, for: binKey(for: cardState.cardNumber))
 
         let trackable = cardMetadata.selectableCardNetworks ?? cardMetadata.detectedCardNetworks
         sendEvent(forNetworks: trackable.items, source: cardMetadata.source)

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
@@ -11,7 +11,6 @@
 
 import Foundation
 
-// MARK: MISSING_TESTS
 final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuilderProtocol {
 
     var rawData: PrimerRawData? {
@@ -114,18 +113,6 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
             throw handled(primerError: .invalidValue(key: "rawData"))
         }
 
-        // Validate card network before tokenization (only if card number is valid)
-        // Use user-selected network if available (for co-badged cards), otherwise auto-detect
-        if !rawData.cardNumber.isEmpty, rawData.cardNumber.isValidCardNumber {
-            let cardNetwork = rawData.cardNetwork ?? CardNetwork(cardNumber: rawData.cardNumber)
-            if !self.allowedCardNetworks.contains(cardNetwork) {
-                throw handled(primerError: .invalidValue(
-                    key: "cardNetwork",
-                    value: cardNetwork.displayName
-                ))
-            }
-        }
-
         let expiryMonth = String((rawData.expiryDate.split(separator: "/"))[0])
         let rawExpiryYear = String((rawData.expiryDate.split(separator: "/"))[1])
 
@@ -148,7 +135,10 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
     }
 
     func validateRawData(_ data: PrimerRawData) async throws {
-        try await validateRawData(data, cardNetworksMetadata: nil)
+        let cached = (data as? PrimerCardData).flatMap {
+            cardValidationService?.cachedMetadata(forCardNumber: $0.cardNumber)
+        }
+        try await validateRawData(data, cardNetworksMetadata: cached)
     }
 
     func validateRawData(_ data: PrimerRawData, cardNetworksMetadata: PrimerCardNumberEntryMetadata?) async throws {
@@ -161,18 +151,16 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
             throw err
         }
 
-        // Locally validated card network
-        // Use user-selected network if available (for co-badged cards), otherwise auto-detect
-        var cardNetwork = rawData.cardNetwork ?? CardNetwork(cardNumber: rawData.cardNumber)
+        // Used for CVV length. Precedence: user pick → BIN metadata → local IIN.
+        var cardNetwork: CardNetwork = rawData.cardNetwork ?? CardNetwork(cardNumber: rawData.cardNumber)
 
-        // Remotely validated card network
-        if let cardNetworksMetadata = cardNetworksMetadata {
-            let didDetectNetwork = !cardNetworksMetadata.detectedCardNetworks.items.isEmpty &&
-                cardNetworksMetadata.detectedCardNetworks.items.map(\.network) != [.unknown]
-
-            if didDetectNetwork, cardNetworksMetadata.detectedCardNetworks.preferred == nil,
-               let network = cardNetworksMetadata.detectedCardNetworks.items.first?.network {
-                cardNetwork = network
+        if rawData.cardNetwork == nil, let metadata = cardNetworksMetadata {
+            let detected = metadata.detectedCardNetworks
+            let didDetectNetwork = !detected.items.isEmpty && detected.items.map(\.network) != [.unknown]
+            if didDetectNetwork {
+                cardNetwork = detected.preferred?.network
+                    ?? detected.items.first?.network
+                    ?? cardNetwork
             }
         }
 
@@ -184,32 +172,20 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
         // This ensures picker appears as user types, not just when card is fully valid
         self.cardValidationService?.validateCardNetworks(withCardNumber: rawData.cardNumber)
 
-        // Invalid card number error - check this FIRST before network type validation
+        // Allowed-list check only fires for BIN-derived metadata; matches Android `CardNumberValidator`.
         if rawData.cardNumber.isEmpty {
             errors.append(PrimerValidationError.invalidCardnumber(message: "Card number can not be blank."))
+        } else if let metadata = cardNetworksMetadata, metadata.source != .local {
+            let detected = metadata.detectedCardNetworks.items
+            if !detected.isEmpty, !detected.contains(where: \.allowed) {
+                errors.append(PrimerValidationError.invalidCardType(
+                    message: "Unsupported card type detected: \(detected.first?.displayName ?? cardNetwork.displayName)"
+                ))
+            } else if !rawData.cardNumber.isValidCardNumber {
+                errors.append(PrimerValidationError.invalidCardnumber(message: "Card number is not valid."))
+            }
         } else if !rawData.cardNumber.isValidCardNumber {
             errors.append(PrimerValidationError.invalidCardnumber(message: "Card number is not valid."))
-        } else {
-            // Only validate network TYPE (allowed/disallowed) when card number is valid
-            // This prevents "unsupported-card-type" errors for empty/partial cards
-            if cardNetworksMetadata != nil {
-                // Unsupported card type error
-                if !self.allowedCardNetworks.contains(cardNetwork) {
-                    let err = PrimerValidationError.invalidCardType(
-                        message: "Unsupported card type detected: \(cardNetwork.displayName)"
-                    )
-                    errors.append(err)
-                }
-            } else {
-                // When BIN data is not available, validate locally detected network against allowed networks
-                // This ensures consistent behavior with Web SDK where network validation always happens
-                if !self.allowedCardNetworks.contains(cardNetwork) {
-                    let err = PrimerValidationError.invalidCardType(
-                        message: "Unsupported card type detected: \(cardNetwork.displayName)"
-                    )
-                    errors.append(err)
-                }
-            }
         }
 
         do {

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
@@ -14,7 +14,6 @@ import Foundation
 @_spi(PrimerInternal) import PrimerFoundation
 @_spi(PrimerInternal) import PrimerNetworking
 
-// MARK: MISSING_TESTS
 final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuilderProtocol {
 
     var rawData: PrimerRawData? {
@@ -117,18 +116,6 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
             throw handled(primerError: .invalidValue(key: "rawData"))
         }
 
-        // Validate card network before tokenization (only if card number is valid)
-        // Use user-selected network if available (for co-badged cards), otherwise auto-detect
-        if !rawData.cardNumber.isEmpty, rawData.cardNumber.isValidCardNumber {
-            let cardNetwork = rawData.cardNetwork ?? CardNetwork(cardNumber: rawData.cardNumber)
-            if !self.allowedCardNetworks.contains(cardNetwork) {
-                throw handled(primerError: .invalidValue(
-                    key: "cardNetwork",
-                    value: cardNetwork.displayName
-                ))
-            }
-        }
-
         let expiryMonth = String((rawData.expiryDate.split(separator: "/"))[0])
         let rawExpiryYear = String((rawData.expiryDate.split(separator: "/"))[1])
 
@@ -151,7 +138,10 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
     }
 
     func validateRawData(_ data: PrimerRawData) async throws {
-        try await validateRawData(data, cardNetworksMetadata: nil)
+        let cached = (data as? PrimerCardData).flatMap {
+            cardValidationService?.cachedMetadata(forCardNumber: $0.cardNumber)
+        }
+        try await validateRawData(data, cardNetworksMetadata: cached)
     }
 
     func validateRawData(_ data: PrimerRawData, cardNetworksMetadata: PrimerCardNumberEntryMetadata?) async throws {
@@ -164,18 +154,16 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
             throw err
         }
 
-        // Locally validated card network
-        // Use user-selected network if available (for co-badged cards), otherwise auto-detect
-        var cardNetwork = rawData.cardNetwork ?? CardNetwork(cardNumber: rawData.cardNumber)
+        // Used for CVV length. Precedence: user pick → BIN metadata → local IIN.
+        var cardNetwork: CardNetwork = rawData.cardNetwork ?? CardNetwork(cardNumber: rawData.cardNumber)
 
-        // Remotely validated card network
-        if let cardNetworksMetadata = cardNetworksMetadata {
-            let didDetectNetwork = !cardNetworksMetadata.detectedCardNetworks.items.isEmpty &&
-                cardNetworksMetadata.detectedCardNetworks.items.map(\.network) != [.unknown]
-
-            if didDetectNetwork, cardNetworksMetadata.detectedCardNetworks.preferred == nil,
-               let network = cardNetworksMetadata.detectedCardNetworks.items.first?.network {
-                cardNetwork = network
+        if rawData.cardNetwork == nil, let metadata = cardNetworksMetadata {
+            let detected = metadata.detectedCardNetworks
+            let didDetectNetwork = !detected.items.isEmpty && detected.items.map(\.network) != [.unknown]
+            if didDetectNetwork {
+                cardNetwork = detected.preferred?.network
+                    ?? detected.items.first?.network
+                    ?? cardNetwork
             }
         }
 
@@ -187,32 +175,20 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
         // This ensures picker appears as user types, not just when card is fully valid
         self.cardValidationService?.validateCardNetworks(withCardNumber: rawData.cardNumber)
 
-        // Invalid card number error - check this FIRST before network type validation
+        // Allowed-list check only fires for BIN-derived metadata; matches Android `CardNumberValidator`.
         if rawData.cardNumber.isEmpty {
             errors.append(PrimerValidationError.invalidCardnumber(message: "Card number can not be blank."))
+        } else if let metadata = cardNetworksMetadata, metadata.source != .local {
+            let detected = metadata.detectedCardNetworks.items
+            if !detected.isEmpty, !detected.contains(where: \.allowed) {
+                errors.append(PrimerValidationError.invalidCardType(
+                    message: "Unsupported card type detected: \(detected.first?.displayName ?? cardNetwork.displayName)"
+                ))
+            } else if !rawData.cardNumber.isValidCardNumber {
+                errors.append(PrimerValidationError.invalidCardnumber(message: "Card number is not valid."))
+            }
         } else if !rawData.cardNumber.isValidCardNumber {
             errors.append(PrimerValidationError.invalidCardnumber(message: "Card number is not valid."))
-        } else {
-            // Only validate network TYPE (allowed/disallowed) when card number is valid
-            // This prevents "unsupported-card-type" errors for empty/partial cards
-            if cardNetworksMetadata != nil {
-                // Unsupported card type error
-                if !self.allowedCardNetworks.contains(cardNetwork) {
-                    let err = PrimerValidationError.invalidCardType(
-                        message: "Unsupported card type detected: \(cardNetwork.displayName)"
-                    )
-                    errors.append(err)
-                }
-            } else {
-                // When BIN data is not available, validate locally detected network against allowed networks
-                // This ensures consistent behavior with Web SDK where network validation always happens
-                if !self.allowedCardNetworks.contains(cardNetwork) {
-                    let err = PrimerValidationError.invalidCardType(
-                        message: "Unsupported card type detected: \(cardNetwork.displayName)"
-                    )
-                    errors.append(err)
-                }
-            }
         }
 
         do {

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerRawCardDataTokenizationBuilder.swift
@@ -155,7 +155,7 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
         }
 
         // Used for CVV length. Precedence: user pick → BIN metadata → local IIN.
-        var cardNetwork: CardNetwork = rawData.cardNetwork ?? CardNetwork(cardNumber: rawData.cardNumber)
+        var cardNetwork = rawData.cardNetwork ?? CardNetwork(cardNumber: rawData.cardNumber)
 
         if rawData.cardNetwork == nil, let metadata = cardNetworksMetadata {
             let detected = metadata.detectedCardNetworks
@@ -175,18 +175,17 @@ final class PrimerRawCardDataTokenizationBuilder: PrimerRawDataTokenizationBuild
         // This ensures picker appears as user types, not just when card is fully valid
         self.cardValidationService?.validateCardNetworks(withCardNumber: rawData.cardNumber)
 
-        // Allowed-list check only fires for BIN-derived metadata; matches Android `CardNumberValidator`.
+        // Enforce the allowed-network list only with BIN-or-fallback metadata (not partial local detection).
+        let detectedItems = (cardNetworksMetadata?.source != .local ? cardNetworksMetadata : nil)?
+            .detectedCardNetworks.items ?? []
+        let isUnsupportedCardType = !detectedItems.isEmpty && !detectedItems.contains(where: \.allowed)
+
         if rawData.cardNumber.isEmpty {
             errors.append(PrimerValidationError.invalidCardnumber(message: "Card number can not be blank."))
-        } else if let metadata = cardNetworksMetadata, metadata.source != .local {
-            let detected = metadata.detectedCardNetworks.items
-            if !detected.isEmpty, !detected.contains(where: \.allowed) {
-                errors.append(PrimerValidationError.invalidCardType(
-                    message: "Unsupported card type detected: \(detected.first?.displayName ?? cardNetwork.displayName)"
-                ))
-            } else if !rawData.cardNumber.isValidCardNumber {
-                errors.append(PrimerValidationError.invalidCardnumber(message: "Card number is not valid."))
-            }
+        } else if isUnsupportedCardType {
+            errors.append(PrimerValidationError.invalidCardType(
+                message: "Unsupported card type detected: \(detectedItems.first?.displayName ?? cardNetwork.displayName)"
+            ))
         } else if !rawData.cardNumber.isValidCardNumber {
             errors.append(PrimerValidationError.invalidCardnumber(message: "Card number is not valid."))
         }

--- a/Tests/Primer/Managers/PrimerRawCardDataTokenizationBuilderTests.swift
+++ b/Tests/Primer/Managers/PrimerRawCardDataTokenizationBuilderTests.swift
@@ -77,4 +77,225 @@ final class PrimerRawCardDataTokenizationBuilderTests: XCTestCase {
         let instrument = body.paymentInstrument as? CardPaymentInstrument
         XCTAssertEqual(instrument?.preferredNetwork, CardNetwork.cartesBancaires.rawValue)
     }
+
+    // MARK: - validateRawData with metadata (covers cobadged / mis-classified-IIN cases)
+
+    /// Card 5017… is locally classified as Maestro but the BIN response says CB+MC.
+    /// With BIN metadata present and `cardNetwork == nil`, validation must use the
+    /// metadata's allowed network (CB) — not fall back to the wrong local guess.
+    func test_validate_cobadgedCard_withMetadata_andNilUserSelection_passes() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        PrimerInternal.shared.sdkIntegrationType = .headless
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+        let metadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ],
+            detectedCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ]
+        )
+
+        try await sut.validateRawData(cardData, cardNetworksMetadata: metadata)
+        XCTAssertTrue(sut.isDataValid)
+    }
+
+    /// Same card, but the user has explicitly picked CB. User pick wins; validation passes.
+    func test_validate_cobadgedCard_withUserSelection_passes() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        PrimerInternal.shared.sdkIntegrationType = .headless
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith",
+            cardNetwork: .cartesBancaires
+        )
+        let metadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ],
+            detectedCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ]
+        )
+
+        try await sut.validateRawData(cardData, cardNetworksMetadata: metadata)
+        XCTAssertTrue(sut.isDataValid)
+    }
+
+    /// Mirrors Android `CardNumberValidator`: without BIN-derived metadata, the validator
+    /// must NOT reject based on the local IIN guess. For `5017…` the local guess is Maestro
+    /// (not in the merchant's allowed list), but the BIN response will reveal CB+MC. Until
+    /// it arrives, validation passes if the card number is structurally valid.
+    func test_validate_misclassifiedLocalIIN_withoutMetadata_passes_byLuhnAlone() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+
+        try await sut.validateRawData(cardData, cardNetworksMetadata: nil)
+        XCTAssertTrue(sut.isDataValid)
+    }
+
+    /// `source = .local` means the cache only has a partial-typing local-IIN guess. The
+    /// validator must not run the allowed-list check against that — same as Android skipping
+    /// the check when `source == LOCAL`.
+    func test_validate_misclassifiedLocalIIN_withLocalSourceMetadata_passes() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+        let localMetadata = PrimerCardNumberEntryMetadata(
+            source: .local,
+            selectableCardNetworks: nil,
+            detectedCardNetworks: [PrimerCardNetwork(network: .maestro)]
+        )
+
+        try await sut.validateRawData(cardData, cardNetworksMetadata: localMetadata)
+        XCTAssertTrue(sut.isDataValid)
+    }
+
+    /// Once the BIN service has actually been consulted (`source = .localFallback` after a
+    /// failed remote lookup, or `.remote` on success) and every detected network is outside
+    /// the merchant's allowed list, validation must reject — matching Android.
+    func test_validate_disallowedCard_withRemoteMetadata_failsWithUnsupportedCardType() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "6011000990139424",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+        let remoteMetadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: nil,
+            detectedCardNetworks: [PrimerCardNetwork(network: .discover)]
+        )
+
+        do {
+            try await sut.validateRawData(cardData, cardNetworksMetadata: remoteMetadata)
+            XCTFail("Expected validation to fail because Discover is not in the allowed list")
+        } catch {
+            XCTAssertFalse(sut.isDataValid)
+        }
+    }
+
+    /// `makeRequestBodyWithRawData` itself no longer runs an allowed-list check (that's
+    /// validation's job). With user pick = nil and a remote-cache hit indicating CB+MC are
+    /// both allowed, the request must succeed and `preferredNetwork` must stay nil so the
+    /// server picks.
+    func test_makeRequestBody_cobadgedCard_withNilCardNetwork_andCachedAllowedNetwork_succeeds() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        PrimerInternal.shared.sdkIntegrationType = .headless
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let stub = StubCardValidationService()
+        stub.stubbedMetadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ],
+            detectedCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ]
+        )
+        sut.cardValidationService = stub
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+
+        let body = try await sut.makeRequestBodyWithRawData(cardData)
+        let instrument = body.paymentInstrument as? CardPaymentInstrument
+        // User didn't tap, so we must NOT send a preferredNetwork. Server picks.
+        XCTAssertNil(instrument?.preferredNetwork)
+    }
+
+    func test_validate_consultsBinCache_whenNoMetadataIsPassed() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let stub = StubCardValidationService()
+        stub.stubbedMetadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ],
+            detectedCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ]
+        )
+        sut.cardValidationService = stub
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+
+        try await sut.validateRawData(cardData)
+        XCTAssertTrue(sut.isDataValid)
+        XCTAssertEqual(stub.lookupRequests, ["5017679210000700"])
+    }
+}
+
+// MARK: - Test stubs
+
+private final class StubCardValidationService: CardValidationService {
+    var stubbedMetadata: PrimerCardNumberEntryMetadata?
+    private(set) var lookupRequests: [String] = []
+
+    func validateCardNetworks(withCardNumber cardNumber: String) {}
+
+    func createValidationMetadata(
+        networks: [CardNetwork],
+        source: PrimerCardValidationSource
+    ) -> PrimerCardNumberEntryMetadata {
+        PrimerCardNumberEntryMetadata(
+            source: source,
+            selectableCardNetworks: nil,
+            detectedCardNetworks: networks.map(PrimerCardNetwork.init(network:))
+        )
+    }
+
+    func cachedMetadata(forCardNumber cardNumber: String) -> PrimerCardNumberEntryMetadata? {
+        lookupRequests.append(cardNumber)
+        return stubbedMetadata
+    }
 }

--- a/Tests/Primer/Managers/PrimerRawCardDataTokenizationBuilderTests.swift
+++ b/Tests/Primer/Managers/PrimerRawCardDataTokenizationBuilderTests.swift
@@ -78,4 +78,225 @@ final class PrimerRawCardDataTokenizationBuilderTests: XCTestCase {
         let instrument = body.paymentInstrument as? CardPaymentInstrument
         XCTAssertEqual(instrument?.preferredNetwork, CardNetwork.cartesBancaires.rawValue)
     }
+
+    // MARK: - validateRawData with metadata (covers cobadged / mis-classified-IIN cases)
+
+    /// Card 5017… is locally classified as Maestro but the BIN response says CB+MC.
+    /// With BIN metadata present and `cardNetwork == nil`, validation must use the
+    /// metadata's allowed network (CB) — not fall back to the wrong local guess.
+    func test_validate_cobadgedCard_withMetadata_andNilUserSelection_passes() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        PrimerInternal.shared.sdkIntegrationType = .headless
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+        let metadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ],
+            detectedCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ]
+        )
+
+        try await sut.validateRawData(cardData, cardNetworksMetadata: metadata)
+        XCTAssertTrue(sut.isDataValid)
+    }
+
+    /// Same card, but the user has explicitly picked CB. User pick wins; validation passes.
+    func test_validate_cobadgedCard_withUserSelection_passes() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        PrimerInternal.shared.sdkIntegrationType = .headless
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith",
+            cardNetwork: .cartesBancaires
+        )
+        let metadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ],
+            detectedCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ]
+        )
+
+        try await sut.validateRawData(cardData, cardNetworksMetadata: metadata)
+        XCTAssertTrue(sut.isDataValid)
+    }
+
+    /// Mirrors Android `CardNumberValidator`: without BIN-derived metadata, the validator
+    /// must NOT reject based on the local IIN guess. For `5017…` the local guess is Maestro
+    /// (not in the merchant's allowed list), but the BIN response will reveal CB+MC. Until
+    /// it arrives, validation passes if the card number is structurally valid.
+    func test_validate_misclassifiedLocalIIN_withoutMetadata_passes_byLuhnAlone() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+
+        try await sut.validateRawData(cardData, cardNetworksMetadata: nil)
+        XCTAssertTrue(sut.isDataValid)
+    }
+
+    /// `source = .local` means the cache only has a partial-typing local-IIN guess. The
+    /// validator must not run the allowed-list check against that — same as Android skipping
+    /// the check when `source == LOCAL`.
+    func test_validate_misclassifiedLocalIIN_withLocalSourceMetadata_passes() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+        let localMetadata = PrimerCardNumberEntryMetadata(
+            source: .local,
+            selectableCardNetworks: nil,
+            detectedCardNetworks: [PrimerCardNetwork(network: .maestro)]
+        )
+
+        try await sut.validateRawData(cardData, cardNetworksMetadata: localMetadata)
+        XCTAssertTrue(sut.isDataValid)
+    }
+
+    /// Once the BIN service has actually been consulted (`source = .localFallback` after a
+    /// failed remote lookup, or `.remote` on success) and every detected network is outside
+    /// the merchant's allowed list, validation must reject — matching Android.
+    func test_validate_disallowedCard_withRemoteMetadata_failsWithUnsupportedCardType() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let cardData = PrimerCardData(
+            cardNumber: "6011000990139424",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+        let remoteMetadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: nil,
+            detectedCardNetworks: [PrimerCardNetwork(network: .discover)]
+        )
+
+        do {
+            try await sut.validateRawData(cardData, cardNetworksMetadata: remoteMetadata)
+            XCTFail("Expected validation to fail because Discover is not in the allowed list")
+        } catch {
+            XCTAssertFalse(sut.isDataValid)
+        }
+    }
+
+    /// `makeRequestBodyWithRawData` itself no longer runs an allowed-list check (that's
+    /// validation's job). With user pick = nil and a remote-cache hit indicating CB+MC are
+    /// both allowed, the request must succeed and `preferredNetwork` must stay nil so the
+    /// server picks.
+    func test_makeRequestBody_cobadgedCard_withNilCardNetwork_andCachedAllowedNetwork_succeeds() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        PrimerInternal.shared.sdkIntegrationType = .headless
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let stub = StubCardValidationService()
+        stub.stubbedMetadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ],
+            detectedCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ]
+        )
+        sut.cardValidationService = stub
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+
+        let body = try await sut.makeRequestBodyWithRawData(cardData)
+        let instrument = body.paymentInstrument as? CardPaymentInstrument
+        // User didn't tap, so we must NOT send a preferredNetwork. Server picks.
+        XCTAssertNil(instrument?.preferredNetwork)
+    }
+
+    func test_validate_consultsBinCache_whenNoMetadataIsPassed() async throws {
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.cartesBancaires, .visa, .masterCard])
+        let sut = PrimerRawCardDataTokenizationBuilder(paymentMethodType: "PAYMENT_CARD")
+
+        let stub = StubCardValidationService()
+        stub.stubbedMetadata = PrimerCardNumberEntryMetadata(
+            source: .remote,
+            selectableCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ],
+            detectedCardNetworks: [
+                PrimerCardNetwork(network: .cartesBancaires),
+                PrimerCardNetwork(network: .masterCard)
+            ]
+        )
+        sut.cardValidationService = stub
+
+        let cardData = PrimerCardData(
+            cardNumber: "5017679210000700",
+            expiryDate: "03/2030",
+            cvv: "123",
+            cardholderName: "John Smith"
+        )
+
+        try await sut.validateRawData(cardData)
+        XCTAssertTrue(sut.isDataValid)
+        XCTAssertEqual(stub.lookupRequests, ["5017679210000700"])
+    }
+}
+
+// MARK: - Test stubs
+
+private final class StubCardValidationService: CardValidationService {
+    var stubbedMetadata: PrimerCardNumberEntryMetadata?
+    private(set) var lookupRequests: [String] = []
+
+    func validateCardNetworks(withCardNumber cardNumber: String) {}
+
+    func createValidationMetadata(
+        networks: [CardNetwork],
+        source: PrimerCardValidationSource
+    ) -> PrimerCardNumberEntryMetadata {
+        PrimerCardNumberEntryMetadata(
+            source: source,
+            selectableCardNetworks: nil,
+            detectedCardNetworks: networks.map(PrimerCardNetwork.init(network:))
+        )
+    }
+
+    func cachedMetadata(forCardNumber cardNumber: String) -> PrimerCardNumberEntryMetadata? {
+        lookupRequests.append(cardNumber)
+        return stubbedMetadata
+    }
 }

--- a/Tests/Primer/Services/CardValidationServiceTests.swift
+++ b/Tests/Primer/Services/CardValidationServiceTests.swift
@@ -601,6 +601,35 @@ final class CardValidationServiceTests: XCTestCase {
         wait(for: [binDataExpectation], timeout: TestConstants.standardTimeout)
     }
 
+    // MARK: - Cache Key Consistency
+
+    /// Once a remote BIN response is cached, `cachedMetadata(forCardNumber:)` must return it
+    /// for any card number sharing the same 8-char BIN — regardless of length or whitespace.
+    func test_cachedMetadata_returnsStoredMetadataForAnyCardNumberSharingTheBIN() throws {
+        // Given
+        sut = createCardValidationService(allowedNetworks: [.visa, .masterCard])
+        let bin = String(TestConstants.fullCardNumber.prefix(maxBinLength))
+        configureMockAPIClient(bin: bin, networks: ["VISA", "MASTERCARD"])
+
+        let metadataExpectation = expectation(description: "Remote metadata cached")
+        delegate.onMetadataForCardValidationState = { _, networks, _ in
+            if networks.source == .remote {
+                metadataExpectation.fulfill()
+            }
+        }
+
+        // When — populate the cache via a normal validation flow
+        enterCardNumber(TestConstants.fullCardNumber)
+        wait(for: [metadataExpectation], timeout: TestConstants.standardTimeout)
+
+        // Then — cache hits for the exact card number, an extended one with same BIN, and a
+        // formatted variant with whitespace; misses for a different BIN.
+        XCTAssertNotNil(sut.cachedMetadata(forCardNumber: TestConstants.fullCardNumber))
+        XCTAssertNotNil(sut.cachedMetadata(forCardNumber: TestConstants.fullCardNumber + "1234"))
+        XCTAssertNotNil(sut.cachedMetadata(forCardNumber: "5522 6611 7788"))
+        XCTAssertNil(sut.cachedMetadata(forCardNumber: "9999999912345678"))
+    }
+
     // MARK: - Helper Methods
 
     private func createCardValidationService(

--- a/Tests/Primer/Services/CardValidationServiceTests.swift
+++ b/Tests/Primer/Services/CardValidationServiceTests.swift
@@ -617,18 +617,20 @@ final class CardValidationServiceTests: XCTestCase {
         apiClient.binDataResults[bin] = .init(
             firstDigits: firstDigits ?? String(bin.prefix(6)),
             binData: networks.map {
-                .init(displayName: nil,
-                      network: $0,
-                      issuerCountryCode: nil,
-                      issuerName: nil,
-                      accountFundingType: nil,
-                      prepaidReloadableIndicator: nil,
-                      productUsageType: nil,
-                      productCode: nil,
-                      productName: nil,
-                      issuerCurrencyCode: nil,
-                      regionalRestriction: nil,
-                      accountNumberType: nil)
+                .init(
+                    displayName: nil,
+                    network: $0,
+                    issuerCountryCode: nil,
+                    issuerName: nil,
+                    accountFundingType: nil,
+                    prepaidReloadableIndicator: nil,
+                    productUsageType: nil,
+                    productCode: nil,
+                    productName: nil,
+                    issuerCurrencyCode: nil,
+                    regionalRestriction: nil,
+                    accountNumberType: nil
+                )
             }
         )
     }
@@ -637,18 +639,20 @@ final class CardValidationServiceTests: XCTestCase {
         apiClient.binDataResults[bin] = .init(
             firstDigits: "552266",
             binData: [
-                .init(displayName: "Visa",
-                      network: "VISA",
-                      issuerCountryCode: "US",
-                      issuerName: "Chase",
-                      accountFundingType: "DEBIT",
-                      prepaidReloadableIndicator: "NOT_APPLICABLE",
-                      productUsageType: "CONSUMER",
-                      productCode: "A",
-                      productName: "Visa Classic",
-                      issuerCurrencyCode: "USD",
-                      regionalRestriction: "DOMESTIC_USE_ONLY",
-                      accountNumberType: "PRIMARY_ACCOUNT_NUMBER")
+                .init(
+                    displayName: "Visa",
+                    network: "VISA",
+                    issuerCountryCode: "US",
+                    issuerName: "Chase",
+                    accountFundingType: "DEBIT",
+                    prepaidReloadableIndicator: "NOT_APPLICABLE",
+                    productUsageType: "CONSUMER",
+                    productCode: "A",
+                    productName: "Visa Classic",
+                    issuerCurrencyCode: "USD",
+                    regionalRestriction: "DOMESTIC_USE_ONLY",
+                    accountNumberType: "PRIMARY_ACCOUNT_NUMBER"
+                )
             ]
         )
     }

--- a/Tests/Primer/Services/CardValidationServiceTests.swift
+++ b/Tests/Primer/Services/CardValidationServiceTests.swift
@@ -603,6 +603,35 @@ final class CardValidationServiceTests: XCTestCase {
         wait(for: [binDataExpectation], timeout: TestConstants.standardTimeout)
     }
 
+    // MARK: - Cache Key Consistency
+
+    /// Once a remote BIN response is cached, `cachedMetadata(forCardNumber:)` must return it
+    /// for any card number sharing the same 8-char BIN — regardless of length or whitespace.
+    func test_cachedMetadata_returnsStoredMetadataForAnyCardNumberSharingTheBIN() throws {
+        // Given
+        sut = createCardValidationService(allowedNetworks: [.visa, .masterCard])
+        let bin = String(TestConstants.fullCardNumber.prefix(maxBinLength))
+        configureMockAPIClient(bin: bin, networks: ["VISA", "MASTERCARD"])
+
+        let metadataExpectation = expectation(description: "Remote metadata cached")
+        delegate.onMetadataForCardValidationState = { _, networks, _ in
+            if networks.source == .remote {
+                metadataExpectation.fulfill()
+            }
+        }
+
+        // When — populate the cache via a normal validation flow
+        enterCardNumber(TestConstants.fullCardNumber)
+        wait(for: [metadataExpectation], timeout: TestConstants.standardTimeout)
+
+        // Then — cache hits for the exact card number, an extended one with same BIN, and a
+        // formatted variant with whitespace; misses for a different BIN.
+        XCTAssertNotNil(sut.cachedMetadata(forCardNumber: TestConstants.fullCardNumber))
+        XCTAssertNotNil(sut.cachedMetadata(forCardNumber: TestConstants.fullCardNumber + "1234"))
+        XCTAssertNotNil(sut.cachedMetadata(forCardNumber: "5522 6611 7788"))
+        XCTAssertNil(sut.cachedMetadata(forCardNumber: "9999999912345678"))
+    }
+
     // MARK: - Helper Methods
 
     private func createCardValidationService(


### PR DESCRIPTION
# Description

Fixes the headless cobadge case where a card whose local IIN guess is **not** in the merchant's allowed list (e.g. BIN \`5017…\` is locally classified as Maestro, but the BIN response says CB + MC) is rejected at validation, leaving the pay button disabled forever.

**Root cause:** \`PrimerRawCardDataTokenizationBuilder.validateRawData(_:)\` ran on every keystroke with \`cardNetworksMetadata: nil\` and fell back to \`CardNetwork(cardNumber:)\`. The SDK already had the authoritative BIN response cached in \`CardValidationService.metadataCacheBacking\`, but the validator never consulted it.

**Fix:** validator now consults the BIN cache, and the allowed-list check is now expressed the same way Android does it. iOS and Android headless validators are now behaviourally aligned.

## What changed

- **\`PrimerRawCardDataTokenizationBuilder\`**
  - \`validateRawData(_:)\` reads \`CardValidationService.cachedMetadata(forCardNumber:)\` and forwards it to the metadata-aware overload.
  - The unsupported-card-type check now only fires when the cache holds **BIN-derived** metadata (\`source != .local\`) — same gate as Android \`CardNumberValidator.kt:28\`. Local-IIN guesses (chars 1–7, before the BIN response arrives) no longer trigger a false reject.
  - The check is now "**any detected network is allowed**" (\`detected.contains(where: \\.allowed)\`) instead of "the resolved network is in the allowed list". Matches Android, keeps cobadged cards valid even when the user hasn't picked yet.
  - Drops the redundant defensive allowed-list check in \`makeRequestBodyWithRawData\`. \`RawDataManager.submit\` always runs validation first, and Android's \`CardTokenizationDelegate\` doesn't repeat the check either.
- **\`CardValidationService\`**
  - All caches are now keyed by 8-char BIN via a single \`binKey(for:)\` helper. Previously two paths keyed by full PAN and one by BIN — typing digits 9–16 was needlessly refetching.
  - Exposes \`cachedMetadata(forCardNumber:)\` on the protocol so the builder can read the cache without going through validation.
- **\`MerchantHeadlessCheckoutRawDataViewController\` (Debug App)**
  - Preserves the user's tap when \`didReceiveCardMetadata\` re-fires (submit-time re-validation was clobbering the tap).
  - Only treats a selectable list with **>1 items** as interactive — single-item lists fall through to the non-interactive single/fallback branch.

## iOS ↔ Android parity

| Behaviour | iOS (before) | iOS (now) | Android |
|---|---|---|---|
| BIN cache lookup keyed by 8-char BIN | mixed (PAN + BIN) | ✅ | ✅ |
| Validation consults BIN cache (no-metadata path) | ❌ | ✅ | ✅ |
| Allowed-list check only for REMOTE / LOCAL_FALLBACK | ❌ runs always | ✅ | ✅ |
| "Any detected network allowed" check | ❌ "resolved is in allowed" | ✅ | ✅ |
| No submit-time defensive allowed-list check | ❌ | ✅ | ✅ |
| \`preferredNetwork = cardData.cardNetwork\` pass-through at submit | filters EFTPOS in headless | filters EFTPOS in headless | pass-through |

The EFTPOS filter is a deliberate iOS-specific behaviour (covered by an existing test, out of scope here). Everything else is now in lockstep with Android \`CardNumberValidator.kt\`.

# Manual Testing

Verified end-to-end in the Debug App against the sandbox client session with \`orderedAllowedCardNetworks=[CB, VISA, MASTERCARD]\`. Cases below come from the test matrix in [\`specs/TEST-CASES.md\`](specs/TEST-CASES.md):

| # | Scenario | Card | User action | Expected \`preferredNetwork\` | Result |
|---|---|---|---|---|---|
| 1 | CB + MC cobadge, no tap | \`5017 6792 1000 0700\` | fill all fields | \`nil\` | ✅ |
| 2 | CB + MC, tap CB | \`5017 6792 1000 0700\` | tap CB then Pay | \`CARTES_BANCAIRES\` | ✅ |
| 3 | CB + MC, tap MC | \`5017 6792 1000 0700\` | tap MC then Pay | \`MASTERCARD\` | ✅ |
| 4 | Single VISA, no tap | \`4242 4242 4242 4242\` | fill all fields | \`nil\` | ✅ |
| 5 | Single VISA, badge non-interactive | \`4242 4242 4242 4242\` | tap badge | \`nil\` (badge not selectable) | ✅ |
| 6 | EFTPOS-cobadged | \`4434 0200 0000 0006\` | fill all fields | \`nil\` (EFTPOS filtered, no user choice) | ✅ |
| 7 | Single MC, no tap | \`5454 5454 5454 5454\` | fill all fields | \`nil\` | ✅ |
| 8 | Cobadge, tap CB then MC | \`5017 6792 1000 0700\` | tap CB → tap MC → Pay | \`MASTERCARD\` (last tap wins) | ✅ |

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)