### PR TITLE
fix: close error-analytics logging gaps (searchable diagnostics IDs + decode spam) [ESC-905]

### DIFF
--- a/Sources/PrimerSDK/Classes/Data Models/PrimerConfiguration.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerConfiguration.swift
@@ -358,8 +358,10 @@ extension Response.Body.Configuration {
                 self.cardHolderName = (try? container.decode(Bool?.self, forKey: .cardHolderName)) ?? nil
                 self.saveCardCheckbox = (try? container.decode(Bool?.self, forKey: .saveCardCheckbox)) ?? nil
 
+                // Signals "not this module type" to the polymorphic decode in CheckoutModule.init(from:),
+                // where it is caught by `try?`. It is expected control flow, so it must not be logged.
                 if self.cardHolderName == nil, self.saveCardCheckbox == nil {
-                    throw handled(error: InternalError.failedToDecode(message: "All fields are nil"))
+                    throw InternalError.failedToDecode(message: "All fields are nil")
                 }
             }
         }
@@ -434,6 +436,8 @@ extension Response.Body.Configuration {
                 self.phoneNumber = (try? container.decode(Bool?.self, forKey: .phoneNumber)) ?? nil
                 self.state = (try? container.decode(Bool?.self, forKey: .state)) ?? nil
 
+                // Signals "not this module type" to the polymorphic decode in CheckoutModule.init(from:),
+                // where it is caught by `try?`. It is expected control flow, so it must not be logged.
                 if self.firstName == nil,
                    self.lastName == nil,
                    self.city == nil,
@@ -443,7 +447,7 @@ extension Response.Body.Configuration {
                    self.countryCode == nil,
                    self.phoneNumber == nil,
                    self.state == nil {
-                    throw handled(error: InternalError.failedToDecode(message: "All fields are nil"))
+                    throw InternalError.failedToDecode(message: "All fields are nil")
                 }
             }
         }

--- a/Sources/PrimerSDK/Classes/Error Handler/ErrorHandler.swift
+++ b/Sources/PrimerSDK/Classes/Error Handler/ErrorHandler.swift
@@ -36,52 +36,63 @@ final class ErrorHandler: LogReporter {
             return
         }
 
-        var event: Analytics.Event!
+        Analytics.Service.fire(event: event(for: error))
+    }
 
+    // Preserves the `diagnosticsId` for every `PrimerErrorProtocol` error (notably `InternalError`);
+    // without this they fall through to the NSError branch and the id surfaced to the merchant has
+    // no matching backend log entry.
+    func event(for error: Error) -> Analytics.Event {
         if let threeDsError = error as? Primer3DSErrorContainer {
-
-            event = Analytics.Event.message(
+            var event = Analytics.Event.message(
                 message: threeDsError.errorDescription,
                 messageType: .error,
                 severity: .error,
                 diagnosticsId: threeDsError.diagnosticsId,
                 context: threeDsError.analyticsContext
             )
-
             if let createdAt = (threeDsError.info?["createdAt"] as? String)?.toDate() {
                 event.createdAt = createdAt.millisecondsSince1970
             }
-        } else if let primerError = error as? PrimerError {
-            event = Analytics.Event.message(
+            return event
+        }
+
+        if let primerError = error as? PrimerError {
+            var event = Analytics.Event.message(
                 message: primerError.errorDescription,
                 messageType: .error,
                 severity: determineErrorSeverity(primerError),
                 diagnosticsId: primerError.diagnosticsId,
                 context: primerError.analyticsContext
             )
-
             if let createdAt = (primerError.errorUserInfo["createdAt"] as? String)?.toDate() {
                 event.createdAt = createdAt.millisecondsSince1970
             }
-        } else {
-            let nsError = error as NSError
-            var userInfo = nsError.userInfo
-            userInfo["description"] = nsError.description
+            return event
+        }
 
-            if userInfo[NSLocalizedDescriptionKey] != nil {
-                userInfo[NSLocalizedDescriptionKey] = nil
-            }
-
-            event = Analytics.Event.message(
-                message: "\(nsError.domain) [\(nsError.code)]: \(nsError.localizedDescription)",
+        if let primerError = error as? (any PrimerErrorProtocol) {
+            return Analytics.Event.message(
+                message: primerError.errorDescription,
                 messageType: .error,
                 severity: .error,
-                diagnosticsId: nil,
-                context: userInfo
+                diagnosticsId: primerError.diagnosticsId,
+                context: primerError.analyticsContext
             )
         }
 
-        Analytics.Service.fire(event: event)
+        let nsError = error as NSError
+        var userInfo = nsError.userInfo
+        userInfo["description"] = nsError.description
+        userInfo[NSLocalizedDescriptionKey] = nil
+
+        return Analytics.Event.message(
+            message: "\(nsError.domain) [\(nsError.code)]: \(nsError.localizedDescription)",
+            messageType: .error,
+            severity: .error,
+            diagnosticsId: nil,
+            context: userInfo
+        )
     }
 
     private func shouldFilterError(_ error: Error) -> Bool {

--- a/Tests/Primer/Errors/ErrorHandlerTests.swift
+++ b/Tests/Primer/Errors/ErrorHandlerTests.swift
@@ -4,83 +4,80 @@
 //  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import PrimerFoundation
+@_spi(PrimerInternal) import PrimerCore
+@_spi(PrimerInternal) import PrimerFoundation
 @testable import PrimerSDK
 import XCTest
 
 final class ErrorHandlerTests: XCTestCase {
-    
-    var sut: ErrorHandler!
-    
+
+    private var sut: ErrorHandler!
+
     override func setUp() {
         super.setUp()
         sut = ErrorHandler()
     }
-    
+
     override func tearDown() {
         sut = nil
         super.tearDown()
     }
-    
-    // MARK: - Handle Error Tests
-    
-    func testHandleError_WithApplePayNoCardsInWallet() {
-        let error = PrimerError.applePayNoCardsInWallet(diagnosticsId: "test-123")
-        
-        // This error should be filtered (based on ErrorHandler implementation)
-        // We can't test private methods directly, but we can verify the public API works
-        XCTAssertNoThrow(sut.handle(error: error))
-    }
-    
-    func testHandleError_WithApplePayDeviceNotSupported() {
-        let error = PrimerError.applePayDeviceNotSupported(diagnosticsId: "test-456")
 
-        // This error should be filtered (based on ErrorHandler implementation)
-        XCTAssertNoThrow(sut.handle(error: error))
+    // MARK: - event(for:) — diagnosticsId is preserved for every PrimerErrorProtocol error
+
+    func testEvent_forInternalError_preservesDiagnosticsId() {
+        let error = InternalError.serverError(status: 500, diagnosticsId: "internal-diag-123")
+
+        let properties = sut.event(for: error).properties as? MessageEventProperties
+
+        XCTAssertEqual(properties?.diagnosticsId, "internal-diag-123")
     }
-    
-    func testHandleError_WithPrimerError_CreatesCorrectEvent() {
-        let diagnosticsId = "test-789"
-        let error = PrimerError.applePayConfigurationError(merchantIdentifier: "merchant.id")
-        
-        // Handle the error
-        sut.handle(error: error)
-        
-        // We can't easily verify Analytics.Service.fire was called with correct parameters
-        // without dependency injection, but we can verify the method completes
-        XCTAssertTrue(true) // Placeholder assertion
+
+    func testEvent_forPrimerError_preservesDiagnosticsId() {
+        let error = PrimerError.unknown(diagnosticsId: "primer-diag-456")
+
+        let properties = sut.event(for: error).properties as? MessageEventProperties
+
+        XCTAssertEqual(properties?.diagnosticsId, "primer-diag-456")
     }
-    
-    func testHandleError_With3DSError_CreatesCorrectEvent() {
-        // Create a 3DS error using an available case
-        let threeDsError = Primer3DSErrorContainer.missingSdkDependency()
-        
-        // Handle the error
-        sut.handle(error: threeDsError)
-        
-        // Verify method completes without errors
-        XCTAssertTrue(true)
+
+    func testEvent_for3DSError_preservesDiagnosticsId() {
+        let error = Primer3DSErrorContainer.missingSdkDependency()
+
+        let properties = sut.event(for: error).properties as? MessageEventProperties
+
+        XCTAssertEqual(properties?.diagnosticsId, error.diagnosticsId)
     }
-    
-    func testHandleError_WithGenericError_CreatesCorrectEvent() {
+
+    func testEvent_forGenericNSError_hasNilDiagnosticsId() {
         let error = NSError(domain: "TestDomain", code: 500, userInfo: ["test": "data"])
-        
-        // Handle the error
-        sut.handle(error: error)
-        
-        // Verify method completes without errors
-        XCTAssertTrue(true)
+
+        let properties = sut.event(for: error).properties as? MessageEventProperties
+
+        XCTAssertNil(properties?.diagnosticsId)
     }
-    
-    func testHandleError_WithDifferentPrimerErrors() {
-        // Test various PrimerError cases to ensure they're handled correctly
+
+    // MARK: - handle(error:)
+
+    func testHandle_withFilteredErrors_doesNotThrow() {
         let errors: [PrimerError] = [
-            .unableToPresentApplePay(diagnosticsId: "test-1"),
-            .applePayTimedOut(diagnosticsId: "test-2"),
-            .applePayPresentationFailed(reason: "test", diagnosticsId: "test-3"),
-            .unknown(diagnosticsId: "test-4")
+            .applePayNoCardsInWallet(diagnosticsId: "test-1"),
+            .applePayDeviceNotSupported(diagnosticsId: "test-2")
         ]
-        
+
+        for error in errors {
+            XCTAssertNoThrow(sut.handle(error: error))
+        }
+    }
+
+    func testHandle_withVariousErrors_doesNotThrow() {
+        let errors: [Error] = [
+            PrimerError.unableToPresentApplePay(diagnosticsId: "test-1"),
+            PrimerError.unknown(diagnosticsId: "test-2"),
+            InternalError.noData(),
+            NSError(domain: "TestDomain", code: 1)
+        ]
+
         for error in errors {
             XCTAssertNoThrow(sut.handle(error: error))
         }


### PR DESCRIPTION
## What & why

Fixes [ESC-905](https://primerapi.atlassian.net/browse/ESC-905). Two related error-analytics logging fixes.

### 1. Diagnostics IDs surfaced on errors weren't searchable in backend logs

A merchant (Dabble) reported `[unknown] Something went wrong (diagnosticsId: E11BD422-…)`, but that ID could not be found anywhere in Kibana.

That error is `PrimerError.unknown`, which in the common case originates from an `InternalError` (e.g. `server-error`, `failed-to-decode`) exposed via `InternalError.exposedError → PrimerError.unknown(diagnosticsId:)`, **preserving the internal error's `diagnosticsId`**. But `ErrorHandler.handle()` only extracted the `diagnosticsId` for `PrimerError` and `Primer3DSErrorContainer`. `InternalError` conforms to `PrimerErrorProtocol` and *has* a `diagnosticsId`, yet fell through to the generic `NSError` branch that fires with **`diagnosticsId: nil`** — so the ID shown to the merchant was never written to the searchable field.

Verified in production logs: over the retained window, **~38% of all SDK error events (2,588,766 / 6,743,514) had no searchable `diagnosticsId`**, dominated by `failed-to-decode` / `server-error` `InternalError`s.

**Fix:** `ErrorHandler` now records the `diagnosticsId` + analytics context for **any `PrimerErrorProtocol`** error (covers `InternalError`, `PrimerKlarnaError`, `PrimerIPay88Error`). Existing `PrimerError` / 3DS / `NSError` behaviour is unchanged. Event construction is extracted into a testable `event(for:)` method.

### 2. False-positive `failed-to-decode` error spam from polymorphic config decoding

The single most common error in backend logs was `[failed-to-decode] Failed to decode (All fields are nil)`. `CheckoutModule.init(from:)` selects the concrete options type by trying each candidate with `try?`; the `CardInformationOptions` / `PostalCodeOptions` decoders threw via `handled(...)`, logging an analytics error for **every non-matching candidate** — i.e. on every normal config. These throws are expected control flow swallowed by `try?`.

**Fix:** throw the `InternalError` directly without logging (matching the bare-throw pattern already used elsewhere in the same file). Decode behaviour is unchanged.

## Test plan

`xcodebuild test -workspace PrimerSDK.xcworkspace -scheme PrimerSDKTests -destination "platform=iOS Simulator,name=iPhone 17 Pro Max" -testPlan UnitTestsTestPlan` for:
- `Tests/ErrorHandlerTests` — rewrote placeholders into 6 real tests; the key one (`testEvent_forInternalError_preservesDiagnosticsId`) was previously `nil`.
- `Tests/PaymentMethodConfigTests`, `Tests/ConfigurationCacheTests` — confirm config decoding is unchanged by fix #2.
- → **Executed 12 tests, 0 failures.**

## Follow-up — now addressed in #1793

There is a third, lower-frequency gap: `error.asPrimerError` wraps a *non-Primer* error as `PrimerError.unknown(message:)` with a **freshly minted** `diagnosticsId` that is never logged, because the merchant-facing chokepoint (`PrimerDelegateProxy.primerDidFailWithError`) doesn't log to analytics. After discussion (ORC-7439), this is fixed in #1793 via the per-site approach — wrapping the boundary conversions with `handled(...)` — chosen over proxy-level logging to avoid double-counting errors already logged deeper.


[ESC-905]: https://primerapi.atlassian.net/browse/ESC-905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
