### PR TITLE
refactor: Tighten payment-method protocol surface [ACC-7173]

### DIFF
--- a/Debug App/Podfile
+++ b/Debug App/Podfile
@@ -9,6 +9,10 @@ target 'Debug App' do
 
   # Pods for Debug App
   pod 'PrimerSDK', :path => '../'
+  pod 'PrimerFoundation', :path => '../'
+  pod 'PrimerStepResolver', :path => '../'
+  pod 'PrimerBDCEngine', :path => '../'
+  pod 'PrimerBDCCore', :path => '../'
   pod 'Primer3DS'
   pod 'PrimerKlarnaSDK'
   pod 'PrimerIPay88MYSDK'

--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -38,35 +38,39 @@ PODS:
   - IQTextView (1.0.5):
     - IQKeyboardToolbar/Placeholderable
   - Primer3DS (2.8.0)
-  - PrimerBDCCore (2.47.0):
-    - PrimerBDCEngine (= 2.47.0)
-    - PrimerFoundation (= 2.47.0)
-    - PrimerStepResolver (= 2.47.0)
-  - PrimerBDCEngine (2.47.0):
-    - PrimerFoundation (= 2.47.0)
-    - PrimerStepResolver (= 2.47.0)
-  - PrimerFoundation (2.47.0)
+  - PrimerBDCCore (3.0.0-b0):
+    - PrimerBDCEngine (= 3.0.0-b0)
+    - PrimerFoundation (= 3.0.0-b0)
+    - PrimerStepResolver (= 3.0.0-b0)
+  - PrimerBDCEngine (3.0.0-b0):
+    - PrimerFoundation (= 3.0.0-b0)
+    - PrimerStepResolver (= 3.0.0-b0)
+  - PrimerFoundation (3.0.0-b0)
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.3.1)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerSDK (2.47.0):
-    - PrimerSDK/Core (= 2.47.0)
-  - PrimerSDK/Core (2.47.0):
-    - PrimerBDCCore (= 2.47.0)
-    - PrimerBDCEngine (= 2.47.0)
-    - PrimerFoundation (= 2.47.0)
-    - PrimerStepResolver (= 2.47.0)
-  - PrimerStepResolver (2.47.0):
-    - PrimerFoundation (= 2.47.0)
+  - PrimerSDK (3.0.0-b0):
+    - PrimerSDK/Core (= 3.0.0-b0)
+  - PrimerSDK/Core (3.0.0-b0):
+    - PrimerBDCCore (= 3.0.0-b0)
+    - PrimerBDCEngine (= 3.0.0-b0)
+    - PrimerFoundation (= 3.0.0-b0)
+    - PrimerStepResolver (= 3.0.0-b0)
+  - PrimerStepResolver (3.0.0-b0):
+    - PrimerFoundation (= 3.0.0-b0)
   - PrimerStripeSDK (1.0.1)
 
 DEPENDENCIES:
   - IQKeyboardManagerSwift
   - Primer3DS
+  - PrimerBDCCore (from `../`)
+  - PrimerBDCEngine (from `../`)
+  - PrimerFoundation (from `../`)
   - PrimerIPay88MYSDK
   - PrimerKlarnaSDK
   - PrimerNolPaySDK
   - PrimerSDK (from `../`)
+  - PrimerStepResolver (from `../`)
   - PrimerStripeSDK
 
 SPEC REPOS:
@@ -80,17 +84,21 @@ SPEC REPOS:
     - IQTextInputViewNotification
     - IQTextView
     - Primer3DS
-    - PrimerBDCCore
-    - PrimerBDCEngine
-    - PrimerFoundation
     - PrimerIPay88MYSDK
     - PrimerKlarnaSDK
     - PrimerNolPaySDK
-    - PrimerStepResolver
     - PrimerStripeSDK
 
 EXTERNAL SOURCES:
+  PrimerBDCCore:
+    :path: "../"
+  PrimerBDCEngine:
+    :path: "../"
+  PrimerFoundation:
+    :path: "../"
   PrimerSDK:
+    :path: "../"
+  PrimerStepResolver:
     :path: "../"
 
 SPEC CHECKSUMS:
@@ -103,16 +111,16 @@ SPEC CHECKSUMS:
   IQTextInputViewNotification: 3b9fb27a16e7ee8958cc9092cfb07a1a9e1fd559
   IQTextView: ae13b4922f22e6f027f62c557d9f4f236b19d5c7
   Primer3DS: b8b583ef260f703180870358bc55069de74f8f51
-  PrimerBDCCore: 4c9887b37a07cd2e3823bb6d23e3d972100edf8c
-  PrimerBDCEngine: 4b5ba78cdb328f70b27b9bd7e9196f5dd535b4de
-  PrimerFoundation: 8ac513a7fa9d7a07d222bf69a10306b45b296e5f
+  PrimerBDCCore: c605ac8752627ec45e319fabc54dcdf5dd6b1df2
+  PrimerBDCEngine: 987ae084a2d02f41b73ac869c3b342833ca918c8
+  PrimerFoundation: 85277369f88e839c9ec483fd5fa46249aab64fe7
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 104962584ac6baad20424f73ee8493c8503fd487
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerSDK: 1f849d143528b5400b8556fb44388ab3931d8272
-  PrimerStepResolver: fded5733b09668a7146480637dbd90616ac6f971
+  PrimerSDK: 79625a1f2f5852970c8fd05c96358932c2163811
+  PrimerStepResolver: c2e1cc4fa8602d55122a61c7f1be227bbdbfdb13
   PrimerStripeSDK: dce5e37d10223ee724f33d1cdeaa17235a71ddbb
 
-PODFILE CHECKSUM: 665eac28ae49fa5a7b983ebc01493e77d5e13406
+PODFILE CHECKSUM: b8e7ac67d7c58bd5df400fbd39c0740865fb3ccd
 
 COCOAPODS: 1.16.2

--- a/PrimerBDCCore.podspec
+++ b/PrimerBDCCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerBDCCore"
-    s.version      = "2.47.0"
+    s.version      = "3.0.0-b0"
     s.summary      = "Backend Driven Checkout core orchestration for Primer iOS SDK"
     s.description  = "Core orchestration layer for Primer Backend Driven Checkout."
     s.homepage     = "https://www.primer.io"

--- a/PrimerBDCEngine.podspec
+++ b/PrimerBDCEngine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerBDCEngine"
-    s.version      = "2.47.0"
+    s.version      = "3.0.0-b0"
     s.summary      = "Backend Driven Checkout engine for Primer iOS SDK"
     s.description  = "JS-based state processing engine for Primer Backend Driven Checkout."
     s.homepage     = "https://www.primer.io"

--- a/PrimerFoundation.podspec
+++ b/PrimerFoundation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerFoundation"
-    s.version      = "2.47.0"
+    s.version      = "3.0.0-b0"
     s.summary      = "Foundation utilities for Primer iOS SDK"
     s.description  = "Foundation utilities, models, and extensions for the Primer iOS SDK."
     s.homepage     = "https://www.primer.io"

--- a/PrimerStepResolver.podspec
+++ b/PrimerStepResolver.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerStepResolver"
-    s.version      = "2.47.0"
+    s.version      = "3.0.0-b0"
     s.summary      = "Step resolution engine for Primer iOS SDK"
     s.description  = "Step resolution and navigation logic for Primer Backend Driven Checkout."
     s.homepage     = "https://www.primer.io"

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -374,6 +374,57 @@ final class DefaultCheckoutScope: PrimerCheckoutScope, ObservableObject, LogRepo
     getPaymentMethodScope(for: methodType.rawValue)
   }
 
+  // MARK: - Per-protocol scope access (existential metatypes)
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerCardFormScope).Type) -> (any PrimerCardFormScope)? {
+    findScope()
+  }
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerKlarnaScope).Type) -> (any PrimerKlarnaScope)? {
+    findScope()
+  }
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerAdyenKlarnaScope).Type) -> (any PrimerAdyenKlarnaScope)? {
+    findScope()
+  }
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerWebRedirectScope).Type) -> (any PrimerWebRedirectScope)? {
+    findScope()
+  }
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerFormRedirectScope).Type) -> (any PrimerFormRedirectScope)? {
+    findScope()
+  }
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerBillingAddressRedirectScope).Type) -> (any PrimerBillingAddressRedirectScope)? {
+    findScope()
+  }
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerApplePayScope).Type) -> (any PrimerApplePayScope)? {
+    findScope()
+  }
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerPayPalScope).Type) -> (any PrimerPayPalScope)? {
+    findScope()
+  }
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerQRCodeScope).Type) -> (any PrimerQRCodeScope)? {
+    findScope()
+  }
+
+  func getPaymentMethodScope(_ scopeType: (any PrimerAchScope).Type) -> (any PrimerAchScope)? {
+    findScope()
+  }
+
+  /// Returns the first cached scope conforming to the requested protocol existential.
+  private func findScope<P>() -> P? {
+    guard let scope = paymentMethodScopeCache.values.first(where: { $0 is P }) as? P else { return nil }
+    if let paymentMethodScope = scope as? any PrimerPaymentMethodScope {
+      currentPaymentMethodScope = paymentMethodScope
+    }
+    return scope
+  }
+
   func onDismiss() {
     updateState(.dismissed)
     updateNavigationState(.dismissed)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -395,44 +395,47 @@ final class DefaultCheckoutScope: CheckoutScopeInternal, ObservableObject, LogRe
   }
 
   // MARK: - Per-protocol scope access (existential metatypes)
+  //
+  // The metatype parameter is unused at runtime — it exists only as a type discriminator
+  // for overload resolution at the call site. `findScope<P>()` infers `P` from the return type.
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerCardFormScope).Type) -> (any PrimerCardFormScope)? {
+  func getPaymentMethodScope(_: (any PrimerCardFormScope).Type) -> (any PrimerCardFormScope)? {
     findScope()
   }
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerKlarnaScope).Type) -> (any PrimerKlarnaScope)? {
+  func getPaymentMethodScope(_: (any PrimerKlarnaScope).Type) -> (any PrimerKlarnaScope)? {
     findScope()
   }
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerAdyenKlarnaScope).Type) -> (any PrimerAdyenKlarnaScope)? {
+  func getPaymentMethodScope(_: (any PrimerAdyenKlarnaScope).Type) -> (any PrimerAdyenKlarnaScope)? {
     findScope()
   }
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerWebRedirectScope).Type) -> (any PrimerWebRedirectScope)? {
+  func getPaymentMethodScope(_: (any PrimerWebRedirectScope).Type) -> (any PrimerWebRedirectScope)? {
     findScope()
   }
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerFormRedirectScope).Type) -> (any PrimerFormRedirectScope)? {
+  func getPaymentMethodScope(_: (any PrimerFormRedirectScope).Type) -> (any PrimerFormRedirectScope)? {
     findScope()
   }
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerBillingAddressRedirectScope).Type) -> (any PrimerBillingAddressRedirectScope)? {
+  func getPaymentMethodScope(_: (any PrimerBillingAddressRedirectScope).Type) -> (any PrimerBillingAddressRedirectScope)? {
     findScope()
   }
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerApplePayScope).Type) -> (any PrimerApplePayScope)? {
+  func getPaymentMethodScope(_: (any PrimerApplePayScope).Type) -> (any PrimerApplePayScope)? {
     findScope()
   }
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerPayPalScope).Type) -> (any PrimerPayPalScope)? {
+  func getPaymentMethodScope(_: (any PrimerPayPalScope).Type) -> (any PrimerPayPalScope)? {
     findScope()
   }
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerQRCodeScope).Type) -> (any PrimerQRCodeScope)? {
+  func getPaymentMethodScope(_: (any PrimerQRCodeScope).Type) -> (any PrimerQRCodeScope)? {
     findScope()
   }
 
-  func getPaymentMethodScope(_ scopeType: (any PrimerAchScope).Type) -> (any PrimerAchScope)? {
+  func getPaymentMethodScope(_: (any PrimerAchScope).Type) -> (any PrimerAchScope)? {
     findScope()
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Ach/AchPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Ach/AchPaymentMethod.swift
@@ -9,15 +9,13 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct AchPaymentMethod: PaymentMethodProtocol {
 
-  typealias ScopeType = DefaultAchScope
-
   static let paymentMethodType: String = PrimerPaymentMethodType.stripeAch.rawValue
 
   @MainActor
   static func createScope(
     checkoutScope: PrimerCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> DefaultAchScope {
+  ) async throws -> any PrimerPaymentMethodScope {
 
     let (defaultCheckoutScope, paymentMethodContext) = try DefaultCheckoutScope.validated(from: checkoutScope)
 
@@ -48,23 +46,13 @@ struct AchPaymentMethod: PaymentMethodProtocol {
 
   @MainActor
   static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView? {
-    guard let achScope = checkoutScope.getPaymentMethodScope(DefaultAchScope.self) else {
+    guard let achScope = checkoutScope.getPaymentMethodScope(PrimerAchScope.self) else {
       PrimerLogging.shared.logger.error(message: "Failed to retrieve ACH scope from checkout scope")
       return nil
     }
 
     return achScope.screen.map { AnyView($0(achScope)) }
       ?? AnyView(AchView(scope: achScope))
-  }
-
-  @MainActor
-  func content<V: View>(@ViewBuilder content: @escaping (DefaultAchScope) -> V) -> AnyView {
-    fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-  }
-
-  @MainActor
-  func defaultContent() -> AnyView {
-    fatalError("Default content method should be implemented by the CheckoutComponents framework")
   }
 }
 
@@ -73,7 +61,11 @@ extension AchPaymentMethod {
 
   @MainActor
   static func register() {
-    PaymentMethodRegistry.shared.register(AchPaymentMethod.self)
+    PaymentMethodRegistry.shared.register(
+      forKey: paymentMethodType,
+      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+      viewCreator: { createView(checkoutScope: $0) }
+    )
 
     #if DEBUG
       TestAchPaymentMethod.register()
@@ -85,15 +77,13 @@ extension AchPaymentMethod {
   @available(iOS 15.0, *)
   struct TestAchPaymentMethod: PaymentMethodProtocol {
 
-    typealias ScopeType = DefaultAchScope
-
     static let paymentMethodType: String = "PRIMER_TEST_STRIPE_ACH"
 
     @MainActor
     static func createScope(
       checkoutScope: PrimerCheckoutScope,
       diContainer: any ContainerProtocol
-    ) async throws -> DefaultAchScope {
+    ) async throws -> any PrimerPaymentMethodScope {
       try await AchPaymentMethod.createScope(checkoutScope: checkoutScope, diContainer: diContainer)
     }
 
@@ -103,18 +93,12 @@ extension AchPaymentMethod {
     }
 
     @MainActor
-    func content<V: View>(@ViewBuilder content: @escaping (DefaultAchScope) -> V) -> AnyView {
-      fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-    }
-
-    @MainActor
-    func defaultContent() -> AnyView {
-      fatalError("Default content method should be implemented by the CheckoutComponents framework")
-    }
-
-    @MainActor
     static func register() {
-      PaymentMethodRegistry.shared.register(TestAchPaymentMethod.self)
+      PaymentMethodRegistry.shared.register(
+        forKey: paymentMethodType,
+        scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+        viewCreator: { createView(checkoutScope: $0) }
+      )
     }
   }
 #endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Ach/AchPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Ach/AchPaymentMethod.swift
@@ -63,8 +63,8 @@ extension AchPaymentMethod {
   static func register() {
     PaymentMethodRegistry.shared.register(
       forKey: paymentMethodType,
-      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
-      viewCreator: { createView(checkoutScope: $0) }
+      scopeCreator: createScope,
+      viewCreator: createView
     )
 
     #if DEBUG
@@ -96,8 +96,8 @@ extension AchPaymentMethod {
     static func register() {
       PaymentMethodRegistry.shared.register(
         forKey: paymentMethodType,
-        scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
-        viewCreator: { createView(checkoutScope: $0) }
+        scopeCreator: createScope,
+        viewCreator: createView
       )
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/AdyenKlarna/AdyenKlarnaPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/AdyenKlarna/AdyenKlarnaPaymentMethod.swift
@@ -9,15 +9,13 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct AdyenKlarnaPaymentMethod: PaymentMethodProtocol {
 
-    typealias ScopeType = DefaultAdyenKlarnaScope
-
     static let paymentMethodType: String = PrimerPaymentMethodType.adyenKlarna.rawValue
 
     @MainActor
     static func createScope(
         checkoutScope: PrimerCheckoutScope,
         diContainer: any ContainerProtocol
-    ) async throws -> DefaultAdyenKlarnaScope {
+    ) async throws -> any PrimerPaymentMethodScope {
 
         let (defaultCheckoutScope, paymentMethodContext) = try DefaultCheckoutScope.validated(from: checkoutScope)
 
@@ -57,23 +55,13 @@ struct AdyenKlarnaPaymentMethod: PaymentMethodProtocol {
 
     @MainActor
     static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView? {
-        guard let adyenKlarnaScope = checkoutScope.getPaymentMethodScope(DefaultAdyenKlarnaScope.self) else {
+        guard let adyenKlarnaScope = checkoutScope.getPaymentMethodScope(PrimerAdyenKlarnaScope.self) else {
             PrimerLogging.shared.logger.error(message: "Failed to retrieve Adyen Klarna scope from checkout scope")
             return nil
         }
 
         return adyenKlarnaScope.screen.map { AnyView($0(adyenKlarnaScope)) }
             ?? AnyView(AdyenKlarnaScreen(scope: adyenKlarnaScope))
-    }
-
-    @MainActor
-    func content<V: View>(@ViewBuilder content: @escaping (DefaultAdyenKlarnaScope) -> V) -> AnyView {
-        fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-    }
-
-    @MainActor
-    func defaultContent() -> AnyView {
-        fatalError("Default content method should be implemented by the CheckoutComponents framework")
     }
 }
 
@@ -82,6 +70,10 @@ extension AdyenKlarnaPaymentMethod {
 
     @MainActor
     static func register() {
-        PaymentMethodRegistry.shared.register(AdyenKlarnaPaymentMethod.self)
+        PaymentMethodRegistry.shared.register(
+            forKey: paymentMethodType,
+            scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+            viewCreator: { createView(checkoutScope: $0) }
+        )
     }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/AdyenKlarna/AdyenKlarnaPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/AdyenKlarna/AdyenKlarnaPaymentMethod.swift
@@ -72,8 +72,8 @@ extension AdyenKlarnaPaymentMethod {
     static func register() {
         PaymentMethodRegistry.shared.register(
             forKey: paymentMethodType,
-            scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
-            viewCreator: { createView(checkoutScope: $0) }
+            scopeCreator: createScope,
+            viewCreator: createView
         )
     }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/ApplePay/ApplePayPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/ApplePay/ApplePayPaymentMethod.swift
@@ -9,15 +9,13 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct ApplePayPaymentMethod: PaymentMethodProtocol {
 
-  typealias ScopeType = DefaultApplePayScope
-
   static let paymentMethodType: String = "APPLE_PAY"
 
   @MainActor
   static func createScope(
     checkoutScope: PrimerCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> DefaultApplePayScope {
+  ) async throws -> any PrimerPaymentMethodScope {
     let (defaultCheckoutScope, paymentMethodContext) = try DefaultCheckoutScope.validated(from: checkoutScope)
 
     return DefaultApplePayScope(
@@ -28,21 +26,13 @@ struct ApplePayPaymentMethod: PaymentMethodProtocol {
 
   @MainActor
   static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView? {
+    // ACC-7173: audit §2a — ApplePayScreen uses @ObservedObject DefaultApplePayScope so the
+    // metatype must stay concrete; SwiftUI's ObservableObject requires a concrete class.
     checkoutScope.getPaymentMethodScope(DefaultApplePayScope.self)
       .map { scope in
         scope.screen.map { AnyView($0(scope)) }
           ?? AnyView(ApplePayScreen(scope: scope))
       }
-  }
-
-  @MainActor
-  func content<V: View>(@ViewBuilder content: @escaping (DefaultApplePayScope) -> V) -> AnyView {
-    fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-  }
-
-  @MainActor
-  func defaultContent() -> AnyView {
-    fatalError("Default content method should be implemented by the CheckoutComponents framework")
   }
 }
 
@@ -51,6 +41,10 @@ extension ApplePayPaymentMethod {
 
   @MainActor
   static func register() {
-    PaymentMethodRegistry.shared.register(ApplePayPaymentMethod.self)
+    PaymentMethodRegistry.shared.register(
+      forKey: paymentMethodType,
+      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+      viewCreator: { createView(checkoutScope: $0) }
+    )
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/ApplePay/ApplePayPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/ApplePay/ApplePayPaymentMethod.swift
@@ -43,8 +43,8 @@ extension ApplePayPaymentMethod {
   static func register() {
     PaymentMethodRegistry.shared.register(
       forKey: paymentMethodType,
-      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
-      viewCreator: { createView(checkoutScope: $0) }
+      scopeCreator: createScope,
+      viewCreator: createView
     )
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/BillingAddressRedirect/BillingAddressRedirectPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/BillingAddressRedirect/BillingAddressRedirectPaymentMethod.swift
@@ -56,6 +56,9 @@ enum BillingAddressRedirectPaymentMethod {
     for paymentMethodType: String,
     checkoutScope: any PrimerCheckoutScope
   ) -> AnyView? {
+    // ACC-7173: string-keyed `getPaymentMethodScope<T>(for:)` carries the same `T: PrimerPaymentMethodScope`
+    // constraint that rejects existentials. Keep concrete metatype here; downstream screen still accepts
+    // `any PrimerBillingAddressRedirectScope`.
     guard let billingScope: DefaultBillingAddressRedirectScope = checkoutScope.getPaymentMethodScope(for: paymentMethodType) else {
       return nil
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Card/CardPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Card/CardPaymentMethod.swift
@@ -9,15 +9,13 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct CardPaymentMethod: PaymentMethodProtocol {
 
-  typealias ScopeType = DefaultCardFormScope
-
   static let paymentMethodType: String = PrimerPaymentMethodType.paymentCard.rawValue
 
   @MainActor
   static func createScope(
     checkoutScope: PrimerCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> DefaultCardFormScope {
+  ) async throws -> any PrimerPaymentMethodScope {
 
     let (defaultCheckoutScope, paymentMethodContext) = try DefaultCheckoutScope.validated(from: checkoutScope)
 
@@ -70,21 +68,14 @@ struct CardPaymentMethod: PaymentMethodProtocol {
 
   @MainActor
   static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView? {
+    // ACC-7173: audit §2a — CardFormScreen takes `any CardFormFieldScopeInternal` (sub-protocol of
+    // PrimerCardFormScope); rebinding to PrimerCardFormScope.self would force a downcast through
+    // an internal protocol which reintroduces the silent-no-op pattern. Keep concrete metatype.
     checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self)
       .map { scope in
         scope.screen.map { AnyView($0(scope)) }
           ?? AnyView(CardFormScreen(scope: scope))
       }
-  }
-
-  @MainActor
-  func content<V: View>(@ViewBuilder content: @escaping (DefaultCardFormScope) -> V) -> AnyView {
-    fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-  }
-
-  @MainActor
-  func defaultContent() -> AnyView {
-    fatalError("Default content method should be implemented by the CheckoutComponents framework")
   }
 }
 
@@ -93,6 +84,10 @@ extension CardPaymentMethod {
 
   @MainActor
   static func register() {
-    PaymentMethodRegistry.shared.register(CardPaymentMethod.self)
+    PaymentMethodRegistry.shared.register(
+      forKey: paymentMethodType,
+      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+      viewCreator: { createView(checkoutScope: $0) }
+    )
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Card/CardPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Card/CardPaymentMethod.swift
@@ -86,8 +86,8 @@ extension CardPaymentMethod {
   static func register() {
     PaymentMethodRegistry.shared.register(
       forKey: paymentMethodType,
-      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
-      viewCreator: { createView(checkoutScope: $0) }
+      scopeCreator: createScope,
+      viewCreator: createView
     )
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/FormRedirect/FormRedirectPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/FormRedirect/FormRedirectPaymentMethod.swift
@@ -14,7 +14,7 @@ enum FormRedirectPaymentMethodHelper {
     _ paymentMethodType: String,
     checkoutScope: DefaultCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> DefaultFormRedirectScope {
+  ) async throws -> any PrimerPaymentMethodScope {
     let paymentMethodContext: PresentationContext =
       checkoutScope.availablePaymentMethods.count > 1 ? .fromPaymentSelection : .direct
 
@@ -52,6 +52,8 @@ enum FormRedirectPaymentMethodHelper {
 
   @MainActor
   static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView? {
+    // ACC-7173: audit §2a — FormRedirectContainerView uses @ObservedObject DefaultFormRedirectScope
+    // so the metatype must stay concrete; SwiftUI's ObservableObject requires a concrete class.
     checkoutScope.getPaymentMethodScope(DefaultFormRedirectScope.self)
       .map { scope in
         scope.screen.map { AnyView($0(scope)) }
@@ -85,7 +87,6 @@ private struct FormRedirectContainerView: View {
 
 @available(iOS 15.0, *)
 struct BlikPaymentMethod: PaymentMethodProtocol {
-  typealias ScopeType = DefaultFormRedirectScope
 
   static let paymentMethodType: String = PrimerPaymentMethodType.adyenBlik.rawValue
 
@@ -93,7 +94,7 @@ struct BlikPaymentMethod: PaymentMethodProtocol {
   static func createScope(
     checkoutScope: PrimerCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> DefaultFormRedirectScope {
+  ) async throws -> any PrimerPaymentMethodScope {
     let (scope, _) = try DefaultCheckoutScope.validated(from: checkoutScope)
     return try await FormRedirectPaymentMethodHelper.createScopeForPaymentMethodType(
       paymentMethodType,
@@ -107,20 +108,10 @@ struct BlikPaymentMethod: PaymentMethodProtocol {
     FormRedirectPaymentMethodHelper.createView(checkoutScope: checkoutScope)
   }
 
-  @MainActor
-  func content<V: View>(@ViewBuilder content: @escaping (DefaultFormRedirectScope) -> V) -> AnyView {
-    fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-  }
-
-  @MainActor
-  func defaultContent() -> AnyView {
-    fatalError("Default content method should be implemented by the CheckoutComponents framework")
-  }
 }
 
 @available(iOS 15.0, *)
 struct MBWayPaymentMethod: PaymentMethodProtocol {
-  typealias ScopeType = DefaultFormRedirectScope
 
   static let paymentMethodType: String = PrimerPaymentMethodType.adyenMBWay.rawValue
 
@@ -128,7 +119,7 @@ struct MBWayPaymentMethod: PaymentMethodProtocol {
   static func createScope(
     checkoutScope: PrimerCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> DefaultFormRedirectScope {
+  ) async throws -> any PrimerPaymentMethodScope {
     let (scope, _) = try DefaultCheckoutScope.validated(from: checkoutScope)
     return try await FormRedirectPaymentMethodHelper.createScopeForPaymentMethodType(
       paymentMethodType,
@@ -142,15 +133,6 @@ struct MBWayPaymentMethod: PaymentMethodProtocol {
     FormRedirectPaymentMethodHelper.createView(checkoutScope: checkoutScope)
   }
 
-  @MainActor
-  func content<V: View>(@ViewBuilder content: @escaping (DefaultFormRedirectScope) -> V) -> AnyView {
-    fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-  }
-
-  @MainActor
-  func defaultContent() -> AnyView {
-    fatalError("Default content method should be implemented by the CheckoutComponents framework")
-  }
 }
 
 @available(iOS 15.0, *)
@@ -158,7 +140,15 @@ enum FormRedirectPaymentMethod {
 
   @MainActor
   static func register() {
-    PaymentMethodRegistry.shared.register(BlikPaymentMethod.self)
-    PaymentMethodRegistry.shared.register(MBWayPaymentMethod.self)
+    PaymentMethodRegistry.shared.register(
+      forKey: BlikPaymentMethod.paymentMethodType,
+      scopeCreator: { try await BlikPaymentMethod.createScope(checkoutScope: $0, diContainer: $1) },
+      viewCreator: { BlikPaymentMethod.createView(checkoutScope: $0) }
+    )
+    PaymentMethodRegistry.shared.register(
+      forKey: MBWayPaymentMethod.paymentMethodType,
+      scopeCreator: { try await MBWayPaymentMethod.createScope(checkoutScope: $0, diContainer: $1) },
+      viewCreator: { MBWayPaymentMethod.createView(checkoutScope: $0) }
+    )
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/FormRedirect/FormRedirectPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/FormRedirect/FormRedirectPaymentMethod.swift
@@ -142,13 +142,13 @@ enum FormRedirectPaymentMethod {
   static func register() {
     PaymentMethodRegistry.shared.register(
       forKey: BlikPaymentMethod.paymentMethodType,
-      scopeCreator: { try await BlikPaymentMethod.createScope(checkoutScope: $0, diContainer: $1) },
-      viewCreator: { BlikPaymentMethod.createView(checkoutScope: $0) }
+      scopeCreator: BlikPaymentMethod.createScope,
+      viewCreator: BlikPaymentMethod.createView
     )
     PaymentMethodRegistry.shared.register(
       forKey: MBWayPaymentMethod.paymentMethodType,
-      scopeCreator: { try await MBWayPaymentMethod.createScope(checkoutScope: $0, diContainer: $1) },
-      viewCreator: { MBWayPaymentMethod.createView(checkoutScope: $0) }
+      scopeCreator: MBWayPaymentMethod.createScope,
+      viewCreator: MBWayPaymentMethod.createView
     )
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Klarna/KlarnaPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Klarna/KlarnaPaymentMethod.swift
@@ -9,15 +9,13 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct KlarnaPaymentMethod: PaymentMethodProtocol {
 
-  typealias ScopeType = DefaultKlarnaScope
-
   static let paymentMethodType: String = PrimerPaymentMethodType.klarna.rawValue
 
   @MainActor
   static func createScope(
     checkoutScope: PrimerCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> DefaultKlarnaScope {
+  ) async throws -> any PrimerPaymentMethodScope {
 
     let (defaultCheckoutScope, paymentMethodContext) = try DefaultCheckoutScope.validated(from: checkoutScope)
 
@@ -48,23 +46,13 @@ struct KlarnaPaymentMethod: PaymentMethodProtocol {
 
   @MainActor
   static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView? {
-    guard let klarnaScope = checkoutScope.getPaymentMethodScope(DefaultKlarnaScope.self) else {
+    guard let klarnaScope = checkoutScope.getPaymentMethodScope(PrimerKlarnaScope.self) else {
       PrimerLogging.shared.logger.error(message: "Failed to retrieve Klarna scope from checkout scope")
       return nil
     }
 
     return klarnaScope.screen.map { AnyView($0(klarnaScope)) }
       ?? AnyView(KlarnaView(scope: klarnaScope))
-  }
-
-  @MainActor
-  func content<V: View>(@ViewBuilder content: @escaping (DefaultKlarnaScope) -> V) -> AnyView {
-    fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-  }
-
-  @MainActor
-  func defaultContent() -> AnyView {
-    fatalError("Default content method should be implemented by the CheckoutComponents framework")
   }
 }
 
@@ -73,7 +61,11 @@ extension KlarnaPaymentMethod {
 
   @MainActor
   static func register() {
-    PaymentMethodRegistry.shared.register(KlarnaPaymentMethod.self)
+    PaymentMethodRegistry.shared.register(
+      forKey: paymentMethodType,
+      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+      viewCreator: { createView(checkoutScope: $0) }
+    )
 
     #if DEBUG
       TestKlarnaPaymentMethod.register()
@@ -85,15 +77,13 @@ extension KlarnaPaymentMethod {
   @available(iOS 15.0, *)
   struct TestKlarnaPaymentMethod: PaymentMethodProtocol {
 
-    typealias ScopeType = DefaultKlarnaScope
-
     static let paymentMethodType: String = "PRIMER_TEST_KLARNA"
 
     @MainActor
     static func createScope(
       checkoutScope: PrimerCheckoutScope,
       diContainer: any ContainerProtocol
-    ) async throws -> DefaultKlarnaScope {
+    ) async throws -> any PrimerPaymentMethodScope {
       try await KlarnaPaymentMethod.createScope(checkoutScope: checkoutScope, diContainer: diContainer)
     }
 
@@ -103,18 +93,12 @@ extension KlarnaPaymentMethod {
     }
 
     @MainActor
-    func content<V: View>(@ViewBuilder content: @escaping (DefaultKlarnaScope) -> V) -> AnyView {
-      fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-    }
-
-    @MainActor
-    func defaultContent() -> AnyView {
-      fatalError("Default content method should be implemented by the CheckoutComponents framework")
-    }
-
-    @MainActor
     static func register() {
-      PaymentMethodRegistry.shared.register(TestKlarnaPaymentMethod.self)
+      PaymentMethodRegistry.shared.register(
+        forKey: paymentMethodType,
+        scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+        viewCreator: { createView(checkoutScope: $0) }
+      )
     }
   }
 #endif

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Klarna/KlarnaPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/Klarna/KlarnaPaymentMethod.swift
@@ -63,8 +63,8 @@ extension KlarnaPaymentMethod {
   static func register() {
     PaymentMethodRegistry.shared.register(
       forKey: paymentMethodType,
-      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
-      viewCreator: { createView(checkoutScope: $0) }
+      scopeCreator: createScope,
+      viewCreator: createView
     )
 
     #if DEBUG
@@ -96,8 +96,8 @@ extension KlarnaPaymentMethod {
     static func register() {
       PaymentMethodRegistry.shared.register(
         forKey: paymentMethodType,
-        scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
-        viewCreator: { createView(checkoutScope: $0) }
+        scopeCreator: createScope,
+        viewCreator: createView
       )
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/PayPal/PayPalPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/PayPal/PayPalPaymentMethod.swift
@@ -9,15 +9,13 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct PayPalPaymentMethod: PaymentMethodProtocol {
 
-  typealias ScopeType = DefaultPayPalScope
-
   static let paymentMethodType: String = PrimerPaymentMethodType.payPal.rawValue
 
   @MainActor
   static func createScope(
     checkoutScope: PrimerCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> DefaultPayPalScope {
+  ) async throws -> any PrimerPaymentMethodScope {
 
     let (defaultCheckoutScope, paymentMethodContext) = try DefaultCheckoutScope.validated(from: checkoutScope)
 
@@ -48,22 +46,12 @@ struct PayPalPaymentMethod: PaymentMethodProtocol {
 
   @MainActor
   static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView? {
-    guard let payPalScope = checkoutScope.getPaymentMethodScope(DefaultPayPalScope.self) else {
+    guard let payPalScope = checkoutScope.getPaymentMethodScope(PrimerPayPalScope.self) else {
       return nil
     }
 
     return payPalScope.screen.map { AnyView($0(payPalScope)) }
       ?? AnyView(PayPalView(scope: payPalScope))
-  }
-
-  @MainActor
-  func content<V: View>(@ViewBuilder content: @escaping (DefaultPayPalScope) -> V) -> AnyView {
-    fatalError("Custom content method should be implemented by the CheckoutComponents framework")
-  }
-
-  @MainActor
-  func defaultContent() -> AnyView {
-    fatalError("Default content method should be implemented by the CheckoutComponents framework")
   }
 }
 
@@ -72,6 +60,10 @@ extension PayPalPaymentMethod {
 
   @MainActor
   static func register() {
-    PaymentMethodRegistry.shared.register(PayPalPaymentMethod.self)
+    PaymentMethodRegistry.shared.register(
+      forKey: paymentMethodType,
+      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+      viewCreator: { createView(checkoutScope: $0) }
+    )
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/PayPal/PayPalPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/PayPal/PayPalPaymentMethod.swift
@@ -62,8 +62,8 @@ extension PayPalPaymentMethod {
   static func register() {
     PaymentMethodRegistry.shared.register(
       forKey: paymentMethodType,
-      scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
-      viewCreator: { createView(checkoutScope: $0) }
+      scopeCreator: createScope,
+      viewCreator: createView
     )
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/QRCode/QRCodePaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/QRCode/QRCodePaymentMethod.swift
@@ -64,7 +64,7 @@ enum QRCodePaymentMethod {
 
   @MainActor
   static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView? {
-    checkoutScope.getPaymentMethodScope(DefaultQRCodeScope.self)
+    checkoutScope.getPaymentMethodScope(PrimerQRCodeScope.self)
       .map { scope in
         scope.screen.map { AnyView($0(scope)) }
           ?? AnyView(QRCodeView(scope: scope))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/WebRedirect/WebRedirectPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PaymentMethods/WebRedirect/WebRedirectPaymentMethod.swift
@@ -9,8 +9,6 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct WebRedirectPaymentMethod: PaymentMethodProtocol {
 
-  typealias ScopeType = DefaultWebRedirectScope
-
   static var paymentMethodType: String { "WEB_REDIRECT" }
 
   @MainActor
@@ -29,7 +27,7 @@ struct WebRedirectPaymentMethod: PaymentMethodProtocol {
     for paymentMethodType: String,
     checkoutScope: any PrimerCheckoutScope,
     container: any ContainerProtocol
-  ) async throws -> DefaultWebRedirectScope {
+  ) async throws -> any PrimerPaymentMethodScope {
     let (defaultCheckoutScope, paymentMethodContext) = try DefaultCheckoutScope.validated(from: checkoutScope)
 
     let mapper = try? await container.resolve(PaymentMethodMapper.self)
@@ -60,6 +58,9 @@ struct WebRedirectPaymentMethod: PaymentMethodProtocol {
     for paymentMethodType: String,
     checkoutScope: any PrimerCheckoutScope
   ) -> AnyView? {
+    // ACC-7173: string-keyed `getPaymentMethodScope<T>(for:)` carries the same
+    // `T: PrimerPaymentMethodScope` constraint that rejects existentials. Keep concrete metatype
+    // here; the downstream WebRedirectScreen still accepts `any PrimerWebRedirectScope`.
     guard let webRedirectScope: DefaultWebRedirectScope = checkoutScope.getPaymentMethodScope(for: paymentMethodType) else {
       return nil
     }
@@ -72,7 +73,7 @@ struct WebRedirectPaymentMethod: PaymentMethodProtocol {
   static func createScope(
     checkoutScope: PrimerCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> DefaultWebRedirectScope {
+  ) async throws -> any PrimerPaymentMethodScope {
     throw PrimerError.invalidArchitecture(
       description: "WebRedirectPaymentMethod.createScope requires a payment method type parameter",
       recoverSuggestion: "Use register(types:) for dynamic registration instead"
@@ -82,16 +83,6 @@ struct WebRedirectPaymentMethod: PaymentMethodProtocol {
   @MainActor
   static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView? {
     nil
-  }
-
-  @MainActor
-  func content<V: View>(@ViewBuilder content: @escaping (DefaultWebRedirectScope) -> V) -> AnyView {
-    fatalError("Use register(types:) for dynamic registration instead")
-  }
-
-  @MainActor
-  func defaultContent() -> AnyView {
-    fatalError("Use register(types:) for dynamic registration instead")
   }
 }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerAdyenKlarnaScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerAdyenKlarnaScope.swift
@@ -51,9 +51,6 @@ public typealias AdyenKlarnaButtonComponent = (any PrimerAdyenKlarnaScope) -> an
 @MainActor
 public protocol PrimerAdyenKlarnaScope: PrimerPaymentMethodScope where State == PrimerAdyenKlarnaState {
 
-    /// The payment method type identifier (`"ADYEN_KLARNA"`).
-    var paymentMethodType: String { get }
-
     /// Selects a Klarna payment option and initiates the redirect payment flow.
     func selectOption(_ option: AdyenKlarnaPaymentOption)
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutScope.swift
@@ -76,6 +76,38 @@ public protocol PrimerCheckoutScope: AnyObject {
   /// ```
   func getPaymentMethodScope<T: PrimerPaymentMethodScope>(for paymentMethodType: String) -> T?
 
+  // MARK: - Per-protocol scope access (existential metatypes)
+
+  /// Gets the card-form scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerCardFormScope).Type) -> (any PrimerCardFormScope)?
+
+  /// Gets the Klarna scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerKlarnaScope).Type) -> (any PrimerKlarnaScope)?
+
+  /// Gets the Adyen Klarna scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerAdyenKlarnaScope).Type) -> (any PrimerAdyenKlarnaScope)?
+
+  /// Gets the web-redirect scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerWebRedirectScope).Type) -> (any PrimerWebRedirectScope)?
+
+  /// Gets the form-redirect scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerFormRedirectScope).Type) -> (any PrimerFormRedirectScope)?
+
+  /// Gets the billing-address-redirect scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerBillingAddressRedirectScope).Type) -> (any PrimerBillingAddressRedirectScope)?
+
+  /// Gets the Apple Pay scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerApplePayScope).Type) -> (any PrimerApplePayScope)?
+
+  /// Gets the PayPal scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerPayPalScope).Type) -> (any PrimerPayPalScope)?
+
+  /// Gets the QR code scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerQRCodeScope).Type) -> (any PrimerQRCodeScope)?
+
+  /// Gets the ACH scope as the public protocol existential.
+  func getPaymentMethodScope(_ scopeType: (any PrimerAchScope).Type) -> (any PrimerAchScope)?
+
   // MARK: - Payment Callbacks
 
   /// Called before a payment is created. Use the decision handler to provide an idempotency key
@@ -93,6 +125,26 @@ public protocol PrimerCheckoutScope: AnyObject {
 
   /// Dismisses the checkout flow.
   func onDismiss()
+}
+
+// MARK: - Default no-op implementations
+//
+// Each per-protocol overload defaults to nil so that custom `PrimerCheckoutScope` conformers
+// (test mocks, merchant-side implementations) don't have to stub all 10 methods. The SDK's
+// `DefaultCheckoutScope` overrides every one with the real cache-backed lookup.
+
+@available(iOS 15.0, *)
+public extension PrimerCheckoutScope {
+  func getPaymentMethodScope(_ scopeType: (any PrimerCardFormScope).Type) -> (any PrimerCardFormScope)? { nil }
+  func getPaymentMethodScope(_ scopeType: (any PrimerKlarnaScope).Type) -> (any PrimerKlarnaScope)? { nil }
+  func getPaymentMethodScope(_ scopeType: (any PrimerAdyenKlarnaScope).Type) -> (any PrimerAdyenKlarnaScope)? { nil }
+  func getPaymentMethodScope(_ scopeType: (any PrimerWebRedirectScope).Type) -> (any PrimerWebRedirectScope)? { nil }
+  func getPaymentMethodScope(_ scopeType: (any PrimerFormRedirectScope).Type) -> (any PrimerFormRedirectScope)? { nil }
+  func getPaymentMethodScope(_ scopeType: (any PrimerBillingAddressRedirectScope).Type) -> (any PrimerBillingAddressRedirectScope)? { nil }
+  func getPaymentMethodScope(_ scopeType: (any PrimerApplePayScope).Type) -> (any PrimerApplePayScope)? { nil }
+  func getPaymentMethodScope(_ scopeType: (any PrimerPayPalScope).Type) -> (any PrimerPayPalScope)? { nil }
+  func getPaymentMethodScope(_ scopeType: (any PrimerQRCodeScope).Type) -> (any PrimerQRCodeScope)? { nil }
+  func getPaymentMethodScope(_ scopeType: (any PrimerAchScope).Type) -> (any PrimerAchScope)? { nil }
 }
 
 // MARK: - State Definition

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutScope.swift
@@ -135,16 +135,16 @@ public protocol PrimerCheckoutScope: AnyObject {
 
 @available(iOS 15.0, *)
 public extension PrimerCheckoutScope {
-  func getPaymentMethodScope(_ scopeType: (any PrimerCardFormScope).Type) -> (any PrimerCardFormScope)? { nil }
-  func getPaymentMethodScope(_ scopeType: (any PrimerKlarnaScope).Type) -> (any PrimerKlarnaScope)? { nil }
-  func getPaymentMethodScope(_ scopeType: (any PrimerAdyenKlarnaScope).Type) -> (any PrimerAdyenKlarnaScope)? { nil }
-  func getPaymentMethodScope(_ scopeType: (any PrimerWebRedirectScope).Type) -> (any PrimerWebRedirectScope)? { nil }
-  func getPaymentMethodScope(_ scopeType: (any PrimerFormRedirectScope).Type) -> (any PrimerFormRedirectScope)? { nil }
-  func getPaymentMethodScope(_ scopeType: (any PrimerBillingAddressRedirectScope).Type) -> (any PrimerBillingAddressRedirectScope)? { nil }
-  func getPaymentMethodScope(_ scopeType: (any PrimerApplePayScope).Type) -> (any PrimerApplePayScope)? { nil }
-  func getPaymentMethodScope(_ scopeType: (any PrimerPayPalScope).Type) -> (any PrimerPayPalScope)? { nil }
-  func getPaymentMethodScope(_ scopeType: (any PrimerQRCodeScope).Type) -> (any PrimerQRCodeScope)? { nil }
-  func getPaymentMethodScope(_ scopeType: (any PrimerAchScope).Type) -> (any PrimerAchScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerCardFormScope).Type) -> (any PrimerCardFormScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerKlarnaScope).Type) -> (any PrimerKlarnaScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerAdyenKlarnaScope).Type) -> (any PrimerAdyenKlarnaScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerWebRedirectScope).Type) -> (any PrimerWebRedirectScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerFormRedirectScope).Type) -> (any PrimerFormRedirectScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerBillingAddressRedirectScope).Type) -> (any PrimerBillingAddressRedirectScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerApplePayScope).Type) -> (any PrimerApplePayScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerPayPalScope).Type) -> (any PrimerPayPalScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerQRCodeScope).Type) -> (any PrimerQRCodeScope)? { nil }
+  func getPaymentMethodScope(_: (any PrimerAchScope).Type) -> (any PrimerAchScope)? { nil }
 }
 
 // MARK: - State Definition

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodScope.swift
@@ -93,12 +93,10 @@ extension PrimerPaymentMethodScope {
 @available(iOS 15.0, *)
 protocol PaymentMethodProtocol {
 
-  associatedtype ScopeType: PrimerPaymentMethodScope
-
   /// The payment method type identifier (e.g., "PAYMENT_CARD", "PAYPAL", "APPLE_PAY")
   static var paymentMethodType: String { get }
 
-  /// Creates a scope instance for this payment method
+  /// Creates a scope instance for this payment method.
   /// - Parameters:
   ///   - checkoutScope: The parent checkout scope for navigation and coordination
   ///   - diContainer: The dependency injection container for resolving services
@@ -107,7 +105,7 @@ protocol PaymentMethodProtocol {
   static func createScope(
     checkoutScope: PrimerCheckoutScope,
     diContainer: any ContainerProtocol
-  ) async throws -> ScopeType
+  ) async throws -> any PrimerPaymentMethodScope
 
   /// Creates the view for this payment method by retrieving its scope and rendering the appropriate UI.
   /// This method handles both custom screens (if provided) and default screens.
@@ -115,16 +113,6 @@ protocol PaymentMethodProtocol {
   /// - Returns: The view for this payment method, or nil if the scope cannot be retrieved
   @MainActor
   static func createView(checkoutScope: any PrimerCheckoutScope) -> AnyView?
-
-  /// Provides custom UI for this payment method using ViewBuilder.
-  /// - Parameter content: A ViewBuilder closure that uses the payment method's scope as a parameter,
-  ///                      allowing full access to the payment method's state and behavior.
-  @MainActor
-  func content<V: View>(@ViewBuilder content: @escaping (ScopeType) -> V) -> AnyView
-
-  /// Provides the default UI implementation for this payment method.
-  @MainActor
-  func defaultContent() -> AnyView
 }
 
 // MARK: - Payment Method Registry
@@ -141,12 +129,12 @@ final class PaymentMethodRegistry: LogReporter {
 
   private var creators: [String: ScopeCreator] = [:]
   private var viewBuilders: [String: ViewCreator] = [:]
-  private var typeToIdentifier: [String: String] = [:]
 
   static let shared = PaymentMethodRegistry()
 
   private init() {}
 
+  /// Registers a payment method by its type identifier with explicit scope/view creators.
   func register(
     forKey key: String,
     scopeCreator: @escaping @MainActor (PrimerCheckoutScope, any ContainerProtocol) async throws -> any PrimerPaymentMethodScope,
@@ -154,45 +142,25 @@ final class PaymentMethodRegistry: LogReporter {
   ) {
     creators[key] = scopeCreator
     viewBuilders[key] = viewCreator
-    logger.debug(message: "[PaymentMethodRegistry] Payment method \(key) registered")
-  }
 
-  /// Registers a payment method implementation
-  /// - Parameter paymentMethodType: The payment method implementation to register
-  func register<T: PaymentMethodProtocol>(_ paymentMethodType: T.Type) {
-    let typeKey = paymentMethodType.paymentMethodType
-    creators[typeKey] = { checkoutScope, diContainer in
-      try await paymentMethodType.createScope(checkoutScope: checkoutScope, diContainer: diContainer)
-    }
-
-    // Register view builder for dynamic UI creation
-    viewBuilders[typeKey] = { checkoutScope in
-      paymentMethodType.createView(checkoutScope: checkoutScope)
-    }
-
-    // Register type-to-identifier mapping for type-safe lookups
-    let scopeTypeName = String(describing: T.ScopeType.self)
-    typeToIdentifier[scopeTypeName] = typeKey
-
-    // PAYMENT METHOD OPTIONS INTEGRATION: Log when payment methods requiring special settings are registered
-    // Based on PrimerPaymentMethodOptionsProtocol: applePayOptions, klarnaOptions, stripeOptions
-    if typeKey == PrimerPaymentMethodType.applePay.rawValue {
+    // PAYMENT METHOD OPTIONS INTEGRATION: log when payment methods requiring special settings are registered.
+    if key == PrimerPaymentMethodType.applePay.rawValue {
       logger.info(
         message:
           "[PaymentMethodRegistry] Apple Pay registered - requires PrimerSettings.paymentMethodOptions.applePayOptions"
       )
-    } else if [PrimerPaymentMethodType.klarna, .primerTestKlarna].map(\.rawValue).contains(typeKey) {
+    } else if [PrimerPaymentMethodType.klarna, .primerTestKlarna].map(\.rawValue).contains(key) {
       logger.info(
         message:
           "[PaymentMethodRegistry] Klarna registered - requires PrimerSettings.paymentMethodOptions.klarnaOptions"
       )
-    } else if typeKey.contains("STRIPE") {
+    } else if key.contains("STRIPE") {
       logger.info(
         message:
-          "[PaymentMethodRegistry] Stripe (\(typeKey)) registered - requires PrimerSettings.paymentMethodOptions.stripeOptions"
+          "[PaymentMethodRegistry] Stripe (\(key)) registered - requires PrimerSettings.paymentMethodOptions.stripeOptions"
       )
     } else {
-      logger.debug(message: "[PaymentMethodRegistry] Payment method \(typeKey) registered")
+      logger.debug(message: "[PaymentMethodRegistry] Payment method \(key) registered")
     }
   }
 
@@ -231,26 +199,6 @@ final class PaymentMethodRegistry: LogReporter {
 
     let scope = try await creator(checkoutScope, diContainer)
     return scope as? T
-  }
-
-  /// Creates a scope for the specified scope type (type-safe with metatype)
-  /// - Parameters:
-  ///   - scopeType: The scope type to create (e.g., PrimerCardFormScope.self)
-  ///   - checkoutScope: The parent checkout scope
-  ///   - diContainer: The dependency injection container
-  /// - Returns: A configured scope instance, or nil if the scope type is not registered
-  func createScope<T: PrimerPaymentMethodScope>(
-    _ scopeType: T.Type,
-    checkoutScope: PrimerCheckoutScope,
-    diContainer: any ContainerProtocol
-  ) async throws -> T? {
-    let typeName = String(describing: scopeType)
-    guard let paymentMethodType = typeToIdentifier[typeName] else {
-      return nil
-    }
-
-    return try await createScope(
-      for: paymentMethodType, checkoutScope: checkoutScope, diContainer: diContainer)
   }
 
   /// Creates a scope for the specified payment method enum case
@@ -298,6 +246,5 @@ final class PaymentMethodRegistry: LogReporter {
   func reset() {
     creators.removeAll()
     viewBuilders.removeAll()
-    typeToIdentifier.removeAll()
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/Providers/CardFormProvider.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/Providers/CardFormProvider.swift
@@ -56,9 +56,7 @@ public struct CardFormProvider<Content: View>: View, LogReporter {
 
   public var body: some View {
     if let checkoutScope,
-      // C3: Uses concrete type because Swift generics can't accept protocol metatypes with associated types.
-      // The registry lookup uses `is T` conformance check, but the method signature requires a concrete T.
-      let cardFormScope = checkoutScope.getPaymentMethodScope(DefaultCardFormScope.self) {
+      let cardFormScope = checkoutScope.getPaymentMethodScope(PrimerCardFormScope.self) {
       content(cardFormScope)
         .environment(\.primerCardFormScope, cardFormScope)
         .task {

--- a/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultCheckoutScopeTests.swift
@@ -556,6 +556,39 @@ final class DefaultCheckoutScopeBehaviorTests: XCTestCase {
         XCTAssertNil(scope)
     }
 
+    // MARK: - getPaymentMethodScope per-protocol existential overload Tests
+
+    func test_getPaymentMethodScope_perProtocol_emptyCache_returnsNil() {
+        // Given
+        sut = makeSut()
+
+        // Then — every per-protocol overload returns nil when cache is empty.
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerCardFormScope).self))
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerKlarnaScope).self))
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerAdyenKlarnaScope).self))
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerWebRedirectScope).self))
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerFormRedirectScope).self))
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerBillingAddressRedirectScope).self))
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerApplePayScope).self))
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerPayPalScope).self))
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerQRCodeScope).self))
+        XCTAssertNil(sut.getPaymentMethodScope((any PrimerAchScope).self))
+    }
+
+    func test_getPaymentMethodScope_perProtocol_populatedCache_returnsCachedScope() {
+        // Given
+        sut = makeSut()
+        let mock = MockCardFormScope()
+        sut.paymentMethodScopeCache[PrimerPaymentMethodType.paymentCard.rawValue] = mock
+
+        // When
+        let scope = sut.getPaymentMethodScope((any PrimerCardFormScope).self)
+
+        // Then
+        XCTAssertNotNil(scope)
+        XCTAssertTrue(scope === mock)
+    }
+
     // MARK: - setVaultedPaymentMethods Tests (on real scope)
 
     func test_setVaultedPaymentMethods_setsMethodsAndDefaultSelection() {

--- a/Tests/Primer/CheckoutComponents/FormRedirect/DefaultFormRedirectScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/FormRedirect/DefaultFormRedirectScopeTests.swift
@@ -301,7 +301,7 @@ final class DefaultFormRedirectScopeTests: XCTestCase {
     @MainActor
     func test_submit_pollingStarted_transitionsToAwaitingExternalCompletion() async throws {
         mockInteractor.shouldCallOnPollingStarted = true
-        mockInteractor.executeDelay = 0.3
+        mockInteractor.executeDelay = 0.6
         let scope = createScope(paymentMethodType: FormRedirectTestData.Constants.blikPaymentMethodType)
         scope.start()
         try await Task.sleep(nanoseconds: 50_000_000)

--- a/Tests/Primer/CheckoutComponents/QRCode/QRCodePaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/QRCode/QRCodePaymentMethodTests.swift
@@ -125,10 +125,8 @@ final class QRCodePaymentMethodTests: XCTestCase {
         )
 
         // Then
-        XCTAssertNotNil(scope)
-        if let qrScope = scope as? DefaultQRCodeScope {
-            XCTAssertEqual(qrScope.presentationContext, .direct)
-        }
+        let qrScope = try XCTUnwrap(scope as? DefaultQRCodeScope)
+        XCTAssertEqual(qrScope.presentationContext, .direct)
     }
 
     func test_createScope_withMultiplePaymentMethods_usesPaymentSelectionContext() async throws {
@@ -145,10 +143,8 @@ final class QRCodePaymentMethodTests: XCTestCase {
         )
 
         // Then
-        XCTAssertNotNil(scope)
-        if let qrScope = scope as? DefaultQRCodeScope {
-            XCTAssertEqual(qrScope.presentationContext, .fromPaymentSelection)
-        }
+        let qrScope = try XCTUnwrap(scope as? DefaultQRCodeScope)
+        XCTAssertEqual(qrScope.presentationContext, .fromPaymentSelection)
     }
 
     // MARK: - createView Tests

--- a/Tests/Primer/CheckoutComponents/Registry/PaymentMethodRegistryTests.swift
+++ b/Tests/Primer/CheckoutComponents/Registry/PaymentMethodRegistryTests.swift
@@ -33,7 +33,7 @@ final class PaymentMethodRegistryTests: XCTestCase {
         XCTAssertFalse(PaymentMethodRegistry.shared.registeredTypes.contains("MOCK_PAYMENT"))
 
         // When
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
+        MockPaymentMethod.register()
 
         // Then
         XCTAssertTrue(PaymentMethodRegistry.shared.registeredTypes.contains("MOCK_PAYMENT"))
@@ -41,8 +41,8 @@ final class PaymentMethodRegistryTests: XCTestCase {
 
     func test_register_multiplePaymentMethods_addsAllToRegistry() {
         // When
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
-        PaymentMethodRegistry.shared.register(MockPaymentMethod2.self)
+        MockPaymentMethod.register()
+        MockPaymentMethod2.register()
 
         // Then
         XCTAssertEqual(PaymentMethodRegistry.shared.registeredTypes.count, 2)
@@ -52,8 +52,8 @@ final class PaymentMethodRegistryTests: XCTestCase {
 
     func test_register_samePaymentMethodTwice_replacesPrevious() {
         // When
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
+        MockPaymentMethod.register()
+        MockPaymentMethod.register()
 
         // Then
         let count = PaymentMethodRegistry.shared.registeredTypes.filter { $0 == "MOCK_PAYMENT" }.count
@@ -65,7 +65,7 @@ final class PaymentMethodRegistryTests: XCTestCase {
     func test_createScope_forRegisteredType_returnsScope() async throws {
         // Given — register after scope creation since init calls reset()
         let checkoutScope = await createMockCheckoutScope()
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
+        MockPaymentMethod.register()
 
         // When
         let scope = try await PaymentMethodRegistry.shared.createScope(
@@ -98,7 +98,7 @@ final class PaymentMethodRegistryTests: XCTestCase {
     func test_getView_forRegisteredType_returnsView() async {
         // Given — register after scope creation since init calls reset()
         let checkoutScope = await createMockCheckoutScope()
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
+        MockPaymentMethod.register()
 
         // When
         let view = PaymentMethodRegistry.shared.getView(
@@ -128,8 +128,8 @@ final class PaymentMethodRegistryTests: XCTestCase {
 
     func test_reset_clearsAllRegisteredPaymentMethods() {
         // Given
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
-        PaymentMethodRegistry.shared.register(MockPaymentMethod2.self)
+        MockPaymentMethod.register()
+        MockPaymentMethod2.register()
         XCTAssertEqual(PaymentMethodRegistry.shared.registeredTypes.count, 2)
 
         // When
@@ -141,7 +141,7 @@ final class PaymentMethodRegistryTests: XCTestCase {
 
     func test_reset_afterReset_createScopeReturnsNil() async throws {
         // Given
-        PaymentMethodRegistry.shared.register(MockPaymentMethod.self)
+        MockPaymentMethod.register()
         PaymentMethodRegistry.shared.reset()
         let checkoutScope = await createMockCheckoutScope()
 
@@ -196,15 +196,13 @@ struct MockPaymentMethodState: Equatable {
 
 @available(iOS 15.0, *)
 struct MockPaymentMethod: PaymentMethodProtocol {
-    typealias ScopeType = MockPaymentMethodScope
-
     static var paymentMethodType: String { "MOCK_PAYMENT" }
 
     @MainActor
     static func createScope(
         checkoutScope: PrimerCheckoutScope,
         diContainer: any ContainerProtocol
-    ) async throws -> MockPaymentMethodScope {
+    ) async throws -> any PrimerPaymentMethodScope {
         MockPaymentMethodScope()
     }
 
@@ -214,13 +212,12 @@ struct MockPaymentMethod: PaymentMethodProtocol {
     }
 
     @MainActor
-    func content<V: View>(@ViewBuilder content: @escaping (MockPaymentMethodScope) -> V) -> AnyView {
-        AnyView(EmptyView())
-    }
-
-    @MainActor
-    func defaultContent() -> AnyView {
-        AnyView(Text("Default Mock Content"))
+    static func register() {
+        PaymentMethodRegistry.shared.register(
+            forKey: paymentMethodType,
+            scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+            viewCreator: { createView(checkoutScope: $0) }
+        )
     }
 }
 
@@ -245,15 +242,13 @@ final class MockPaymentMethod2Scope: PrimerPaymentMethodScope {
 
 @available(iOS 15.0, *)
 struct MockPaymentMethod2: PaymentMethodProtocol {
-    typealias ScopeType = MockPaymentMethod2Scope
-
     static var paymentMethodType: String { "MOCK_PAYMENT_2" }
 
     @MainActor
     static func createScope(
         checkoutScope: PrimerCheckoutScope,
         diContainer: any ContainerProtocol
-    ) async throws -> MockPaymentMethod2Scope {
+    ) async throws -> any PrimerPaymentMethodScope {
         MockPaymentMethod2Scope()
     }
 
@@ -263,12 +258,11 @@ struct MockPaymentMethod2: PaymentMethodProtocol {
     }
 
     @MainActor
-    func content<V: View>(@ViewBuilder content: @escaping (MockPaymentMethod2Scope) -> V) -> AnyView {
-        AnyView(EmptyView())
-    }
-
-    @MainActor
-    func defaultContent() -> AnyView {
-        AnyView(Text("Default Mock 2 Content"))
+    static func register() {
+        PaymentMethodRegistry.shared.register(
+            forKey: paymentMethodType,
+            scopeCreator: { try await createScope(checkoutScope: $0, diContainer: $1) },
+            viewCreator: { createView(checkoutScope: $0) }
+        )
     }
 }

--- a/Tests/Primer/CheckoutComponents/WebRedirect/WebRedirectPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/WebRedirect/WebRedirectPaymentMethodTests.swift
@@ -168,10 +168,8 @@ final class WebRedirectPaymentMethodTests: XCTestCase {
         )
 
         // Then
-        XCTAssertNotNil(scope)
-        if let webRedirectScope = scope as? DefaultWebRedirectScope {
-            XCTAssertEqual(webRedirectScope.presentationContext, .direct)
-        }
+        let webRedirectScope = try XCTUnwrap(scope as? DefaultWebRedirectScope)
+        XCTAssertEqual(webRedirectScope.presentationContext, .direct)
     }
 
     func test_registeredScope_withMultiplePaymentMethods_usesPaymentSelectionContext() async throws {
@@ -188,10 +186,8 @@ final class WebRedirectPaymentMethodTests: XCTestCase {
         )
 
         // Then
-        XCTAssertNotNil(scope)
-        if let webRedirectScope = scope as? DefaultWebRedirectScope {
-            XCTAssertEqual(webRedirectScope.presentationContext, .fromPaymentSelection)
-        }
+        let webRedirectScope = try XCTUnwrap(scope as? DefaultWebRedirectScope)
+        XCTAssertEqual(webRedirectScope.presentationContext, .fromPaymentSelection)
     }
 
     // MARK: - getView via Registry


### PR DESCRIPTION
# Description

[ACC-7173](https://primerapi.atlassian.net/browse/ACC-7173)

Final follow-up to ACC-7135 / ACC-7172 / ACC-7171. Cleans up the internal `PaymentMethodProtocol` machinery and adds public-protocol metatype access on `PrimerCheckoutScope` so most call sites no longer need the concrete `Default*Scope` type to look a scope up.

## Scope A — `PaymentMethodProtocol` cleanup

- Drop the `associatedtype ScopeType: PrimerPaymentMethodScope` from `PaymentMethodProtocol` and have `createScope(...)` return `any PrimerPaymentMethodScope` directly.
- Delete dead code that depended on `ScopeType`: the `content<V>` and `defaultContent` requirements (every conformer was a `fatalError` stub, no callers in `Sources/`, `Tests/`, or `Debug App/`), the unused `register<T: PaymentMethodProtocol>` overload, the `typeToIdentifier` field, and the unused `createScope<T>(_ scopeType:)` overload.
- Each PaymentMethod's `register()` now calls the existing low-level `register(forKey:scopeCreator:viewCreator:)` directly (the same pattern `WebRedirectPaymentMethod` was already using). Drops 8× `typealias ScopeType = Default*Scope` and 16 stub bodies.
- Removes invariant `paymentMethodType: String { get }` from `PrimerAdyenKlarnaScope` (always `"ADYEN_KLARNA"` — pure boilerplate).

## Scope B Approach 1 — per-protocol existential overloads on `PrimerCheckoutScope`

- Add 10 new `getPaymentMethodScope(_:)` overloads that take `(any Primer<Method>Scope).Type` so call sites can pass the public-protocol metatype instead of the concrete `Default*Scope`. The protocol extension provides `nil`-returning defaults so test mocks and merchant-side conformers don't have to stub all 10. `DefaultCheckoutScope` overrides each with the real cache-backed lookup via a private generic helper.
- Public-API addition only — no break.
- Rebind 7 of 10 internal call sites to the public-protocol metatype (Klarna, AdyenKlarna, Ach, PayPal, WebRedirect, QRCode, BillingAddressRedirect). 3 sites stay on the concrete metatype with inline `audit §2a` notes — `CardFormScreen` takes an internal sub-protocol, and `ApplePayScreen` / `FormRedirectContainerView` use `@ObservedObject Default*Scope` which SwiftUI requires to be concrete.

## Bonus

- Fix a public-API leak in `CardFormProvider` (a public type) where `getPaymentMethodScope(DefaultCardFormScope.self)` was reaching into the internal concrete class. Now uses `PrimerCardFormScope.self`.
- 4 test-suite cleanups — convert `if let scope = … as? Default*Scope { XCTAssertEqual(...) }` to `let scope = try XCTUnwrap(... as? Default*Scope); XCTAssertEqual(...)` in `WebRedirectPaymentMethodTests` and `QRCodePaymentMethodTests`.

The SDK is in beta with no merchants on this surface yet, so the public-API additions are safe.

# Manual Testing

- [ ] Run a card payment end-to-end (covers Card path)
- [ ] Run a Klarna payment if backend supports it (covers metatype rebind)

# Contributor Checklist

- [ ] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable
- [ ] I have manually tested newly added UX
- [x] I have open a documentation PR, if applicable (N/A — internal refactor)

[ACC-7173]: https://primerapi.atlassian.net/browse/ACC-7173