### PR TITLE
feat: Expose orderedAllowedCardNetworks via ComponentsClientSessionBridge [ACC-7158]

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsClientSessionBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsClientSessionBridge.swift
@@ -30,6 +30,15 @@ public final class ComponentsClientSessionBridge {
         return PrimerClientSession(from: configuration)
     }
 
+    public func getOrderedAllowedCardNetworks() -> [String]? {
+        Analytics.Service.fire(event: Analytics.Event.sdk(
+            name: "\(Self.self).\(#function)",
+            params: ["category": "CLIENT_SESSION"]
+        ))
+
+        return configurationProvider()?.clientSession?.paymentMethod?.orderedAllowedCardNetworks
+    }
+
     public func getCheckoutModules() -> [ComponentsCheckoutModule]? {
         Analytics.Service.fire(event: Analytics.Event.sdk(
             name: "\(Self.self).\(#function)",

--- a/Tests/Primer/CheckoutComponents/Bridge/ComponentsClientSessionBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/ComponentsClientSessionBridgeTests.swift
@@ -40,6 +40,29 @@ final class ComponentsClientSessionBridgeTests: XCTestCase {
         XCTAssertEqual(session?.orderId, "order-123")
     }
 
+    // MARK: - getOrderedAllowedCardNetworks
+
+    func test_getOrderedAllowedCardNetworks_returnsNil_whenConfigurationMissing() {
+        XCTAssertNil(sut.getOrderedAllowedCardNetworks())
+    }
+
+    func test_getOrderedAllowedCardNetworks_returnsNil_whenPaymentMethodMissing() {
+        configuration = makeConfiguration(clientSession: makeClientSession(orderId: "order-123"))
+
+        XCTAssertNil(sut.getOrderedAllowedCardNetworks())
+    }
+
+    func test_getOrderedAllowedCardNetworks_returnsList_whenPaymentMethodPresent() {
+        configuration = makeConfiguration(
+            clientSession: makeClientSession(
+                orderId: "order-123",
+                orderedAllowedCardNetworks: ["VISA", "MASTERCARD", "AMEX"]
+            )
+        )
+
+        XCTAssertEqual(sut.getOrderedAllowedCardNetworks(), ["VISA", "MASTERCARD", "AMEX"])
+    }
+
     // MARK: - getCheckoutModules
 
     func test_getCheckoutModules_returnsNil_whenConfigurationMissing() {
@@ -125,10 +148,21 @@ final class ComponentsClientSessionBridgeTests: XCTestCase {
         )
     }
 
-    private func makeClientSession(orderId: String) -> ClientSession.APIResponse {
-        ClientSession.APIResponse(
+    private func makeClientSession(
+        orderId: String,
+        orderedAllowedCardNetworks: [String]? = nil
+    ) -> ClientSession.APIResponse {
+        let paymentMethod = orderedAllowedCardNetworks.map { networks in
+            ClientSession.PaymentMethod(
+                vaultOnSuccess: false,
+                options: nil,
+                orderedAllowedCardNetworks: networks,
+                descriptor: nil
+            )
+        }
+        return ClientSession.APIResponse(
             clientSessionId: "client-session-id",
-            paymentMethod: nil,
+            paymentMethod: paymentMethod,
             order: .init(
                 id: orderId,
                 merchantAmount: nil,


### PR DESCRIPTION
# Description

[ACC-7158](https://primerapi.atlassian.net/browse/ACC-7158)

Adds a `getOrderedAllowedCardNetworks()` accessor to the existing `@_spi(PrimerInternal)` `ComponentsClientSessionBridge`. Returns the merchant's allowed-network list from the client session for the React Native chip-row component (`PrimerAcceptedCardNetworks`).

No public-model change — the internal `ClientSession.PaymentMethod.orderedAllowedCardNetworks` is read directly from the bridge, mirroring how `getCheckoutModules()` already works. The public `PrimerClientSession` model is untouched.

# Manual Testing

Consumed by [ACC-7158 RN PR](https://github.com/primer-io/primer-sdk-react-native/pulls?q=is%3Aopen+ACC-7158) — the chip row above the card number input renders the merchant's networks.

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable
- [x] I have manually tested newly added UX
- [ ] I have open a documentation PR, if applicable

[ACC-7158]: https://primerapi.atlassian.net/browse/ACC-7158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ