### PR TITLE
feat: Add ComponentsBillingAddressBridge for RN interop (ACC-7169)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsBillingAddressBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsBillingAddressBridge.swift
@@ -1,0 +1,71 @@
+//
+//  ComponentsBillingAddressBridge.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+@_spi(PrimerInternal)
+public final class ComponentsBillingAddressBridge {
+
+    private let dispatch: (ClientSession.Address) async throws -> Void
+
+    public init() {
+        dispatch = { address in
+            try await ClientSessionActionsModule
+                .updateBillingAddressViaClientSessionActionWithAddressIfNeeded(address)
+        }
+    }
+
+    init(dispatch: @escaping (ClientSession.Address) async throws -> Void) {
+        self.dispatch = dispatch
+    }
+
+    public func setBillingAddress(_ address: PrimerAddress) async throws {
+        Analytics.Service.fire(event: Analytics.Event.sdk(
+            name: "\(Self.self).\(#function)",
+            params: ["category": "RAW_DATA"]
+        ))
+
+        try validate(billingAddress: address)
+        try await dispatch(.init(from: address))
+    }
+
+    private func validate(billingAddress address: PrimerAddress) throws {
+        let hasAnyField = [
+            address.firstName,
+            address.lastName,
+            address.addressLine1,
+            address.addressLine2,
+            address.city,
+            address.state,
+            address.postalCode,
+            address.countryCode
+        ].contains { $0?.isEmpty == false }
+
+        guard hasAnyField else {
+            throw PrimerValidationError.invalidRawData()
+        }
+
+        if let code = address.countryCode, !code.isEmpty, CountryCode(rawValue: code) == nil {
+            throw PrimerValidationError.invalidRawData()
+        }
+    }
+}
+
+private extension ClientSession.Address {
+    init(from address: PrimerAddress) {
+        self.init(
+            firstName: address.firstName,
+            lastName: address.lastName,
+            addressLine1: address.addressLine1,
+            addressLine2: address.addressLine2,
+            city: address.city,
+            postalCode: address.postalCode,
+            state: address.state,
+            countryCode: address.countryCode.flatMap(CountryCode.init(rawValue:))
+        )
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Bridge/ComponentsBillingAddressBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/ComponentsBillingAddressBridgeTests.swift
@@ -1,0 +1,189 @@
+//
+//  ComponentsBillingAddressBridgeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import XCTest
+@_spi(PrimerInternal) @testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class ComponentsBillingAddressBridgeTests: XCTestCase {
+
+    private var sut: ComponentsBillingAddressBridge!
+    private var dispatchedAddresses: [ClientSession.Address] = []
+    private var dispatchError: Error?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        dispatchedAddresses = []
+        dispatchError = nil
+        sut = ComponentsBillingAddressBridge { [self] address in
+            dispatchedAddresses.append(address)
+            if let error = dispatchError {
+                throw error
+            }
+        }
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        dispatchedAddresses = []
+        dispatchError = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Validation Tests
+
+    func test_setBillingAddress_allFieldsBlank_throwsInvalidRawData() async {
+        // Given
+        let address = PrimerAddress(
+            firstName: nil, lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: nil
+        )
+
+        // When / Then
+        await assertThrowsInvalidRawData {
+            try await self.sut.setBillingAddress(address)
+        }
+        XCTAssertTrue(dispatchedAddresses.isEmpty)
+    }
+
+    func test_setBillingAddress_allFieldsEmptyStrings_throwsInvalidRawData() async {
+        // Given
+        let address = PrimerAddress(
+            firstName: "", lastName: "",
+            addressLine1: "", addressLine2: "",
+            postalCode: "", city: "",
+            state: "", countryCode: ""
+        )
+
+        // When / Then
+        await assertThrowsInvalidRawData {
+            try await self.sut.setBillingAddress(address)
+        }
+        XCTAssertTrue(dispatchedAddresses.isEmpty)
+    }
+
+    func test_setBillingAddress_invalidCountryCode_throwsInvalidRawData() async {
+        // Given
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: "USA"
+        )
+
+        // When / Then
+        await assertThrowsInvalidRawData {
+            try await self.sut.setBillingAddress(address)
+        }
+        XCTAssertTrue(dispatchedAddresses.isEmpty)
+    }
+
+    func test_setBillingAddress_emptyCountryCodeWithOtherFields_dispatchesAction() async throws {
+        // Given
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: ""
+        )
+
+        // When
+        try await sut.setBillingAddress(address)
+
+        // Then
+        XCTAssertEqual(dispatchedAddresses.count, 1)
+        XCTAssertNil(dispatchedAddresses.first?.countryCode)
+    }
+
+    // MARK: - Dispatch Tests
+
+    func test_setBillingAddress_validAddress_dispatchesActionWithMappedFields() async throws {
+        // Given
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: "Var",
+            addressLine1: "1 Test St", addressLine2: "Apt 2",
+            postalCode: "EC1A 1AA", city: "London",
+            state: "Greater London", countryCode: "GB"
+        )
+
+        // When
+        try await sut.setBillingAddress(address)
+
+        // Then
+        XCTAssertEqual(dispatchedAddresses.count, 1)
+        let dispatched = try XCTUnwrap(dispatchedAddresses.first)
+        XCTAssertEqual(dispatched.firstName, "Onur")
+        XCTAssertEqual(dispatched.lastName, "Var")
+        XCTAssertEqual(dispatched.addressLine1, "1 Test St")
+        XCTAssertEqual(dispatched.addressLine2, "Apt 2")
+        XCTAssertEqual(dispatched.city, "London")
+        XCTAssertEqual(dispatched.postalCode, "EC1A 1AA")
+        XCTAssertEqual(dispatched.state, "Greater London")
+        XCTAssertEqual(dispatched.countryCode, .gb)
+    }
+
+    func test_setBillingAddress_singleField_dispatchesAction() async throws {
+        // Given
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: nil
+        )
+
+        // When
+        try await sut.setBillingAddress(address)
+
+        // Then
+        XCTAssertEqual(dispatchedAddresses.count, 1)
+        XCTAssertEqual(dispatchedAddresses.first?.firstName, "Onur")
+    }
+
+    func test_setBillingAddress_dispatchFails_propagatesError() async {
+        // Given
+        let expected = NSError(domain: "test", code: 42)
+        dispatchError = expected
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: nil
+        )
+
+        // When / Then
+        do {
+            try await sut.setBillingAddress(address)
+            XCTFail("expected dispatch error")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "test")
+            XCTAssertEqual(error.code, 42)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrowsInvalidRawData(
+        _ block: @escaping () async throws -> Void,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        do {
+            try await block()
+            XCTFail("expected PrimerValidationError.invalidRawData", file: file, line: line)
+        } catch let error as PrimerValidationError {
+            switch error {
+            case .invalidRawData:
+                break
+            default:
+                XCTFail("expected .invalidRawData, got \(error)", file: file, line: line)
+            }
+        } catch {
+            XCTFail("expected PrimerValidationError.invalidRawData, got \(error)", file: file, line: line)
+        }
+    }
+}


### PR DESCRIPTION
# Description

[ACC-7169](https://primerapi.atlassian.net/browse/ACC-7169)

Adds `ComponentsBillingAddressBridge` under `@_spi(PrimerInternal)` so the React Native SDK can dispatch a billing-address client-session action without a public master API. Wraps the existing internal `ClientSessionActionsModule.updateBillingAddressViaClientSessionActionWithAddressIfNeeded` and validates that the address has at least one non-empty field with a valid `CountryCode`.

Mirrors the precedent set by `ComponentsAnalyticsLoggingBridge` (#1668).

This supersedes the public `RawDataManager.setBillingAddress` API merged in #1707, which will be reverted in a follow-up PR after M2 and M3 of the bridge migration land.

# Manual Testing

End-to-end verified via the RN example app (primer-io/primer-sdk-react-native#351) on iOS simulator: dispatched a hardcoded `PrimerAddress` through the bridge; `onClientSessionUpdate` confirmed the server echoed back the new address.

7/7 unit tests pass: `Tests/Primer/CheckoutComponents/Bridge/ComponentsBillingAddressBridgeTests`.

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

[ACC-7169]: https://primerapi.atlassian.net/browse/ACC-7169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ