### PR TITLE
chore: Bypass Apple Pay filter for LambdaTest PoC [ACC-7238]

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/PrimerConfiguration.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerConfiguration.swift
@@ -113,12 +113,15 @@ extension Response.Body {
                 .compactMap(\.tokenizationViewModel)
                 ?? []
 
-            if !ApplePayUtils.canMakeApplePayPayments() {
-                if let applePayViewModel = viewModels.filter({ $0.config.type == PrimerPaymentMethodType.applePay.rawValue }).first,
-                   let applePayViewModelIndex = viewModels.firstIndex(where: { $0 == applePayViewModel }) {
-                    viewModels.remove(at: applePayViewModelIndex)
-                }
-            }
+            // SPIKE ACC-7238: filter bypassed to test whether LambdaTest's
+            // applePay cap surfaces the tile even when canMakePayments()
+            // returns false on the provisioned device. Revert before merge.
+            // if !ApplePayUtils.canMakeApplePayPayments() {
+            //     if let applePayViewModel = viewModels.filter({ $0.config.type == PrimerPaymentMethodType.applePay.rawValue }).first,
+            //        let applePayViewModelIndex = viewModels.firstIndex(where: { $0 == applePayViewModel }) {
+            //         viewModels.remove(at: applePayViewModelIndex)
+            //     }
+            // }
 
             #if !canImport(PrimerKlarnaSDK)
                 if let klarnaViewModelIndex = viewModels.firstIndex(where: { $0.config.type == PrimerPaymentMethodType.klarna.rawValue }) {


### PR DESCRIPTION
## Summary
- Temporarily comments out the `canMakePayments()` filter at `PrimerConfiguration.swift:116-121` that removes APPLE_PAY from the Drop-in payment-method list
- Goal: verify whether LambdaTest's `applePay: true` capability provisions the device enough for the tile to be tapped and the sheet to fire

## Why
ACC-7238 spike investigation. Network capture from the LT device confirms the backend returns APPLE_PAY in `paymentMethodConfigs`, but the iOS Drop-in filters it out client-side because `PKPaymentAuthorizationController.canMakePayments()` returns false on the LT-provisioned device. Bypassing the filter lets us prove (or disprove) whether the LT cap actually provisions Wallet behind the scenes.

## Not for merge
This PR exists only to push a debug build to LambdaTest (`preview-ios` custom_id). The change must be reverted before any production merge.

## Test plan
- [ ] Manually dispatch `Run UI Tests and publish nightly build` workflow on this branch
- [ ] Wait for upload to LambdaTest with `preview-ios` custom_id
- [ ] Point e2e-tests pipeline at `preview-ios` and re-run Apple Pay scenario