### PR TITLE
fix: record diagnostics IDs for boundary-surfaced errors in backend analytics [ORC-7439]

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/Models/BanksTokenizationComponent.swift
+++ b/Sources/PrimerSDK/Classes/Core/Models/BanksTokenizationComponent.swift
@@ -142,7 +142,7 @@ final class BanksTokenizationComponent: NSObject, LogReporter {
                self.config.type == PrimerPaymentMethodType.payPal.rawValue {
                 await uiManager.primerRootViewController?.popToMainScreen(completion: nil)
             } else {
-                let primerErr = error.asPrimerError
+                let primerErr = handled(primerError: error.asPrimerError)
                 let merchantErrorMessage = await PrimerDelegateProxy.raisePrimerDidFailWithError(
                     primerErr,
                     data: paymentCheckoutData

--- a/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
+++ b/Sources/PrimerSDK/Classes/Core/Primer/PrimerInternal.swift
@@ -192,7 +192,7 @@ final class PrimerInternal: LogReporter {
                 self.recordLoadedEvent(start, source: .universalCheckout)
                 completion?(nil)
             } catch {
-                let primerErr = error.asPrimerError
+                let primerErr = handled(primerError: error.asPrimerError)
                 PrimerUIManager.handleErrorBasedOnSDKSettings(primerErr)
                 completion?(error)
             }
@@ -230,7 +230,7 @@ final class PrimerInternal: LogReporter {
                 self.recordLoadedEvent(start, source: .vaultManager)
                 completion?(nil)
             } catch {
-                let primerErr = error.asPrimerError
+                let primerErr = handled(primerError: error.asPrimerError)
                 PrimerUIManager.handleErrorBasedOnSDKSettings(primerErr)
                 completion?(error)
             }
@@ -267,7 +267,7 @@ final class PrimerInternal: LogReporter {
                 self.recordLoadedEvent(start, source: .showPaymentMethod)
                 completion?(nil)
             } catch {
-                let primerErr = error.asPrimerError
+                let primerErr = handled(primerError: error.asPrimerError)
                 PrimerUIManager.handleErrorBasedOnSDKSettings(primerErr)
                 completion?(error)
             }

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/VaultManager.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/VaultManager.swift
@@ -208,7 +208,7 @@ extension PrimerHeadlessUniversalCheckout {
 
                     return await PrimerDelegateProxy.primerDidCompleteCheckoutWithData(paymentCheckoutData)
                 } catch {
-                    let primerError = error.asPrimerErrorProtocol
+                    let primerError = handled(error: error.asPrimerErrorProtocol)
                     _ = await PrimerDelegateProxy.primerDidFailWithError(primerError, data: self.paymentCheckoutData)
                 }
             }

--- a/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/CardFormPaymentMethodTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Tokenization View Models/FormsTokenizationViewModel/CardFormPaymentMethodTokenizationViewModel.swift
@@ -380,7 +380,7 @@ final class CardFormPaymentMethodTokenizationViewModel: PaymentMethodTokenizatio
                     } catch {}
                 } else {
                     do {
-                        let primerErr = error.asPrimerError
+                        let primerErr = handled(primerError: error.asPrimerError)
                         try await clientSessionActionsModule.unselectPaymentMethodIfNeeded()
                         await showResultScreenIfNeeded(error: primerErr)
                         let merchantErrorMessage = await PrimerDelegateProxy.raisePrimerDidFailWithError(primerErr, data: paymentCheckoutData)

--- a/Sources/PrimerSDK/Classes/User Interface/Root/PrimerUniversalCheckoutViewController.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/Root/PrimerUniversalCheckoutViewController.swift
@@ -59,7 +59,7 @@ final class PrimerUniversalCheckoutViewController: PrimerFormViewController {
                 try await vaultService.fetchVaultedPaymentMethods()
                 renderSelectedPaymentInstrument(insertAt: 1)
             } catch {
-                let primerErr = error.asPrimerError
+                let primerErr = handled(primerError: error.asPrimerError)
                 PrimerDelegateProxy.primerDidFailWithError(primerErr, data: nil) { errorDecision in
                     switch errorDecision.type {
                     case let .fail(message):

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/CheckoutWithVaultedPaymentMethodViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/CheckoutWithVaultedPaymentMethodViewModel.swift
@@ -67,7 +67,7 @@ final class CheckoutWithVaultedPaymentMethodViewModel: LogReporter {
             await handleSuccessfulFlow()
         } catch {
             didFinishPayment?(error)
-            let primerErr = error.asPrimerError
+            let primerErr = handled(primerError: error.asPrimerError)
             let merchantErrorMessage = await PrimerDelegateProxy.raisePrimerDidFailWithError(primerErr, data: paymentCheckoutData)
             await handleFailureFlow(errorMessage: merchantErrorMessage)
         }

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/PaymentMethodTokenizationViewModel+Logic.swift
@@ -40,7 +40,7 @@ extension PaymentMethodTokenizationViewModel {
                 } else {
                     do {
                         try await clientSessionActionsModule.unselectPaymentMethodIfNeeded()
-                        let primerErr = error.asPrimerError
+                        let primerErr = handled(primerError: error.asPrimerError)
                         await showResultScreenIfNeeded(error: primerErr)
                         let merchantErrorMessage = await PrimerDelegateProxy.raisePrimerDidFailWithError(primerErr, data: self.paymentCheckoutData)
                         await handleFailureFlow(errorMessage: merchantErrorMessage)
@@ -116,7 +116,7 @@ extension PaymentMethodTokenizationViewModel {
                self.config.type == PrimerPaymentMethodType.payPal.rawValue {
                 await PrimerUIManager.primerRootViewController?.popToMainScreen(completion: nil)
             } else {
-                let primerErr = error.asPrimerError
+                let primerErr = handled(primerError: error.asPrimerError)
                 setCheckoutDataFromError(primerErr)
                 await showResultScreenIfNeeded(error: primerErr)
                 let merchantErrorMessage = await PrimerDelegateProxy.raisePrimerDidFailWithError(primerErr, data: paymentCheckoutData)


### PR DESCRIPTION
## What & why

Implements [ORC-7439](https://primerapi.atlassian.net/browse/ORC-7439) — the third diagnostics-ID gap split out from [ESC-905](https://primerapi.atlassian.net/browse/ESC-905) / PR #1792.

Several flow boundary `catch` blocks converted a caught error to a `PrimerError` via `error.asPrimerError` and surfaced it to the merchant (through `PrimerDelegateProxy`) **without logging it**. For genuinely non-Primer errors, `asPrimerError` mints a fresh `PrimerError.unknown(diagnosticsId:)` — so the merchant sees a `diagnosticsId` that was never written to backend analytics and can't be found when they report it.

## The fix

Wrap the conversion with `handled(...)` at the surface sites that raise to the merchant without already logging, so the surfaced error and its `diagnosticsId` are recorded. This is the per-site approach decided on ORC-7439 (with Henry) over blanket logging at the proxy.

**Sites changed (10):**
- `CardFormPaymentMethodTokenizationViewModel` · `PaymentMethodTokenizationViewModel+Logic` (×2) · `CheckoutWithVaultedPaymentMethodViewModel` · `BanksTokenizationComponent` · `PrimerInternal` (×3: universal checkout / vault manager / payment method) · `PrimerUniversalCheckoutViewController` · `VaultManager`

```swift
// before
let primerErr = error.asPrimerError
// after
let primerErr = handled(primerError: error.asPrimerError)
```

**Deliberately not changed:** sites that already log via `handled(...)` (`InternalCardComponentsManager`, `StripeAchTokenizationViewModel`, `NolPayLinkedCardsComponent`, `PrimerHeadlessComposable`), and `3DSService`'s `throw error.asPrimerError` (a rethrow that is logged at the downstream surface site).

## Tradeoff (reviewer note)

These are the final, merchant-facing errors (one per failed flow). Where the underlying error was already logged deeper, this adds a second event — but with the **same** `diagnosticsId`, so it stays searchable rather than spawning an unsearchable id. This is the contained cost of the per-site approach; the proxy alternative would double-count far more broadly across error-rate dashboards/alerting.

## Test plan

- Behaviour-preserving: `handled(primerError:)` logs and returns its argument unchanged; only the logging side-effect is added.
- `xcodebuild test … -only-testing:"Tests/CardFormPaymentMethodTokenizationViewModelTests"` → **Executed 7 tests, 0 failures**; full SDK compiles (incl. the `handled(error: error.asPrimerErrorProtocol)` existential in `VaultManager`).
- swiftformat clean; no new swiftlint violations.

## Related

- Decision + rationale: ORC-7439
- Escalation: ESC-905
- Sibling fixes (the `InternalError` + decode-spam gaps): #1792


[ORC-7439]: https://primerapi.atlassian.net/browse/ORC-7439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESC-905]: https://primerapi.atlassian.net/browse/ESC-905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ