### PR TITLE
ci: guard pr_number when building LambdaTest preview custom_id

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -284,7 +284,7 @@ platform :ios do
     custom_id = case source_branch_trimmed
       when "release/next" then "release-latest-ios"
       when "master" then "nightly-latest-ios"
-      else pr_number.to_s.empty? ? "preview_ios" : "preview-" + pr_number + "-ios"
+      else pr_number.to_s.empty? ? "preview-ios" : "preview-" + pr_number + "-ios"
     end
 
     upload_to_lambdatest(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -284,7 +284,7 @@ platform :ios do
     custom_id = case source_branch_trimmed
       when "release/next" then "release-latest-ios"
       when "master" then "nightly-latest-ios"
-      else "preview-" + pr_number + "-ios"
+      else pr_number.to_s.empty? ? "preview_ios" : "preview-" + pr_number + "-ios"
     end
 
     upload_to_lambdatest(


### PR DESCRIPTION
# Description

CHKT-XXXX

When \`PR_NUMBER\` is unset (manual runs, non-PR branches), \`"preview-" + pr_number + "-ios"\` raises \`TypeError\` and the LambdaTest upload fails. Falls back to \`preview_ios\` when \`pr_number\` is missing.

# Manual Testing

- PR branch with \`PR_NUMBER\` set → \`custom_id\` unchanged (\`preview-<n>-ios\`).
- Manual run without \`PR_NUMBER\` → \`custom_id\` is \`preview_ios\`, upload succeeds.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)