### PR TITLE
fix: Convert Apple Pay amounts by currency decimalDigits

### DIFF
--- a/Modules/PrimerFoundation/Sources/PrimerFoundation/Extensions/Int.swift
+++ b/Modules/PrimerFoundation/Sources/PrimerFoundation/Extensions/Int.swift
@@ -16,11 +16,10 @@ public extension Int {
         numberFormatter.numberStyle = .currency
         numberFormatter.locale = locale
         numberFormatter.currencySymbol = currencySymbol
-        numberFormatter.minimumFractionDigits = currency.isZeroDecimal ? 0 : 2
-        numberFormatter.maximumFractionDigits = currency.isZeroDecimal ? 0 : 2
+        numberFormatter.minimumFractionDigits = currency.decimalDigits
+        numberFormatter.maximumFractionDigits = currency.decimalDigits
 
-        // Convert amount to Decimal. If currency is zero decimal, no need to divide by 100
-        let amount = currency.isZeroDecimal ? Decimal(self) : Decimal(self) / 100
+        let amount = Decimal(self) / currency.minorUnitDivisor
 
         // Get formatted value with currency symbol
         guard let formattedValue = numberFormatter.string(from: amount as NSDecimalNumber) else {
@@ -39,16 +38,6 @@ public extension Int {
     }
 
     func formattedCurrencyAmount(currency: Currency) -> Decimal {
-        let numberFormatter = NumberFormatter()
-
-        numberFormatter.usesGroupingSeparator = true
-        numberFormatter.numberStyle = .currency
-        numberFormatter.locale = .current
-        numberFormatter.currencySymbol = currency.symbol ?? currency.code
-        numberFormatter.minimumFractionDigits = currency.isZeroDecimal ? 0 : 2
-        numberFormatter.maximumFractionDigits = currency.isZeroDecimal ? 0 : 2
-
-        // Convert amount to Decimal. If currency is zero decimal, no need to divide by 100
-        return currency.isZeroDecimal ? Decimal(self) : Decimal(self) / 100
+        Decimal(self) / currency.minorUnitDivisor
     }
 }

--- a/Modules/PrimerFoundation/Sources/PrimerFoundation/Model/Currency.swift
+++ b/Modules/PrimerFoundation/Sources/PrimerFoundation/Model/Currency.swift
@@ -10,17 +10,17 @@ import Foundation
 public struct Currency: Codable {
     public let code: String
     public let decimalDigits: Int
-    
+
     private enum CodingKeys: String, CodingKey {
         case code = "c"
         case decimalDigits = "m"
     }
-    
+
     public init(code: String, decimalDigits: Int) {
         self.code = code
         self.decimalDigits = decimalDigits
     }
-    
+
     public var symbol: String? {
         let localeIdentifier = Locale.identifier(fromComponents: [NSLocale.Key.currencyCode.rawValue: code])
         let locale = Locale(identifier: localeIdentifier)
@@ -29,5 +29,10 @@ public struct Currency: Codable {
 
     public var isZeroDecimal: Bool {
         decimalDigits == 0
+    }
+
+    /// Divisor that converts a minor-unit amount into its major-unit value (`10^decimalDigits`).
+    public var minorUnitDivisor: Decimal {
+        pow(10, decimalDigits)
     }
 }

--- a/Modules/PrimerFoundation/Sources/PrimerFoundation/Model/Currency.swift
+++ b/Modules/PrimerFoundation/Sources/PrimerFoundation/Model/Currency.swift
@@ -27,10 +27,6 @@ public struct Currency: Codable {
         return locale.currencySymbol
     }
 
-    public var isZeroDecimal: Bool {
-        decimalDigits == 0
-    }
-
     /// Divisor that converts a minor-unit amount into its major-unit value (`10^decimalDigits`).
     public var minorUnitDivisor: Decimal {
         pow(10, decimalDigits)

--- a/Sources/PrimerSDK/Classes/Data Models/ApplePayOrderItem.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/ApplePayOrderItem.swift
@@ -1,13 +1,13 @@
 //
 //  ApplePayOrderItem.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 import Foundation
 import PassKit
 
-internal struct ApplePayOrderItem: Codable, Equatable {
+struct ApplePayOrderItem: Codable, Equatable {
 
     public let name: String
     public let unitAmount: Int?
@@ -17,9 +17,6 @@ internal struct ApplePayOrderItem: Codable, Equatable {
     public var isPending: Bool = false
 
     public var applePayItem: PKPaymentSummaryItem {
-
-        var paymentSummaryItem: NSDecimalNumber!
-
         let tmpUnitAmount = unitAmount ?? 0
         let tmpQuantity = quantity
         let tmpAmount = tmpUnitAmount * tmpQuantity
@@ -27,11 +24,8 @@ internal struct ApplePayOrderItem: Codable, Equatable {
         let tmpTaxAmount = taxAmount ?? 0
         let tmpTotalOrderItemAmount = tmpAmount - tmpDiscountAmount + tmpTaxAmount
 
-        if AppState.current.currency?.isZeroDecimal == true {
-            paymentSummaryItem = NSDecimalNumber(value: tmpTotalOrderItemAmount)
-        } else {
-            paymentSummaryItem = NSDecimalNumber(value: tmpTotalOrderItemAmount).dividing(by: 100)
-        }
+        let divisor = AppState.current.currency.map { NSDecimalNumber(decimal: $0.minorUnitDivisor) } ?? 100
+        let paymentSummaryItem = NSDecimalNumber(value: tmpTotalOrderItemAmount).dividing(by: divisor)
 
         let item = PKPaymentSummaryItem(label: name, amount: paymentSummaryItem)
         item.type = isPending ? .pending : .final
@@ -46,7 +40,7 @@ internal struct ApplePayOrderItem: Codable, Equatable {
         taxAmount: Int?,
         isPending: Bool = false
     ) throws {
-        if isPending && unitAmount != nil {
+        if isPending, unitAmount != nil {
             throw handled(
                 primerError: .invalidValue(
                     key: "amount",
@@ -56,7 +50,7 @@ internal struct ApplePayOrderItem: Codable, Equatable {
             )
         }
 
-        if !isPending && unitAmount == nil {
+        if !isPending, unitAmount == nil {
             throw handled(
                 primerError: .invalidValue(
                     key: "amount",

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -233,12 +233,7 @@ final class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
             return .init(shippingMethods: nil, selectedShippingMethodOrderItem: nil)
         }
 
-        var factor: NSDecimalNumber
-        if AppState.current.currency?.isZeroDecimal == true {
-            factor = 1
-        } else {
-            factor = 100
-        }
+        let factor = AppState.current.currency.map { NSDecimalNumber(decimal: $0.minorUnitDivisor) } ?? 100
 
         // Convert to PKShippingMethods
         let apShippingMethods = options.shippingMethods.map {

--- a/Tests/Primer/Utils/CurrencyFormatting/KWD_CurrencyFormattingTests.swift
+++ b/Tests/Primer/Utils/CurrencyFormatting/KWD_CurrencyFormattingTests.swift
@@ -1,0 +1,36 @@
+//
+//  KWD_CurrencyFormattingTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@_spi(PrimerInternal) import PrimerFoundation
+@testable import PrimerSDK
+import XCTest
+
+final class KWD_CurrencyFormattingTests: XCTestCase {
+    private let kwd = Currency(code: "KWD", decimalDigits: 3)
+
+    func test_minorUnitDivisor_matchesDecimalDigits() {
+        XCTAssertEqual(Currency(code: "JPY", decimalDigits: 0).minorUnitDivisor, 1)
+        XCTAssertEqual(Currency(code: "USD", decimalDigits: 2).minorUnitDivisor, 100)
+        XCTAssertEqual(kwd.minorUnitDivisor, 1000)
+    }
+
+    func test_formattedCurrencyAmount_dividesByTenToTheDecimalDigits() {
+        XCTAssertEqual(8000.formattedCurrencyAmount(currency: kwd), Decimal(string: "8.000")!)
+        XCTAssertEqual(1234.formattedCurrencyAmount(currency: kwd), Decimal(string: "1.234")!)
+        XCTAssertEqual(1.formattedCurrencyAmount(currency: kwd), Decimal(string: "0.001")!)
+    }
+
+    func test_formattedCurrencyAmount_unchangedForZeroAndTwoDecimalCurrencies() {
+        XCTAssertEqual(8000.formattedCurrencyAmount(currency: Currency(code: "USD", decimalDigits: 2)), Decimal(80))
+        XCTAssertEqual(8000.formattedCurrencyAmount(currency: Currency(code: "ALL", decimalDigits: 2)), Decimal(80))
+        XCTAssertEqual(8000.formattedCurrencyAmount(currency: Currency(code: "JPY", decimalDigits: 0)), Decimal(8000))
+    }
+
+    func test_toCurrencyString_usesThreeFractionDigits() {
+        let formatted = 8000.toCurrencyString(currency: kwd, locale: Locale(identifier: "en_US"))
+        XCTAssertTrue(formatted.contains("8.000"), "Expected three fraction digits, got [\(formatted)]")
+    }
+}


### PR DESCRIPTION
# Description

ORC-7507

Apple Pay amount conversion divided **every** non-zero-decimal currency by `100`, instead of `10^decimalDigits`. For **3-decimal currencies** (BHD, IQD, JOD, KWD, LYD, OMR, TND) this divided by 100 instead of 1000, so the Apple Pay sheet displayed an amount **10× larger** than the real charge (e.g. `8000` KWD minor units → `80.00` instead of `8.000`).

This was found while investigating ESC-982 (Albanian Lek on Google Pay). Note: **ALL is not affected on iOS** — it is correctly a 2-decimal currency, and iOS has no Google Pay. ESC-982 is a Web-only fix; this is a separate latent iOS bug. Android already handles it correctly (`amount / 10^fractionDigits`).

### What these changes do

- Add a single source of truth `Currency.minorUnitDivisor` (`10^decimalDigits`).
- Use it in place of the binary `isZeroDecimal` (÷1 or ÷100) check across:
  - `ApplePayOrderItem` — payment summary item total
  - `Int.formattedCurrencyAmount(currency:)` — recurring / deferred / automatic-reload Apple Pay requests
  - `Int.toCurrencyString(currency:locale:)` — divisor **and** min/max fraction digits now use `decimalDigits`
  - `ApplePayTokenizationViewModel` — shipping method amounts
- Add `KWD_CurrencyFormattingTests` (3-decimal) covering the conversion and 0/2-decimal regression.

No breaking changes. Amounts stored in the dashboard and sent to the PSP are unaffected — this is display/formatting only.

# Other Notes

- `Int.formattedCurrencyAmount` previously built a `NumberFormatter` it never used; removed.
- `IPay88TokenizationViewModel` has a separate hardcoded `/100`, but it is currently harmless (MYR is 2-decimal) and out of scope here.
- The `internal`→default, `&&`→`,` and copyright-year changes in `ApplePayOrderItem` are SwiftFormat/SwiftLint auto-fixes.

# Manual Testing

Covered by unit tests (`KWD_CurrencyFormattingTests` + existing per-currency suites). No UI change beyond the corrected amount string.

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable
- [ ] I have manually tested newly added UX
- [ ] I have open a documentation PR, if applicable
