### PR TITLE
feat: Add CardNetworkSelectionBridge for RN interop (ACC-6922)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsCardNetworkSelectionBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsCardNetworkSelectionBridge.swift
@@ -29,8 +29,6 @@ public final class ComponentsCardNetworkSelectionBridge: LogReporter {
     )
   }
 
-  private static let identifierPattern = #"^[A-Z][A-Z0-9_]*$"#
-
   private let interactorResolver: () async -> CardNetworkDetectionInteractor?
   private let allowedNetworksProvider: () -> [String]?
 
@@ -53,32 +51,21 @@ public final class ComponentsCardNetworkSelectionBridge: LogReporter {
     self.allowedNetworksProvider = allowedNetworksProvider
   }
 
-  public func setSelectedNetwork(_ identifier: String) async throws {
-    logger.debug(message: "[CardNetworkSelectionBridge] setSelectedNetwork(identifier=\(identifier))")
+  public func setSelectedNetwork(_ network: CardNetwork) async throws {
+    logger.debug(message: "[CardNetworkSelectionBridge] setSelectedNetwork(network=\(network.rawValue))")
 
     Analytics.Service.fire(event: Analytics.Event.sdk(
       name: "\(Self.self).\(#function)",
       params: ["category": "CARD_NETWORK_SELECTION"]
     ))
 
-    do {
-      try Self.validate(identifier: identifier)
-    } catch {
-      logger.error(message: "[CardNetworkSelectionBridge] identifier=\"\(identifier)\" failed format validation")
-      throw error
-    }
-
-    guard let cardNetwork = CardNetwork(rawValue: identifier) else {
-      logger.error(message: "[CardNetworkSelectionBridge] identifier=\(identifier) is not a known CardNetwork")
-      throw PrimerValidationError.invalidRawData()
-    }
     guard let interactor = await interactorResolver() else {
       logger.error(message: "[CardNetworkSelectionBridge] no CardNetworkDetectionInteractor registered in DI")
       throw PrimerError.unknown(message: "No active CardNetworkDetectionInteractor")
     }
-    logger.debug(message: "[CardNetworkSelectionBridge] -> interactor.selectNetwork(\(identifier))")
-    await interactor.selectNetwork(cardNetwork)
-    logger.info(message: "[CardNetworkSelectionBridge] selectNetwork(\(identifier)) completed")
+    logger.debug(message: "[CardNetworkSelectionBridge] -> interactor.selectNetwork(\(network.rawValue))")
+    await interactor.selectNetwork(network)
+    logger.info(message: "[CardNetworkSelectionBridge] selectNetwork(\(network.rawValue)) completed")
   }
 
   public var state: AsyncStream<State> {
@@ -123,12 +110,6 @@ public final class ComponentsCardNetworkSelectionBridge: LogReporter {
     let available = snapshot.availableNetworks.map(\.identifier)
     let selected = snapshot.selectedIdentifier ?? "nil"
     return "[CardNetworkSelectionBridge] yield(\(label)): available=\(available) selected=\(selected) selectable=\(snapshot.isNetworkSelectable)"
-  }
-
-  private static func validate(identifier: String) throws {
-    guard identifier.range(of: identifierPattern, options: .regularExpression) != nil else {
-      throw PrimerValidationError.invalidRawData()
-    }
   }
 
   static func makeDescriptor(for network: CardNetwork, allowed: Set<String>) -> NetworkDescriptor? {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsCardNetworkSelectionBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsCardNetworkSelectionBridge.swift
@@ -1,0 +1,181 @@
+//
+//  ComponentsCardNetworkSelectionBridge.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import Foundation
+
+@available(iOS 15.0, *)
+@_spi(PrimerInternal)
+public final class ComponentsCardNetworkSelectionBridge: LogReporter {
+
+  public struct NetworkDescriptor: Sendable {
+    public let identifier: String
+    public let displayName: String
+    public let allowed: Bool
+    public let allowsUserSelection: Bool
+  }
+
+  public struct State: Sendable {
+    public let availableNetworks: [NetworkDescriptor]
+    public let selectedIdentifier: String?
+    public let isNetworkSelectable: Bool
+
+    public static let empty = State(
+      availableNetworks: [],
+      selectedIdentifier: nil,
+      isNetworkSelectable: false
+    )
+  }
+
+  private static let identifierPattern = #"^[A-Z][A-Z0-9_]*$"#
+
+  private let interactorResolver: () async -> CardNetworkDetectionInteractor?
+  private let allowedNetworksProvider: () -> [String]?
+
+  public init() {
+    interactorResolver = {
+      guard let container = await DIContainer.current else { return nil }
+      return try? await container.resolve(CardNetworkDetectionInteractor.self)
+    }
+    allowedNetworksProvider = {
+      PrimerAPIConfigurationModule.apiConfiguration?
+        .clientSession?.paymentMethod?.orderedAllowedCardNetworks
+    }
+  }
+
+  init(
+    interactorResolver: @escaping () async -> CardNetworkDetectionInteractor?,
+    allowedNetworksProvider: @escaping () -> [String]?
+  ) {
+    self.interactorResolver = interactorResolver
+    self.allowedNetworksProvider = allowedNetworksProvider
+  }
+
+  public func setSelectedNetwork(_ identifier: String) async throws {
+    logger.debug(message: "[CardNetworkSelectionBridge] setSelectedNetwork(identifier=\(identifier))")
+
+    Analytics.Service.fire(event: Analytics.Event.sdk(
+      name: "\(Self.self).\(#function)",
+      params: ["category": "CARD_NETWORK_SELECTION"]
+    ))
+
+    do {
+      try Self.validate(identifier: identifier)
+    } catch {
+      logger.error(message: "[CardNetworkSelectionBridge] identifier=\"\(identifier)\" failed format validation")
+      throw error
+    }
+
+    guard let cardNetwork = CardNetwork(rawValue: identifier) else {
+      logger.error(message: "[CardNetworkSelectionBridge] identifier=\(identifier) is not a known CardNetwork")
+      throw PrimerValidationError.invalidRawData()
+    }
+    guard let interactor = await interactorResolver() else {
+      logger.error(message: "[CardNetworkSelectionBridge] no CardNetworkDetectionInteractor registered in DI")
+      throw PrimerError.unknown(message: "No active CardNetworkDetectionInteractor")
+    }
+    logger.debug(message: "[CardNetworkSelectionBridge] -> interactor.selectNetwork(\(identifier))")
+    await interactor.selectNetwork(cardNetwork)
+    logger.info(message: "[CardNetworkSelectionBridge] selectNetwork(\(identifier)) completed")
+  }
+
+  public var state: AsyncStream<State> {
+    AsyncStream { continuation in
+      let task = Task { [self] in
+        guard let interactor = await interactorResolver() else {
+          logger.debug(message: "[CardNetworkSelectionBridge] state stream: no interactor, yielding .empty")
+          continuation.yield(.empty)
+          continuation.finish()
+          return
+        }
+        logger.debug(message: "[CardNetworkSelectionBridge] state stream started")
+        let aggregator = StateAggregator()
+
+        async let detection: Void = {
+          for await networks in interactor.networkDetectionStream {
+            logger.debug(message: "[CardNetworkSelectionBridge] detection tick: \(networks.map(\.rawValue))")
+            let snapshot = await aggregator.applyDetection(networks, allowed: allowedNetworksProvider())
+            logger.debug(message: Self.formatYield(label: "detection", snapshot: snapshot))
+            continuation.yield(snapshot)
+          }
+        }()
+
+        async let binData: Void = {
+          for await bin in interactor.binDataStream {
+            let preferredId = bin.preferred?.network.rawValue ?? "nil"
+            logger.debug(message: "[CardNetworkSelectionBridge] binData tick: preferred=\(preferredId)")
+            let snapshot = await aggregator.applyBinData(bin)
+            logger.debug(message: Self.formatYield(label: "binData", snapshot: snapshot))
+            continuation.yield(snapshot)
+          }
+        }()
+
+        _ = await (detection, binData)
+        continuation.finish()
+      }
+      continuation.onTermination = { _ in task.cancel() }
+    }
+  }
+
+  private static func formatYield(label: String, snapshot: State) -> String {
+    let available = snapshot.availableNetworks.map(\.identifier)
+    let selected = snapshot.selectedIdentifier ?? "nil"
+    return "[CardNetworkSelectionBridge] yield(\(label)): available=\(available) selected=\(selected) selectable=\(snapshot.isNetworkSelectable)"
+  }
+
+  private static func validate(identifier: String) throws {
+    guard identifier.range(of: identifierPattern, options: .regularExpression) != nil else {
+      throw PrimerValidationError.invalidRawData()
+    }
+  }
+
+  static func makeDescriptor(for network: CardNetwork, allowed: Set<String>) -> NetworkDescriptor? {
+    guard network != .unknown else { return nil }
+    let identifier = network.rawValue
+    let isAllowed = allowed.isEmpty || allowed.contains(identifier)
+    return NetworkDescriptor(
+      identifier: identifier,
+      displayName: network.displayName,
+      allowed: isAllowed,
+      allowsUserSelection: network != .eftpos
+    )
+  }
+}
+
+@available(iOS 15.0, *)
+private actor StateAggregator {
+  private var availableNetworks: [ComponentsCardNetworkSelectionBridge.NetworkDescriptor] = []
+  private var selectedIdentifier: String?
+  private var isNetworkSelectable = false
+
+  func applyDetection(
+    _ networks: [CardNetwork],
+    allowed: [String]?
+  ) -> ComponentsCardNetworkSelectionBridge.State {
+    let allowedSet = Set(allowed ?? [])
+    let descriptors = networks
+      .compactMap { ComponentsCardNetworkSelectionBridge.makeDescriptor(for: $0, allowed: allowedSet) }
+      .filter(\.allowed)
+    availableNetworks = descriptors
+    isNetworkSelectable = !descriptors.isEmpty && descriptors.allSatisfy(\.allowsUserSelection)
+    if let selectedIdentifier, !descriptors.contains(where: { $0.identifier == selectedIdentifier }) {
+      self.selectedIdentifier = nil
+    }
+    return snapshot()
+  }
+
+  func applyBinData(_ bin: PrimerBinData) -> ComponentsCardNetworkSelectionBridge.State {
+    selectedIdentifier = bin.preferred?.network.rawValue
+    return snapshot()
+  }
+
+  private func snapshot() -> ComponentsCardNetworkSelectionBridge.State {
+    ComponentsCardNetworkSelectionBridge.State(
+      availableNetworks: availableNetworks,
+      selectedIdentifier: selectedIdentifier,
+      isNetworkSelectable: isNetworkSelectable
+    )
+  }
+}

--- a/Tests/Primer/CheckoutComponents/Bridge/ComponentsCardNetworkSelectionBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/ComponentsCardNetworkSelectionBridgeTests.swift
@@ -31,52 +31,20 @@ final class ComponentsCardNetworkSelectionBridgeTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - setSelectedNetwork — validation
-
-    func test_setSelectedNetwork_throwsValidationError_whenIdentifierIsEmpty() async {
-        await assertThrowsValidationError {
-            try await self.sut.setSelectedNetwork("")
-        }
-    }
-
-    func test_setSelectedNetwork_throwsValidationError_whenIdentifierIsLowercase() async {
-        await assertThrowsValidationError {
-            try await self.sut.setSelectedNetwork("visa")
-        }
-    }
-
-    func test_setSelectedNetwork_throwsValidationError_whenIdentifierContainsHyphen() async {
-        await assertThrowsValidationError {
-            try await self.sut.setSelectedNetwork("CARTES-BANCAIRES")
-        }
-    }
-
-    func test_setSelectedNetwork_throwsValidationError_whenIdentifierStartsWithDigit() async {
-        await assertThrowsValidationError {
-            try await self.sut.setSelectedNetwork("3DS")
-        }
-    }
-
-    func test_setSelectedNetwork_throwsValidationError_whenIdentifierIsNotAKnownCardNetwork() async {
-        await assertThrowsValidationError {
-            try await self.sut.setSelectedNetwork("MADE_UP_NETWORK")
-        }
-    }
-
     // MARK: - setSelectedNetwork — forwarding
 
     func test_setSelectedNetwork_forwardsToInteractor_forKnownNetwork() async throws {
-        try await sut.setSelectedNetwork("VISA")
+        try await sut.setSelectedNetwork(.visa)
 
         XCTAssertEqual(interactor.selectNetworkCallCount, 1)
-        XCTAssertEqual(interactor.selectedNetwork, CardNetwork.visa)
+        XCTAssertEqual(interactor.selectedNetwork, .visa)
     }
 
     func test_setSelectedNetwork_forwardsCartesBancaires() async throws {
-        try await sut.setSelectedNetwork("CARTES_BANCAIRES")
+        try await sut.setSelectedNetwork(.cartesBancaires)
 
         XCTAssertEqual(interactor.selectNetworkCallCount, 1)
-        XCTAssertEqual(interactor.selectedNetwork, CardNetwork.cartesBancaires)
+        XCTAssertEqual(interactor.selectedNetwork, .cartesBancaires)
     }
 
     func test_setSelectedNetwork_throwsPrimerError_whenInteractorMissing() async {
@@ -86,7 +54,7 @@ final class ComponentsCardNetworkSelectionBridgeTests: XCTestCase {
         )
 
         do {
-            try await sut.setSelectedNetwork("VISA")
+            try await sut.setSelectedNetwork(.visa)
             XCTFail("Expected error")
         } catch let error as PrimerError {
             // Expected — exact case is `.unknown` but we don't assert on the enum case
@@ -140,20 +108,4 @@ final class ComponentsCardNetworkSelectionBridgeTests: XCTestCase {
         XCTAssertFalse(descriptor?.allowsUserSelection ?? true)
     }
 
-    // MARK: - Helpers
-
-    private func assertThrowsValidationError(
-        _ block: @escaping () async throws -> Void,
-        file: StaticString = #file,
-        line: UInt = #line
-    ) async {
-        do {
-            try await block()
-            XCTFail("Expected PrimerValidationError", file: file, line: line)
-        } catch is PrimerValidationError {
-            // Expected.
-        } catch {
-            XCTFail("Expected PrimerValidationError, got \(error)", file: file, line: line)
-        }
-    }
 }

--- a/Tests/Primer/CheckoutComponents/Bridge/ComponentsCardNetworkSelectionBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/ComponentsCardNetworkSelectionBridgeTests.swift
@@ -1,0 +1,159 @@
+//
+//  ComponentsCardNetworkSelectionBridgeTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import XCTest
+@_spi(PrimerInternal) @testable import PrimerSDK
+
+@available(iOS 15.0, *)
+final class ComponentsCardNetworkSelectionBridgeTests: XCTestCase {
+
+    private var interactor: MockCardNetworkDetectionInteractor!
+    private var allowedNetworks: [String]?
+    private var sut: ComponentsCardNetworkSelectionBridge!
+
+    override func setUp() {
+        super.setUp()
+        interactor = MockCardNetworkDetectionInteractor()
+        allowedNetworks = nil
+        sut = ComponentsCardNetworkSelectionBridge(
+            interactorResolver: { [self] in interactor },
+            allowedNetworksProvider: { [self] in allowedNetworks }
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        interactor = nil
+        allowedNetworks = nil
+        super.tearDown()
+    }
+
+    // MARK: - setSelectedNetwork — validation
+
+    func test_setSelectedNetwork_throwsValidationError_whenIdentifierIsEmpty() async {
+        await assertThrowsValidationError {
+            try await self.sut.setSelectedNetwork("")
+        }
+    }
+
+    func test_setSelectedNetwork_throwsValidationError_whenIdentifierIsLowercase() async {
+        await assertThrowsValidationError {
+            try await self.sut.setSelectedNetwork("visa")
+        }
+    }
+
+    func test_setSelectedNetwork_throwsValidationError_whenIdentifierContainsHyphen() async {
+        await assertThrowsValidationError {
+            try await self.sut.setSelectedNetwork("CARTES-BANCAIRES")
+        }
+    }
+
+    func test_setSelectedNetwork_throwsValidationError_whenIdentifierStartsWithDigit() async {
+        await assertThrowsValidationError {
+            try await self.sut.setSelectedNetwork("3DS")
+        }
+    }
+
+    func test_setSelectedNetwork_throwsValidationError_whenIdentifierIsNotAKnownCardNetwork() async {
+        await assertThrowsValidationError {
+            try await self.sut.setSelectedNetwork("MADE_UP_NETWORK")
+        }
+    }
+
+    // MARK: - setSelectedNetwork — forwarding
+
+    func test_setSelectedNetwork_forwardsToInteractor_forKnownNetwork() async throws {
+        try await sut.setSelectedNetwork("VISA")
+
+        XCTAssertEqual(interactor.selectNetworkCallCount, 1)
+        XCTAssertEqual(interactor.selectedNetwork, CardNetwork.visa)
+    }
+
+    func test_setSelectedNetwork_forwardsCartesBancaires() async throws {
+        try await sut.setSelectedNetwork("CARTES_BANCAIRES")
+
+        XCTAssertEqual(interactor.selectNetworkCallCount, 1)
+        XCTAssertEqual(interactor.selectedNetwork, CardNetwork.cartesBancaires)
+    }
+
+    func test_setSelectedNetwork_throwsPrimerError_whenInteractorMissing() async {
+        sut = ComponentsCardNetworkSelectionBridge(
+            interactorResolver: { nil },
+            allowedNetworksProvider: { nil }
+        )
+
+        do {
+            try await sut.setSelectedNetwork("VISA")
+            XCTFail("Expected error")
+        } catch let error as PrimerError {
+            // Expected — exact case is `.unknown` but we don't assert on the enum case
+            // since it's an internal failure path.
+            _ = error
+        } catch {
+            XCTFail("Expected PrimerError, got \(error)")
+        }
+    }
+
+    // MARK: - makeDescriptor
+
+    func test_makeDescriptor_returnsNil_forUnknownNetwork() {
+        XCTAssertNil(
+            ComponentsCardNetworkSelectionBridge.makeDescriptor(for: .unknown, allowed: [])
+        )
+    }
+
+    func test_makeDescriptor_marksAllowed_whenAllowedListEmpty() {
+        let descriptor = ComponentsCardNetworkSelectionBridge.makeDescriptor(
+            for: .visa,
+            allowed: []
+        )
+
+        XCTAssertEqual(descriptor?.identifier, "VISA")
+        XCTAssertTrue(descriptor?.allowed ?? false)
+        XCTAssertTrue(descriptor?.allowsUserSelection ?? false)
+    }
+
+    func test_makeDescriptor_respectsAllowedList() {
+        let allowedDescriptor = ComponentsCardNetworkSelectionBridge.makeDescriptor(
+            for: .visa,
+            allowed: ["VISA", "MASTERCARD"]
+        )
+        let disallowedDescriptor = ComponentsCardNetworkSelectionBridge.makeDescriptor(
+            for: .amex,
+            allowed: ["VISA", "MASTERCARD"]
+        )
+
+        XCTAssertTrue(allowedDescriptor?.allowed ?? false)
+        XCTAssertFalse(disallowedDescriptor?.allowed ?? true)
+    }
+
+    func test_makeDescriptor_marksEftposNotUserSelectable() {
+        let descriptor = ComponentsCardNetworkSelectionBridge.makeDescriptor(
+            for: .eftpos,
+            allowed: []
+        )
+
+        XCTAssertEqual(descriptor?.identifier, "EFTPOS")
+        XCTAssertFalse(descriptor?.allowsUserSelection ?? true)
+    }
+
+    // MARK: - Helpers
+
+    private func assertThrowsValidationError(
+        _ block: @escaping () async throws -> Void,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        do {
+            try await block()
+            XCTFail("Expected PrimerValidationError", file: file, line: line)
+        } catch is PrimerValidationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected PrimerValidationError, got \(error)", file: file, line: line)
+        }
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Mocks/MockCardNetworkDetectionInteractor.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockCardNetworkDetectionInteractor.swift
@@ -11,6 +11,8 @@ import Foundation
 final class MockCardNetworkDetectionInteractor: CardNetworkDetectionInteractor {
 
     private(set) var detectNetworksCallCount = 0
+    private(set) var selectNetworkCallCount = 0
+    private(set) var selectedNetwork: CardNetwork?
 
     var networkDetectionStream: AsyncStream<[CardNetwork]> {
         AsyncStream { continuation in
@@ -29,5 +31,8 @@ final class MockCardNetworkDetectionInteractor: CardNetworkDetectionInteractor {
         detectNetworksCallCount += 1
     }
 
-    func selectNetwork(_ network: CardNetwork) async {}
+    func selectNetwork(_ network: CardNetwork) async {
+        selectNetworkCallCount += 1
+        selectedNetwork = network
+    }
 }


### PR DESCRIPTION
# Description

[ACC-6922](https://primerapi.atlassian.net/browse/ACC-6922)

Adds `@_spi(PrimerInternal)` `ComponentsCardNetworkSelectionBridge` that wraps `CardNetworkDetectionInteractor` and exposes co-badged network selection to React Native consumers without exporting `PrimerCardData` or scope-internal types. Returns POD types (`NetworkDescriptor`, `State`) and accepts string identifiers.

Mirrors precedents set by `ComponentsBillingAddressBridge` (#1727) and `ComponentsClientSessionBridge` (#1731).

# Manual Testing

Consumed by [ACC-6922 RN PR](https://github.com/primer-io/primer-sdk-react-native/pulls?q=is%3Aopen+ACC-6922) — co-badge popover in the example app (MASTERCARD + CARTES_BANCAIRES) drives the bridge through ` setSelectedNetwork`; `preferredNetwork` reaches `POST /payment-instruments` and the token returned uses the picked network.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

[ACC-6922]: https://primerapi.atlassian.net/browse/ACC-6922