### PR TITLE
feat: Add Apple Pay card type and network filtering [ORC-7503]

### DIFF
--- a/Modules/PrimerCore/Sources/PrimerCore/Settings/PrimerApplePayOptions.swift
+++ b/Modules/PrimerCore/Sources/PrimerCore/Settings/PrimerApplePayOptions.swift
@@ -4,6 +4,8 @@
 //  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
+import PrimerFoundation
+
 public final class PrimerApplePayOptions: Codable {
 
     @_spi(PrimerInternal) public let merchantIdentifier: String
@@ -20,6 +22,10 @@ public final class PrimerApplePayOptions: Codable {
     @_spi(PrimerInternal) public let checkProvidedNetworks: Bool
     @_spi(PrimerInternal) public let shippingOptions: ShippingOptions?
     @_spi(PrimerInternal) public let billingOptions: BillingOptions?
+    /// Card types the Apple Pay sheet should offer. `nil` or empty allows all types.
+    @_spi(PrimerInternal) public let allowedCardTypes: [CardType]?
+    /// Card networks the Apple Pay sheet should offer, intersected with the client session's allowed networks. `nil` or empty allows all.
+    @_spi(PrimerInternal) public let allowedCardNetworks: [CardNetwork]?
 
     public init(
         merchantIdentifier: String,
@@ -35,6 +41,8 @@ public final class PrimerApplePayOptions: Codable {
         self.checkProvidedNetworks = checkProvidedNetworks
         self.shippingOptions = nil
         self.billingOptions = nil
+        self.allowedCardTypes = nil
+        self.allowedCardNetworks = nil
     }
 
     public init(
@@ -44,7 +52,9 @@ public final class PrimerApplePayOptions: Codable {
         showApplePayForUnsupportedDevice: Bool = true,
         checkProvidedNetworks: Bool = true,
         shippingOptions: ShippingOptions? = nil,
-        billingOptions: BillingOptions? = nil
+        billingOptions: BillingOptions? = nil,
+        allowedCardTypes: [CardType]? = nil,
+        allowedCardNetworks: [CardNetwork]? = nil
     ) {
         self.merchantIdentifier = merchantIdentifier
         self.merchantName = merchantName
@@ -53,6 +63,8 @@ public final class PrimerApplePayOptions: Codable {
         self.checkProvidedNetworks = checkProvidedNetworks
         self.shippingOptions = shippingOptions
         self.billingOptions = billingOptions
+        self.allowedCardTypes = allowedCardTypes
+        self.allowedCardNetworks = allowedCardNetworks
     }
 
     public struct ShippingOptions: Codable {

--- a/Modules/PrimerFoundation/Sources/PrimerFoundation/Model/CardType.swift
+++ b/Modules/PrimerFoundation/Sources/PrimerFoundation/Model/CardType.swift
@@ -1,0 +1,11 @@
+//
+//  CardType.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+/// Card funding type used to filter which cards Apple Pay offers.
+public enum CardType: String, Codable {
+    case credit
+    case debit
+}

--- a/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
@@ -20,10 +20,6 @@ protocol ApplePayPresenting {
 
 final class ApplePayPresentationManager: ApplePayPresenting, LogReporter, Sendable {
 
-    private var supportedNetworks: [PKPaymentNetwork] {
-        ApplePayUtils.supportedPKPaymentNetworks()
-    }
-
     var isPresentable: Bool {
         ApplePayUtils.canMakeApplePayPayments()
     }
@@ -67,8 +63,8 @@ final class ApplePayPresentationManager: ApplePayPresenting, LogReporter, Sendab
         request.currencyCode = applePayRequest.currency.code
         request.countryCode = applePayRequest.countryCode.rawValue
         request.merchantIdentifier = applePayRequest.merchantIdentifier
-        request.merchantCapabilities = [.capability3DS]
-        request.supportedNetworks = supportedNetworks
+        request.merchantCapabilities = merchantCapabilities(for: applePayOptions)
+        request.supportedNetworks = supportedNetworks(for: applePayOptions)
         request.paymentSummaryItems = applePayRequest.items.compactMap(\.applePayItem)
 
         if let shippingMethods = applePayRequest.shippingMethods {
@@ -168,6 +164,34 @@ final class ApplePayPresentationManager: ApplePayPresenting, LogReporter, Sendab
         self.logger.error(message: "Cannot present Apple Pay")
         let err = PrimerError.unableToPresentApplePay()
         return err
+    }
+
+    private func merchantCapabilities(for options: PrimerApplePayOptions?) -> PKMerchantCapability {
+        var capabilities: PKMerchantCapability = [.capability3DS]
+
+        guard let allowedCardTypes = options?.allowedCardTypes, !allowedCardTypes.isEmpty else {
+            return capabilities
+        }
+
+        if allowedCardTypes.contains(.credit) {
+            capabilities.insert(.capabilityCredit)
+        }
+        if allowedCardTypes.contains(.debit) {
+            capabilities.insert(.capabilityDebit)
+        }
+
+        return capabilities
+    }
+
+    private func supportedNetworks(for options: PrimerApplePayOptions?) -> [PKPaymentNetwork] {
+        var networks = [CardNetwork].allowedCardNetworks
+        if let allowedCardNetworks = options?.allowedCardNetworks, !allowedCardNetworks.isEmpty {
+            networks = networks.filter(allowedCardNetworks.contains)
+            if networks.isEmpty {
+                logger.warn(message: "[Apple Pay] allowedCardNetworks doesn't overlap the client session's allowed networks; Apple Pay may not present.")
+            }
+        }
+        return ApplePayUtils.supportedPKPaymentNetworks(cardNetworks: networks)
     }
 }
 

--- a/Tests/Primer/ApplePay/ApplePayPresentationManagerTests.swift
+++ b/Tests/Primer/ApplePay/ApplePayPresentationManagerTests.swift
@@ -336,4 +336,150 @@ final class ApplePayPresentationManagerTests: XCTestCase {
         XCTAssertEqual(PrimerApplePayOptions.RequiredContactField.phoneNumber.toPKContact(), .phoneNumber)
         XCTAssertEqual(PrimerApplePayOptions.RequiredContactField.postalAddress.toPKContact(), .postalAddress)
     }
+
+    // MARK: - Card type filtering (merchantCapabilities)
+
+    func testMerchantCapabilitiesDefaultsTo3DSWhenNoCardTypes() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: nil)
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.merchantCapabilities, [.capability3DS])
+    }
+
+    func testMerchantCapabilitiesCreditAddsCreditKeeps3DS() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        registerApplePayOptions(allowedCardTypes: [.credit], allowedCardNetworks: nil)
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.merchantCapabilities, [.capability3DS, .capabilityCredit])
+    }
+
+    func testMerchantCapabilitiesDebitAddsDebitKeeps3DS() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        registerApplePayOptions(allowedCardTypes: [.debit], allowedCardNetworks: nil)
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.merchantCapabilities, [.capability3DS, .capabilityDebit])
+    }
+
+    func testMerchantCapabilitiesCreditAndDebitAddsBoth() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        registerApplePayOptions(allowedCardTypes: [.credit, .debit], allowedCardNetworks: nil)
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.merchantCapabilities, [.capability3DS, .capabilityCredit, .capabilityDebit])
+    }
+
+    func testMerchantCapabilitiesEmptyStaysUnrestricted() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        registerApplePayOptions(allowedCardTypes: [], allowedCardNetworks: nil)
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.merchantCapabilities, [.capability3DS])
+    }
+
+    // MARK: - Card network filtering (supportedNetworks)
+
+    func testSupportedNetworksIntersectAccountNetworks() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa, .masterCard, .cartesBancaires])
+        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: [.visa, .masterCard])
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.supportedNetworks, [.visa, .masterCard])
+    }
+
+    func testSupportedNetworksCannotWidenBeyondAccount() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa])
+        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: [.visa, .masterCard])
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.supportedNetworks, [.visa])
+    }
+
+    func testSupportedNetworksNilUsesAccountNetworks() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa, .masterCard])
+        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: nil)
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.supportedNetworks, [.visa, .masterCard])
+    }
+
+    func testSupportedNetworksEmptyWhenNoOverlapWithAccount() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa])
+        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: [.masterCard])
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.supportedNetworks, [])
+    }
+
+    func testTypeAndNetworkFiltersCombined() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa, .masterCard])
+        registerApplePayOptions(allowedCardTypes: [.credit], allowedCardNetworks: [.visa])
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.merchantCapabilities, [.capability3DS, .capabilityCredit])
+        XCTAssertEqual(request.supportedNetworks, [.visa])
+    }
+
+    func testNilApplePayOptionsUsesAccountNetworksAndDefaultCapabilities() throws {
+        SDKSessionHelper.setUp()
+        defer { SDKSessionHelper.tearDown() }
+        DependencyContainer.register(PrimerSettings(paymentMethodOptions: .init(applePayOptions: nil)) as PrimerSettingsProtocol)
+
+        let request = try sut.createRequest(for: makeApplePayRequest())
+
+        XCTAssertEqual(request.merchantCapabilities, [.capability3DS])
+        XCTAssertEqual(request.supportedNetworks, [.visa, .masterCard, .amex, .discover])
+    }
+
+    func makeApplePayRequest() -> ApplePayRequest {
+        ApplePayRequest(
+            currency: Currency(code: "GBP", decimalDigits: 2),
+            merchantIdentifier: "merchant_id",
+            countryCode: .gb,
+            items: [],
+            shippingMethods: nil
+        )
+    }
+
+    func registerApplePayOptions(allowedCardTypes: [CardType]?, allowedCardNetworks: [CardNetwork]?) {
+        let settings = PrimerSettings(
+            paymentMethodOptions: .init(
+                applePayOptions: .init(
+                    merchantIdentifier: "merchant_id",
+                    merchantName: "merchant_name",
+                    checkProvidedNetworks: true,
+                    allowedCardTypes: allowedCardTypes,
+                    allowedCardNetworks: allowedCardNetworks
+                )
+            )
+        )
+        DependencyContainer.register(settings as PrimerSettingsProtocol)
+    }
 }


### PR DESCRIPTION
# Description

ORC-7503

Adds optional `allowedCardTypes` (credit/debit) and `allowedCardNetworks` to `PrimerApplePayOptions`:

- Card types map to Apple Pay `merchantCapabilities` (`.capability3DS` is always kept).
- Networks intersect the client session's `orderedAllowedCardNetworks` — narrows only, never widens.

Absent or empty values apply no restriction, so existing integrations are unaffected.

# Manual Testing

Tested on a real device against the demo backend:

- Network filter (e.g. Visa-only) → only that network is selectable.
- credit-only / debit-only → matching card types enabled, others greyed out.
- No eligible card → Apple Pay falls back to "add a card".

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge
