### PR TITLE
fix: Apply merchant theme to inline CheckoutComponents [ORC-7505]

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Session/PrimerCheckoutSessionModifier.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Session/PrimerCheckoutSessionModifier.swift
@@ -32,19 +32,25 @@ public extension View {
 }
 
 @available(iOS 15.0, *)
-private struct PrimerCheckoutSessionModifier: ViewModifier {
+private struct PrimerCheckoutSessionModifier: ViewModifier, LogReporter {
 
   @ObservedObject var session: PrimerCheckoutSession
   let onCompletion: ((PrimerCheckoutState) -> Void)?
+  @Environment(\.colorScheme) private var colorScheme
+  @StateObject private var designTokensManager = DesignTokensManager()
 
   func body(content: Content) -> some View {
     content
       .environment(\.primerCheckoutSession, session)
       .environment(\.primerCardFormSession, session.cardForm)
       .environment(\.primerSelectionSession, session.selection)
-      // Inline composables (PrimerCardForm, …) resolve their services — ValidationService etc. —
-      // from this container; without it each input field renders its disabled placeholder fallback.
+      // Mirror the managed path's CheckoutScopeObserver so inline composables behave identically:
+      // the DI container resolves their services (without it, input fields render disabled
+      // placeholders), the design tokens apply the merchant's theme (without them, a custom theme
+      // is silently ignored inline), and the checkout scope is exposed for parity.
       .environment(\.diContainer, DIContainer.currentSync)
+      .environment(\.designTokens, designTokensManager.tokens)
+      .environment(\.primerCheckoutScope, session.internalScope)
       .overlay {
         if session.phase == .ready, let scope = session.internalScope {
           InlineFlowHost(scope: scope, theme: session.theme)
@@ -54,6 +60,21 @@ private struct PrimerCheckoutSessionModifier: ViewModifier {
         session.setCompletionHandler(onCompletion)
         await session.start()
       }
+      .task {
+        designTokensManager.applyTheme(session.theme)
+        await loadDesignTokens(for: colorScheme)
+      }
+      .onChange(of: colorScheme) { newColorScheme in
+        Task { await loadDesignTokens(for: newColorScheme) }
+      }
       .onDisappear { session.cancel() }
+  }
+
+  private func loadDesignTokens(for colorScheme: ColorScheme) async {
+    do {
+      try await designTokensManager.fetchTokens(for: colorScheme)
+    } catch {
+      logger.error(message: "Failed to load design tokens: \(error)")
+    }
   }
 }


### PR DESCRIPTION
# Description

[ORC-7505](https://primerapi.atlassian.net/browse/ORC-7505)

The inline `.primerCheckoutSession` modifier injected fewer SwiftUI environment values than the managed path's `CheckoutScopeObserver`, so a custom `PrimerCheckoutTheme` passed to `PrimerCheckoutSession` was **never applied to inline composables** (`PrimerCardForm`, `PrimerPaymentMethods`, `PrimerVaultedPaymentMethods`) — they silently fell back to SDK default design tokens. It's invisible under the default theme, but it breaks the theming contract for the composable/inline integration the moment a merchant customizes.

This change mirrors the managed path inside the modifier:

- Adds a `@StateObject DesignTokensManager`, applies `session.theme`, and injects `\.designTokens` so inline composables pick up the merchant theme (colors, radius, spacing, typography).
- Reloads tokens on `colorScheme` change (light/dark parity).
- Injects `\.primerCheckoutScope` for parity with `CheckoutScopeObserver` / `InlineFlowHost`.

The `\.diContainer` half of this same parity gap was already fixed in `c21dd68ab` (inline card fields not tappable); this completes it. General rule going forward: the inline modifier must mirror `CheckoutScopeObserver`'s environment injections.

**No breaking changes** — purely additive environment injection on the inline path. The managed `PrimerCheckout` and UIKit `PrimerCheckoutPresenter` entry points route through `CheckoutScopeObserver`, **not** this modifier, so they are unaffected (verified — no double injection).

# Other Notes

- No new unit test: the changed code is a SwiftUI `ViewModifier` body, which is intentionally coverage-excluded in CheckoutComponents (render tests were deliberately pruned and are not being re-added). The existing `PrimerCheckoutSessionModifierTests` still passes.
- `\.primerCheckoutScope` currently has no readers in the inline content path — it's added purely for parity/future-proofing and is an inert injection today (confirmed zero consumers).

# Manual Testing

- `PrimerSDK` framework + `PrimerSDKTests` target both build against the change: `** TEST BUILD SUCCEEDED **`.
- Existing `PrimerCheckoutSessionModifierTests.test_modifier_rendersInlineFlowOverlay_whenReady` passes.
- **Recommended visual check (pending):** in Primer Studio, open an inline demo under a custom theme (e.g. "Custom Theme") and confirm the embedded card form / payment-method list now render with the merchant brand colors / radius / typography, in both light and dark mode.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge


[ORC-7505]: https://primerapi.atlassian.net/browse/ORC-7505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ