### PR TITLE
feat: Add Apple Pay bridge for React Native consumers [ACC-6923]

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsApplePayBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsApplePayBridge.swift
@@ -6,38 +6,24 @@
 
 import Foundation
 
-/// Bridge surface used by `primer-io-react-native` to drive Apple Pay through the new
-/// Checkout Components scope without going through `PrimerCheckout` (SwiftUI) or
-/// `PrimerCheckoutPresenter` (UIKit). Matches the pattern of
-/// `ComponentsBillingAddressBridge` and `ComponentsClientSessionBridge`: imported on the
-/// consumer side via `@_spi(PrimerInternal) import PrimerSDK`.
-///
-/// Lifecycle:
-/// 1. `init()` — cheap, allocates only the wrapper.
-/// 2. `setup(clientToken:settings:)` async — performs the same SDK initialization that
-///    `PrimerCheckout` does at first render (`CheckoutSDKInitializer.initialize()`), then
-///    resolves `PrimerApplePayScope` from the resulting checkout scope.
-/// 3. State observation via `stateStream` — async stream of POD `ComponentsApplePayState`.
-/// 4. `startPayment()` / `cancel()` — proxy to the underlying scope.
-/// 5. `dispose()` async — tears down the observation task, dismisses the checkout scope,
-///    clears the DI container.
+/// Bridge surface used by `primer-io-react-native` to drive Apple Pay through the Checkout
+/// Components scope without going through `PrimerCheckout` (SwiftUI) or
+/// `PrimerCheckoutPresenter` (UIKit). Mirrors `ComponentsBillingAddressBridge` and
+/// `ComponentsClientSessionBridge`.
 @available(iOS 15.0, *)
 @MainActor
 @_spi(PrimerInternal)
 public final class ComponentsApplePayBridge {
 
-    /// Async stream of Apple Pay state changes. Bridge-public POD type — does not carry
-    /// PassKit types across the boundary. Set up at init so yields produced by `setup`
-    /// don't race the consumer attaching its iterator.
     public let stateStream: AsyncStream<ComponentsApplePayState>
     private let stateContinuation: AsyncStream<ComponentsApplePayState>.Continuation
 
-    /// Async stream of terminal Apple Pay outcomes. The new Checkout Components scope
-    /// does NOT fire `PrimerDelegate.primerDidCompleteCheckoutWithData` — terminal results
-    /// only propagate through `PrimerCheckoutScope.state`. This bridge observes that
-    /// stream and re-emits Apple Pay outcomes as POD events so the RN bridge can route
-    /// them into `PrimerCheckoutProvider.paymentOutcome` / `onCheckoutComplete` /
-    /// `onError`. Cancellations do not emit (matching the card flow's behaviour).
+    /// The Checkout Components scope does NOT fire
+    /// `PrimerDelegate.primerDidCompleteCheckoutWithData` — terminal results only propagate
+    /// through `PrimerCheckoutScope.state`. This bridge observes that stream and re-emits
+    /// Apple Pay outcomes so the RN bridge can route them into
+    /// `PrimerCheckoutProvider.paymentOutcome` / `onCheckoutComplete` / `onError`.
+    /// Cancellations do not emit (matching the card flow's behaviour).
     public let outcomeStream: AsyncStream<ComponentsApplePayOutcome>
     private let outcomeContinuation: AsyncStream<ComponentsApplePayOutcome>.Continuation
 
@@ -48,6 +34,8 @@ public final class ComponentsApplePayBridge {
     private var outcomeObservationTask: Task<Void, Never>?
 
     public init() {
+        // Streams are created at init (not in setup) so yields from setup can't race the
+        // consumer attaching its iterator.
         var capturedStateContinuation: AsyncStream<ComponentsApplePayState>.Continuation!
         stateStream = AsyncStream { continuation in
             capturedStateContinuation = continuation
@@ -61,14 +49,8 @@ public final class ComponentsApplePayBridge {
         outcomeContinuation = capturedOutcomeContinuation
     }
 
-    // MARK: - Setup
-
-    /// Initialise the underlying Checkout Components scope and resolve `PrimerApplePayScope`.
-    /// Must be called before `startPayment`, `cancel`, or `stateStream` produce values.
-    ///
-    /// Reads `PrimerSettings.current` internally — bridge consumers (RN, etc.) do not need
-    /// to pass settings since they're already populated globally by the prior
-    /// `PrimerHeadlessUniversalCheckout.startWithClientToken` call.
+    /// Reads `PrimerSettings.current` internally — settings are already populated globally
+    /// by the prior `PrimerHeadlessUniversalCheckout.startWithClientToken` call.
     public func setup(clientToken: String) async throws {
         Analytics.Service.fire(event: Analytics.Event.sdk(
             name: "\(Self.self).\(#function)",
@@ -90,13 +72,9 @@ public final class ComponentsApplePayBridge {
         self.initializer = initializer
         checkoutScope = scope
 
-        // `DefaultCheckoutScope.init` spawns an async Task that loads payment methods from
-        // the server and only then populates `paymentMethodScopeCache` (which is what
-        // `getPaymentMethodScope` reads). Until that completes, the cache is empty and the
-        // lookup returns nil. Wait for `.ready` (or `.failure`) on `scope.state` before
-        // resolving the Apple Pay scope. `scope.state` is a computed property that returns
-        // a fresh AsyncStream replaying the current state, so this iterator is independent
-        // of the one used later by `startOutcomeObservation`.
+        // `DefaultCheckoutScope.init` spawns an async Task that loads payment methods and
+        // only then populates `paymentMethodScopeCache` (what `getPaymentMethodScope`
+        // reads). Wait for `.ready` (or `.failure`) before resolving the Apple Pay scope.
         waitForReady: for await state in scope.state {
             switch state {
             case .ready:
@@ -120,10 +98,6 @@ public final class ComponentsApplePayBridge {
         startOutcomeObservation(on: scope)
     }
 
-    // MARK: - Actions
-
-    /// Begin an Apple Pay payment. Resolves when the SDK has handed off to PassKit
-    /// (the sheet is presenting). Rejects on pre-sheet failure.
     public func startPayment() async throws {
         guard let applePayScope else {
             throw PrimerError.unableToPresentPaymentMethod(
@@ -134,13 +108,10 @@ public final class ComponentsApplePayBridge {
         applePayScope.submit()
     }
 
-    /// Cancel an in-flight Apple Pay attempt. Safe no-op when no attempt is in flight.
     public func cancel() async {
         applePayScope?.cancel()
     }
 
-    /// Tear down state observation and release the checkout scope. After `dispose()` the
-    /// instance can be discarded; create a new bridge for a new client token.
     public func dispose() async {
         Analytics.Service.fire(event: Analytics.Event.sdk(
             name: "\(Self.self).\(#function)",
@@ -160,8 +131,6 @@ public final class ComponentsApplePayBridge {
         initializer = nil
         await DIContainer.clearContainer()
     }
-
-    // MARK: - Private
 
     private func startStateObservation(on scope: any PrimerApplePayScope) {
         stateObservationTask?.cancel()
@@ -191,9 +160,6 @@ public final class ComponentsApplePayBridge {
 
 // MARK: - Bridge-Public Types
 
-/// POD state mirror of `PrimerApplePayState` for cross-bridge transport.
-/// Does not carry PassKit types (`PKPaymentButtonStyle`, etc.) — those stay on the iOS side
-/// behind the bridge, where they are configured via props on the RN view manager.
 @available(iOS 15.0, *)
 @_spi(PrimerInternal)
 public struct ComponentsApplePayState: Sendable {
@@ -213,7 +179,6 @@ public struct ComponentsApplePayState: Sendable {
     }
 }
 
-/// POD availability-error mirror.
 @available(iOS 15.0, *)
 @_spi(PrimerInternal)
 public struct ComponentsApplePayAvailabilityError: Sendable {
@@ -227,9 +192,8 @@ public struct ComponentsApplePayAvailabilityError: Sendable {
     }
 }
 
-/// Terminal Apple Pay outcome — the bridge-public mirror of `PrimerCheckoutState.success` /
-/// `.failure`. Cancellations do not produce an outcome (matching the card flow's
-/// "cancel = no `paymentOutcome` change" behaviour).
+/// Cancellations do not produce an outcome (matching the card flow's "cancel = no
+/// `paymentOutcome` change" behaviour).
 @available(iOS 15.0, *)
 @_spi(PrimerInternal)
 public enum ComponentsApplePayOutcome: Sendable {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsApplePayBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsApplePayBridge.swift
@@ -1,0 +1,292 @@
+//
+//  ComponentsApplePayBridge.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+/// Bridge surface used by `primer-io-react-native` to drive Apple Pay through the new
+/// Checkout Components scope without going through `PrimerCheckout` (SwiftUI) or
+/// `PrimerCheckoutPresenter` (UIKit). Matches the pattern of
+/// `ComponentsBillingAddressBridge` and `ComponentsClientSessionBridge`: imported on the
+/// consumer side via `@_spi(PrimerInternal) import PrimerSDK`.
+///
+/// Lifecycle:
+/// 1. `init()` — cheap, allocates only the wrapper.
+/// 2. `setup(clientToken:settings:)` async — performs the same SDK initialization that
+///    `PrimerCheckout` does at first render (`CheckoutSDKInitializer.initialize()`), then
+///    resolves `PrimerApplePayScope` from the resulting checkout scope.
+/// 3. State observation via `stateStream` — async stream of POD `ComponentsApplePayState`.
+/// 4. `startPayment()` / `cancel()` — proxy to the underlying scope.
+/// 5. `dispose()` async — tears down the observation task, dismisses the checkout scope,
+///    clears the DI container.
+@available(iOS 15.0, *)
+@MainActor
+@_spi(PrimerInternal)
+public final class ComponentsApplePayBridge {
+
+    /// Async stream of Apple Pay state changes. Bridge-public POD type — does not carry
+    /// PassKit types across the boundary. Set up at init so yields produced by `setup`
+    /// don't race the consumer attaching its iterator.
+    public let stateStream: AsyncStream<ComponentsApplePayState>
+    private let stateContinuation: AsyncStream<ComponentsApplePayState>.Continuation
+
+    /// Async stream of terminal Apple Pay outcomes. The new Checkout Components scope
+    /// does NOT fire `PrimerDelegate.primerDidCompleteCheckoutWithData` — terminal results
+    /// only propagate through `PrimerCheckoutScope.state`. This bridge observes that
+    /// stream and re-emits Apple Pay outcomes as POD events so the RN bridge can route
+    /// them into `PrimerCheckoutProvider.paymentOutcome` / `onCheckoutComplete` /
+    /// `onError`. Cancellations do not emit (matching the card flow's behaviour).
+    public let outcomeStream: AsyncStream<ComponentsApplePayOutcome>
+    private let outcomeContinuation: AsyncStream<ComponentsApplePayOutcome>.Continuation
+
+    private var initializer: CheckoutSDKInitializer?
+    private var checkoutScope: DefaultCheckoutScope?
+    private var applePayScope: (any PrimerApplePayScope)?
+    private var stateObservationTask: Task<Void, Never>?
+    private var outcomeObservationTask: Task<Void, Never>?
+
+    public init() {
+        var capturedStateContinuation: AsyncStream<ComponentsApplePayState>.Continuation!
+        stateStream = AsyncStream { continuation in
+            capturedStateContinuation = continuation
+        }
+        stateContinuation = capturedStateContinuation
+
+        var capturedOutcomeContinuation: AsyncStream<ComponentsApplePayOutcome>.Continuation!
+        outcomeStream = AsyncStream { continuation in
+            capturedOutcomeContinuation = continuation
+        }
+        outcomeContinuation = capturedOutcomeContinuation
+    }
+
+    // MARK: - Setup
+
+    /// Initialise the underlying Checkout Components scope and resolve `PrimerApplePayScope`.
+    /// Must be called before `startPayment`, `cancel`, or `stateStream` produce values.
+    ///
+    /// Reads `PrimerSettings.current` internally — bridge consumers (RN, etc.) do not need
+    /// to pass settings since they're already populated globally by the prior
+    /// `PrimerHeadlessUniversalCheckout.startWithClientToken` call.
+    public func setup(clientToken: String) async throws {
+        Analytics.Service.fire(event: Analytics.Event.sdk(
+            name: "\(Self.self).\(#function)",
+            params: ["category": "APPLE_PAY"]
+        ))
+
+        let initializer = CheckoutSDKInitializer(
+            clientToken: clientToken,
+            primerSettings: PrimerSettings.current,
+            primerTheme: PrimerCheckoutTheme(),
+            diContainer: DIContainer.shared,
+            navigator: CheckoutNavigator(),
+            presentationContext: .direct
+        )
+
+        let result = try await initializer.initialize()
+        let scope = result.checkoutScope
+
+        self.initializer = initializer
+        checkoutScope = scope
+
+        // `DefaultCheckoutScope.init` spawns an async Task that loads payment methods from
+        // the server and only then populates `paymentMethodScopeCache` (which is what
+        // `getPaymentMethodScope` reads). Until that completes, the cache is empty and the
+        // lookup returns nil. Wait for `.ready` (or `.failure`) on `scope.state` before
+        // resolving the Apple Pay scope. `scope.state` is a computed property that returns
+        // a fresh AsyncStream replaying the current state, so this iterator is independent
+        // of the one used later by `startOutcomeObservation`.
+        waitForReady: for await state in scope.state {
+            switch state {
+            case .ready:
+                break waitForReady
+            case let .failure(error):
+                throw error
+            default:
+                continue
+            }
+        }
+
+        guard let applePay = scope.getPaymentMethodScope((any PrimerApplePayScope).self) else {
+            throw PrimerError.unableToPresentPaymentMethod(
+                paymentMethodType: "APPLE_PAY",
+                reason: "Apple Pay scope is not registered for this session"
+            )
+        }
+        applePayScope = applePay
+
+        startStateObservation(on: applePay)
+        startOutcomeObservation(on: scope)
+    }
+
+    // MARK: - Actions
+
+    /// Begin an Apple Pay payment. Resolves when the SDK has handed off to PassKit
+    /// (the sheet is presenting). Rejects on pre-sheet failure.
+    public func startPayment() async throws {
+        guard let applePayScope else {
+            throw PrimerError.unableToPresentPaymentMethod(
+                paymentMethodType: "APPLE_PAY",
+                reason: "Apple Pay bridge has not been set up. Call setup() first."
+            )
+        }
+        applePayScope.submit()
+    }
+
+    /// Cancel an in-flight Apple Pay attempt. Safe no-op when no attempt is in flight.
+    public func cancel() async {
+        applePayScope?.cancel()
+    }
+
+    /// Tear down state observation and release the checkout scope. After `dispose()` the
+    /// instance can be discarded; create a new bridge for a new client token.
+    public func dispose() async {
+        Analytics.Service.fire(event: Analytics.Event.sdk(
+            name: "\(Self.self).\(#function)",
+            params: ["category": "APPLE_PAY"]
+        ))
+
+        stateObservationTask?.cancel()
+        stateObservationTask = nil
+        outcomeObservationTask?.cancel()
+        outcomeObservationTask = nil
+        stateContinuation.finish()
+        outcomeContinuation.finish()
+        checkoutScope?.onDismiss()
+        checkoutScope = nil
+        applePayScope = nil
+        initializer?.cleanup()
+        initializer = nil
+        await DIContainer.clearContainer()
+    }
+
+    // MARK: - Private
+
+    private func startStateObservation(on scope: any PrimerApplePayScope) {
+        stateObservationTask?.cancel()
+        stateObservationTask = Task { [stateContinuation] in
+            for await state in scope.state {
+                stateContinuation.yield(ComponentsApplePayState(from: state))
+            }
+        }
+    }
+
+    private func startOutcomeObservation(on scope: DefaultCheckoutScope) {
+        outcomeObservationTask?.cancel()
+        outcomeObservationTask = Task { [outcomeContinuation] in
+            for await state in scope.state {
+                switch state {
+                case let .success(result):
+                    outcomeContinuation.yield(ComponentsApplePayOutcome(from: result))
+                case let .failure(error):
+                    outcomeContinuation.yield(ComponentsApplePayOutcome(from: error))
+                default:
+                    continue
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Bridge-Public Types
+
+/// POD state mirror of `PrimerApplePayState` for cross-bridge transport.
+/// Does not carry PassKit types (`PKPaymentButtonStyle`, etc.) — those stay on the iOS side
+/// behind the bridge, where they are configured via props on the RN view manager.
+@available(iOS 15.0, *)
+@_spi(PrimerInternal)
+public struct ComponentsApplePayState: Sendable {
+
+    public let isAvailable: Bool
+    public let isLoading: Bool
+    public let availabilityError: ComponentsApplePayAvailabilityError?
+
+    public init(
+        isAvailable: Bool,
+        isLoading: Bool,
+        availabilityError: ComponentsApplePayAvailabilityError?
+    ) {
+        self.isAvailable = isAvailable
+        self.isLoading = isLoading
+        self.availabilityError = availabilityError
+    }
+}
+
+/// POD availability-error mirror.
+@available(iOS 15.0, *)
+@_spi(PrimerInternal)
+public struct ComponentsApplePayAvailabilityError: Sendable {
+
+    public let code: String
+    public let message: String
+
+    public init(code: String, message: String) {
+        self.code = code
+        self.message = message
+    }
+}
+
+/// Terminal Apple Pay outcome — the bridge-public mirror of `PrimerCheckoutState.success` /
+/// `.failure`. Cancellations do not produce an outcome (matching the card flow's
+/// "cancel = no `paymentOutcome` change" behaviour).
+@available(iOS 15.0, *)
+@_spi(PrimerInternal)
+public enum ComponentsApplePayOutcome: Sendable {
+    case success(paymentId: String, status: String, amount: Int?, currencyCode: String?, paymentMethodType: String)
+    case failure(errorCode: String, errorMessage: String, diagnosticsId: String)
+}
+
+@available(iOS 15.0, *)
+extension ComponentsApplePayOutcome {
+    init(from result: PaymentResult) {
+        self = .success(
+            paymentId: result.paymentId,
+            status: String(describing: result.status),
+            amount: result.amount,
+            currencyCode: result.currencyCode,
+            paymentMethodType: result.paymentMethodType ?? "APPLE_PAY"
+        )
+    }
+
+    init(from error: PrimerError) {
+        self = .failure(
+            errorCode: error.errorId,
+            errorMessage: error.errorDescription ?? "Apple Pay payment failed.",
+            diagnosticsId: error.diagnosticsId
+        )
+    }
+}
+
+// MARK: - State Mapping
+
+@available(iOS 15.0, *)
+extension ComponentsApplePayState {
+    init(from state: PrimerApplePayState) {
+        isAvailable = state.isAvailable
+        isLoading = state.isLoading
+        availabilityError = state.availabilityError.map { message in
+            ComponentsApplePayAvailabilityError(
+                code: Self.stableCode(for: message),
+                message: message
+            )
+        }
+    }
+
+    static func stableCode(for message: String) -> String {
+        let lower = message.lowercased()
+        if lower.contains("os version") || lower.contains("ios 15") || lower.contains("unsupported os") {
+            return "OS_VERSION_TOO_LOW"
+        }
+        if lower.contains("wallet") || lower.contains("no card") || lower.contains("no eligible card") {
+            return "NO_WALLET_CARD"
+        }
+        if lower.contains("merchant identifier") || lower.contains("merchantidentifier") {
+            return "MERCHANT_IDENTIFIER_MISSING"
+        }
+        if lower.contains("client session") || lower.contains("clientsession") {
+            return "CHECKOUT_SESSION_INVALID"
+        }
+        return "UNKNOWN"
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Bridge/ComponentsApplePayBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/ComponentsApplePayBridgeTests.swift
@@ -1,0 +1,137 @@
+//
+//  ComponentsApplePayBridgeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import XCTest
+@_spi(PrimerInternal) @testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class ComponentsApplePayBridgeTests: XCTestCase {
+
+    // MARK: - stableCode(for:)
+
+    func test_stableCode_osVersionMessage_returnsOSVersionTooLow() {
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "OS version too low"), "OS_VERSION_TOO_LOW")
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "iOS 15 or later is required"), "OS_VERSION_TOO_LOW")
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "Unsupported OS"), "OS_VERSION_TOO_LOW")
+    }
+
+    func test_stableCode_walletMessage_returnsNoWalletCard() {
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "No cards in wallet"), "NO_WALLET_CARD")
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "No eligible card for Apple Pay"), "NO_WALLET_CARD")
+    }
+
+    func test_stableCode_merchantIdentifierMessage_returnsMerchantIdMissing() {
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "Merchant identifier is missing"), "MERCHANT_IDENTIFIER_MISSING")
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "merchantIdentifier not set"), "MERCHANT_IDENTIFIER_MISSING")
+    }
+
+    func test_stableCode_clientSessionMessage_returnsCheckoutSessionInvalid() {
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "Client session is invalid"), "CHECKOUT_SESSION_INVALID")
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "clientSession missing payment options"), "CHECKOUT_SESSION_INVALID")
+    }
+
+    func test_stableCode_unrelatedMessage_returnsUnknown() {
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: "Something else went wrong"), "UNKNOWN")
+        XCTAssertEqual(ComponentsApplePayState.stableCode(for: ""), "UNKNOWN")
+    }
+
+    // MARK: - ComponentsApplePayState.init(from:)
+
+    func test_componentsApplePayState_fromAvailableState_mapsAvailableNoError() {
+        // Given
+        let upstream = PrimerApplePayState.available()
+
+        // When
+        let sut = ComponentsApplePayState(from: upstream)
+
+        // Then
+        XCTAssertTrue(sut.isAvailable)
+        XCTAssertFalse(sut.isLoading)
+        XCTAssertNil(sut.availabilityError)
+    }
+
+    func test_componentsApplePayState_fromUnavailableWithMessage_includesTypedCode() {
+        // Given
+        let upstream = PrimerApplePayState.unavailable(error: "No cards in wallet")
+
+        // When
+        let sut = ComponentsApplePayState(from: upstream)
+
+        // Then
+        XCTAssertFalse(sut.isAvailable)
+        XCTAssertEqual(sut.availabilityError?.code, "NO_WALLET_CARD")
+        XCTAssertEqual(sut.availabilityError?.message, "No cards in wallet")
+    }
+
+    func test_componentsApplePayState_fromLoadingState_setsIsLoading() {
+        // Given
+        let upstream = PrimerApplePayState.loading
+
+        // When
+        let sut = ComponentsApplePayState(from: upstream)
+
+        // Then
+        XCTAssertTrue(sut.isLoading)
+        XCTAssertTrue(sut.isAvailable)
+        XCTAssertNil(sut.availabilityError)
+    }
+
+    // MARK: - ComponentsApplePayOutcome.init(from:)
+
+    func test_componentsApplePayOutcome_fromPaymentResult_mapsToSuccess() {
+        // Given
+        let result = PaymentResult(
+            paymentId: "pay-123",
+            status: .success,
+            amount: 1500,
+            currencyCode: "GBP",
+            paymentMethodType: "APPLE_PAY"
+        )
+
+        // When
+        let sut = ComponentsApplePayOutcome(from: result)
+
+        // Then
+        guard case let .success(paymentId, status, amount, currencyCode, paymentMethodType) = sut else {
+            return XCTFail("expected .success, got \(sut)")
+        }
+        XCTAssertEqual(paymentId, "pay-123")
+        XCTAssertEqual(status, "success")
+        XCTAssertEqual(amount, 1500)
+        XCTAssertEqual(currencyCode, "GBP")
+        XCTAssertEqual(paymentMethodType, "APPLE_PAY")
+    }
+
+    func test_componentsApplePayOutcome_fromPaymentResultMissingMethodType_defaultsToApplePay() {
+        // Given — `paymentMethodType` is optional on `PaymentResult`; native sometimes omits it.
+        let result = PaymentResult(paymentId: "pay-456", status: .success, paymentMethodType: nil)
+
+        // When
+        let sut = ComponentsApplePayOutcome(from: result)
+
+        // Then
+        guard case let .success(_, _, _, _, paymentMethodType) = sut else {
+            return XCTFail("expected .success, got \(sut)")
+        }
+        XCTAssertEqual(paymentMethodType, "APPLE_PAY")
+    }
+
+    func test_componentsApplePayOutcome_fromPrimerError_mapsToFailureWithErrorId() {
+        // Given
+        let error = PrimerError.invalidValue(key: "applePayConfig.id")
+
+        // When
+        let sut = ComponentsApplePayOutcome(from: error)
+
+        // Then
+        guard case let .failure(errorCode, errorMessage, diagnosticsId) = sut else {
+            return XCTFail("expected .failure, got \(sut)")
+        }
+        XCTAssertEqual(errorCode, error.errorId)
+        XCTAssertFalse(errorMessage.isEmpty)
+        XCTAssertEqual(diagnosticsId, error.diagnosticsId)
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Bridge/ComponentsApplePayBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/ComponentsApplePayBridgeTests.swift
@@ -134,4 +134,61 @@ final class ComponentsApplePayBridgeTests: XCTestCase {
         XCTAssertFalse(errorMessage.isEmpty)
         XCTAssertEqual(diagnosticsId, error.diagnosticsId)
     }
+
+    // MARK: - Bridge lifecycle (without setup)
+
+    @MainActor
+    func test_startPayment_withoutSetup_throwsUnableToPresentPaymentMethod() async {
+        // Given
+        let sut = ComponentsApplePayBridge()
+
+        // When / Then
+        do {
+            try await sut.startPayment()
+            XCTFail("expected startPayment to throw")
+        } catch let error as PrimerError {
+            guard case let .unableToPresentPaymentMethod(paymentMethodType, _, _) = error else {
+                return XCTFail("expected .unableToPresentPaymentMethod, got \(error)")
+            }
+            XCTAssertEqual(paymentMethodType, "APPLE_PAY")
+        } catch {
+            XCTFail("expected PrimerError, got \(error)")
+        }
+    }
+
+    @MainActor
+    func test_cancel_withoutSetup_isNoOp() async {
+        // Given
+        let sut = ComponentsApplePayBridge()
+
+        // When / Then — no scope to cancel against; must not throw or crash.
+        await sut.cancel()
+    }
+
+    @MainActor
+    func test_dispose_finishesStateAndOutcomeStreams() async {
+        // Given
+        let sut = ComponentsApplePayBridge()
+        let stateStream = sut.stateStream
+        let outcomeStream = sut.outcomeStream
+        let stateTask = Task {
+            var count = 0
+            for await _ in stateStream { count += 1 }
+            return count
+        }
+        let outcomeTask = Task {
+            var count = 0
+            for await _ in outcomeStream { count += 1 }
+            return count
+        }
+
+        // When
+        await sut.dispose()
+
+        // Then — both streams terminate without emitting.
+        let stateCount = await stateTask.value
+        let outcomeCount = await outcomeTask.value
+        XCTAssertEqual(stateCount, 0)
+        XCTAssertEqual(outcomeCount, 0)
+    }
 }


### PR DESCRIPTION
# Description

[ACC-6923](https://primerapi.atlassian.net/browse/ACC-6923)

Adds `@_spi(PrimerInternal)` `ComponentsApplePayBridge` wrapping `CheckoutSDKInitializer` + `PrimerApplePayScope` resolution. Exposes POD types (`ComponentsApplePayState`, `ComponentsApplePayAvailabilityError`, `ComponentsApplePayOutcome`) so React Native consumers can drive Apple Pay through the new Components scope without importing PassKit or scope-internal types.

The bridge re-emits terminal outcomes via a dedicated `outcomeStream` because the Components scope doesn't fire `PrimerDelegate.primerDidCompleteCheckoutWithData` — outcomes only propagate through `PrimerCheckoutScope.state`.

# Manual Testing

Consumed by [ACC-6923 RN PR](https://github.com/primer-io/primer-sdk-react-native/pull/374) — Apple Pay tile in the example app's Checkout Components sheet drives the bridge end-to-end through tokenize + \`/payments\`.

# Contributor Checklist

- [ ] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable
- [x] I have manually tested newly added UX
- [ ] I have open a documentation PR, if applicable

[ACC-6923]: https://primerapi.atlassian.net/browse/ACC-6923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ