### PR TITLE
ci: Improve build and release resilience

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,19 @@ build-and-release:
         echo "Pushing ${POD}.podspec"
         pod trunk push "${POD}.podspec" --allow-root --allow-warnings --synchronous
       done
-    - pod trunk push PrimerSDK.podspec --allow-root
+    - |
+      ATTEMPTS=60
+      SLEEP=30
+      for i in $(seq 1 $ATTEMPTS); do
+        pod repo update trunk >/dev/null 2>&1 || true
+        if pod trunk push PrimerSDK.podspec --allow-root --allow-warnings --synchronous; then
+          echo "Pushing PrimerSDK: succeeded after $i/$ATTEMPTS"
+          exit 0
+        fi
+        echo "Pushing PrimerSDK: attempt $i/$ATTEMPTS failed; sleeping ${SLEEP}s"
+        sleep "$SLEEP"
+      done
+      echo "Pushing PrimerSDK: never succeeded after $ATTEMPTS attempts" >&2
+      exit 1
   when: manual
   environment: production


### PR DESCRIPTION
If the Cocoapods CDN doesn't see one of the BDC pushes, we should retry rather than fail