### PR TITLE
chore: Update Package.Klarna version

### DIFF
--- a/Package.Klarna.swift
+++ b/Package.Klarna.swift
@@ -15,7 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/primer-io/primer-klarna-sdk-ios", from: "1.3.1"),
+        .package(url: "https://github.com/primer-io/primer-klarna-sdk-ios", from: "1.4.0"),
     ],
     targets: [
         packageTarget(name: "PrimerFoundation"),


### PR DESCRIPTION
Bump PrimerKlarnaSDK SPM dependency 1.3.1 → 1.4.0 to pick up the latest Klarna iOS SDK release.