### PR TITLE
chore: Re-export PrimerFoundation to merchants

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Primer/Primer.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/Primer.swift
@@ -4,7 +4,7 @@
 //  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import PrimerFoundation
+@_exported import PrimerFoundation
 import UIKit
 
 // swiftlint:disable identifier_name


### PR DESCRIPTION
This prevents merchants needing to explicitly import PrimerFoundation. It's only needed in one place per the [proposal](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md):

_any module that the current module re-exports in any of its source files will be considered visible in every other source file._