### PR TITLE
refactor: Finish CardFormScope decoupling [ACC-7171]

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/CLAUDE.md
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/CLAUDE.md
@@ -108,7 +108,7 @@ for await state in scope.state {
 Customize individual fields with partial or full replacement via scope properties:
 ```swift
 // Access card form scope and customize fields
-if let cardFormScope = checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self) {
+if let cardFormScope = checkoutScope.getPaymentMethodScope(PrimerCardFormScope.self) {
     cardFormScope.cardNumberConfig = InputFieldConfig(
         label: "Card Number",
         placeholder: "0000 0000 0000 0000",

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Composite/BillingAddressView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Composite/BillingAddressView.swift
@@ -22,14 +22,14 @@ struct BillingAddressConfiguration {
 
 @available(iOS 15.0, *)
 struct BillingAddressView: View, LogReporter {
-  let cardFormScope: DefaultCardFormScope
+  let cardFormScope: any CardFormFieldScopeInternal
   let configuration: BillingAddressConfiguration
   let styling: PrimerFieldStyling?
 
   @Environment(\.designTokens) private var tokens
 
   init(
-    cardFormScope: DefaultCardFormScope,
+    cardFormScope: any CardFormFieldScopeInternal,
     configuration: BillingAddressConfiguration,
     styling: PrimerFieldStyling? = nil
   ) {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
@@ -4,7 +4,6 @@
 //  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import Combine
 import SwiftUI
 import UIKit
 
@@ -16,7 +15,7 @@ struct CountryInputField: View, LogReporter {
 
   // MARK: - Private Properties
 
-  private let scope: DefaultCardFormScope
+  private let scope: any CardFormFieldScopeInternal
   @Environment(\.diContainer) private var container
   @State private var validationService: ValidationService?
   @State private var countryName: String = ""
@@ -38,7 +37,7 @@ struct CountryInputField: View, LogReporter {
   }
 
   private var selectedCountryFromScope: PrimerCountry? {
-    scope.structuredState.selectedCountry
+    scope.currentState.selectedCountry
   }
 
   private var fieldFont: Font {
@@ -50,7 +49,7 @@ struct CountryInputField: View, LogReporter {
   init(
     label: String?,
     placeholder: String,
-    scope: DefaultCardFormScope,
+    scope: any CardFormFieldScopeInternal,
     styling: PrimerFieldStyling? = nil
   ) {
     self.label = label
@@ -107,12 +106,13 @@ struct CountryInputField: View, LogReporter {
       setupValidationService()
       updateFromExternalState()
     }
-    .onReceive(
-      scope.$structuredState
-        .map(\.selectedCountry)
-        .removeDuplicates()
-    ) { country in
-      updateFromExternalState(with: country)
+    .task {
+      var previousCountry: PrimerCountry? = scope.currentState.selectedCountry
+      for await state in scope.state {
+        guard state.selectedCountry != previousCountry else { continue }
+        previousCountry = state.selectedCountry
+        updateFromExternalState(with: state.selectedCountry)
+      }
     }
     .sheet(isPresented: $showCountryPicker) {
       SelectCountryScreen(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputFieldWrapper.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputFieldWrapper.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct CountryInputFieldWrapper: View, LogReporter {
-  let scope: DefaultCardFormScope
+  let scope: any CardFormFieldScopeInternal
 
   let label: String?
   let placeholder: String

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/CardFormFieldScopeInternal.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/CardFormFieldScopeInternal.swift
@@ -26,6 +26,9 @@ struct FieldValidationStates: Equatable {
 @available(iOS 15.0, *)
 @MainActor
 protocol CardFormFieldScopeInternal: PrimerCardFormScope {
+  var currentState: PrimerCardFormState { get }
+
   func updateValidationState(_ keyPath: WritableKeyPath<FieldValidationStates, Bool>, isValid: Bool)
   func updateValidationStateIfNeeded(for field: PrimerInputElementType, isValid: Bool)
+  func performSubmit() async
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
@@ -65,6 +65,8 @@ final class DefaultCardFormScope: CardFormFieldScopeInternal, ObservableObject, 
   @Published var structuredState = PrimerCardFormState()
   var fieldValidationStates = FieldValidationStates()
 
+  var currentState: PrimerCardFormState { structuredState }
+
   private weak var checkoutScope: DefaultCheckoutScope?
   private let processCardPaymentInteractor: ProcessCardPaymentInteractor
   private let validateInputInteractor: ValidateInputInteractor?

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
@@ -295,7 +295,7 @@ struct CardFormScreen: View, LogReporter {
 
   private func submitAction() {
     Task {
-      await (scope as? DefaultCardFormScope)?.performSubmit()
+      await scope.performSubmit()
     }
   }
 
@@ -451,11 +451,11 @@ struct CardFormScreen: View, LogReporter {
       if let customComponent = config?.component {
         AnyView(customComponent())
           .focused($focusedField, equals: .countryCode)
-      } else if let defaultCardFormScope = scope as? DefaultCardFormScope {
+      } else {
         CountryInputField(
           label: config?.label ?? CheckoutComponentsStrings.countryLabel,
           placeholder: config?.placeholder ?? CheckoutComponentsStrings.selectCountryPlaceholder,
-          scope: defaultCardFormScope,
+          scope: scope,
           styling: config?.styling
         )
         .focused($focusedField, equals: .countryCode)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Views/CardFormFieldsView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Views/CardFormFieldsView.swift
@@ -168,16 +168,14 @@ struct CardFormFieldsView: View {
       .onSubmit { moveToNextField(from: .postalCode) }
 
     case .countryCode:
-      if let defaultCardFormScope = scope as? DefaultCardFormScope {
-        CountryInputField(
-          label: CheckoutComponentsStrings.countryLabel,
-          placeholder: CheckoutComponentsStrings.selectCountryPlaceholder,
-          scope: defaultCardFormScope,
-          styling: styling
-        )
-        .focused($focusedField, equals: .countryCode)
-        .onSubmit { moveToNextField(from: .countryCode) }
-      }
+      CountryInputField(
+        label: CheckoutComponentsStrings.countryLabel,
+        placeholder: CheckoutComponentsStrings.selectCountryPlaceholder,
+        scope: scope,
+        styling: styling
+      )
+      .focused($focusedField, equals: .countryCode)
+      .onSubmit { moveToNextField(from: .countryCode) }
 
     case .city:
       CityInputField(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockCardFormScope.swift
@@ -242,6 +242,21 @@
       log("updateValidationStateIfNeeded field: \(field), isValid: \(isValid)")
     }
 
+    public var currentState: PrimerCardFormState {
+      PrimerCardFormState(
+        data: FormData(),
+        isLoading: initialIsLoading,
+        isValid: initialIsValid,
+        selectedNetwork: initialSelectedNetwork.map { PrimerCardNetwork(network: $0) },
+        availableNetworks: initialAvailableNetworks.map { PrimerCardNetwork(network: $0) },
+        surchargeAmount: initialSurchargeAmount
+      )
+    }
+
+    public func performSubmit() async {
+      log("performSubmit() called")
+    }
+
     // MARK: - Structured State Support
 
     public func updateField(_ fieldType: PrimerInputElementType, value: String) {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckout.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckout.swift
@@ -24,7 +24,7 @@ import SwiftUI
 ///         checkoutScope.splashScreen = { CustomSplash() }
 ///
 ///         // Customize card form fields via InputFieldConfig
-///         if let cardFormScope = checkoutScope.getPaymentMethodScope(PrimerCardFormScope.self) as? DefaultCardFormScope {
+///         if let cardFormScope = checkoutScope.getPaymentMethodScope(PrimerCardFormScope.self) {
 ///             cardFormScope.cardNumberConfig = InputFieldConfig(placeholder: "Enter card number")
 ///             cardFormScope.cvvConfig = InputFieldConfig(styling: PrimerFieldStyling(borderColor: .blue))
 ///         }

--- a/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
@@ -37,6 +37,23 @@ final class DefaultCardFormScopeTests: XCTestCase {
         )
     }
 
+    // MARK: - currentState Tests
+
+    func test_currentState_mirrorsStructuredState() async throws {
+        let container = try await createTestContainer()
+
+        await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+
+            XCTAssertEqual(scope.currentState, scope.structuredState)
+            XCTAssertEqual(scope.currentState.data[.cardNumber], scope.structuredState.data[.cardNumber])
+        }
+    }
+
     // MARK: - Card Number Field Validation Tests
 
     func test_cardNumberField_validatesCorrectly() async throws {


### PR DESCRIPTION
# Description

[ACC-7171](https://primerapi.atlassian.net/browse/ACC-7171)

Follow-up to ACC-7135 (PR #1711). Removes the 3 remaining `as? DefaultCardFormScope` downcasts in card-form views and finishes decoupling the country-picker observation from `@Published`/Combine.

- Promote `currentState: PrimerCardFormState` and `performSubmit() async` to `CardFormFieldScopeInternal` (already-implemented members on `DefaultCardFormScope`; just exposing them via the protocol).
- Retype `CountryInputField`, `CountryInputFieldWrapper`, and `BillingAddressView` from `DefaultCardFormScope` to `any CardFormFieldScopeInternal`.
- Replace `CountryInputField`'s `.onReceive(scope.$structuredState…)` with `.task { for await state in scope.state }` to match the AsyncStream pattern used elsewhere. Drop `import Combine`.
- Drop 3 downcasts in `CardFormScreen` and `CardFormFieldsView`. Fix a stale `as? DefaultCardFormScope` example in `PrimerCheckout` doc comment and `CheckoutComponents/CLAUDE.md`.
- `MockCardFormScope` adopts the two new protocol members.

No breaking changes. Public `PrimerCardFormScope` is unchanged.

# Manual Testing

- [x] Card form → enter card details, verify all fields validate and submit works
- [x] Card form with billing address → tap country field → select a country → verify field updates
- [x] Card form → tap Pay → verify processing flow

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable
- [ ] I have manually tested newly added UX
- [x] I have open a documentation PR, if applicable (N/A — no docs change)

[ACC-7171]: https://primerapi.atlassian.net/browse/ACC-7171