### PR TITLE
feat: Add getCaptureVaultedCardCvv to ComponentsClientSessionBridge (ACC-7315)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsClientSessionBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsClientSessionBridge.swift
@@ -48,6 +48,17 @@ public final class ComponentsClientSessionBridge {
         guard let modules = configurationProvider()?.checkoutModules else { return nil }
         return modules.map(ComponentsCheckoutModule.init(module:))
     }
+
+    public func getCaptureVaultedCardCvv() -> Bool {
+        Analytics.Service.fire(event: Analytics.Event.sdk(
+            name: "\(Self.self).\(#function)",
+            params: ["category": "CLIENT_SESSION"]
+        ))
+
+        let cardPaymentMethod = configurationProvider()?.paymentMethods?
+            .first { $0.type == PrimerPaymentMethodType.paymentCard.rawValue }
+        return (cardPaymentMethod?.options as? CardOptions)?.captureVaultedCardCvv == true
+    }
 }
 
 @available(iOS 15.0, *)


### PR DESCRIPTION
# Description

ACC-7315

Adds a public `getCaptureVaultedCardCvv()` to `ComponentsClientSessionBridge`, reading `captureVaultedCardCvv` from the card payment method's config options. Lets the React Native bridge surface CVV-recapture for vaulted cards — the value was previously only reachable through internal CheckoutComponents services. Additive only; no change to existing callers.

Related: RN `primer-io/primer-sdk-react-native#363` and the matching Android `components-bridge` change.

# Manual Testing

Verified via the RN example app (iOS): the value round-trips bridge → RN `requiresVaultedCardCvv()` → provider, and the CVV-recapture field renders on a vaulted card.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge
