### PR TITLE
chore: Align beta versioning with Android (semver2) [ORC-7496]

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,7 @@
 [tool.commitizen]
-version_scheme = "semver"
-version = "3.0.0-b0"
+version_scheme = "semver2"
+version = "3.0.0-beta.0"
+prerelease_offset = 1
 version_files = [
   "Sources/PrimerSDK/Classes/version.swift:let PrimerSDKVersion",
   "*.podspec:s.version"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -47,7 +47,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 #v8.1.1
         with:
           token: ${{ secrets.RELEASE_ACCESS_TOKEN }}
-          base: master
+          base: ${{ github.ref_name }}
           branch: release/next
           delete-branch: true
           title: Release ${{ env.TO_VERSION }}

--- a/PrimerBDCCore.podspec
+++ b/PrimerBDCCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerBDCCore"
-    s.version      = "3.0.0-b0"
+    s.version      = "3.0.0-beta.0"
     s.summary      = "Backend Driven Checkout core orchestration for Primer iOS SDK"
     s.description  = "Core orchestration layer for Primer Backend Driven Checkout."
     s.homepage     = "https://www.primer.io"

--- a/PrimerBDCEngine.podspec
+++ b/PrimerBDCEngine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerBDCEngine"
-    s.version      = "3.0.0-b0"
+    s.version      = "3.0.0-beta.0"
     s.summary      = "Backend Driven Checkout engine for Primer iOS SDK"
     s.description  = "JS-based state processing engine for Primer Backend Driven Checkout."
     s.homepage     = "https://www.primer.io"

--- a/PrimerCore.podspec
+++ b/PrimerCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerCore"
-    s.version      = "3.0.0-b0"
+    s.version      = "3.0.0-beta.0"
     s.summary      = "Core objects + utilities for Primer SDK"
     s.description  = "Core objects and utilities used by PrimerSDK."
     s.homepage     = "https://www.primer.io"

--- a/PrimerFoundation.podspec
+++ b/PrimerFoundation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerFoundation"
-    s.version      = "3.0.0-b0"
+    s.version      = "3.0.0-beta.0"
     s.summary      = "Foundation utilities for Primer iOS SDK"
     s.description  = "Foundation utilities, models, and extensions for the Primer iOS SDK."
     s.homepage     = "https://www.primer.io"

--- a/PrimerNetworking.podspec
+++ b/PrimerNetworking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerNetworking"
-    s.version      = "3.0.0-b0"
+    s.version      = "3.0.0-beta.0"
     s.summary      = "Networking objects + utilities for Primer SDK"
     s.description  = "Networking objects and utilities used by PrimerSDK."
     s.homepage     = "https://www.primer.io"

--- a/PrimerResources.podspec
+++ b/PrimerResources.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerResources"
-    s.version      = "3.0.0-b0"
+    s.version      = "3.0.0-beta.0"
     s.summary      = "Resources for Primer SDK"
     s.description  = "Contains resources (images, localisations, etc) used by PrimerSDK."
     s.homepage     = "https://www.primer.io"

--- a/PrimerSDK.podspec
+++ b/PrimerSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerSDK"
-    s.version      = "3.0.0-b0"
+    s.version      = "3.0.0-beta.0"
     s.summary      = "Official iOS SDK for Primer"
     s.description  = <<-DESC
     This library contains the official iOS SDK for Primer. Install this Cocoapod to seemlessly integrate the Primer Checkout & API platform in your app.

--- a/PrimerStepResolver.podspec
+++ b/PrimerStepResolver.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerStepResolver"
-    s.version      = "3.0.0-b0"
+    s.version      = "3.0.0-beta.0"
     s.summary      = "Step resolution engine for Primer iOS SDK"
     s.description  = "Step resolution and navigation logic for Primer Backend Driven Checkout."
     s.homepage     = "https://www.primer.io"

--- a/PrimerUI.podspec
+++ b/PrimerUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "PrimerUI"
-    s.version      = "3.0.0-b0"
+    s.version      = "3.0.0-beta.0"
     s.summary      = "UI and UI extensions for Primer SDK"
     s.description  = "This library contains UI and UI extensions used by PrimerSDK."
     s.homepage     = "https://www.primer.io"

--- a/Sources/PrimerSDK/Classes/version.swift
+++ b/Sources/PrimerSDK/Classes/version.swift
@@ -5,4 +5,4 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 // swiftlint:disable:next identifier_name
-public let PrimerSDKVersion = "3.0.0-b0"
+public let PrimerSDKVersion = "3.0.0-beta.0"


### PR DESCRIPTION
# Description

[ORC-7496](https://primerapi.atlassian.net/browse/ORC-7496)

Align iOS CheckoutComponents beta versioning with Android, and make the release base branch dynamic so we can cut the next beta off the integration branch.

- Switch commitizen to `version_scheme = "semver2"` + `prerelease_offset = 1`, so betas are spelled `3.0.0-beta.N` (matching Android, currently on `3.0.0-beta.2`) instead of `3.0.0-bN`.
- Re-spell the current `3.0.0-b0` → `3.0.0-beta.0` across `.cz.toml`, `version.swift`, and all 9 podspecs. Same version, just the notation. This is required: flipping the scheme alone updates `.cz.toml` but leaves the literal `b0` in the version files (cz searches for the normalized `3.0.0-beta.0`), which would ship a mismatched release — reproduced locally with commitizen 4.10.1.
- Make the `Create Release` workflow `base` dynamic (`${{ github.ref_name }}`) so the version-bump PR targets whichever branch the workflow is dispatched from — the `checkout-components` line now, `master` automatically after the 3.0 merge. Nothing to revert.

## Breaking changes
None — version notation only, no code or API changes.

# Other Notes

After this merges, cut the beta with: Actions → **Create Release** → "Use workflow from" = `bn/feature/checkout-components`, releaseType = `beta` → produces `3.0.0-beta.1`. Then merge the `release/next` PR (auto-tags + GitHub Release + SPM), and publish CocoaPods manually with `bundle exec fastlane release_pods`.

# Manual Testing

Ran a commitizen 4.10.1 dry-run against the repo with these changes: next bump = `3.0.0-beta.0 → 3.0.0-beta.1`, with `.cz.toml`, `version.swift` and all 9 podspecs rewritten consistently. Confirmed `3.0.0-b0 < 3.0.0-beta.1` in semver, so SPM/CocoaPods resolve beta.1 as newer than the published b0.

# Contributor Checklist

- [ ] All status checks have passed prior to code review
- [x] Unit tests — N/A (release configuration only, no code change)
- [x] UI tests — N/A
- [x] Manual testing — covered above (commitizen dry-run)
- [ ] I have opened a documentation PR, if applicable


[ORC-7496]: https://primerapi.atlassian.net/browse/ORC-7496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ