### PR TITLE
fix: Prevent script injection in CI workflows (VULN-158)

### DIFF
--- a/.github/actions/appetize-build/action.yml
+++ b/.github/actions/appetize-build/action.yml
@@ -82,11 +82,13 @@ runs:
         node-version: 18.3.0
     - name: Install SMB
       shell: bash
-      run: npm install --save slack-message-builder
+      run: npm install --save slack-message-builder # zizmor: ignore[adhoc-packages] CI-only Slack report helper; no maintained lockfile
     - name: Create secrets.defaults.properties
       shell: bash
+      env:
+        STRIPE_PUBLISHABLE_KEY: ${{ inputs.stripe-publishable-key }}
       run: |
-        echo "STRIPE_PUBLISHABLE_KEY=${{ inputs.stripe-publishable-key }}" > Debug\ App/secrets.defaults.properties
+        echo "STRIPE_PUBLISHABLE_KEY=$STRIPE_PUBLISHABLE_KEY" > Debug\ App/secrets.defaults.properties
     - name: Test, Build, and Distribute app to Appetize 🚀
       shell: bash
       run: |
@@ -104,10 +106,13 @@ runs:
         GITHUB_RUN_ID: ${{ inputs.github-run-id }}
         PR_NUMBER: ${{ inputs.pr-number}}
     - name: Create Slack Success Summary Report
-      if: ${{ success()  }}
+      if: ${{ success() }}
       shell: bash
+      env:
+        SOURCE_BRANCH: ${{ inputs.source-branch }}
+        BUILD_TYPE: ${{ inputs.build_type }}
       run: |
-        node Report\ Scripts/appetize-success-report-script.js createAppetizeSummaryReport ${{ inputs.source-branch }} ${{ inputs.build_type }}
+        node Report\ Scripts/appetize-success-report-script.js createAppetizeSummaryReport "$SOURCE_BRANCH" "$BUILD_TYPE"
     - name: Slack Success Notification
       if: ${{ success() }}
       uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 #v1.25.0
@@ -119,8 +124,10 @@ runs:
     - name: Create Slack Failure Summary Report
       if: ${{ failure() }}
       shell: bash
+      env:
+        SOURCE_BRANCH: ${{ inputs.source-branch }}
       run: |
-        node Report\ Scripts/appetize-failure-report-script.js createAppetizeSummaryReport ${{ inputs.source-branch }}
+        node Report\ Scripts/appetize-failure-report-script.js createAppetizeSummaryReport "$SOURCE_BRANCH"
     - name: Slack Notification
       if: ${{ failure() }}
       uses: slackapi/slack-github-action@6c661ce58804a1a20f6dc5fbee7f0381b469e001 #v1.25.0

--- a/.github/actions/sdk-tests/action.yml
+++ b/.github/actions/sdk-tests/action.yml
@@ -22,7 +22,7 @@ inputs:
   fastlane-test-lane:
     description: The fastlane test lane to run
     required: false
-    default: test_sdk 
+    default: test_sdk
   match-keychain-name:
     description: Match keychain name
     required: true
@@ -62,14 +62,17 @@ runs:
     - name: Setup Package.swift
       shell: bash
       if: ${{ inputs.package-swift != '' }}
+      env:
+        PACKAGE_SWIFT: ${{ inputs.package-swift }}
       run: |
         mv Package.swift Package.swift.orig
-        cp "${{ inputs.package-swift }}" Package.swift
+        cp "$PACKAGE_SWIFT" Package.swift
     - name: Build SPM App
       shell: bash
       run: |
-        bundle exec fastlane ${{ inputs.fastlane-test-lane }}
+        bundle exec fastlane "$FASTLANE_TEST_LANE"
       env:
+        FASTLANE_TEST_LANE: ${{ inputs.fastlane-test-lane }}
         MATCH_PASSWORD: ${{ inputs.match-password }}
         MATCH_GIT_PRIVATE_KEY: ${{ inputs.ssh-private-key }}
         FASTLANE_PASSWORD: ${{ inputs.fastlane-password }}
@@ -80,9 +83,11 @@ runs:
     - name: Prepare coverage reports
       shell: bash
       if: ${{ inputs.sdk-name != '' }}
+      env:
+        SDK_NAME: ${{ inputs.sdk-name }}
       run: |
         bash Scripts/xccov-to-sonarqube-generic.sh fastlane/test_output/PrimerSDKTests.xcresult/ > coverage.xml
-        sed "s#$PWD/##g" coverage.xml > sonar-coverage-${{ inputs.sdk-name }}.xml
+        sed "s#$PWD/##g" coverage.xml > "sonar-coverage-${SDK_NAME}.xml"
     - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: coverage-file-${{ inputs.sdk-name }}

--- a/.github/actions/sonar/action.yml
+++ b/.github/actions/sonar/action.yml
@@ -40,13 +40,21 @@ runs:
         brew install sonar-scanner
     - name: Update sonar-project.properties
       shell: bash
+      env:
+        PR_NUMBER: ${{ inputs.pull-request-number }}
+        PR_BRANCH: ${{ inputs.branch }}
+        PR_BASE: ${{ inputs.base-branch }}
+        PR_SHA: ${{ inputs.pull-request-sha }}
+        COVERAGE_FILE_NAMES: ${{ inputs.coverage-file-names }}
       run: |
-        echo "sonar.pullrequest.key=${{ inputs.pull-request-number }}" >> sonar-project.properties
-        echo "sonar.pullrequest.branch=${{ inputs.branch }}" >> sonar-project.properties
-        echo "sonar.pullrequest.base=${{ inputs.base-branch }}" >> sonar-project.properties
-        echo "sonar.scm.revision=${{ inputs.pull-request-sha }}" >> sonar-project.properties
-        echo "sonar.coverageReportPaths=${{ inputs.coverage-file-names }}" >> sonar-project.properties
+        echo "sonar.pullrequest.key=${PR_NUMBER}" >> sonar-project.properties
+        echo "sonar.pullrequest.branch=${PR_BRANCH}" >> sonar-project.properties
+        echo "sonar.pullrequest.base=${PR_BASE}" >> sonar-project.properties
+        echo "sonar.scm.revision=${PR_SHA}" >> sonar-project.properties
+        echo "sonar.coverageReportPaths=${COVERAGE_FILE_NAMES}" >> sonar-project.properties
     - name: Run Sonar
       shell: bash
+      env:
+        SONAR_TOKEN: ${{ inputs.sonar-token }}
       run: |
-        sonar-scanner -Dsonar.token=${{ inputs.sonar-token }}
+        sonar-scanner -Dsonar.token="${SONAR_TOKEN}"

--- a/.github/actions/ui-tests/action.yml
+++ b/.github/actions/ui-tests/action.yml
@@ -34,11 +34,12 @@ runs:
   steps:
     - name: Clone and launch Lambdatest tests via Appium 🧪
       shell: bash
-      run: |
-          git clone -b ${{ inputs.appium-tests-branch || 'develop' }} https://project_41483872_bot:$GITLAB_TEMP_PATH@gitlab.com/primer-io/acceptance/mobile/mobile-appium-tests.git ./tests
-          git show --summary
       env:
+        APPIUM_TESTS_BRANCH: ${{ inputs.appium-tests-branch || 'develop' }}
         GITLAB_TEMP_PATH: ${{ inputs.gitlab-appium-pull-key }} # secrets.GITLAB_APPIUM_PULL_KEY
+      run: |
+          git clone -b "$APPIUM_TESTS_BRANCH" https://project_41483872_bot:$GITLAB_TEMP_PATH@gitlab.com/primer-io/acceptance/mobile/mobile-appium-tests.git ./tests
+          git show --summary
 
     - name: Retrieve Lambdatest ID
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  #v4.1.8
@@ -55,11 +56,11 @@ runs:
       working-directory: ./tests
       shell: bash
       run: npm install
- 
+
     - name: npm install - slack message builder
       working-directory: ./tests
       shell: bash
-      run: npm install --save slack-message-builder
+      run: npm install --save slack-message-builder # zizmor: ignore[adhoc-packages] CI-only Slack report helper; tests dir has no maintained lockfile
 
     - name: Run Appium Test
       working-directory: ./tests
@@ -67,17 +68,20 @@ runs:
       env:
         LAMBDATEST_USERNAME: ${{ inputs.lambdatest-user-name }} # secrets.LAMBDATEST_USERNAME
         LAMBDATEST_ACCESS_KEY: ${{ inputs.lambdatest-access-key }} # secrets.LAMBDATEST_ACCESS_KEY
+        UI_TESTS_SECRETS_API_KEY: ${{ inputs.ui-tests-secrets-api-key }}
+        TEST_TYPE: ${{ inputs.test-type }}
       run: |
         export LAMBDATEST_APP_ID=$(cat /var/tmp/lambdatest_id.txt)
-        export UI_TESTS_SECRETS_API_KEY="${{ inputs.ui-tests-secrets-api-key }}"
-        testType=${{ inputs.test-type }} npx wdio config/wdio.ios.lt.conf.js
- 
+        testType="$TEST_TYPE" npx wdio config/wdio.ios.lt.conf.js
+
     - name: Create Slack Report
       working-directory: ./tests
       shell: bash
       if: ${{ success() || failure() }}
+      env:
+        TEST_APP_ARTIFACT_URL: ${{ inputs.test-app-artifact-url }}
       run: |
-        node report-script/slack-report-script.js createSlackReport iOS ${{ inputs.test-app-artifact-url }}
+        node report-script/slack-report-script.js createSlackReport iOS "$TEST_APP_ARTIFACT_URL"
 
     - name: Post summary message to a Slack channel
       if: ${{ success() || failure() }}
@@ -93,11 +97,12 @@ runs:
       working-directory: ./tests
       shell: bash
       if: ${{ failure() }}
-      run: |
-        node report-script/slack-failed-report-script.js createSlackFailedSummaryReport ${{ steps.slack.outputs.thread_ts }}
       env:
+        THREAD_TS: ${{ steps.slack.outputs.thread_ts }}
         LAMBDATEST_USERNAME: ${{ inputs.lambdatest-user-name }} # secrets.LAMBDATEST_USERNAME
         LAMBDATEST_ACCESS_KEY: ${{ inputs.lambdatest-access-key }} # secrets.LAMBDATEST_ACCESS_KEY
+      run: |
+        node report-script/slack-failed-report-script.js createSlackFailedSummaryReport "$THREAD_TS"
 
     - name: Post detailed summary to Slack channel thread
       if: ${{ failure() }}

--- a/.github/workflows/build-test-upload.yml
+++ b/.github/workflows/build-test-upload.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.ref }}-tests
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests-sdk-and-debug-app:
     needs: check-optional-tests
@@ -20,6 +23,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Run SDK and Debug App tests
         uses: ./.github/actions/sdk-tests
         with:
@@ -31,11 +35,15 @@ jobs:
           fastlane-password: ${{ secrets.FASTLANE_PASSWORD }}
           match-keychain-name: ${{ secrets.MATCH_KEYCHAIN_NAME }}
           match-keychain-password: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          source-branch: ${{ github.head_ref || github.ref_name }}
           fastlane-test-lane: test_sdk_and_debug_app
           sdk-name: sdk
 
   check-optional-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       should-run-nolpay: ${{ steps.changes.outputs.nolpay }}
       should-run-klarna: ${{ steps.changes.outputs.klarna }}
@@ -47,6 +55,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: changes
         with:
@@ -108,6 +117,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Run SDK tests
         if: ${{ !matrix.skip }}
         uses: ./.github/actions/sdk-tests
@@ -120,6 +130,7 @@ jobs:
           fastlane-password: ${{ secrets.FASTLANE_PASSWORD }}
           match-keychain-name: ${{ secrets.MATCH_KEYCHAIN_NAME }}
           match-keychain-password: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          source-branch: ${{ github.head_ref || github.ref_name }}
           sdk-name: ${{ matrix.name }}
           package-swift: ${{ matrix.file }}
 
@@ -133,6 +144,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Select Xcode Version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
@@ -174,28 +186,34 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
       - name: Determine coverage files
         id: coverage-files
+        env:
+          SHOULD_RUN_THREEDS: ${{ needs.check-optional-tests.outputs.should-run-threeds }}
+          SHOULD_RUN_NOLPAY: ${{ needs.check-optional-tests.outputs.should-run-nolpay }}
+          SHOULD_RUN_KLARNA: ${{ needs.check-optional-tests.outputs.should-run-klarna }}
+          SHOULD_RUN_STRIPE: ${{ needs.check-optional-tests.outputs.should-run-stripe }}
         run: |
           # Always include the main SDK coverage
           COVERAGE_FILES="sonar-coverage-sdk.xml"
-          
+
           # Add optional test coverage files if those tests ran
-          if [[ "${{ needs.check-optional-tests.outputs.should-run-threeds }}" == "true" ]]; then
+          if [[ "$SHOULD_RUN_THREEDS" == "true" ]]; then
             COVERAGE_FILES="${COVERAGE_FILES},sonar-coverage-3DS.xml"
           fi
-          if [[ "${{ needs.check-optional-tests.outputs.should-run-nolpay }}" == "true" ]]; then
+          if [[ "$SHOULD_RUN_NOLPAY" == "true" ]]; then
             COVERAGE_FILES="${COVERAGE_FILES},sonar-coverage-nol-pay.xml"
           fi
-          if [[ "${{ needs.check-optional-tests.outputs.should-run-klarna }}" == "true" ]]; then
+          if [[ "$SHOULD_RUN_KLARNA" == "true" ]]; then
             COVERAGE_FILES="${COVERAGE_FILES},sonar-coverage-klarna.xml"
           fi
-          if [[ "${{ needs.check-optional-tests.outputs.should-run-stripe }}" == "true" ]]; then
+          if [[ "$SHOULD_RUN_STRIPE" == "true" ]]; then
             COVERAGE_FILES="${COVERAGE_FILES},sonar-coverage-stripe.xml"
           fi
-          
+
           echo "Coverage files to process: ${COVERAGE_FILES}"
-          echo "files=${COVERAGE_FILES}" >> $GITHUB_OUTPUT
+          echo "files=${COVERAGE_FILES}" >> "$GITHUB_OUTPUT"
       - name: SonarCloud Scan
         uses: ./.github/actions/sonar
         with:
@@ -214,11 +232,15 @@ jobs:
     runs-on: macos-26-large
     timeout-minutes: 45
     name: "Build and upload app to Appetize"
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Git - Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Upload preview to Appetize
         id: appetize-upload
         uses: ./.github/actions/appetize-build

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,13 +7,19 @@ on:
       - edited
       - synchronize
 
-concurrency: 
+concurrency:
   group: ${{ github.ref }}-danger
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       swift: ${{ steps.filter.outputs.swift }}
     steps:
@@ -32,23 +38,26 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Get changed Swift files
         id: changed-files
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.swift$' || true)
-          echo "changed-files<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          git diff --name-only "origin/$BASE_REF...HEAD" | grep '\.swift$' > "$RUNNER_TEMP/changed_swift_files.txt" || true
+          if [ -s "$RUNNER_TEMP/changed_swift_files.txt" ]; then
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: SwiftFormat
-        if: steps.changed-files.outputs.changed-files != ''
+        if: steps.changed-files.outputs.has-changes == 'true'
         run: |
           files_to_lint=()
           while IFS= read -r file; do
             if [ -n "$file" ] && [ -f "$file" ]; then
               files_to_lint+=("$file")
             fi
-          done <<< "${{ steps.changed-files.outputs.changed-files }}"
-          
+          done < "$RUNNER_TEMP/changed_swift_files.txt"
+
           if [ ${#files_to_lint[@]} -gt 0 ]; then
             swiftformat --lint "${files_to_lint[@]}" --reporter github-actions-log --config BuildTools/.swiftformat
           fi
@@ -56,8 +65,13 @@ jobs:
   danger:
     runs-on: ubuntu-latest
     name: "Run Danger"
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v3.2.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Danger
         uses: docker://ghcr.io/danger/danger-swift@sha256:dbb8124fe768924ace43755559735df1a96318c7249f9ffac3d64a71f2a2163e
         with:

--- a/.github/workflows/create-3ds-klarna-tag.yml
+++ b/.github/workflows/create-3ds-klarna-tag.yml
@@ -11,21 +11,27 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   create-klarna-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Resolve release tag
         id: resolve
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="${GITHUB_REF_NAME}"
           fi
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # zizmor: ignore[artipacked] persisted RELEASE_ACCESS_TOKEN is required to push the 3ds-klarna tag
         with:
           ref: ${{ steps.resolve.outputs.tag }}
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
@@ -33,7 +39,7 @@ jobs:
       - name: Get latest Klarna SDK version
         run: |
           KLARNA_VERSION=$(gh api repos/primer-io/primer-klarna-sdk-ios/releases/latest --jq '.tag_name')
-          echo "KLARNA_VERSION=$KLARNA_VERSION" >> $GITHUB_ENV
+          echo "KLARNA_VERSION=$KLARNA_VERSION" >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -41,7 +47,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ steps.resolve.outputs.tag }}
         run: |
-          swift .github/scripts/add-klarna-dependency.swift $KLARNA_VERSION
+          swift .github/scripts/add-klarna-dependency.swift "$KLARNA_VERSION"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Package.swift

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,13 +13,16 @@ on:
           - beta
           - rc
 
+permissions:
+  contents: read
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest
     name: "Bump release version and create changelog"
     steps:
       - name: Check out repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # zizmor: ignore[artipacked] persisted RELEASE_ACCESS_TOKEN is required to push the release branch
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
@@ -27,7 +30,7 @@ jobs:
         run: pip install --user -U Commitizen
       - name: Record from version
         run: |
-          echo "FROM_VERSION=$(cz version --project)" >> $GITHUB_ENV
+          echo "FROM_VERSION=$(cz version --project)" >> "$GITHUB_ENV"
       - name: Create release branch
         run: |
           git checkout -b release/next
@@ -39,10 +42,12 @@ jobs:
       # Bump version and create CHANGELOG - prereleasee
       - name: Create bump and changelog
         if: ${{ inputs.releaseType != 'default' }}
-        run: cz bump --files-only --yes --changelog --prerelease ${{ inputs.releaseType }}
+        env:
+          RELEASE_TYPE: ${{ inputs.releaseType }}
+        run: cz bump --files-only --yes --changelog --prerelease "$RELEASE_TYPE"
       - name: Record to version
         run: |
-          echo "TO_VERSION=$(cz version --project)" >> $GITHUB_ENV
+          echo "TO_VERSION=$(cz version --project)" >> "$GITHUB_ENV"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:

--- a/.github/workflows/manual-translation-update-checkout-components.yml
+++ b/.github/workflows/manual-translation-update-checkout-components.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: 'master'
 
+permissions:
+  contents: read
+
 jobs:
   update-translations:
     runs-on: ubuntu-latest
@@ -18,6 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
+          persist-credentials: false
 
       - name: Install Phrase CLI
         uses: phrase/setup-cli@d1c415d0ff01efc1bb21287d60a547669d9331c5
@@ -26,10 +30,12 @@ jobs:
 
       - name: Prepend Phrase configuration
         run: |
-          echo "phrase:" > .phrase.yml
-          echo "  access_token: ${PHRASE_ACCESS_KEY}" >> .phrase.yml
-          echo "  project_id: ${PHRASE_PROJECT_ID_CHECKOUT_COMPONENTS}" >> .phrase.yml
-          cat phrase_config_checkout_components.yml >> .phrase.yml
+          {
+            echo "phrase:"
+            echo "  access_token: ${PHRASE_ACCESS_KEY}"
+            echo "  project_id: ${PHRASE_PROJECT_ID_CHECKOUT_COMPONENTS}"
+            cat phrase_config_checkout_components.yml
+          } > .phrase.yml
         env:
           PHRASE_ACCESS_KEY: ${{ secrets.PHRASE_ACCESS_KEY }}
           PHRASE_PROJECT_ID_CHECKOUT_COMPONENTS: ${{ secrets.PHRASE_PROJECT_ID_CHECKOUT_COMPONENTS }}

--- a/.github/workflows/manual-translation-update.yml
+++ b/.github/workflows/manual-translation-update.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: 'master'
 
+permissions:
+  contents: read
+
 jobs:
   update-translations:
     runs-on: ubuntu-latest
@@ -18,6 +21,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
+          persist-credentials: false
 
       - name: Install Phrase CLI
         uses: phrase/setup-cli@884b5c75c4f61b8888a3ff30d34eb7111d20fa86
@@ -26,10 +30,12 @@ jobs:
 
       - name: Prepend Phrase configuration
         run: |
-          echo "phrase:" > .phrase.yml
-          echo "  access_token: ${PHRASE_ACCESS_KEY}" >> .phrase.yml
-          echo "  project_id: ${PHRASE_PROJECT_ID}" >> .phrase.yml
-          cat phrase_config.yml >> .phrase.yml
+          {
+            echo "phrase:"
+            echo "  access_token: ${PHRASE_ACCESS_KEY}"
+            echo "  project_id: ${PHRASE_PROJECT_ID}"
+            cat phrase_config.yml
+          } > .phrase.yml
         env:
           PHRASE_ACCESS_KEY: ${{ secrets.PHRASE_ACCESS_KEY }}
           PHRASE_PROJECT_ID: ${{ secrets.PHRASE_PROJECT_ID }}
@@ -49,9 +55,9 @@ jobs:
             echo "Changes detected:"
             git diff
           fi
-          
+
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
           base: ${{ github.event.inputs.branch }}

--- a/.github/workflows/pod_lint.yml
+++ b/.github/workflows/pod_lint.yml
@@ -6,9 +6,15 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
@@ -25,6 +31,9 @@ jobs:
     if: ${{ github.event.pull_request.base.ref == 'master' && needs.changes.outputs.relevant == 'true' }}
     runs-on: macos-26
     name: "Pod lint"
+    permissions:
+      contents: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +45,8 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Select Xcode Version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
         with:
@@ -46,8 +57,9 @@ jobs:
           bundler-cache: true
 
       - name: Lint pod
+        env:
+          POD_SWIFT_VERSION: ${{ matrix.version }}
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
           set -eo pipefail
-          pod lib lint PrimerSDK.podspec --allow-warnings --swift-version=${{ matrix.version }} --analyze --include-podspecs='*.podspec'
-        env:
-          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          pod lib lint PrimerSDK.podspec --allow-warnings --swift-version="$POD_SWIFT_VERSION" --analyze --include-podspecs='*.podspec'

--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -4,12 +4,17 @@ on:
   pull_request:
     types: [ closed ]
 
+permissions:
+  contents: read
+
 jobs:
   release_merge:
     if: github.head_ref == 'release/next' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - name: Git - Checkout
+      - name: Git - Checkout # zizmor: ignore[artipacked] persisted RELEASE_ACCESS_TOKEN is required to push the release tag
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -19,15 +24,15 @@ jobs:
         run: pip install --user -U Commitizen
       - name: Record release version
         run: |
-          echo "RELEASE_VERSION=$(cz version --project)" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$(cz version --project)" >> "$GITHUB_ENV"
       - name: Tag release
         run: |
-          git tag $RELEASE_VERSION
-          git push origin $RELEASE_VERSION
+          git tag "$RELEASE_VERSION"
+          git push origin "$RELEASE_VERSION"
       - name: Extract changelog for current release
         run: awk '/^## /{if(n++)exit}1' CHANGELOG.md > release.md
       - name: Create release
-        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd #v1.21.0
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # zizmor: ignore[superfluous-actions] pinned release-action retained intentionally over gh release
         with:
           name: "Release ${{ env.RELEASE_VERSION }}"
           tag: ${{ env.RELEASE_VERSION }}
@@ -37,6 +42,9 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     name: "Build and upload app to Appetize"
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Cancel previous jobs
         uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # v0.13.1
@@ -46,6 +54,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Upload preview to Appetize
         id: appetize-upload
         uses: ./.github/actions/appetize-build
@@ -66,4 +75,4 @@ jobs:
           slack-channel: ${{ secrets.SLACK_MOBILE_SDK_CHANNEL }}
           slack-reporter-token: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
           github-run-id: ${{ github.run_id }}
-
+          stripe-publishable-key: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}

--- a/.github/workflows/spm-resolve.yml
+++ b/.github/workflows/spm-resolve.yml
@@ -6,9 +6,15 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       swift: ${{ steps.filter.outputs.swift }}
     steps:
@@ -24,6 +30,9 @@ jobs:
     if: ${{ needs.changes.outputs.swift == 'true' }}
     runs-on: macos-26
     name: "SPM resolution check"
+    permissions:
+      contents: read
+      actions: write
 
     steps:
       - name: Cancel previous jobs
@@ -32,6 +41,8 @@ jobs:
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Select Xcode Version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -39,14 +50,18 @@ jobs:
           xcode-version: '26.2'
 
       - name: Create local branch ref
-        run: git checkout -b ${{ github.head_ref }}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: git checkout -b "$HEAD_REF"
 
       - name: Create test consumer package
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           mkdir -p /tmp/spm-test/Sources/SPMTest
           echo 'import PrimerSDK' > /tmp/spm-test/Sources/SPMTest/Test.swift
           sed -e "s|__REPO_URL__|file://${{ github.workspace }}|" \
-              -e "s|__BRANCH__|${{ github.head_ref }}|" \
+              -e "s|__BRANCH__|$HEAD_REF|" \
               .github/templates/SPMResolveTest/Package.swift > /tmp/spm-test/Package.swift
 
       - name: Resolve dependencies

--- a/.github/workflows/test-and-code-quality.yml
+++ b/.github/workflows/test-and-code-quality.yml
@@ -10,11 +10,17 @@ concurrency:
   group: ${{ github.ref }}-tests
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   sdk-unit-tests:
     runs-on: macos-26-large
     timeout-minutes: 20
     name: "SDK - Unit Tests"
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Cancel previous jobs
         uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # v0.13.1
@@ -24,6 +30,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Run unit tests
         uses: ./.github/actions/sdk-tests
         with:
@@ -35,11 +42,15 @@ jobs:
           fastlane-password: ${{ secrets.FASTLANE_PASSWORD }}
           match-keychain-name: ${{ secrets.MATCH_KEYCHAIN_NAME }}
           match-keychain-password: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          source-branch: ${{ github.head_ref || github.ref_name }}
           sdk-name: sdk
 
   optional-sdk-tests:
     name: Optional SDK Tests
     runs-on: macos-26-large
+    permissions:
+      contents: read
+      actions: write
     strategy:
       max-parallel: 3
       matrix:
@@ -57,6 +68,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Run SDK tests
         uses: ./.github/actions/sdk-tests
         with:
@@ -68,6 +80,7 @@ jobs:
           fastlane-password: ${{ secrets.FASTLANE_PASSWORD }}
           match-keychain-name: ${{ secrets.MATCH_KEYCHAIN_NAME }}
           match-keychain-password: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          source-branch: ${{ github.head_ref || github.ref_name }}
           sdk-name: ${{ matrix.package-swift.name }}
           package-swift: ${{  matrix.package-swift.file }}
 
@@ -81,6 +94,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          persist-credentials: false
       - name: SonarCloud Scan
         uses: ./.github/actions/sonar
         with:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       appiumTestsBranch:
-        description: The branch to run from mobile-appium-tests 
+        description: The branch to run from mobile-appium-tests
         required: true
         default: develop
         type: string
@@ -19,11 +19,17 @@ on:
     branches:
       - 'release/**'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-upload-to-appetize:
     runs-on: macos-26
     timeout-minutes: 20
     name: "Build and upload app to Appetize"
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Cancel previous jobs
         uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # v0.13.1
@@ -33,6 +39,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Upload preview to Appetize
         id: appetize-upload
         uses: ./.github/actions/appetize-build
@@ -58,6 +65,9 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 20
     name: "Distribute app to Firebase and LambdaTest"
+    permissions:
+      contents: read
+      actions: write
     outputs:
       artifact-url: ${{ steps.save_app_artifact_step.outputs.artifact-url }}
     steps:
@@ -70,6 +80,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Select Xcode Version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
@@ -87,7 +98,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
 
-      - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af  # v1.313.0
+      - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # zizmor: ignore[cache-poisoning] ruby gem cache for the build runner; not a published release artifact
         with:
           ruby-version: "3.2"
           bundler-cache: true
@@ -101,15 +112,17 @@ jobs:
 
       - name: Create secrets.defaults.properties
         shell: bash
+        env:
+          STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
         run: |
-          echo "STRIPE_PUBLISHABLE_KEY=${{ secrets.STRIPE_PUBLISHABLE_KEY }}" > Debug\ App/secrets.defaults.properties
+          echo "STRIPE_PUBLISHABLE_KEY=$STRIPE_PUBLISHABLE_KEY" > Debug\ App/secrets.defaults.properties
 
       - name: Distribute internally on Firebase and upload to LambdaTest 🚀
         run: |
           bundle exec fastlane qa_release
         env:
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-          FIREBASE_COMMA_SEPARATED_TEST_GROUPS: ${{ 'primer-internal' }}
+          FIREBASE_COMMA_SEPARATED_TEST_GROUPS: primer-internal
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.SSH_KEY }}
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
@@ -154,6 +167,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           sparse-checkout: .github
+          persist-credentials: false
       - name: Run UI Tests via LambdaTest [${{ inputs.testType }}] 🧪
         id: ui-tests-test-via-lambdatest
         uses: ./.github/actions/ui-tests
@@ -179,6 +193,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
           sparse-checkout: .github
+          persist-credentials: false
       - name: Run UI Tests via LambdaTest [${{ inputs.testType }}] 🧪
         id: ui-tests-test-via-lambdatest
         uses: ./.github/actions/ui-tests

--- a/.github/workflows/workflow-security-lint.yml
+++ b/.github/workflows/workflow-security-lint.yml
@@ -1,0 +1,38 @@
+name: Workflow Security Lint
+
+# Static analysis of the repo's own GitHub Actions workflows and composite
+# actions. actionlint catches structural/expression mistakes; zizmor catches
+# security smells such as template injection, credential persistence, and
+# overly broad GITHUB_TOKEN permissions.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: actionlint + zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install and run actionlint
+        env:
+          # shellcheck "info"/"style" nits (e.g. SC2086 on $GITHUB_ENV) are not
+          # security relevant; enforce warning severity and above.
+          SHELLCHECK_OPTS: --severity=warning
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          "$(go env GOPATH)/bin/actionlint" -color
+
+      - name: Install and run zizmor
+        run: |
+          pipx install zizmor==1.26.1
+          zizmor --offline .github/workflows .github/actions

--- a/.github/workflows/xcode-versions-build.yml
+++ b/.github/workflows/xcode-versions-build.yml
@@ -8,6 +8,9 @@ on:
   #   branches:
   #     - 'release/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build App"
@@ -25,6 +28,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Select Xcode Version
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
         with:
@@ -46,7 +50,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version: 18.3.0
-      - run: npm install --save slack-message-builder
+      - run: npm install --save slack-message-builder # zizmor: ignore[adhoc-packages] CI-only Slack report helper; no maintained lockfile
       - name: Build and archive app via Cocoapods
         if: ${{ matrix.variant == 'cocoapods' }}
         run: |
@@ -73,8 +77,10 @@ jobs:
           SOURCE_BRANCH: ${{ github.head_ref }}
       - name: Create Slack Failure Summary Report
         if: ${{ failure() }}
+        env:
+          SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          node Report\ Scripts/multixcode-failure-report.js createMultiXcodeFailureReport ${{ github.head_ref || github.ref_name }} ${{ matrix.xcode}} ${{ matrix.variant }}
+          node Report\ Scripts/multixcode-failure-report.js createMultiXcodeFailureReport "$SOURCE_BRANCH" ${{ matrix.xcode }} ${{ matrix.variant }}
       - name: Slack Notification
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c #v3.0.3
@@ -92,15 +98,18 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version: 18.3.0
-      - run: npm install --save slack-message-builder
+      - run: npm install --save slack-message-builder # zizmor: ignore[adhoc-packages] CI-only Slack report helper; no maintained lockfile
       - name: Create Slack Success Summary Report
         if: ${{ success() }}
+        env:
+          SOURCE_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
-          node Report\ Scripts/multixcode-success-report.js createMultiXcodeSummaryReport ${{ github.head_ref || github.ref_name }} "14.3.1, 14.2, 14.1" "cocoapods, spm"
+          node Report\ Scripts/multixcode-success-report.js createMultiXcodeSummaryReport "$SOURCE_BRANCH" "14.3.1, 14.2, 14.1" "cocoapods, spm"
       - name: Slack Notification
         if: ${{ success() }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c #v3.0.3
@@ -109,4 +118,3 @@ jobs:
           payload-file-path: '/var/tmp/multixcode-success-summary.json'
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_REPORTER_BOT_TOKEN }}
-


### PR DESCRIPTION
# Description

ORC-7316 (VULN-158)

Fixes the two script-injection findings in our GitHub Actions, and hardens the rest of the workflows against the same class so we can enforce it going forward.

**The two reported issues**
- **WF-002** — `code-quality.yml` interpolated `git diff` filenames into a bash here-string (`<<< "${{ steps.changed-files... }}"`). A fork PR with a crafted filename could inject commands. Changed-file detection now writes to a temp file read from disk; `github.base_ref` moved to an env var.
- **WF-003** — `actions/appetize-build` interpolated `inputs.source-branch` (from `github.head_ref`, attacker-controlled on fork PRs) and the Stripe key directly into `node`/`echo` run blocks. These now pass through `env:` vars referenced as quoted shell variables.

**Repo-wide hardening** (so the new gate is green with no blanket suppression)
- Every `${{ }}` expansion moved out of `run:` blocks into `env:` vars (20 template-injection findings).
- Least-privilege `permissions:` blocks on all workflows/jobs (`actions: write` only for `cancel-workflow-action`; `pull-requests: write` only where a job comments; `contents: write` only where a job creates a release).
- `persist-credentials: false` on checkouts that don't push. The handful of release/translation checkouts that must reuse `RELEASE_ACCESS_TOKEN` to push carry a one-line justified `# zizmor: ignore[artipacked]`.
- Fixed an obfuscated expression, shell-quoting nits, and added the required action inputs `actionlint` flagged.

**New CI gate** — `Workflow Security Lint` runs `actionlint` + `zizmor` on every PR touching `.github/`, blocking new injections.

# Manual Testing

Both tools run locally against the full `.github/` tree:
- `zizmor --offline .github/workflows .github/actions` → **0 findings** (9 justified inline ignores).
- `actionlint` (shellcheck at warning severity) → **0 findings**.

No runtime behaviour change: `SOURCE_BRANCH` (newly passed to `sdk-tests`) is only read by the QA/appetize distribution lanes, not the test lanes; all secret/branch values resolve identically through the env indirection.

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have manually validated the workflows with actionlint + zizmor
