### PR TITLE
fix(apple-pay): remove allowedCardNetworks option, rely on client session [ORC-7503]

### DIFF
--- a/Modules/PrimerCore/Sources/PrimerCore/Settings/PrimerApplePayOptions.swift
+++ b/Modules/PrimerCore/Sources/PrimerCore/Settings/PrimerApplePayOptions.swift
@@ -24,8 +24,6 @@ public final class PrimerApplePayOptions: Codable {
     @_spi(PrimerInternal) public let billingOptions: BillingOptions?
     /// Card types the Apple Pay sheet should offer. `nil` or empty allows all types.
     @_spi(PrimerInternal) public let allowedCardTypes: [CardType]?
-    /// Card networks the Apple Pay sheet should offer, intersected with the client session's allowed networks. `nil` or empty allows all.
-    @_spi(PrimerInternal) public let allowedCardNetworks: [CardNetwork]?
 
     public init(
         merchantIdentifier: String,
@@ -42,7 +40,6 @@ public final class PrimerApplePayOptions: Codable {
         self.shippingOptions = nil
         self.billingOptions = nil
         self.allowedCardTypes = nil
-        self.allowedCardNetworks = nil
     }
 
     public init(
@@ -53,8 +50,7 @@ public final class PrimerApplePayOptions: Codable {
         checkProvidedNetworks: Bool = true,
         shippingOptions: ShippingOptions? = nil,
         billingOptions: BillingOptions? = nil,
-        allowedCardTypes: [CardType]? = nil,
-        allowedCardNetworks: [CardNetwork]? = nil
+        allowedCardTypes: [CardType]? = nil
     ) {
         self.merchantIdentifier = merchantIdentifier
         self.merchantName = merchantName
@@ -64,7 +60,6 @@ public final class PrimerApplePayOptions: Codable {
         self.shippingOptions = shippingOptions
         self.billingOptions = billingOptions
         self.allowedCardTypes = allowedCardTypes
-        self.allowedCardNetworks = allowedCardNetworks
     }
 
     public struct ShippingOptions: Codable {

--- a/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/ApplePayPresentationManager.swift
@@ -64,7 +64,7 @@ final class ApplePayPresentationManager: ApplePayPresenting, LogReporter, Sendab
         request.countryCode = applePayRequest.countryCode.rawValue
         request.merchantIdentifier = applePayRequest.merchantIdentifier
         request.merchantCapabilities = merchantCapabilities(for: applePayOptions)
-        request.supportedNetworks = supportedNetworks(for: applePayOptions)
+        request.supportedNetworks = ApplePayUtils.supportedPKPaymentNetworks(cardNetworks: .allowedCardNetworks)
         request.paymentSummaryItems = applePayRequest.items.compactMap(\.applePayItem)
 
         if let shippingMethods = applePayRequest.shippingMethods {
@@ -181,17 +181,6 @@ final class ApplePayPresentationManager: ApplePayPresenting, LogReporter, Sendab
         }
 
         return capabilities
-    }
-
-    private func supportedNetworks(for options: PrimerApplePayOptions?) -> [PKPaymentNetwork] {
-        var networks = [CardNetwork].allowedCardNetworks
-        if let allowedCardNetworks = options?.allowedCardNetworks, !allowedCardNetworks.isEmpty {
-            networks = networks.filter(allowedCardNetworks.contains)
-            if networks.isEmpty {
-                logger.warn(message: "[Apple Pay] allowedCardNetworks doesn't overlap the client session's allowed networks; Apple Pay may not present.")
-            }
-        }
-        return ApplePayUtils.supportedPKPaymentNetworks(cardNetworks: networks)
     }
 }
 

--- a/Tests/Primer/ApplePay/ApplePayPresentationManagerTests.swift
+++ b/Tests/Primer/ApplePay/ApplePayPresentationManagerTests.swift
@@ -342,7 +342,7 @@ final class ApplePayPresentationManagerTests: XCTestCase {
     func testMerchantCapabilitiesDefaultsTo3DSWhenNoCardTypes() throws {
         SDKSessionHelper.setUp()
         defer { SDKSessionHelper.tearDown() }
-        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: nil)
+        registerApplePayOptions(allowedCardTypes: nil)
 
         let request = try sut.createRequest(for: makeApplePayRequest())
 
@@ -352,7 +352,7 @@ final class ApplePayPresentationManagerTests: XCTestCase {
     func testMerchantCapabilitiesCreditAddsCreditKeeps3DS() throws {
         SDKSessionHelper.setUp()
         defer { SDKSessionHelper.tearDown() }
-        registerApplePayOptions(allowedCardTypes: [.credit], allowedCardNetworks: nil)
+        registerApplePayOptions(allowedCardTypes: [.credit])
 
         let request = try sut.createRequest(for: makeApplePayRequest())
 
@@ -362,7 +362,7 @@ final class ApplePayPresentationManagerTests: XCTestCase {
     func testMerchantCapabilitiesDebitAddsDebitKeeps3DS() throws {
         SDKSessionHelper.setUp()
         defer { SDKSessionHelper.tearDown() }
-        registerApplePayOptions(allowedCardTypes: [.debit], allowedCardNetworks: nil)
+        registerApplePayOptions(allowedCardTypes: [.debit])
 
         let request = try sut.createRequest(for: makeApplePayRequest())
 
@@ -372,7 +372,7 @@ final class ApplePayPresentationManagerTests: XCTestCase {
     func testMerchantCapabilitiesCreditAndDebitAddsBoth() throws {
         SDKSessionHelper.setUp()
         defer { SDKSessionHelper.tearDown() }
-        registerApplePayOptions(allowedCardTypes: [.credit, .debit], allowedCardNetworks: nil)
+        registerApplePayOptions(allowedCardTypes: [.credit, .debit])
 
         let request = try sut.createRequest(for: makeApplePayRequest())
 
@@ -382,69 +382,11 @@ final class ApplePayPresentationManagerTests: XCTestCase {
     func testMerchantCapabilitiesEmptyStaysUnrestricted() throws {
         SDKSessionHelper.setUp()
         defer { SDKSessionHelper.tearDown() }
-        registerApplePayOptions(allowedCardTypes: [], allowedCardNetworks: nil)
+        registerApplePayOptions(allowedCardTypes: [])
 
         let request = try sut.createRequest(for: makeApplePayRequest())
 
         XCTAssertEqual(request.merchantCapabilities, [.capability3DS])
-    }
-
-    // MARK: - Card network filtering (supportedNetworks)
-
-    func testSupportedNetworksIntersectAccountNetworks() throws {
-        SDKSessionHelper.setUp()
-        defer { SDKSessionHelper.tearDown() }
-        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa, .masterCard, .cartesBancaires])
-        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: [.visa, .masterCard])
-
-        let request = try sut.createRequest(for: makeApplePayRequest())
-
-        XCTAssertEqual(request.supportedNetworks, [.visa, .masterCard])
-    }
-
-    func testSupportedNetworksCannotWidenBeyondAccount() throws {
-        SDKSessionHelper.setUp()
-        defer { SDKSessionHelper.tearDown() }
-        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa])
-        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: [.visa, .masterCard])
-
-        let request = try sut.createRequest(for: makeApplePayRequest())
-
-        XCTAssertEqual(request.supportedNetworks, [.visa])
-    }
-
-    func testSupportedNetworksNilUsesAccountNetworks() throws {
-        SDKSessionHelper.setUp()
-        defer { SDKSessionHelper.tearDown() }
-        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa, .masterCard])
-        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: nil)
-
-        let request = try sut.createRequest(for: makeApplePayRequest())
-
-        XCTAssertEqual(request.supportedNetworks, [.visa, .masterCard])
-    }
-
-    func testSupportedNetworksEmptyWhenNoOverlapWithAccount() throws {
-        SDKSessionHelper.setUp()
-        defer { SDKSessionHelper.tearDown() }
-        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa])
-        registerApplePayOptions(allowedCardTypes: nil, allowedCardNetworks: [.masterCard])
-
-        let request = try sut.createRequest(for: makeApplePayRequest())
-
-        XCTAssertEqual(request.supportedNetworks, [])
-    }
-
-    func testTypeAndNetworkFiltersCombined() throws {
-        SDKSessionHelper.setUp()
-        defer { SDKSessionHelper.tearDown() }
-        SDKSessionHelper.updateAllowedCardNetworks(cardNetworks: [.visa, .masterCard])
-        registerApplePayOptions(allowedCardTypes: [.credit], allowedCardNetworks: [.visa])
-
-        let request = try sut.createRequest(for: makeApplePayRequest())
-
-        XCTAssertEqual(request.merchantCapabilities, [.capability3DS, .capabilityCredit])
-        XCTAssertEqual(request.supportedNetworks, [.visa])
     }
 
     func testNilApplePayOptionsUsesAccountNetworksAndDefaultCapabilities() throws {
@@ -468,15 +410,14 @@ final class ApplePayPresentationManagerTests: XCTestCase {
         )
     }
 
-    func registerApplePayOptions(allowedCardTypes: [CardType]?, allowedCardNetworks: [CardNetwork]?) {
+    func registerApplePayOptions(allowedCardTypes: [CardType]?) {
         let settings = PrimerSettings(
             paymentMethodOptions: .init(
                 applePayOptions: .init(
                     merchantIdentifier: "merchant_id",
                     merchantName: "merchant_name",
                     checkProvidedNetworks: true,
-                    allowedCardTypes: allowedCardTypes,
-                    allowedCardNetworks: allowedCardNetworks
+                    allowedCardTypes: allowedCardTypes
                 )
             )
         )


### PR DESCRIPTION
# Description

ORC-7503

- Removes the `allowedCardNetworks` option from `PrimerApplePayOptions`. Apple Pay's supported networks now come solely from the client session's `orderedAllowedCardNetworks`.
- Card-type filtering (`allowedCardTypes` → `merchantCapabilities`) is unchanged.
- No breaking change: the removed field is `@_spi(PrimerInternal)` (internal-only), shipped in 2.51.0.

# Other Notes

- Reverts the per-wallet network filter added in #1817 — the client session already filters networks for Apple Pay, so the extra option was redundant.

# Manual Testing

N/A — removal only. "Networks come from the client session" stays covered by the retained unit test `testNilApplePayOptionsUsesAccountNetworksAndDefaultCapabilities`.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)