### PR TITLE
feat: Add ComponentsClientSessionBridge for RN interop (ACC-7224)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsBillingAddressBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsBillingAddressBridge.swift
@@ -1,0 +1,71 @@
+//
+//  ComponentsBillingAddressBridge.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+@_spi(PrimerInternal)
+public final class ComponentsBillingAddressBridge {
+
+    private let dispatch: (ClientSession.Address) async throws -> Void
+
+    public init() {
+        dispatch = { address in
+            try await ClientSessionActionsModule
+                .updateBillingAddressViaClientSessionActionWithAddressIfNeeded(address)
+        }
+    }
+
+    init(dispatch: @escaping (ClientSession.Address) async throws -> Void) {
+        self.dispatch = dispatch
+    }
+
+    public func setBillingAddress(_ address: PrimerAddress) async throws {
+        Analytics.Service.fire(event: Analytics.Event.sdk(
+            name: "\(Self.self).\(#function)",
+            params: ["category": "RAW_DATA"]
+        ))
+
+        try validate(billingAddress: address)
+        try await dispatch(.init(from: address))
+    }
+
+    private func validate(billingAddress address: PrimerAddress) throws {
+        let hasAnyField = [
+            address.firstName,
+            address.lastName,
+            address.addressLine1,
+            address.addressLine2,
+            address.city,
+            address.state,
+            address.postalCode,
+            address.countryCode
+        ].contains { $0?.isEmpty == false }
+
+        guard hasAnyField else {
+            throw PrimerValidationError.invalidRawData()
+        }
+
+        if let code = address.countryCode, !code.isEmpty, CountryCode(rawValue: code) == nil {
+            throw PrimerValidationError.invalidRawData()
+        }
+    }
+}
+
+private extension ClientSession.Address {
+    init(from address: PrimerAddress) {
+        self.init(
+            firstName: address.firstName,
+            lastName: address.lastName,
+            addressLine1: address.addressLine1,
+            addressLine2: address.addressLine2,
+            city: address.city,
+            postalCode: address.postalCode,
+            state: address.state,
+            countryCode: address.countryCode.flatMap(CountryCode.init(rawValue:))
+        )
+    }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsCheckoutModule.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsCheckoutModule.swift
@@ -1,0 +1,20 @@
+//
+//  ComponentsCheckoutModule.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+@_spi(PrimerInternal)
+public struct ComponentsCheckoutModule {
+
+    public let type: String
+    public let options: [String: Bool]?
+
+    public init(type: String, options: [String: Bool]?) {
+        self.type = type
+        self.options = options
+    }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsClientSessionBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsClientSessionBridge.swift
@@ -1,0 +1,72 @@
+//
+//  ComponentsClientSessionBridge.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+@_spi(PrimerInternal)
+public final class ComponentsClientSessionBridge {
+
+    private let configurationProvider: () -> PrimerAPIConfiguration?
+
+    public init() {
+        configurationProvider = { PrimerAPIConfigurationModule.apiConfiguration }
+    }
+
+    init(configurationProvider: @escaping () -> PrimerAPIConfiguration?) {
+        self.configurationProvider = configurationProvider
+    }
+
+    public func getClientSession() -> PrimerClientSession? {
+        Analytics.Service.fire(event: Analytics.Event.sdk(
+            name: "\(Self.self).\(#function)",
+            params: ["category": "CLIENT_SESSION"]
+        ))
+
+        guard let configuration = configurationProvider() else { return nil }
+        return PrimerClientSession(from: configuration)
+    }
+
+    public func getCheckoutModules() -> [ComponentsCheckoutModule]? {
+        Analytics.Service.fire(event: Analytics.Event.sdk(
+            name: "\(Self.self).\(#function)",
+            params: ["category": "CLIENT_SESSION"]
+        ))
+
+        guard let modules = configurationProvider()?.checkoutModules else { return nil }
+        return modules.map(ComponentsCheckoutModule.init(module:))
+    }
+}
+
+@available(iOS 15.0, *)
+private extension ComponentsCheckoutModule {
+    init(module: PrimerAPIConfiguration.CheckoutModule) {
+        self.init(type: module.type, options: Self.flatten(module.options))
+    }
+
+    static func flatten(_ options: CheckoutModuleOptions?) -> [String: Bool]? {
+        if let postal = options as? PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions {
+            var dict: [String: Bool] = [:]
+            if let v = postal.firstName { dict["firstName"] = v }
+            if let v = postal.lastName { dict["lastName"] = v }
+            if let v = postal.city { dict["city"] = v }
+            if let v = postal.postalCode { dict["postalCode"] = v }
+            if let v = postal.addressLine1 { dict["addressLine1"] = v }
+            if let v = postal.addressLine2 { dict["addressLine2"] = v }
+            if let v = postal.countryCode { dict["countryCode"] = v }
+            if let v = postal.phoneNumber { dict["phoneNumber"] = v }
+            if let v = postal.state { dict["state"] = v }
+            return dict.isEmpty ? nil : dict
+        }
+        if let card = options as? PrimerAPIConfiguration.CheckoutModule.CardInformationOptions {
+            var dict: [String: Bool] = [:]
+            if let v = card.cardHolderName { dict["cardHolderName"] = v }
+            if let v = card.saveCardCheckbox { dict["saveCardCheckbox"] = v }
+            return dict.isEmpty ? nil : dict
+        }
+        return nil
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Bridge/ComponentsBillingAddressBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/ComponentsBillingAddressBridgeTests.swift
@@ -1,0 +1,189 @@
+//
+//  ComponentsBillingAddressBridgeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import XCTest
+@_spi(PrimerInternal) @testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class ComponentsBillingAddressBridgeTests: XCTestCase {
+
+    private var sut: ComponentsBillingAddressBridge!
+    private var dispatchedAddresses: [ClientSession.Address] = []
+    private var dispatchError: Error?
+
+    override func setUp() async throws {
+        try await super.setUp()
+        dispatchedAddresses = []
+        dispatchError = nil
+        sut = ComponentsBillingAddressBridge { [self] address in
+            dispatchedAddresses.append(address)
+            if let error = dispatchError {
+                throw error
+            }
+        }
+    }
+
+    override func tearDown() async throws {
+        sut = nil
+        dispatchedAddresses = []
+        dispatchError = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Validation Tests
+
+    func test_setBillingAddress_allFieldsBlank_throwsInvalidRawData() async {
+        // Given
+        let address = PrimerAddress(
+            firstName: nil, lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: nil
+        )
+
+        // When / Then
+        await assertThrowsInvalidRawData {
+            try await self.sut.setBillingAddress(address)
+        }
+        XCTAssertTrue(dispatchedAddresses.isEmpty)
+    }
+
+    func test_setBillingAddress_allFieldsEmptyStrings_throwsInvalidRawData() async {
+        // Given
+        let address = PrimerAddress(
+            firstName: "", lastName: "",
+            addressLine1: "", addressLine2: "",
+            postalCode: "", city: "",
+            state: "", countryCode: ""
+        )
+
+        // When / Then
+        await assertThrowsInvalidRawData {
+            try await self.sut.setBillingAddress(address)
+        }
+        XCTAssertTrue(dispatchedAddresses.isEmpty)
+    }
+
+    func test_setBillingAddress_invalidCountryCode_throwsInvalidRawData() async {
+        // Given
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: "USA"
+        )
+
+        // When / Then
+        await assertThrowsInvalidRawData {
+            try await self.sut.setBillingAddress(address)
+        }
+        XCTAssertTrue(dispatchedAddresses.isEmpty)
+    }
+
+    func test_setBillingAddress_emptyCountryCodeWithOtherFields_dispatchesAction() async throws {
+        // Given
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: ""
+        )
+
+        // When
+        try await sut.setBillingAddress(address)
+
+        // Then
+        XCTAssertEqual(dispatchedAddresses.count, 1)
+        XCTAssertNil(dispatchedAddresses.first?.countryCode)
+    }
+
+    // MARK: - Dispatch Tests
+
+    func test_setBillingAddress_validAddress_dispatchesActionWithMappedFields() async throws {
+        // Given
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: "Var",
+            addressLine1: "1 Test St", addressLine2: "Apt 2",
+            postalCode: "EC1A 1AA", city: "London",
+            state: "Greater London", countryCode: "GB"
+        )
+
+        // When
+        try await sut.setBillingAddress(address)
+
+        // Then
+        XCTAssertEqual(dispatchedAddresses.count, 1)
+        let dispatched = try XCTUnwrap(dispatchedAddresses.first)
+        XCTAssertEqual(dispatched.firstName, "Onur")
+        XCTAssertEqual(dispatched.lastName, "Var")
+        XCTAssertEqual(dispatched.addressLine1, "1 Test St")
+        XCTAssertEqual(dispatched.addressLine2, "Apt 2")
+        XCTAssertEqual(dispatched.city, "London")
+        XCTAssertEqual(dispatched.postalCode, "EC1A 1AA")
+        XCTAssertEqual(dispatched.state, "Greater London")
+        XCTAssertEqual(dispatched.countryCode, .gb)
+    }
+
+    func test_setBillingAddress_singleField_dispatchesAction() async throws {
+        // Given
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: nil
+        )
+
+        // When
+        try await sut.setBillingAddress(address)
+
+        // Then
+        XCTAssertEqual(dispatchedAddresses.count, 1)
+        XCTAssertEqual(dispatchedAddresses.first?.firstName, "Onur")
+    }
+
+    func test_setBillingAddress_dispatchFails_propagatesError() async {
+        // Given
+        let expected = NSError(domain: "test", code: 42)
+        dispatchError = expected
+        let address = PrimerAddress(
+            firstName: "Onur", lastName: nil,
+            addressLine1: nil, addressLine2: nil,
+            postalCode: nil, city: nil,
+            state: nil, countryCode: nil
+        )
+
+        // When / Then
+        do {
+            try await sut.setBillingAddress(address)
+            XCTFail("expected dispatch error")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "test")
+            XCTAssertEqual(error.code, 42)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrowsInvalidRawData(
+        _ block: @escaping () async throws -> Void,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        do {
+            try await block()
+            XCTFail("expected PrimerValidationError.invalidRawData", file: file, line: line)
+        } catch let error as PrimerValidationError {
+            switch error {
+            case .invalidRawData:
+                break
+            default:
+                XCTFail("expected .invalidRawData, got \(error)", file: file, line: line)
+            }
+        } catch {
+            XCTFail("expected PrimerValidationError.invalidRawData, got \(error)", file: file, line: line)
+        }
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Bridge/ComponentsClientSessionBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/ComponentsClientSessionBridgeTests.swift
@@ -1,0 +1,146 @@
+//
+//  ComponentsClientSessionBridgeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import XCTest
+@_spi(PrimerInternal) @testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class ComponentsClientSessionBridgeTests: XCTestCase {
+
+    private var configuration: PrimerAPIConfiguration?
+    private var sut: ComponentsClientSessionBridge!
+
+    override func setUp() {
+        super.setUp()
+        configuration = nil
+        sut = ComponentsClientSessionBridge { [self] in configuration }
+    }
+
+    override func tearDown() {
+        sut = nil
+        configuration = nil
+        super.tearDown()
+    }
+
+    // MARK: - getClientSession
+
+    func test_getClientSession_returnsNil_whenConfigurationMissing() {
+        XCTAssertNil(sut.getClientSession())
+    }
+
+    func test_getClientSession_returnsMappedSession_whenConfigurationPresent() {
+        configuration = makeConfiguration(clientSession: makeClientSession(orderId: "order-123"))
+
+        let session = sut.getClientSession()
+
+        XCTAssertNotNil(session)
+        XCTAssertEqual(session?.orderId, "order-123")
+    }
+
+    // MARK: - getCheckoutModules
+
+    func test_getCheckoutModules_returnsNil_whenConfigurationMissing() {
+        XCTAssertNil(sut.getCheckoutModules())
+    }
+
+    func test_getCheckoutModules_returnsNil_whenModulesMissing() {
+        configuration = makeConfiguration(checkoutModules: nil)
+        XCTAssertNil(sut.getCheckoutModules())
+    }
+
+    func test_getCheckoutModules_returnsEmpty_whenModulesEmpty() {
+        configuration = makeConfiguration(checkoutModules: [])
+        XCTAssertEqual(sut.getCheckoutModules()?.count, 0)
+    }
+
+    func test_getCheckoutModules_flattensPostalCodeOptions() {
+        let postal = PrimerAPIConfiguration.CheckoutModule.PostalCodeOptions(
+            firstName: true,
+            lastName: false,
+            postalCode: true,
+            countryCode: true
+        )
+        configuration = makeConfiguration(
+            checkoutModules: [.init(type: "BILLING_ADDRESS", requestUrlStr: nil, options: postal)]
+        )
+
+        let modules = sut.getCheckoutModules()
+
+        XCTAssertEqual(modules?.count, 1)
+        XCTAssertEqual(modules?.first?.type, "BILLING_ADDRESS")
+        XCTAssertEqual(modules?.first?.options?["firstName"], true)
+        XCTAssertEqual(modules?.first?.options?["lastName"], false)
+        XCTAssertEqual(modules?.first?.options?["postalCode"], true)
+        XCTAssertEqual(modules?.first?.options?["countryCode"], true)
+        XCTAssertNil(modules?.first?.options?["city"])
+    }
+
+    func test_getCheckoutModules_flattensCardInformationOptions() throws {
+        let json = #"{"cardHolderName":true,"saveCardCheckbox":false}"#.data(using: .utf8)!
+        let card = try JSONDecoder().decode(
+            PrimerAPIConfiguration.CheckoutModule.CardInformationOptions.self,
+            from: json
+        )
+        configuration = makeConfiguration(
+            checkoutModules: [.init(type: "CARD_INFORMATION", requestUrlStr: nil, options: card)]
+        )
+
+        let modules = sut.getCheckoutModules()
+
+        XCTAssertEqual(modules?.first?.type, "CARD_INFORMATION")
+        XCTAssertEqual(modules?.first?.options?["cardHolderName"], true)
+        XCTAssertEqual(modules?.first?.options?["saveCardCheckbox"], false)
+    }
+
+    func test_getCheckoutModules_returnsNilOptions_forUnsupportedOptionType() {
+        configuration = makeConfiguration(
+            checkoutModules: [.init(type: "SHIPPING", requestUrlStr: nil, options: nil)]
+        )
+
+        let modules = sut.getCheckoutModules()
+
+        XCTAssertEqual(modules?.first?.type, "SHIPPING")
+        XCTAssertNil(modules?.first?.options)
+    }
+
+    // MARK: - Helpers
+
+    private func makeConfiguration(
+        clientSession: ClientSession.APIResponse? = nil,
+        checkoutModules: [PrimerAPIConfiguration.CheckoutModule]? = nil
+    ) -> PrimerAPIConfiguration {
+        PrimerAPIConfiguration(
+            coreUrl: nil,
+            pciUrl: nil,
+            binDataUrl: nil,
+            assetsUrl: nil,
+            clientSession: clientSession,
+            paymentMethods: nil,
+            primerAccountId: nil,
+            keys: nil,
+            checkoutModules: checkoutModules
+        )
+    }
+
+    private func makeClientSession(orderId: String) -> ClientSession.APIResponse {
+        ClientSession.APIResponse(
+            clientSessionId: "client-session-id",
+            paymentMethod: nil,
+            order: .init(
+                id: orderId,
+                merchantAmount: nil,
+                totalOrderAmount: 1234,
+                totalTaxAmount: nil,
+                countryCode: nil,
+                currencyCode: nil,
+                fees: nil,
+                lineItems: nil
+            ),
+            customer: nil,
+            testId: nil
+        )
+    }
+}


### PR DESCRIPTION
Adds `ComponentsClientSessionBridge` to expose `getClientSession()` and `getCheckoutModules()` to the RN bridge via `@_spi(PrimerInternal)`.

Stacked on M1 (#1727 — `ComponentsBillingAddressBridge`).

Replaces the public-API approach proposed by #1714 + #1715 (both will be closed). Mirrors the analytics bridge precedent (#1668) and the M1 billing-address bridge (#1727).

## Test plan
- [x] Unit tests in `ComponentsClientSessionBridgeTests.swift` — 8/8 passing
- [x] E2E verified in RN example app on iPhone simulator: bridge fires on `start()` and on subsequent session updates; checkout completes