### PR TITLE
fix: Redact PCI fields in CheckoutComponents scope API (VULN-156)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Core/Data/PrimerCardFormState.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Core/Data/PrimerCardFormState.swift
@@ -302,3 +302,30 @@ public struct PrimerCardFormState: Equatable {
     fieldErrors.removeAll { $0.fieldType == fieldType }
   }
 }
+
+// MARK: - PCI Redaction
+
+@available(iOS 15.0, *)
+extension PrimerCardFormState {
+  /// A copy of the state with PCI fields masked, safe to expose to merchant code.
+  ///
+  /// The card number keeps only its BIN (first 6) and last 4 digits; the CVV is cleared.
+  /// All non-PCI fields (validation, networks, billing, surcharge, etc.) are preserved.
+  func redactedForMerchant() -> PrimerCardFormState {
+    var redacted = self
+    redacted.data[.cardNumber] = Self.maskedPAN(data[.cardNumber])
+    redacted.data[.cvv] = ""
+    return redacted
+  }
+
+  /// Masks a PAN to the PCI-permitted BIN + last 4 (e.g. `424242••••••4242`).
+  /// Below 11 digits the BIN is dropped so it can never overlap the last 4.
+  static func maskedPAN(_ pan: String) -> String {
+    let digits = pan.filter(\.isNumber)
+    guard !digits.isEmpty else { return "" }
+    let last4 = String(digits.suffix(4))
+    let bin = digits.count > 10 ? String(digits.prefix(6)) : ""
+    let maskedCount = max(0, digits.count - bin.count - last4.count)
+    return bin + String(repeating: "•", count: maskedCount) + last4
+  }
+}

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCardFormScope.swift
@@ -26,7 +26,7 @@ final class DefaultCardFormScope: CardFormFieldScopeInternal, ObservableObject, 
     AsyncStream { continuation in
       let task = Task { [self] in
         for await _ in $structuredState.values {
-          continuation.yield(structuredState)
+          continuation.yield(structuredState.redactedForMerchant())
         }
         continuation.finish()
       }
@@ -40,7 +40,7 @@ final class DefaultCardFormScope: CardFormFieldScopeInternal, ObservableObject, 
   @Published var structuredState = PrimerCardFormState()
   var fieldValidationStates = FieldValidationStates()
 
-  var currentState: PrimerCardFormState { structuredState }
+  var currentState: PrimerCardFormState { structuredState.redactedForMerchant() }
 
   private weak var checkoutScope: DefaultCheckoutScope?
   private let processCardPaymentInteractor: ProcessCardPaymentInteractor
@@ -527,7 +527,11 @@ final class DefaultCardFormScope: CardFormFieldScopeInternal, ObservableObject, 
   }
 
   func getFieldValue(_ fieldType: PrimerInputElementType) -> String {
-    structuredState.data[fieldType]
+    switch fieldType {
+    case .cardNumber: PrimerCardFormState.maskedPAN(structuredState.data[.cardNumber])
+    case .cvv: ""
+    default: structuredState.data[fieldType]
+    }
   }
 
   func setFieldError(

--- a/Tests/Primer/CheckoutComponents/Core/PrimerCardFormStateTests.swift
+++ b/Tests/Primer/CheckoutComponents/Core/PrimerCardFormStateTests.swift
@@ -256,4 +256,61 @@ final class PrimerCardFormStateTests: XCTestCase {
         // Then
         XCTAssertTrue(state.fieldErrors.isEmpty)
     }
+
+    // MARK: - PCI Redaction Tests
+
+    func test_maskedPAN_keepsBinAndLast4_forFullPAN() {
+        XCTAssertEqual(PrimerCardFormState.maskedPAN("4242 4242 4242 4242"), "424242••••••4242")
+    }
+
+    func test_maskedPAN_handlesAmex15Digits() {
+        XCTAssertEqual(PrimerCardFormState.maskedPAN("3782 822463 10005"), "378282•••••0005")
+    }
+
+    func test_maskedPAN_emptyInput_returnsEmpty() {
+        XCTAssertEqual(PrimerCardFormState.maskedPAN(""), "")
+    }
+
+    func test_maskedPAN_shortInput_dropsBinToProtectDigits() {
+        // Fewer than 11 digits: no BIN is shown so it can never overlap the last 4.
+        XCTAssertEqual(PrimerCardFormState.maskedPAN("411111"), "••1111")
+    }
+
+    func test_redactedForMerchant_masksPANAndClearsCVV_preservingOtherFields() {
+        // Given
+        let state = PrimerCardFormState(
+            data: FormData([
+                .cardNumber: "4242 4242 4242 4242",
+                .cvv: "123",
+                .expiryDate: "12/30",
+                .cardholderName: "Jane Doe",
+                .postalCode: "SW1A 1AA",
+            ]),
+            isValid: true,
+            selectedCountry: PrimerCountry(code: "GB", name: "United Kingdom")
+        )
+
+        // When
+        let redacted = state.redactedForMerchant()
+
+        // Then — PCI fields masked
+        XCTAssertEqual(redacted.data[.cardNumber], "424242••••••4242")
+        XCTAssertEqual(redacted.data[.cvv], "")
+        // Non-PCI fields preserved
+        XCTAssertEqual(redacted.data[.expiryDate], "12/30")
+        XCTAssertEqual(redacted.data[.cardholderName], "Jane Doe")
+        XCTAssertEqual(redacted.data[.postalCode], "SW1A 1AA")
+        XCTAssertTrue(redacted.isValid)
+        XCTAssertEqual(redacted.selectedCountry?.code, "GB")
+        // Original is left untouched (value semantics)
+        XCTAssertEqual(state.data[.cardNumber], "4242 4242 4242 4242")
+        XCTAssertEqual(state.data[.cvv], "123")
+    }
+
+    func test_redactedForMerchant_emptyForm_yieldsEmptyPCIFields() {
+        let redacted = PrimerCardFormState().redactedForMerchant()
+
+        XCTAssertEqual(redacted.data[.cardNumber], "")
+        XCTAssertEqual(redacted.data[.cvv], "")
+    }
 }

--- a/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Scope/DefaultCardFormScopeTests.swift
@@ -41,7 +41,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
 
     // MARK: - currentState Tests
 
-    func test_currentState_mirrorsStructuredState() async throws {
+    func test_currentState_isRedactedForMerchant() async throws {
         let container = try await createTestContainer()
 
         await DIContainer.withContainer(container) {
@@ -51,8 +51,35 @@ final class DefaultCardFormScopeTests: XCTestCase {
             scope.updateCardNumber(TestData.CardNumbers.validVisa)
             scope.updateCvv("123")
 
-            XCTAssertEqual(scope.currentState, scope.structuredState)
-            XCTAssertEqual(scope.currentState.data[.cardNumber], scope.structuredState.data[.cardNumber])
+            // currentState is the merchant-facing view: PCI fields are masked...
+            XCTAssertEqual(
+                scope.currentState.data[.cardNumber],
+                PrimerCardFormState.maskedPAN(TestData.CardNumbers.validVisa)
+            )
+            XCTAssertEqual(scope.currentState.data[.cvv], "")
+            // ...while structuredState keeps the raw values for tokenisation.
+            XCTAssertEqual(scope.structuredState.data[.cardNumber], TestData.CardNumbers.validVisa)
+            XCTAssertEqual(scope.structuredState.data[.cvv], "123")
+        }
+    }
+
+    func test_stateStream_yieldsRedactedPCIFields() async throws {
+        let container = try await createTestContainer()
+
+        try await DIContainer.withContainer(container) {
+            let checkoutScope = await ContainerTestHelpers.createMockCheckoutScope()
+            let scope = createCardFormScope(checkoutScope: checkoutScope)
+
+            scope.updateCardNumber(TestData.CardNumbers.validVisa)
+            scope.updateCvv("123")
+
+            // The merchant-observable AsyncStream must never carry raw PAN/CVV.
+            let state = try await awaitFirst(scope.state)
+            XCTAssertEqual(
+                state.data[.cardNumber],
+                PrimerCardFormState.maskedPAN(TestData.CardNumbers.validVisa)
+            )
+            XCTAssertEqual(state.data[.cvv], "")
         }
     }
 
@@ -73,8 +100,13 @@ final class DefaultCardFormScopeTests: XCTestCase {
 
             scope.updateCardNumber(TestData.CardNumbers.validVisa)
 
-            let cardNumber = scope.getFieldValue(.cardNumber)
-            XCTAssertEqual(cardNumber, TestData.CardNumbers.validVisa)
+            // The raw value is stored internally for tokenisation...
+            XCTAssertEqual(scope.structuredState.data[.cardNumber], TestData.CardNumbers.validVisa)
+            // ...but the merchant-facing getter returns it masked.
+            XCTAssertEqual(
+                scope.getFieldValue(.cardNumber),
+                PrimerCardFormState.maskedPAN(TestData.CardNumbers.validVisa)
+            )
         }
     }
 
@@ -93,12 +125,13 @@ final class DefaultCardFormScopeTests: XCTestCase {
             )
 
             scope.updateCvv("123")
-            let cvv3Digit = scope.getFieldValue(.cvv)
-            XCTAssertEqual(cvv3Digit, "123")
+            XCTAssertEqual(scope.structuredState.data[.cvv], "123")
+            // CVV is never surfaced through the merchant-facing getter.
+            XCTAssertEqual(scope.getFieldValue(.cvv), "")
 
             scope.updateCvv("1234")
-            let cvv4Digit = scope.getFieldValue(.cvv)
-            XCTAssertEqual(cvv4Digit, "1234")
+            XCTAssertEqual(scope.structuredState.data[.cvv], "1234")
+            XCTAssertEqual(scope.getFieldValue(.cvv), "")
         }
     }
 
@@ -858,9 +891,10 @@ final class DefaultCardFormScopeTests: XCTestCase {
             let scope = createCardFormScope(checkoutScope: checkoutScope)
 
             scope.updateCardNumber(TestData.CardNumbers.validVisa)
-            XCTAssertEqual(scope.getFieldValue(.cardNumber), TestData.CardNumbers.validVisa)
+            XCTAssertEqual(scope.structuredState.data[.cardNumber], TestData.CardNumbers.validVisa)
 
             scope.updateCardNumber("")
+            XCTAssertEqual(scope.structuredState.data[.cardNumber], "")
             XCTAssertEqual(scope.getFieldValue(.cardNumber), "")
         }
     }
@@ -1097,7 +1131,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
 
             scope.updateField(.cardNumber, value: TestData.CardNumbers.validVisa)
 
-            XCTAssertEqual(scope.getFieldValue(.cardNumber), TestData.CardNumbers.validVisa)
+            XCTAssertEqual(scope.structuredState.data[.cardNumber], TestData.CardNumbers.validVisa)
         }
     }
 
@@ -1110,7 +1144,7 @@ final class DefaultCardFormScopeTests: XCTestCase {
 
             scope.updateField(.cvv, value: "999")
 
-            XCTAssertEqual(scope.getFieldValue(.cvv), "999")
+            XCTAssertEqual(scope.structuredState.data[.cvv], "999")
         }
     }
 


### PR DESCRIPTION
# Description

ORC-7317 (VULN-156)

`DefaultCardFormScope` exposed unmasked PAN and CVV to merchant code. A merchant observing the card-form session could read the full card number and CVV through three paths:
1. the `state` `AsyncStream` (`state.data[.cardNumber]` → `"4242 4242 4242 4242"`, `state.data[.cvv]` → `"123"`),
2. `currentState` (feeds `PrimerCardFormSession.state` and the success/dismiss completion callback),
3. the `getFieldValue()` getter.

This creates PCI DSS scope ambiguity — merchants using SDK-provided fields could still reach full cardholder data.

## Fix

Redact at the boundary between the internal scope (which keeps raw values for tokenisation) and merchant-facing code:
- **`PrimerCardFormState.redactedForMerchant()`** — masks the PAN to BIN + last 4 (`424242••••••4242`) and clears the CVV, preserving every non-PCI field (validation, networks, billing, surcharge, selected country…).
- The `state` `AsyncStream` and `currentState` now yield the **redacted** state.
- `getFieldValue()` returns the masked PAN for `.cardNumber` and `""` for `.cvv`.

The internal tokenisation path reads `structuredState` directly, so it is **unaffected** — the existing submit tests confirm the raw values still reach the payment interactor. The SDK's own input fields render from local `@State` (not `getFieldValue`), so the live-typing UI is unchanged.

# Manual Testing

- **Unit tests:** `PrimerCardFormStateTests` + `DefaultCardFormScopeTests` — **85 passed, 0 failures**. New coverage: `maskedPAN` (full/Amex/empty/short), `redactedForMerchant`, `currentState` redaction, and the merchant-facing `AsyncStream`. Existing submit tests (raw value reaches tokenisation) still pass.
- **Builds:** SDK + Debug App both build clean (the `CustomPaymentSelectionDemo`, which reads `state.data[.cardNumber]`, compiles unchanged).
- **Simulator:** Debug App launches cleanly on iPhone 17 Pro Max. No view code changed, so the rendering path is unaffected.

# Contributor Checklist

- [x] I have added unit tests to a reasonable level of coverage where suitable
- [x] I have manually tested newly added UX (tests + build + launch; on-screen form gated on a client session)
