### PR TITLE
chore: align CHANGELOG.md with Keep a Changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changelog
+
+All notable changes to `primer-sdk-ios` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## 2.47.0 (2026-04-24)
 
 ### Feat


### PR DESCRIPTION
## Summary

- Engineering standard **014 — Package versioning** requires `CHANGELOG.md` to follow the Keep a Changelog format, starting with a `# Changelog` header.
- The standards check from [`engineering-standards`](https://gitlab.com/primer-io/engineering-standards) flagged this repo as failing: `CHANGELOG.md does not follow Keep a Changelog format (missing '# Changelog' header)`.
- Prepended the standard `# Changelog` header plus a Keep a Changelog / SemVer reference paragraph. Existing version sections are unchanged.

## Test plan

- [x] Ran `primer-standards --repo-type swift-sdk` against this repo — `014_package_versioning [swift]` ✅ now passes (was previously failing)