### PR TITLE
feat: Add vault analytics events and error logging (CheckoutComponents)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Analytics/Data/Models/AnalyticsEventMetadata.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Analytics/Data/Models/AnalyticsEventMetadata.swift
@@ -11,12 +11,14 @@ import Foundation
 /// Optional metadata that can be attached to analytics events.
 /// Not all events require all metadata fields - include only relevant fields per event type.
 /// Analytics event metadata using discriminated unions for type safety.
-/// Each event type carries only its relevant metadata - no optional pollution.
+/// Each metadata case carries only the fields relevant to its event family; vault events share
+/// one struct whose fields are populated per event.
 public enum AnalyticsEventMetadata: Sendable {
   case general(GeneralEvent = GeneralEvent())
   case payment(PaymentEvent)
   case threeDS(ThreeDSEvent)
   case redirect(RedirectEvent)
+  case vault(VaultEvent)
 }
 
 // MARK: - Event Types
@@ -78,6 +80,47 @@ public struct ThreeDSEvent: Sendable {
   }
 }
 
+/// Metadata for vault-management and CVV-recapture events.
+/// Ids are opaque Primer vault tokens; `expectedCvvLength` is a digit count, never a CVV value.
+/// All fields optional: one shared shape for the 13 vault events; required-ness is enforced by
+/// the upstream emitters.
+public struct VaultEvent: Sendable {
+  public let locale: String
+  public let vaultedMethodId: String?
+  public let previousVaultedMethodId: String?
+  public let promotedVaultedMethodId: String?
+  public let isActive: Bool?
+  public let vaultedMethodCount: Int?
+  public let exitedFromConfirmation: Bool?
+  public let network: String?
+  public let expectedCvvLength: Int?
+  public let errorId: String?
+
+  public init(
+    locale: String = GeneralEvent.formattedCurrentLocale,
+    vaultedMethodId: String? = nil,
+    previousVaultedMethodId: String? = nil,
+    promotedVaultedMethodId: String? = nil,
+    isActive: Bool? = nil,
+    vaultedMethodCount: Int? = nil,
+    exitedFromConfirmation: Bool? = nil,
+    network: String? = nil,
+    expectedCvvLength: Int? = nil,
+    errorId: String? = nil
+  ) {
+    self.locale = locale
+    self.vaultedMethodId = vaultedMethodId
+    self.previousVaultedMethodId = previousVaultedMethodId
+    self.promotedVaultedMethodId = promotedVaultedMethodId
+    self.isActive = isActive
+    self.vaultedMethodCount = vaultedMethodCount
+    self.exitedFromConfirmation = exitedFromConfirmation
+    self.network = network
+    self.expectedCvvLength = expectedCvvLength
+    self.errorId = errorId
+  }
+}
+
 /// Metadata for third-party redirect events
 public struct RedirectEvent: Sendable {
   public let locale: String
@@ -105,6 +148,15 @@ extension AnalyticsEventMetadata {
     case let .payment(event): event.locale
     case let .threeDS(event): event.locale
     case let .redirect(event): event.locale
+    case let .vault(event): event.locale
+    }
+  }
+
+  /// Vault context when this is a `.vault` metadata case
+  var vaultEvent: VaultEvent? {
+    switch self {
+    case let .vault(event): event
+    default: nil
     }
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Analytics/Data/Models/AnalyticsEventType.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Analytics/Data/Models/AnalyticsEventType.swift
@@ -8,9 +8,9 @@ import Foundation
 @_spi(PrimerInternal) import PrimerFoundation
 @_spi(PrimerInternal) import PrimerCore
 
-/// Enum defining all 13 CheckoutComponents analytics event types.
+/// Enum defining all CheckoutComponents analytics event types.
 /// Values match the SCREAMING_SNAKE_CASE format from the Notion spec.
-public enum AnalyticsEventType: String, Codable, Sendable {
+public enum AnalyticsEventType: String, Codable, Sendable, CaseIterable {
   /// SDK starts initialization and begins contacting Primer backend services
   case sdkInitStart = "SDK_INIT_START"
 
@@ -49,4 +49,51 @@ public enum AnalyticsEventType: String, Codable, Sendable {
 
   /// User leaves the checkout before completion
   case paymentFlowExited = "PAYMENT_FLOW_EXITED"
+
+  // MARK: - Vault events
+
+  /// Shopper opens the vaulted-methods list ("Show all")
+  case vaultListOpened = "VAULT_LIST_OPENED"
+
+  /// Shopper selects a different vaulted method from the list
+  case vaultMethodSelected = "VAULT_METHOD_SELECTED"
+
+  /// Shopper leaves the vaulted list to see the other payment methods
+  case vaultOtherPayMethodsRequested = "VAULT_OTHER_PAY_METHODS_REQUESTED"
+
+  /// Edit mode entered on the vaulted-methods list
+  case vaultEditModeEntered = "VAULT_EDIT_MODE_ENTERED"
+
+  /// Edit mode exited via the Done action
+  case vaultEditModeExited = "VAULT_EDIT_MODE_EXITED"
+
+  /// Shopper taps delete on a vaulted method row
+  case vaultDeletionRequested = "VAULT_DELETION_REQUESTED"
+
+  /// Delete confirmation dismissed via the Cancel button (not Done/Back)
+  case vaultDeletionCancelled = "VAULT_DELETION_CANCELLED"
+
+  /// Vaulted method deleted; carries the promoted method when the active one was deleted and
+  /// another was promoted in its place
+  case vaultMethodDeleted = "VAULT_METHOD_DELETED"
+
+  /// Deleting a vaulted method failed
+  case vaultMethodDeletionFailed = "VAULT_METHOD_DELETION_FAILED"
+
+  /// CVV recapture input shown for a vaulted card
+  case vaultCvvRequiredRendered = "VAULT_CVV_REQUIRED_RENDERED"
+
+  /// Vaulted payment submitted with a recaptured CVV
+  case vaultCvvSubmitted = "VAULT_CVV_SUBMITTED"
+
+  /// CVV recapture input dismissed without submitting
+  case vaultCvvRequiredDismissed = "VAULT_CVV_REQUIRED_DISMISSED"
+
+  /// Vaulted payment submission with recaptured CVV failed
+  case vaultCvvSubmissionFailed = "VAULT_CVV_SUBMISSION_FAILED"
+}
+
+extension AnalyticsEventType {
+  /// Vault events carry `VaultEvent` metadata instead of payment metadata
+  var isVaultEvent: Bool { rawValue.hasPrefix("VAULT_") }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Analytics/Data/Models/AnalyticsPayload.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Analytics/Data/Models/AnalyticsPayload.swift
@@ -71,4 +71,33 @@ struct AnalyticsPayload: Codable, Sendable {
 
   /// Device category
   let deviceType: String?
+
+  // MARK: - Vault Event Fields
+
+  /// The vaulted method the event is about
+  let vaultedMethodId: String?
+
+  /// Previously selected method on selection change
+  let previousVaultedMethodId: String?
+
+  /// Method promoted after deleting the active one
+  let promotedVaultedMethodId: String?
+
+  /// Whether the targeted method was the active one
+  let isActive: Bool?
+
+  /// Vaulted methods count when entering edit mode
+  let vaultedMethodCount: Int?
+
+  /// Edit mode exited while a delete confirmation was open
+  let exitedFromConfirmation: Bool?
+
+  /// Card network of the vaulted method
+  let network: String?
+
+  /// Expected CVV length for recapture (a digit count, never a CVV value)
+  let expectedCvvLength: Int?
+
+  /// Error identifier on failure events
+  let errorId: String?
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Analytics/Data/Services/AnalyticsPayloadBuilder.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Analytics/Data/Services/AnalyticsPayloadBuilder.swift
@@ -18,7 +18,8 @@ struct AnalyticsPayloadBuilder {
     config: AnalyticsSessionConfig,
     timestamp: Int? = nil
   ) -> AnalyticsPayload {
-    AnalyticsPayload(
+    let vault = metadata?.vaultEvent
+    return AnalyticsPayload(
       id: .uuid,
       timestamp: timestamp ?? Int(Date().timeIntervalSince1970),
       sdkType: Self.isReactNative ? "RN_IOS" : "IOS_NATIVE",
@@ -37,7 +38,16 @@ struct AnalyticsPayloadBuilder {
       threedsResponse: metadata?.threedsResponse,
       browser: nil,
       device: UIDevice.model.rawValue,
-      deviceType: UIDevice.deviceType
+      deviceType: UIDevice.deviceType,
+      vaultedMethodId: vault?.vaultedMethodId,
+      previousVaultedMethodId: vault?.previousVaultedMethodId,
+      promotedVaultedMethodId: vault?.promotedVaultedMethodId,
+      isActive: vault?.isActive,
+      vaultedMethodCount: vault?.vaultedMethodCount,
+      exitedFromConfirmation: vault?.exitedFromConfirmation,
+      network: vault?.network,
+      expectedCvvLength: vault?.expectedCvvLength,
+      errorId: vault?.errorId
     )
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsAnalyticsLoggingBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsAnalyticsLoggingBridge.swift
@@ -71,8 +71,7 @@ public final class ComponentsAnalyticsLoggingBridge: LogReporter {
 
     public func trackEvent(_ eventName: String, metadata: [String: String]?) async {
         guard let eventType = AnalyticsEventType(rawValue: eventName) else {
-            logger.debug(message: "[Analytics] Dropping unknown event name: \(eventName)")
-            return
+            return logger.debug(message: "[Analytics] Dropping unknown event name: \(eventName)")
         }
         await analyticsInteractor.trackEvent(eventType, metadata: Self.mapMetadata(metadata, for: eventType))
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsAnalyticsLoggingBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/ComponentsAnalyticsLoggingBridge.swift
@@ -10,7 +10,13 @@ import Foundation
 
 @available(iOS 15.0, *)
 @_spi(PrimerInternal)
-public final class ComponentsAnalyticsLoggingBridge {
+public final class ComponentsAnalyticsLoggingBridge: LogReporter {
+
+    private static let vaultMetadataKeys: Set<String> = [
+        "vaultedMethodId", "previousVaultedMethodId", "promotedVaultedMethodId",
+        "isActive", "vaultedMethodCount", "exitedFromConfirmation",
+        "network", "expectedCvvLength", "errorId",
+    ]
 
     private let analyticsService: CheckoutComponentsAnalyticsServiceProtocol
     private let analyticsInteractor: CheckoutComponentsAnalyticsInteractorProtocol
@@ -64,8 +70,11 @@ public final class ComponentsAnalyticsLoggingBridge {
     // MARK: - Analytics
 
     public func trackEvent(_ eventName: String, metadata: [String: String]?) async {
-        guard let eventType = AnalyticsEventType(rawValue: eventName) else { return }
-        await analyticsInteractor.trackEvent(eventType, metadata: Self.mapMetadata(metadata))
+        guard let eventType = AnalyticsEventType(rawValue: eventName) else {
+            logger.debug(message: "[Analytics] Dropping unknown event name: \(eventName)")
+            return
+        }
+        await analyticsInteractor.trackEvent(eventType, metadata: Self.mapMetadata(metadata, for: eventType))
     }
 
     // MARK: - Logging
@@ -74,9 +83,55 @@ public final class ComponentsAnalyticsLoggingBridge {
         await loggingService.logInfo(message: message, event: event, userInfo: userInfo)
     }
 
+    public func logError(
+        message: String,
+        event: String? = nil,
+        errorMessage: String? = nil,
+        stack: String? = nil,
+        userInfo: [String: Any]? = nil
+    ) async {
+        await loggingService.logError(
+            message: message,
+            event: event,
+            errorMessage: errorMessage,
+            stack: stack,
+            userInfo: userInfo
+        )
+    }
+
     // MARK: - Metadata Mapping
 
-    static func mapMetadata(_ metadata: [String: String]?) -> AnalyticsEventMetadata {
+    /// Maps the RN string dictionary into typed metadata. Empty strings degrade to nil; Bool/Int
+    /// values must be exactly `"true"`/`"false"`/integer strings — anything else degrades to nil.
+    static func mapMetadata(
+        _ metadata: [String: String]?,
+        for eventType: AnalyticsEventType
+    ) -> AnalyticsEventMetadata {
+        if eventType.isVaultEvent {
+            if let metadata {
+                let unconsumed = Set(metadata.keys).subtracting(vaultMetadataKeys)
+                if !unconsumed.isEmpty {
+                    logger.debug(
+                        message: "[Analytics] Dropping unconsumed vault metadata keys: \(unconsumed.sorted())"
+                    )
+                }
+            }
+            let value: (String) -> String? = { key in
+                metadata?[key].flatMap { $0.isEmpty ? nil : $0 }
+            }
+            return .vault(VaultEvent(
+                vaultedMethodId: value("vaultedMethodId"),
+                previousVaultedMethodId: value("previousVaultedMethodId"),
+                promotedVaultedMethodId: value("promotedVaultedMethodId"),
+                isActive: metadata?["isActive"].flatMap(Bool.init),
+                vaultedMethodCount: metadata?["vaultedMethodCount"].flatMap(Int.init),
+                exitedFromConfirmation: metadata?["exitedFromConfirmation"].flatMap(Bool.init),
+                network: value("network"),
+                expectedCvvLength: metadata?["expectedCvvLength"].flatMap(Int.init),
+                errorId: value("errorId")
+            ))
+        }
+
         guard let metadata else { return .general() }
 
         guard let paymentMethod = metadata["paymentMethod"], !paymentMethod.isEmpty else {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Logging/Data/Services/ComponentsLoggingServiceProtocol.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Logging/Data/Services/ComponentsLoggingServiceProtocol.swift
@@ -11,4 +11,11 @@ import Foundation
 @available(iOS 15.0, *)
 protocol ComponentsLoggingServiceProtocol: Actor {
     func logInfo(message: String, event: String, userInfo: [String: Any]?) async
+    func logError(
+        message: String,
+        event: String?,
+        errorMessage: String?,
+        stack: String?,
+        userInfo: [String: Any]?
+    ) async
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Logging/Data/Services/LoggingService.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Logging/Data/Services/LoggingService.swift
@@ -30,47 +30,9 @@ actor LoggingService: LogReporter, ComponentsLoggingServiceProtocol {
       return
     }
 
-    await sendError(message: message, error: error, userInfo: userInfo)
-  }
-
-  func logInfo(message: String, event: String, userInfo: [String: Any]? = nil) async {
-    await sendInfo(message: message, event: event, userInfo: userInfo)
-  }
-
-  // MARK: - Private Methods
-
-  private func sendInfo(message: String, event: String, userInfo: [String: Any]?) async {
-    do {
-      let sessionData = await LoggingSessionContext.shared.getSessionData()
-
-      let payload = try payloadBuilder.buildInfoPayload(
-        message: message,
-        event: event,
-        userInfo: userInfo,
-        sessionData: sessionData
-      )
-
-      let endpoint = LogEnvironmentProvider.getEndpointURL(for: sessionData.environment)
-
-      try await networkClient.send(
-        payload: payload,
-        to: endpoint,
-        token: sessionData.clientSessionToken
-      )
-    } catch {
-      Self.logger.error(
-        message: "[Logging] Failed to send INFO log: \(error.localizedDescription)")
-    }
-  }
-
-  private func sendError(message: String?, error: Error, userInfo: [String: Any]?) async {
-    do {
-      let sessionData = await LoggingSessionContext.shared.getSessionData()
-
-      let datadogMessage = message ?? Self.extractDatadogMessage(from: error)
-
-      let payload = try payloadBuilder.buildErrorPayload(
-        message: datadogMessage,
+    await dispatch(label: "ERROR") { sessionData in
+      try payloadBuilder.buildErrorPayload(
+        message: message ?? Self.extractDatadogMessage(from: error),
         errorMessage: error.localizedDescription,
         diagnosticsId: Self.extractDiagnosticsId(from: error),
         stack: String(describing: error),
@@ -78,7 +40,49 @@ actor LoggingService: LogReporter, ComponentsLoggingServiceProtocol {
         userInfo: userInfo,
         sessionData: sessionData
       )
+    }
+  }
 
+  func logInfo(message: String, event: String, userInfo: [String: Any]? = nil) async {
+    await dispatch(label: "INFO") { sessionData in
+      try payloadBuilder.buildInfoPayload(
+        message: message,
+        event: event,
+        userInfo: userInfo,
+        sessionData: sessionData
+      )
+    }
+  }
+
+  func logError(
+    message: String,
+    event: String? = nil,
+    errorMessage: String? = nil,
+    stack: String? = nil,
+    userInfo: [String: Any]? = nil
+  ) async {
+    await dispatch(label: "ERROR") { sessionData in
+      try payloadBuilder.buildErrorPayload(
+        message: message,
+        errorMessage: errorMessage,
+        diagnosticsId: nil,
+        stack: stack,
+        event: event,
+        userInfo: userInfo,
+        sessionData: sessionData
+      )
+    }
+  }
+
+  // MARK: - Private Methods
+
+  private func dispatch(
+    label: String,
+    makePayload: (LoggingSessionContext.SessionData) throws -> LogPayload
+  ) async {
+    do {
+      let sessionData = await LoggingSessionContext.shared.getSessionData()
+      let payload = try makePayload(sessionData)
       let endpoint = LogEnvironmentProvider.getEndpointURL(for: sessionData.environment)
 
       try await networkClient.send(
@@ -88,7 +92,7 @@ actor LoggingService: LogReporter, ComponentsLoggingServiceProtocol {
       )
     } catch {
       Self.logger.error(
-        message: "[Logging] Failed to send ERROR log: \(error.localizedDescription)")
+        message: "[Logging] Failed to send \(label) log: \(error.localizedDescription)")
     }
   }
 

--- a/Tests/Primer/Analytics/AnalyticsModelsTests.swift
+++ b/Tests/Primer/Analytics/AnalyticsModelsTests.swift
@@ -32,7 +32,16 @@ final class AnalyticsPayloadTests: XCTestCase {
             threedsResponse: nil,
             browser: nil,
             device: nil,
-            deviceType: nil
+            deviceType: nil,
+            vaultedMethodId: nil,
+            previousVaultedMethodId: nil,
+            promotedVaultedMethodId: nil,
+            isActive: nil,
+            vaultedMethodCount: nil,
+            exitedFromConfirmation: nil,
+            network: nil,
+            expectedCvvLength: nil,
+            errorId: nil
         )
 
         // When
@@ -75,7 +84,16 @@ final class AnalyticsPayloadTests: XCTestCase {
             threedsResponse: nil,
             browser: nil,
             device: nil,
-            deviceType: nil
+            deviceType: nil,
+            vaultedMethodId: nil,
+            previousVaultedMethodId: nil,
+            promotedVaultedMethodId: nil,
+            isActive: nil,
+            vaultedMethodCount: nil,
+            exitedFromConfirmation: nil,
+            network: nil,
+            expectedCvvLength: nil,
+            errorId: nil
         )
 
         // When
@@ -93,6 +111,15 @@ final class AnalyticsPayloadTests: XCTestCase {
         XCTAssertNil(json["browser"])
         XCTAssertNil(json["device"])
         XCTAssertNil(json["deviceType"])
+        XCTAssertNil(json["vaultedMethodId"])
+        XCTAssertNil(json["previousVaultedMethodId"])
+        XCTAssertNil(json["promotedVaultedMethodId"])
+        XCTAssertNil(json["isActive"])
+        XCTAssertNil(json["vaultedMethodCount"])
+        XCTAssertNil(json["exitedFromConfirmation"])
+        XCTAssertNil(json["network"])
+        XCTAssertNil(json["expectedCvvLength"])
+        XCTAssertNil(json["errorId"])
     }
 
     func testAnalyticsPayload_IncludesProvidedOptionalFields() throws {
@@ -116,7 +143,16 @@ final class AnalyticsPayloadTests: XCTestCase {
             threedsResponse: "05",
             browser: "Safari",
             device: "iPhone 15 Pro",
-            deviceType: "phone"
+            deviceType: "phone",
+            vaultedMethodId: nil,
+            previousVaultedMethodId: nil,
+            promotedVaultedMethodId: nil,
+            isActive: nil,
+            vaultedMethodCount: nil,
+            exitedFromConfirmation: nil,
+            network: nil,
+            expectedCvvLength: nil,
+            errorId: nil
         )
 
         // When
@@ -345,6 +381,23 @@ final class AnalyticsEventMetadataTests: XCTestCase {
         XCTAssertEqual(metadata.redirectDestinationUrl, "https://redirect.example.com")
     }
 
+    func testAnalyticsEventMetadata_VaultCase() {
+        // When
+        let metadata: AnalyticsEventMetadata = .vault(VaultEvent(
+            vaultedMethodId: "vm-1",
+            isActive: true,
+            vaultedMethodCount: 2
+        ))
+
+        // Then
+        XCTAssertEqual(metadata.locale, GeneralEvent.formattedCurrentLocale)
+        XCTAssertEqual(metadata.vaultEvent?.vaultedMethodId, "vm-1")
+        XCTAssertEqual(metadata.vaultEvent?.isActive, true)
+        XCTAssertEqual(metadata.vaultEvent?.vaultedMethodCount, 2)
+        XCTAssertNil(metadata.paymentMethod)
+        XCTAssertNil(metadata.paymentId)
+    }
+
     // MARK: - Type Safety Tests
 
     func testAnalyticsEventMetadata_TypeSafety_PreventsMixedFields() {
@@ -399,6 +452,21 @@ final class AnalyticsEventTypeTests: XCTestCase {
         XCTAssertEqual(AnalyticsEventType.paymentFailure.rawValue, "PAYMENT_FAILURE")
         XCTAssertEqual(AnalyticsEventType.paymentReattempted.rawValue, "PAYMENT_REATTEMPTED")
         XCTAssertEqual(AnalyticsEventType.paymentFlowExited.rawValue, "PAYMENT_FLOW_EXITED")
+        XCTAssertEqual(AnalyticsEventType.vaultListOpened.rawValue, "VAULT_LIST_OPENED")
+        XCTAssertEqual(AnalyticsEventType.vaultMethodSelected.rawValue, "VAULT_METHOD_SELECTED")
+        XCTAssertEqual(
+            AnalyticsEventType.vaultOtherPayMethodsRequested.rawValue, "VAULT_OTHER_PAY_METHODS_REQUESTED"
+        )
+        XCTAssertEqual(AnalyticsEventType.vaultEditModeEntered.rawValue, "VAULT_EDIT_MODE_ENTERED")
+        XCTAssertEqual(AnalyticsEventType.vaultEditModeExited.rawValue, "VAULT_EDIT_MODE_EXITED")
+        XCTAssertEqual(AnalyticsEventType.vaultDeletionRequested.rawValue, "VAULT_DELETION_REQUESTED")
+        XCTAssertEqual(AnalyticsEventType.vaultDeletionCancelled.rawValue, "VAULT_DELETION_CANCELLED")
+        XCTAssertEqual(AnalyticsEventType.vaultMethodDeleted.rawValue, "VAULT_METHOD_DELETED")
+        XCTAssertEqual(AnalyticsEventType.vaultMethodDeletionFailed.rawValue, "VAULT_METHOD_DELETION_FAILED")
+        XCTAssertEqual(AnalyticsEventType.vaultCvvRequiredRendered.rawValue, "VAULT_CVV_REQUIRED_RENDERED")
+        XCTAssertEqual(AnalyticsEventType.vaultCvvSubmitted.rawValue, "VAULT_CVV_SUBMITTED")
+        XCTAssertEqual(AnalyticsEventType.vaultCvvRequiredDismissed.rawValue, "VAULT_CVV_REQUIRED_DISMISSED")
+        XCTAssertEqual(AnalyticsEventType.vaultCvvSubmissionFailed.rawValue, "VAULT_CVV_SUBMISSION_FAILED")
     }
 
     func testAnalyticsEventType_IsEncodable() throws {
@@ -426,26 +494,10 @@ final class AnalyticsEventTypeTests: XCTestCase {
         XCTAssertEqual(eventType, .paymentSuccess)
     }
 
-    func testAnalyticsEventType_Count_Is13() {
-        // Given - all event types as per spec
-        let allEventTypes: [AnalyticsEventType] = [
-            .sdkInitStart,
-            .sdkInitEnd,
-            .checkoutFlowStarted,
-            .paymentMethodSelection,
-            .paymentDetailsEntered,
-            .paymentSubmitted,
-            .paymentProcessingStarted,
-            .paymentRedirectToThirdParty,
-            .paymentThreeds,
-            .paymentSuccess,
-            .paymentFailure,
-            .paymentReattempted,
-            .paymentFlowExited
-        ]
-
-        // Then
-        XCTAssertEqual(allEventTypes.count, 13, "Should have exactly 13 event types as per spec")
+    func testAnalyticsEventType_Count_MatchesSpec() {
+        // Then - 13 core lifecycle + 13 vault event types as per spec
+        XCTAssertEqual(AnalyticsEventType.allCases.count, 26)
+        XCTAssertEqual(AnalyticsEventType.allCases.filter(\.isVaultEvent).count, 13)
     }
 }
 

--- a/Tests/Primer/Analytics/AnalyticsPayloadBuilderTests.swift
+++ b/Tests/Primer/Analytics/AnalyticsPayloadBuilderTests.swift
@@ -108,6 +108,42 @@ final class AnalyticsPayloadBuilderTests: XCTestCase {
         XCTAssertEqual(payload.threedsResponse, "authenticated")
     }
 
+    func testBuildPayload_WithVaultMetadata_IncludesAllVaultFields() {
+        // Given
+        let eventType = AnalyticsEventType.vaultMethodDeleted
+        let config = makeTestConfig()
+        let metadata: AnalyticsEventMetadata = .vault(VaultEvent(
+            vaultedMethodId: "vm-1",
+            previousVaultedMethodId: "vm-0",
+            promotedVaultedMethodId: "vm-2",
+            isActive: true,
+            vaultedMethodCount: 3,
+            exitedFromConfirmation: false,
+            network: "VISA",
+            expectedCvvLength: 4,
+            errorId: "vault-delete-failed"
+        ))
+
+        // When
+        let payload = builder.buildPayload(
+            eventType: eventType,
+            metadata: metadata,
+            config: config
+        )
+
+        // Then
+        XCTAssertEqual(payload.vaultedMethodId, "vm-1")
+        XCTAssertEqual(payload.previousVaultedMethodId, "vm-0")
+        XCTAssertEqual(payload.promotedVaultedMethodId, "vm-2")
+        XCTAssertEqual(payload.isActive, true)
+        XCTAssertEqual(payload.vaultedMethodCount, 3)
+        XCTAssertEqual(payload.exitedFromConfirmation, false)
+        XCTAssertEqual(payload.network, "VISA")
+        XCTAssertEqual(payload.expectedCvvLength, 4)
+        XCTAssertEqual(payload.errorId, "vault-delete-failed")
+        XCTAssertNil(payload.paymentMethod)
+    }
+
     func testBuildPayload_AutoFillsUserAgent() {
         // Given
         let eventType = AnalyticsEventType.sdkInitStart

--- a/Tests/Primer/CheckoutComponents/Bridge/ComponentsAnalyticsLoggingBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/ComponentsAnalyticsLoggingBridgeTests.swift
@@ -99,41 +99,48 @@ final class ComponentsAnalyticsLoggingBridgeTests: XCTestCase {
     }
 
     func test_trackEvent_allEventTypes_trackedCorrectly() async {
-        // Given
-        let eventNames = [
-            "SDK_INIT_START", "SDK_INIT_END", "CHECKOUT_FLOW_STARTED",
-            "PAYMENT_METHOD_SELECTION", "PAYMENT_DETAILS_ENTERED", "PAYMENT_SUBMITTED",
-            "PAYMENT_PROCESSING_STARTED", "PAYMENT_REDIRECT_TO_THIRD_PARTY", "PAYMENT_THREEDS",
-            "PAYMENT_SUCCESS", "PAYMENT_FAILURE", "PAYMENT_REATTEMPTED", "PAYMENT_FLOW_EXITED",
-        ]
-
         // When
-        for name in eventNames {
-            await sut.trackEvent(name, metadata: nil)
+        for eventType in AnalyticsEventType.allCases {
+            await sut.trackEvent(eventType.rawValue, metadata: nil)
         }
 
         // Then
         let count = await mockAnalyticsInteractor.trackEventCallCount
-        XCTAssertEqual(count, 13)
+        XCTAssertEqual(count, AnalyticsEventType.allCases.count)
+    }
+
+    func test_trackEvent_vaultEvent_tracksViaInteractor() async {
+        // When
+        await sut.trackEvent("VAULT_METHOD_DELETED", metadata: ["vaultedMethodId": "vm-1"])
+
+        // Then
+        let hasTracked = await mockAnalyticsInteractor.hasTracked(.vaultMethodDeleted)
+        XCTAssertTrue(hasTracked)
     }
 
     // MARK: - Metadata Mapping Tests
 
     func test_mapMetadata_nilMetadata_returnsGeneral() {
-        XCTAssertNil(ComponentsAnalyticsLoggingBridge.mapMetadata(nil).paymentMethod)
+        XCTAssertNil(ComponentsAnalyticsLoggingBridge.mapMetadata(nil, for: .sdkInitStart).paymentMethod)
     }
 
     func test_mapMetadata_emptyMetadata_returnsGeneral() {
-        XCTAssertNil(ComponentsAnalyticsLoggingBridge.mapMetadata([:]).paymentMethod)
+        XCTAssertNil(ComponentsAnalyticsLoggingBridge.mapMetadata([:], for: .sdkInitStart).paymentMethod)
     }
 
     func test_mapMetadata_noPaymentMethod_returnsGeneral() {
-        XCTAssertNil(ComponentsAnalyticsLoggingBridge.mapMetadata(["someKey": "someValue"]).paymentMethod)
+        XCTAssertNil(
+            ComponentsAnalyticsLoggingBridge.mapMetadata(
+                ["someKey": "someValue"], for: .checkoutFlowStarted
+            ).paymentMethod
+        )
     }
 
     func test_mapMetadata_paymentMethodOnly_returnsPayment() {
         // When
-        let result = ComponentsAnalyticsLoggingBridge.mapMetadata(["paymentMethod": "PAYMENT_CARD"])
+        let result = ComponentsAnalyticsLoggingBridge.mapMetadata(
+            ["paymentMethod": "PAYMENT_CARD"], for: .paymentSubmitted
+        )
 
         // Then
         XCTAssertEqual(result.paymentMethod, "PAYMENT_CARD")
@@ -147,7 +154,7 @@ final class ComponentsAnalyticsLoggingBridgeTests: XCTestCase {
         let result = ComponentsAnalyticsLoggingBridge.mapMetadata([
             "paymentMethod": "PAYMENT_CARD",
             "paymentId": "pay_123",
-        ])
+        ], for: .paymentSuccess)
 
         // Then
         XCTAssertEqual(result.paymentMethod, "PAYMENT_CARD")
@@ -159,7 +166,7 @@ final class ComponentsAnalyticsLoggingBridgeTests: XCTestCase {
         let result = ComponentsAnalyticsLoggingBridge.mapMetadata([
             "paymentMethod": "PAYMENT_CARD",
             "threedsProvider": "ADYEN",
-        ])
+        ], for: .paymentThreeds)
 
         // Then
         XCTAssertEqual(result.paymentMethod, "PAYMENT_CARD")
@@ -171,7 +178,7 @@ final class ComponentsAnalyticsLoggingBridgeTests: XCTestCase {
         let result = ComponentsAnalyticsLoggingBridge.mapMetadata([
             "paymentMethod": "PAYPAL",
             "redirectDestinationUrl": "https://paypal.com/checkout",
-        ])
+        ], for: .paymentRedirectToThirdParty)
 
         // Then
         XCTAssertEqual(result.paymentMethod, "PAYPAL")
@@ -184,11 +191,124 @@ final class ComponentsAnalyticsLoggingBridgeTests: XCTestCase {
             "paymentMethod": "PAYMENT_CARD",
             "threedsProvider": "ADYEN",
             "redirectDestinationUrl": "https://example.com",
-        ])
+        ], for: .paymentThreeds)
 
         // Then — threeDS takes priority
         XCTAssertEqual(result.threedsProvider, "ADYEN")
         XCTAssertNil(result.redirectDestinationUrl)
+    }
+
+    // MARK: - Vault Metadata Mapping Tests
+
+    func test_mapMetadata_vaultEvent_mapsAllFields() {
+        // When
+        let result = ComponentsAnalyticsLoggingBridge.mapMetadata([
+            "vaultedMethodId": "vm-1",
+            "previousVaultedMethodId": "vm-0",
+            "promotedVaultedMethodId": "vm-2",
+            "isActive": "true",
+            "vaultedMethodCount": "3",
+            "exitedFromConfirmation": "false",
+            "network": "VISA",
+            "expectedCvvLength": "4",
+            "errorId": "vault-delete-failed",
+        ], for: .vaultMethodDeleted)
+
+        // Then
+        let vault = result.vaultEvent
+        XCTAssertEqual(vault?.vaultedMethodId, "vm-1")
+        XCTAssertEqual(vault?.previousVaultedMethodId, "vm-0")
+        XCTAssertEqual(vault?.promotedVaultedMethodId, "vm-2")
+        XCTAssertEqual(vault?.isActive, true)
+        XCTAssertEqual(vault?.vaultedMethodCount, 3)
+        XCTAssertEqual(vault?.exitedFromConfirmation, false)
+        XCTAssertEqual(vault?.network, "VISA")
+        XCTAssertEqual(vault?.expectedCvvLength, 4)
+        XCTAssertEqual(vault?.errorId, "vault-delete-failed")
+    }
+
+    func test_mapMetadata_vaultEvent_emptyStringsBecomeNil() {
+        // When — RN sends empty strings for absent values
+        let result = ComponentsAnalyticsLoggingBridge.mapMetadata(
+            ["vaultedMethodId": "", "network": ""], for: .vaultCvvSubmitted
+        )
+
+        // Then
+        XCTAssertNotNil(result.vaultEvent)
+        XCTAssertNil(result.vaultEvent?.vaultedMethodId)
+        XCTAssertNil(result.vaultEvent?.network)
+    }
+
+    func test_mapMetadata_vaultEvent_malformedNumbersAndBools_becomeNil() {
+        // When — RN must send "true"/"false" and plain integers; anything else degrades to nil
+        let result = ComponentsAnalyticsLoggingBridge.mapMetadata([
+            "vaultedMethodId": "vm-1",
+            "isActive": "1",
+            "exitedFromConfirmation": "True",
+            "vaultedMethodCount": "3.5",
+            "expectedCvvLength": "notanint",
+        ], for: .vaultMethodDeleted)
+
+        // Then — event still maps to vault, malformed fields dropped
+        XCTAssertEqual(result.vaultEvent?.vaultedMethodId, "vm-1")
+        XCTAssertNil(result.vaultEvent?.isActive)
+        XCTAssertNil(result.vaultEvent?.exitedFromConfirmation)
+        XCTAssertNil(result.vaultEvent?.vaultedMethodCount)
+        XCTAssertNil(result.vaultEvent?.expectedCvvLength)
+    }
+
+    func test_mapMetadata_vaultEvent_nilMetadata_returnsEmptyVault() {
+        // When
+        let result = ComponentsAnalyticsLoggingBridge.mapMetadata(nil, for: .vaultListOpened)
+
+        // Then
+        XCTAssertNotNil(result.vaultEvent)
+        XCTAssertNil(result.vaultEvent?.vaultedMethodId)
+    }
+
+    func test_mapMetadata_vaultEvent_neverMapsToPayment() {
+        // When — a stray paymentMethod key must not turn a vault event into payment metadata
+        let result = ComponentsAnalyticsLoggingBridge.mapMetadata(
+            ["paymentMethod": "PAYMENT_CARD", "vaultedMethodId": "vm-1"],
+            for: .vaultDeletionRequested
+        )
+
+        // Then
+        XCTAssertNil(result.paymentMethod)
+        XCTAssertEqual(result.vaultEvent?.vaultedMethodId, "vm-1")
+    }
+
+    // MARK: - Vault Payload Encoding Tests
+
+    func test_buildPayload_vaultEvent_encodesVaultWireKeys() throws {
+        // Given
+        let config = AnalyticsSessionConfig(
+            environment: .sandbox,
+            checkoutSessionId: "cs-1",
+            clientSessionId: "cls-1",
+            primerAccountId: "acc-1",
+            sdkVersion: "3.0.0",
+            clientSessionToken: "token"
+        )
+
+        // When
+        let payload = AnalyticsPayloadBuilder().buildPayload(
+            eventType: .vaultMethodDeleted,
+            metadata: .vault(VaultEvent(vaultedMethodId: "vm-1", promotedVaultedMethodId: "vm-2", isActive: true)),
+            config: config
+        )
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(payload)) as? [String: Any]
+        )
+
+        // Then — wire keys stay camelCase with native JSON types, absent fields omitted
+        XCTAssertEqual(json["eventName"] as? String, "VAULT_METHOD_DELETED")
+        XCTAssertEqual(json["vaultedMethodId"] as? String, "vm-1")
+        XCTAssertEqual(json["promotedVaultedMethodId"] as? String, "vm-2")
+        XCTAssertEqual(json["isActive"] as? Bool, true)
+        XCTAssertNil(json["vaultedMethodCount"])
+        XCTAssertNil(json["expectedCvvLength"])
+        XCTAssertNil(json["paymentMethod"])
     }
 
     // MARK: - Log Info Tests
@@ -202,6 +322,39 @@ final class ComponentsAnalyticsLoggingBridgeTests: XCTestCase {
         XCTAssertEqual(calls.count, 1)
         XCTAssertEqual(calls.first?.message, "test message")
         XCTAssertEqual(calls.first?.event, "SDK_INIT")
+    }
+
+    // MARK: - Log Error Tests
+
+    func test_logError_delegatesToLoggingService() async {
+        // When
+        await sut.logError(
+            message: "Payment failed",
+            event: "failed-payment",
+            errorMessage: "Network request failed",
+            stack: "at Checkout.pay()"
+        )
+
+        // Then
+        let calls = await mockLoggingService.logErrorCalls
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(calls.first?.message, "Payment failed")
+        XCTAssertEqual(calls.first?.event, "failed-payment")
+        XCTAssertEqual(calls.first?.errorMessage, "Network request failed")
+        XCTAssertEqual(calls.first?.stack, "at Checkout.pay()")
+    }
+
+    func test_logError_defaultsOptionalsToNil() async {
+        // When
+        await sut.logError(message: "boom")
+
+        // Then
+        let calls = await mockLoggingService.logErrorCalls
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(calls.first?.message, "boom")
+        XCTAssertNil(calls.first?.event)
+        XCTAssertNil(calls.first?.errorMessage)
+        XCTAssertNil(calls.first?.stack)
     }
 
 }
@@ -230,10 +383,37 @@ private final actor MockBridgeLoggingService: ComponentsLoggingServiceProtocol {
         let userInfo: [String: Any]?
     }
 
+    struct ErrorCall {
+        let message: String
+        let event: String?
+        let errorMessage: String?
+        let stack: String?
+        let userInfo: [String: Any]?
+    }
+
     private(set) var logInfoCalls: [InfoCall] = []
+    private(set) var logErrorCalls: [ErrorCall] = []
 
     func logInfo(message: String, event: String, userInfo: [String: Any]?) async {
         logInfoCalls.append(InfoCall(message: message, event: event, userInfo: userInfo))
+    }
+
+    func logError(
+        message: String,
+        event: String?,
+        errorMessage: String?,
+        stack: String?,
+        userInfo: [String: Any]?
+    ) async {
+        logErrorCalls.append(
+            ErrorCall(
+                message: message,
+                event: event,
+                errorMessage: errorMessage,
+                stack: stack,
+                userInfo: userInfo
+            )
+        )
     }
 }
 

--- a/Tests/Primer/Logging/LoggingServiceTests.swift
+++ b/Tests/Primer/Logging/LoggingServiceTests.swift
@@ -126,6 +126,43 @@ final class LoggingServiceTests: XCTestCase {
         XCTAssertEqual(payloads.count, 0)
     }
 
+    // MARK: - logError Tests
+
+    func test_logError_sendsErrorPayloadWithFieldsInCorrectSlots() async throws {
+        await loggingService.logError(
+            message: "Payment failed",
+            event: "failed-payment",
+            errorMessage: "Network request failed",
+            stack: "at Checkout.pay()"
+        )
+
+        let payloads = await mockNetworkClient.sentPayloads
+        XCTAssertEqual(payloads.count, 1)
+
+        let messageData = try XCTUnwrap(payloads.first?.message.data(using: .utf8))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: messageData) as? [String: Any])
+        XCTAssertEqual(json["message"] as? String, "Payment failed")
+        XCTAssertEqual(json["status"] as? String, "error")
+        XCTAssertEqual(json["event"] as? String, "failed-payment")
+        XCTAssertEqual(json["error_message"] as? String, "Network request failed")
+        XCTAssertEqual(json["stack"] as? String, "at Checkout.pay()")
+    }
+
+    func test_logError_withOnlyMessage_omitsOptionalErrorFields() async throws {
+        await loggingService.logError(message: "boom")
+
+        let payloads = await mockNetworkClient.sentPayloads
+        XCTAssertEqual(payloads.count, 1)
+
+        let messageData = try XCTUnwrap(payloads.first?.message.data(using: .utf8))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: messageData) as? [String: Any])
+        XCTAssertEqual(json["message"] as? String, "boom")
+        XCTAssertEqual(json["status"] as? String, "error")
+        XCTAssertNil(json["event"])
+        XCTAssertNil(json["error_message"])
+        XCTAssertNil(json["stack"])
+    }
+
     // MARK: - Error Handling Tests
 
     func test_logInfo_doesNotThrowOnNetworkError() async {


### PR DESCRIPTION
# Description

[ORC-7580](https://primerapi.atlassian.net/browse/ORC-7580)

- Adds the 13 typed `VAULT_*` analytics events to CheckoutComponents — enum cases on `AnalyticsEventType` (+`CaseIterable`), a `VaultEvent` case on the `AnalyticsEventMetadata` union, and the 9 flat payload fields — plus an error-log path (`logError` on `ComponentsLoggingServiceProtocol`/`LoggingService` and the RN bridge). This lets the RN SDK emit vault analytics and error logs; wire keys are the locked cross-SDK camelCase contract, mirroring primer-io/primer-sdk-android#1283.
- The bridge maps RN string metadata into typed `VaultEvent` (strict `"true"`/`"false"`/integer parsing, empty-string → nil) and now debug-logs unknown event names and unconsumed vault metadata keys instead of dropping them silently.
- `LoggingService`: new string-based `logError` for the RN boundary, and a `dispatch(label:makePayload:)` extraction deduplicating the info/error send paths. No behavior change to existing methods.
- No public-API impact for merchants: everything touched is `@_spi(PrimerInternal)` or internal.

# Other Notes

- Companion RN PR follows (ORC-6512): RN's vault emitters rename their metadata keys to this canonical set (`fromVaultedMethodId` → `previousVaultedMethodId`/`vaultedMethodId`, `wasActive` → `isActive`, `currentVaultedMethodId`/`activeVaultedMethodId` → `vaultedMethodId`). RN should not consume a version containing this change before that lands — the unconsumed-keys debug log makes any drift visible.
- `bn/feature/cc-08-analytics-logging-a11y` was checked for overlap: it is a stale parallel stack (predates the bridge and logging protocol entirely) — no conflict with this change.
- No PAN/CVV values can flow through the new fields (`expectedCvvLength` is a digit count; vault ids are opaque tokens).
- swiftformat/swiftlint were not available locally; relying on CI auto-format.

# Manual Testing

Unit-tested (wire-shape tests pin the payload encoding end-to-end). Cross-SDK end-to-end verification via Charles happens in the alignment plan's final phase once the RN wiring lands.

# Contributor Checklist

- [ ] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [ ] I have added UI tests to new user flows, if applicable (n/a — no UI)
- [ ] I have manually tested newly added UX (n/a — no UX)
- [ ] I have open a documentation PR, if applicable (n/a)

# Reviewer Checklist

- [ ] I have verified that a suitable set of automated tests has been added
- [ ] I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ] I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ] If introducing a breaking change, I have communicated it internally (none — additive @_spi surface)
- [ ] Any related documentation PRs are ready to merge (n/a)


[ORC-7580]: https://primerapi.atlassian.net/browse/ORC-7580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ