### PR TITLE
chore: Port Primer Studio CC demos into Debug App SwiftUI Examples [ORC-7415]

### DIFF
--- a/Debug App/Primer.io Debug App SPM.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App SPM.xcodeproj/project.pbxproj
@@ -17,12 +17,30 @@
 		044F805C2C6B4F9800E9F878 /* MerchantHeadlessStripeAchFieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044F80572C6B4F9800E9F878 /* MerchantHeadlessStripeAchFieldsView.swift */; };
 		044F805D2C6B4F9800E9F878 /* MerchantHeadlessStripeAchFieldsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 044F80582C6B4F9800E9F878 /* MerchantHeadlessStripeAchFieldsViewModel.swift */; };
 		049A055C2B4BF044002CEEBA /* MerchantHeadlessVaultManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049A055B2B4BF044002CEEBA /* MerchantHeadlessVaultManagerViewController.swift */; };
+		07ECCE4CFE7E50B38D3A8A8F /* CustomResultScreensDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE914C245FEA2E9BE21554A /* CustomResultScreensDemo.swift */; };
+		0E23A44D6172BA67A38955A0 /* PaymentMethodListOnlyDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4F1DB1A8A8238DB1B138E2 /* PaymentMethodListOnlyDemo.swift */; };
+		209D815C3D311FAD27E795C6 /* CustomGridPaymentMethodsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607F97B6D513B6F1A41D0ADD /* CustomGridPaymentMethodsDemo.swift */; };
+		29339E8365E04D1629DE8B96 /* CustomNavigationDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D0C055217F930D217D741B /* CustomNavigationDemo.swift */; };
+		36F13502C5B5108B38DFC63D /* RefreshClientSessionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2041F5A58993314001C16AB /* RefreshClientSessionDemo.swift */; };
+		3C7DA762CA70765941B966D7 /* InlineCheckoutDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E644923BCEB790F052A540 /* InlineCheckoutDemo.swift */; };
+		3EE163781351D1DD34799C58 /* Color+DemoHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84563AE835DF6D2385B6AD99 /* Color+DemoHex.swift */; };
+		4140A7E568E55F8847D64AC9 /* ThemedManagedDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5BF93F1B6021407241AFEF /* ThemedManagedDemo.swift */; };
+		42519C816FA2FBFF45F5FF10 /* InlineCardFormDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EEB34F7D07EDADBB68988DF /* InlineCardFormDemo.swift */; };
+		43272C0C64226498BE2B2DDF /* BeforePaymentGateDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EF286ACD59907AC824A6F3 /* BeforePaymentGateDemo.swift */; };
+		492F03383585193E7C26B8C9 /* MerchantNavigationDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADAAF587DB3A5098521A6D2 /* MerchantNavigationDemo.swift */; };
+		59DDEF30FEF44FB730F5877E /* DemoScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A629098F4542CD7AAF48C8 /* DemoScaffold.swift */; };
+		5C18A7B1F844095EF2751618 /* RadioSelectionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D31F79AE7582BAD0F31DE55 /* RadioSelectionDemo.swift */; };
+		61101AC32721631C84240C2F /* DemoCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B0425B4E015B55C98BFCDA /* DemoCheckout.swift */; };
+		7A1DB74AD9E3A1F1816B7422 /* DynamicVaultDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51D2375B4BB8E65866F369C /* DynamicVaultDemo.swift */; };
+		7C23B3964A940BE52131C8A0 /* ThemeDemos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5566004D482036A73B361C23 /* ThemeDemos.swift */; };
 		8723ADDD2B8E0F5100A5FE23 /* MerchantHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADDC2B8E0F5100A5FE23 /* MerchantHelpers.swift */; };
 		8723ADE42B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADDF2B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView.swift */; };
 		8723ADE52B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADE02B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationViewModel.swift */; };
 		8723ADE62B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView+Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADE12B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView+Elements.swift */; };
 		8723ADE72B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController+Klarna.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADE22B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController+Klarna.swift */; };
 		8723ADE82B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8723ADE32B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController.swift */; };
+		A07F7242200659BFC1965806 /* ManagedCheckoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8813DA419F34A882D7937240 /* ManagedCheckoutView.swift */; };
+		A087956F941E77C61F203BCA /* VaultManagementDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1253E6BFB1BFBE0B7CA08632 /* VaultManagementDemo.swift */; };
 		A79D98422EE700350024B330 /* DefaultCheckoutDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98322EE700350024B330 /* DefaultCheckoutDemo.swift */; };
 		A79D98442EE700350024B330 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98362EE700350024B330 /* LoadingView.swift */; };
 		A79D98452EE700350024B330 /* CheckoutComponentsExamplesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D983B2EE700350024B330 /* CheckoutComponentsExamplesView.swift */; };
@@ -35,10 +53,14 @@
 		A79D984C2EE700350024B330 /* NetworkingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98382EE700350024B330 /* NetworkingUtils.swift */; };
 		A7C561392EF2F08100689089 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C561382EF2F08100689089 /* SceneDelegate.swift */; };
 		BA6BF5912E78581C003D8B3D /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6BF5902E78581A003D8B3D /* Collection+Extensions.swift */; };
+		CD5937A241E9C52DF7AECB27 /* CustomPaymentMethodsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A32D055772B6C11F24A8E5 /* CustomPaymentMethodsDemo.swift */; };
+		CF97371D60965AA1AD73278D /* CardFormSheetDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ED9F91432AF8ED3D89788AA /* CardFormSheetDemo.swift */; };
+		DCB2CCB41AF76D0CFCE40749 /* VaultedPaymentMethodsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DFDCD42068B7EA774E7F54 /* VaultedPaymentMethodsDemo.swift */; };
 		E11F475C2B06C5A40091C31F /* MerchantHeadlessCheckoutBankViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11F47582B06C5A40091C31F /* MerchantHeadlessCheckoutBankViewController.swift */; };
 		E11F475D2B06C5A40091C31F /* BanksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11F47592B06C5A40091C31F /* BanksListView.swift */; };
 		E11F475E2B06C5A40091C31F /* BanksListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11F475A2B06C5A40091C31F /* BanksListModel.swift */; };
 		E11F475F2B06C5A40091C31F /* ImageViewWithUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11F475B2B06C5A40091C31F /* ImageViewWithUrl.swift */; };
+		E85DCDB9E38FAA6FB5C35600 /* VaultModeInlineDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7677B39B4E8B5FFB1D2AC97D /* VaultModeInlineDemo.swift */; };
 		F00C65F82ACC67FA00187028 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC5687FF32E8661F1A00CE5 /* AppDelegate.swift */; };
 		F00C65FA2ACC67FA00187028 /* Range+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9128566126AA7F571FFECA3A /* Range+Extensions.swift */; };
 		F00C65FB2ACC67FA00187028 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9023841AFCE8E3205CB713A /* String+Extensions.swift */; };
@@ -69,6 +91,7 @@
 		F04DFC6F2DAE4F4D0006AEDC /* TestSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04DFC6E2DAE4F4D0006AEDC /* TestSettings.swift */; };
 		F04DFC712DAE4F5E0006AEDC /* TestSettings+PrimerSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04DFC702DAE4F5E0006AEDC /* TestSettings+PrimerSettings.swift */; };
 		F09978842D0326860058E4B5 /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = F09978832D0326860058E4B5 /* Metadata.swift */; };
+		FFC6685B5F04BC4A90B6FB94 /* CustomCardFormDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB7775480FEDD11F4D4B733 /* CustomCardFormDemo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -98,15 +121,18 @@
 		044F80582C6B4F9800E9F878 /* MerchantHeadlessStripeAchFieldsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessStripeAchFieldsViewModel.swift; sourceTree = "<group>"; };
 		049A055B2B4BF044002CEEBA /* MerchantHeadlessVaultManagerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessVaultManagerViewController.swift; sourceTree = "<group>"; };
 		04DFAADB2AAA01E60030FECE /* Debug App Tests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Debug App Tests-Info.plist"; sourceTree = "<group>"; };
+		08E644923BCEB790F052A540 /* InlineCheckoutDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InlineCheckoutDemo.swift; sourceTree = "<group>"; };
 		0DA32ABCF07A4EBED014327B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		0ED746F8924E70AD868BC0F4 /* MerchantNewLineItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantNewLineItemViewController.swift; sourceTree = "<group>"; };
 		0FD08B8CE57A11D1E35A8684 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		1253E6BFB1BFBE0B7CA08632 /* VaultManagementDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultManagementDemo.swift; sourceTree = "<group>"; };
 		13FA89917603E4BA5BB66AFC /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		1D05E65C196E6715D7D8B0C6 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Main.strings; sourceTree = "<group>"; };
 		1F23211288F9B61390C0BF8D /* Pods_Debug_App_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		229849A3DBE0858EE90673B9 /* CreateClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateClientToken.swift; sourceTree = "<group>"; };
 		2A328E38DA586FFE0ED2894B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Main.strings; sourceTree = "<group>"; };
 		2E64F057A39A91CA01CCB57F /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Main.strings; sourceTree = "<group>"; };
+		2ED9F91432AF8ED3D89788AA /* CardFormSheetDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardFormSheetDemo.swift; sourceTree = "<group>"; };
 		33E18D5B5190C64631309D1B /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		39CCCB917D1881082ED75975 /* ViewController+Primer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Primer.swift"; sourceTree = "<group>"; };
 		404E173A513B986A36F835F7 /* MerchantHeadlessCheckoutRawPhoneNumberDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutRawPhoneNumberDataViewController.swift; sourceTree = "<group>"; };
@@ -114,30 +140,43 @@
 		4C353D84EABA4990DAB4DD28 /* MerchantHeadlessCheckoutRawRetailDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutRawRetailDataViewController.swift; sourceTree = "<group>"; };
 		4E79C93EA805E87E1137A513 /* PaymentMethodCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodCell.swift; sourceTree = "<group>"; };
 		52F54EC3C1ACE19DF48BD6E2 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		5566004D482036A73B361C23 /* ThemeDemos.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThemeDemos.swift; sourceTree = "<group>"; };
+		607F97B6D513B6F1A41D0ADD /* CustomGridPaymentMethodsDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomGridPaymentMethodsDemo.swift; sourceTree = "<group>"; };
 		6493EA8D95DDA066DE982B24 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Main.strings; sourceTree = "<group>"; };
+		6ADAAF587DB3A5098521A6D2 /* MerchantNavigationDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MerchantNavigationDemo.swift; sourceTree = "<group>"; };
 		6D2261DDEE5DC5D2ED518037 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		6D665EEA8106E51925C3CF2B /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Main.strings; sourceTree = "<group>"; };
+		6EEB34F7D07EDADBB68988DF /* InlineCardFormDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InlineCardFormDemo.swift; sourceTree = "<group>"; };
 		70D3D6CF0F006A06B7CEC71B /* TransactionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionResponse.swift; sourceTree = "<group>"; };
 		721B75053C8E82756FB8AD0D /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		72845A3010F10A88F2EC7849 /* CheckoutTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutTheme.swift; sourceTree = "<group>"; };
 		72E691B9A6A8EBB9F6A6B266 /* MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift; sourceTree = "<group>"; };
 		743E00065B4A8D6C95092A23 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		7480FE5F665CC66C092BC95A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		7677B39B4E8B5FFB1D2AC97D /* VaultModeInlineDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultModeInlineDemo.swift; sourceTree = "<group>"; };
+		76EF286ACD59907AC824A6F3 /* BeforePaymentGateDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BeforePaymentGateDemo.swift; sourceTree = "<group>"; };
 		77E08473D1DF8C47A6EB61B2 /* Networking+Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Networking+Models.swift"; sourceTree = "<group>"; };
+		84563AE835DF6D2385B6AD99 /* Color+DemoHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Color+DemoHex.swift"; sourceTree = "<group>"; };
 		8723ADDC2B8E0F5100A5FE23 /* MerchantHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHelpers.swift; sourceTree = "<group>"; };
 		8723ADDF2B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessKlarnaInitializationView.swift; sourceTree = "<group>"; };
 		8723ADE02B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessKlarnaInitializationViewModel.swift; sourceTree = "<group>"; };
 		8723ADE12B8E0FAB00A5FE23 /* MerchantHeadlessKlarnaInitializationView+Elements.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MerchantHeadlessKlarnaInitializationView+Elements.swift"; sourceTree = "<group>"; };
 		8723ADE22B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController+Klarna.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MerchantHeadlessCheckoutKlarnaViewController+Klarna.swift"; sourceTree = "<group>"; };
 		8723ADE32B8E0FAB00A5FE23 /* MerchantHeadlessCheckoutKlarnaViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutKlarnaViewController.swift; sourceTree = "<group>"; };
+		8813DA419F34A882D7937240 /* ManagedCheckoutView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManagedCheckoutView.swift; sourceTree = "<group>"; };
 		8A3FDC6FE0EB5AB5828D4D80 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		8D31F79AE7582BAD0F31DE55 /* RadioSelectionDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RadioSelectionDemo.swift; sourceTree = "<group>"; };
 		9128566126AA7F571FFECA3A /* Range+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Range+Extensions.swift"; sourceTree = "<group>"; };
 		92BE0A1A904DCEA405A11CC1 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Main.strings; sourceTree = "<group>"; };
+		93B0425B4E015B55C98BFCDA /* DemoCheckout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoCheckout.swift; sourceTree = "<group>"; };
 		93F15C1E46C70C3D73B50F31 /* UIStackViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensions.swift; sourceTree = "<group>"; };
 		942332BD921CBCAFBC77BD6D /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Main.strings; sourceTree = "<group>"; };
 		98079137F3DE1FE6221DA7EC /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Main.strings; sourceTree = "<group>"; };
 		9874F439DA3EA5854A454687 /* MerchantDropInUIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantDropInUIViewController.swift; sourceTree = "<group>"; };
+		9C5BF93F1B6021407241AFEF /* ThemedManagedDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThemedManagedDemo.swift; sourceTree = "<group>"; };
 		A1604A656AF654D7422A2A5E /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
+		A1D0C055217F930D217D741B /* CustomNavigationDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomNavigationDemo.swift; sourceTree = "<group>"; };
+		A6A629098F4542CD7AAF48C8 /* DemoScaffold.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoScaffold.swift; sourceTree = "<group>"; };
 		A6AEF11B151368BF993C3EA9 /* TestScenario.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestScenario.swift; sourceTree = "<group>"; };
 		A79D98322EE700350024B330 /* DefaultCheckoutDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultCheckoutDemo.swift; sourceTree = "<group>"; };
 		A79D98342EE700350024B330 /* DemoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoRow.swift; sourceTree = "<group>"; };
@@ -150,15 +189,19 @@
 		A79D983E2EE700350024B330 /* DemoProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoProtocol.swift; sourceTree = "<group>"; };
 		A79D983F2EE700350024B330 /* DemoRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoRegistry.swift; sourceTree = "<group>"; };
 		A7C561382EF2F08100689089 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		AAB7775480FEDD11F4D4B733 /* CustomCardFormDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomCardFormDemo.swift; sourceTree = "<group>"; };
 		B18D7E7738BF86467B0F1465 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		B1FD8065D40A2D691F643F3B /* UIViewController+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+API.swift"; sourceTree = "<group>"; };
 		B866FF13033A5CB8B4C3388E /* MerchantHeadlessCheckoutRawDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutRawDataViewController.swift; sourceTree = "<group>"; };
 		BA6BF5902E78581A003D8B3D /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
+		BFE914C245FEA2E9BE21554A /* CustomResultScreensDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomResultScreensDemo.swift; sourceTree = "<group>"; };
 		C18C9664115CFDEB59FED19A /* MerchantSessionAndSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantSessionAndSettingsViewController.swift; sourceTree = "<group>"; };
 		C4DFE77F28AB538220A0F6EE /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = ka.lproj/Main.strings; sourceTree = "<group>"; };
 		C7EB86C62BA46BF51C64ABC2 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		D4139D8F153BB399DA67F2EE /* ViewController+PrimerUIHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+PrimerUIHelpers.swift"; sourceTree = "<group>"; };
+		D51D2375B4BB8E65866F369C /* DynamicVaultDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DynamicVaultDemo.swift; sourceTree = "<group>"; };
 		D5C1B1F65A9382606A25CE77 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Main.strings; sourceTree = "<group>"; };
+		DA4F1DB1A8A8238DB1B138E2 /* PaymentMethodListOnlyDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodListOnlyDemo.swift; sourceTree = "<group>"; };
 		DAC5687FF32E8661F1A00CE5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DBC8EA85D1CBC1EC4AB3EB8C /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		DECCDC4079DC6471CEDDEA84 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -166,6 +209,7 @@
 		E11F47592B06C5A40091C31F /* BanksListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BanksListView.swift; sourceTree = "<group>"; };
 		E11F475A2B06C5A40091C31F /* BanksListModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BanksListModel.swift; sourceTree = "<group>"; };
 		E11F475B2B06C5A40091C31F /* ImageViewWithUrl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewWithUrl.swift; sourceTree = "<group>"; };
+		E1A32D055772B6C11F24A8E5 /* CustomPaymentMethodsDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomPaymentMethodsDemo.swift; sourceTree = "<group>"; };
 		E1AB44CF2AFE139600639DC5 /* URL+NetworkHeaders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+NetworkHeaders.swift"; sourceTree = "<group>"; };
 		E1C3EF0BA039C0A50EDE13A5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Main.strings; sourceTree = "<group>"; };
 		E7640DB186F9638C2F556F77 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
@@ -178,6 +222,8 @@
 		F04DFC6E2DAE4F4D0006AEDC /* TestSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSettings.swift; sourceTree = "<group>"; };
 		F04DFC702DAE4F5E0006AEDC /* TestSettings+PrimerSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TestSettings+PrimerSettings.swift"; sourceTree = "<group>"; };
 		F09978832D0326860058E4B5 /* Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Metadata.swift; path = Sources/Model/Metadata.swift; sourceTree = "<group>"; };
+		F2041F5A58993314001C16AB /* RefreshClientSessionDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RefreshClientSessionDemo.swift; sourceTree = "<group>"; };
+		F4DFDCD42068B7EA774E7F54 /* VaultedPaymentMethodsDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultedPaymentMethodsDemo.swift; sourceTree = "<group>"; };
 		F816A2444633C4336A7CB071 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		F9023841AFCE8E3205CB713A /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		FB1F71737862EF5D0F4FE5AB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -350,6 +396,25 @@
 			isa = PBXGroup;
 			children = (
 				A79D98322EE700350024B330 /* DefaultCheckoutDemo.swift */,
+				6EEB34F7D07EDADBB68988DF /* InlineCardFormDemo.swift */,
+				08E644923BCEB790F052A540 /* InlineCheckoutDemo.swift */,
+				2ED9F91432AF8ED3D89788AA /* CardFormSheetDemo.swift */,
+				AAB7775480FEDD11F4D4B733 /* CustomCardFormDemo.swift */,
+				76EF286ACD59907AC824A6F3 /* BeforePaymentGateDemo.swift */,
+				DA4F1DB1A8A8238DB1B138E2 /* PaymentMethodListOnlyDemo.swift */,
+				E1A32D055772B6C11F24A8E5 /* CustomPaymentMethodsDemo.swift */,
+				607F97B6D513B6F1A41D0ADD /* CustomGridPaymentMethodsDemo.swift */,
+				8D31F79AE7582BAD0F31DE55 /* RadioSelectionDemo.swift */,
+				1253E6BFB1BFBE0B7CA08632 /* VaultManagementDemo.swift */,
+				F4DFDCD42068B7EA774E7F54 /* VaultedPaymentMethodsDemo.swift */,
+				7677B39B4E8B5FFB1D2AC97D /* VaultModeInlineDemo.swift */,
+				D51D2375B4BB8E65866F369C /* DynamicVaultDemo.swift */,
+				6ADAAF587DB3A5098521A6D2 /* MerchantNavigationDemo.swift */,
+				BFE914C245FEA2E9BE21554A /* CustomResultScreensDemo.swift */,
+				A1D0C055217F930D217D741B /* CustomNavigationDemo.swift */,
+				9C5BF93F1B6021407241AFEF /* ThemedManagedDemo.swift */,
+				5566004D482036A73B361C23 /* ThemeDemos.swift */,
+				F2041F5A58993314001C16AB /* RefreshClientSessionDemo.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -360,6 +425,9 @@
 				A79D98342EE700350024B330 /* DemoRow.swift */,
 				A79D98352EE700350024B330 /* ErrorView.swift */,
 				A79D98362EE700350024B330 /* LoadingView.swift */,
+				A6A629098F4542CD7AAF48C8 /* DemoScaffold.swift */,
+				93B0425B4E015B55C98BFCDA /* DemoCheckout.swift */,
+				8813DA419F34A882D7937240 /* ManagedCheckoutView.swift */,
 			);
 			path = SharedComponents;
 			sourceTree = "<group>";
@@ -369,6 +437,7 @@
 			children = (
 				A79D98382EE700350024B330 /* NetworkingUtils.swift */,
 				A79D98392EE700350024B330 /* SimpleCountryPicker.swift */,
+				84563AE835DF6D2385B6AD99 /* Color+DemoHex.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -515,8 +584,6 @@
 				tr,
 			);
 			mainGroup = 1C9799A622D0CCDBBF94925B;
-			packageReferences = (
-			);
 			productRefGroup = DF30711EB149C64C364BB79A /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -602,6 +669,29 @@
 				F00C660F2ACC67FA00187028 /* MerchantNewLineItemViewController.swift in Sources */,
 				F00C66112ACC67FA00187028 /* PaymentMethodCell.swift in Sources */,
 				044F805B2C6B4F9800E9F878 /* MerchantHeadlessCheckoutStripeAchViewController+StripeAch.swift in Sources */,
+				59DDEF30FEF44FB730F5877E /* DemoScaffold.swift in Sources */,
+				61101AC32721631C84240C2F /* DemoCheckout.swift in Sources */,
+				3EE163781351D1DD34799C58 /* Color+DemoHex.swift in Sources */,
+				42519C816FA2FBFF45F5FF10 /* InlineCardFormDemo.swift in Sources */,
+				3C7DA762CA70765941B966D7 /* InlineCheckoutDemo.swift in Sources */,
+				CF97371D60965AA1AD73278D /* CardFormSheetDemo.swift in Sources */,
+				FFC6685B5F04BC4A90B6FB94 /* CustomCardFormDemo.swift in Sources */,
+				43272C0C64226498BE2B2DDF /* BeforePaymentGateDemo.swift in Sources */,
+				0E23A44D6172BA67A38955A0 /* PaymentMethodListOnlyDemo.swift in Sources */,
+				CD5937A241E9C52DF7AECB27 /* CustomPaymentMethodsDemo.swift in Sources */,
+				209D815C3D311FAD27E795C6 /* CustomGridPaymentMethodsDemo.swift in Sources */,
+				5C18A7B1F844095EF2751618 /* RadioSelectionDemo.swift in Sources */,
+				A087956F941E77C61F203BCA /* VaultManagementDemo.swift in Sources */,
+				DCB2CCB41AF76D0CFCE40749 /* VaultedPaymentMethodsDemo.swift in Sources */,
+				E85DCDB9E38FAA6FB5C35600 /* VaultModeInlineDemo.swift in Sources */,
+				7A1DB74AD9E3A1F1816B7422 /* DynamicVaultDemo.swift in Sources */,
+				492F03383585193E7C26B8C9 /* MerchantNavigationDemo.swift in Sources */,
+				07ECCE4CFE7E50B38D3A8A8F /* CustomResultScreensDemo.swift in Sources */,
+				29339E8365E04D1629DE8B96 /* CustomNavigationDemo.swift in Sources */,
+				A07F7242200659BFC1965806 /* ManagedCheckoutView.swift in Sources */,
+				4140A7E568E55F8847D64AC9 /* ThemedManagedDemo.swift in Sources */,
+				7C23B3964A940BE52131C8A0 /* ThemeDemos.swift in Sources */,
+				36F13502C5B5108B38DFC63D /* RefreshClientSessionDemo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
+++ b/Debug App/Primer.io Debug App.xcodeproj/project.pbxproj
@@ -23,11 +23,23 @@
 		0BB8BB3F9A6AC28A0C107DC8 /* UIStackViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F15C1E46C70C3D73B50F31 /* UIStackViewExtensions.swift */; };
 		135E5BFD51371FABB5FF35D3 /* MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E691B9A6A8EBB9F6A6B266 /* MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift */; };
 		14EE32F4821BD1F19F75227F /* MerchantHeadlessCheckoutRawRetailDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C353D84EABA4990DAB4DD28 /* MerchantHeadlessCheckoutRawRetailDataViewController.swift */; };
+		28513A0E74EA69218ACEA172 /* DynamicVaultDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9AEE113E876FC94A73EF601 /* DynamicVaultDemo.swift */; };
+		33086A5888B7380A1ED6592F /* RadioSelectionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DC4D15CE6ABC94F13AAB1A /* RadioSelectionDemo.swift */; };
 		34CDCA7B403C001E4C55D26D /* MerchantSessionAndSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18C9664115CFDEB59FED19A /* MerchantSessionAndSettingsViewController.swift */; };
+		3F5471E1992506698BD8DF47 /* ThemedManagedDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABEE840922AE6C131F8DBA4 /* ThemedManagedDemo.swift */; };
+		4397441889288D805E68A32F /* DemoCheckout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC8194131061281FE50D115 /* DemoCheckout.swift */; };
+		4818DEC07017CBBB6B4CCB35 /* InlineCheckoutDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C909229BE1C054E0945B10 /* InlineCheckoutDemo.swift */; };
+		4B7A4EE11037A10647B01A8C /* ManagedCheckoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB3519F6711694A79B66BDF /* ManagedCheckoutView.swift */; };
 		53E3182FFC4E5F05D866CFAE /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8DE1E4FB055B60582977315 /* Networking.swift */; };
+		5638450F6F483C36005769B8 /* VaultModeInlineDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5ADFE02C37750D49E97575 /* VaultModeInlineDemo.swift */; };
+		57ED5E41DB6664A6BA04DF9C /* CustomNavigationDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6D657944A33EEC8F9575D0 /* CustomNavigationDemo.swift */; };
 		592E00D98C8835CBCDAA26D9 /* MerchantDropInUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9874F439DA3EA5854A454687 /* MerchantDropInUIViewController.swift */; };
+		5B05A35525456BF720FC8E29 /* CardFormSheetDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC45C031EF64BAD93DBA05ED /* CardFormSheetDemo.swift */; };
 		5E24CD5B3084FE3E8A3E85EC /* CheckoutTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72845A3010F10A88F2EC7849 /* CheckoutTheme.swift */; };
 		60F6C3AFA11A7EDB0687856A /* ViewController+PrimerUIHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4139D8F153BB399DA67F2EE /* ViewController+PrimerUIHelpers.swift */; };
+		65192773BC12A325FCC64A45 /* CustomPaymentMethodsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE574B8EE9C6DA41B33F14F8 /* CustomPaymentMethodsDemo.swift */; };
+		6F199AA51090D1814EB90860 /* CustomCardFormDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E18104979BD74EED4DC0BFA /* CustomCardFormDemo.swift */; };
+		716345D2F39D60667F3CDB30 /* CustomGridPaymentMethodsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E0026D906CF8660227AC5C /* CustomGridPaymentMethodsDemo.swift */; };
 		72F8D6065334FCD5B726A52C /* MerchantHeadlessCheckoutRawPhoneNumberDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 404E173A513B986A36F835F7 /* MerchantHeadlessCheckoutRawPhoneNumberDataViewController.swift */; };
 		85605C241F1CD45BA676D4A7 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9023841AFCE8E3205CB713A /* String+Extensions.swift */; };
 		85EDC3F175D699BFF6BD48EF /* ViewController+Primer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39CCCB917D1881082ED75975 /* ViewController+Primer.swift */; };
@@ -41,7 +53,13 @@
 		87FC1AC92BE518BC00C9F474 /* MerchantHeadlessStripeAchFieldsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FC1AC82BE518BC00C9F474 /* MerchantHeadlessStripeAchFieldsView.swift */; };
 		87FC1ACB2BE5194100C9F474 /* MerchantHeadlessStripeAchFieldsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FC1ACA2BE5194100C9F474 /* MerchantHeadlessStripeAchFieldsViewModel.swift */; };
 		87FC1ACD2BE51DCA00C9F474 /* MerchantHeadlessCheckoutStripeAchViewController+StripeAch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87FC1ACC2BE51DCA00C9F474 /* MerchantHeadlessCheckoutStripeAchViewController+StripeAch.swift */; };
+		89BBA18318F00021250E10BE /* Color+DemoHex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E47D44F2F427BD319AD4540 /* Color+DemoHex.swift */; };
+		89E44F5F6D3AE162E6541FAD /* PaymentMethodListOnlyDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54E47699C896E3008B15C62 /* PaymentMethodListOnlyDemo.swift */; };
+		9396BD9456361876C2DD64DE /* VaultedPaymentMethodsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D378D99C790B8A0666028BFF /* VaultedPaymentMethodsDemo.swift */; };
 		949864026D1CDE6F5C62C66E /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE259612A00F85709107B872 /* Main.storyboard */; };
+		9B75385C69FE02C251AC1536 /* MerchantNavigationDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F666249B7C8DF8E573426AB1 /* MerchantNavigationDemo.swift */; };
+		9D3927977BAC95D67856680B /* CustomResultScreensDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4EAD7EBF1E314CDD982291 /* CustomResultScreensDemo.swift */; };
+		A1214B38136DBC3D181786F4 /* RefreshClientSessionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC866297C6C6470232877807 /* RefreshClientSessionDemo.swift */; };
 		A19EF5632B20E22E00A72F60 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A19EF5622B20E22E00A72F60 /* .swiftlint.yml */; };
 		A1A1FD8B2DA599550069B0DB /* chocolate_bar_demo.otf in Resources */ = {isa = PBXBuildFile; fileRef = A1A1FD8A2DA599550069B0DB /* chocolate_bar_demo.otf */; };
 		A79D98242EE6DCE70024B330 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79D98182EE6DCE70024B330 /* LoadingView.swift */; };
@@ -61,7 +79,12 @@
 		BA6BF5952E7858A5003D8B3D /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6BF5942E7858A5003D8B3D /* Collection+Extensions.swift */; };
 		C0115AC7BC96FDF49EF8E530 /* PaymentMethodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E79C93EA805E87E1137A513 /* PaymentMethodCell.swift */; };
 		C75A11E6AEEFC2B7A29BBC04 /* TestScenario.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AEF11B151368BF993C3EA9 /* TestScenario.swift */; };
+		CDD6648FC9356383B1EE6689 /* BeforePaymentGateDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65FBFDFAC16FA7D24033441F /* BeforePaymentGateDemo.swift */; };
 		CE5E673A96BB5B96AE5EFC56 /* Range+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9128566126AA7F571FFECA3A /* Range+Extensions.swift */; };
+		D06E314F3D6FAF3E291A3EAF /* ThemeDemos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B5EAA9A4030EC74DA2D6B6E /* ThemeDemos.swift */; };
+		D1917B092D51CF34DE3D18A6 /* DemoScaffold.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30384F09A95668DBC42303B5 /* DemoScaffold.swift */; };
+		D36BFED6F8219F1AB0F1DACF /* InlineCardFormDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5C0644BB3CD9B71864FF0E /* InlineCardFormDemo.swift */; };
+		D7C34BCB56FFE5456DCD77D7 /* VaultManagementDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6EBCE1A7344DCFA889529A /* VaultManagementDemo.swift */; };
 		D886D8E47D883304B505CE11 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC5687FF32E8661F1A00CE5 /* AppDelegate.swift */; };
 		DE53DA2D0AD108306C92E198 /* UIViewController+API.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FD8065D40A2D691F643F3B /* UIViewController+API.swift */; };
 		E11F47542B06C5030091C31F /* BanksListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E11F47502B06C5030091C31F /* BanksListView.swift */; };
@@ -125,34 +148,44 @@
 		04921D0B2BFB79DC004DFB4D /* MerchantHeadlessCheckoutNolPayViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutNolPayViewController.swift; sourceTree = "<group>"; };
 		049A055D2B4BF057002CEEBA /* MerchantHeadlessVaultManagerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessVaultManagerViewController.swift; sourceTree = "<group>"; };
 		04C1906F2BEA5B75009A225A /* UnitTestsTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTestsTestPlan.xctestplan; sourceTree = "<group>"; };
+		04C909229BE1C054E0945B10 /* InlineCheckoutDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InlineCheckoutDemo.swift; sourceTree = "<group>"; };
 		04F3235B2BD2F99000F5927C /* UIApplication+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extensions.swift"; sourceTree = "<group>"; };
 		04F3235E2BD408C600F5927C /* Debug App Tests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Debug App Tests-Info.plist"; sourceTree = "<group>"; };
 		0DA32ABCF07A4EBED014327B /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		0ED746F8924E70AD868BC0F4 /* MerchantNewLineItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantNewLineItemViewController.swift; sourceTree = "<group>"; };
 		0FD08B8CE57A11D1E35A8684 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		13FA89917603E4BA5BB66AFC /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		18E0026D906CF8660227AC5C /* CustomGridPaymentMethodsDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomGridPaymentMethodsDemo.swift; sourceTree = "<group>"; };
 		1D05E65C196E6715D7D8B0C6 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Main.strings; sourceTree = "<group>"; };
 		229849A3DBE0858EE90673B9 /* CreateClientToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateClientToken.swift; sourceTree = "<group>"; };
 		2A328E38DA586FFE0ED2894B /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Main.strings; sourceTree = "<group>"; };
+		2B5EAA9A4030EC74DA2D6B6E /* ThemeDemos.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThemeDemos.swift; sourceTree = "<group>"; };
 		2E64F057A39A91CA01CCB57F /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/Main.strings; sourceTree = "<group>"; };
+		30384F09A95668DBC42303B5 /* DemoScaffold.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoScaffold.swift; sourceTree = "<group>"; };
 		33E18D5B5190C64631309D1B /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		39CCCB917D1881082ED75975 /* ViewController+Primer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+Primer.swift"; sourceTree = "<group>"; };
+		3E47D44F2F427BD319AD4540 /* Color+DemoHex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Color+DemoHex.swift"; sourceTree = "<group>"; };
+		3E5ADFE02C37750D49E97575 /* VaultModeInlineDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultModeInlineDemo.swift; sourceTree = "<group>"; };
 		404E173A513B986A36F835F7 /* MerchantHeadlessCheckoutRawPhoneNumberDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutRawPhoneNumberDataViewController.swift; sourceTree = "<group>"; };
 		483D2036DE3F89CA2C244C4F /* Debug App Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Debug App Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4ACFB17A73AB7240BED98585 /* ExampleApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ExampleApp.entitlements; sourceTree = "<group>"; };
 		4C353D84EABA4990DAB4DD28 /* MerchantHeadlessCheckoutRawRetailDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutRawRetailDataViewController.swift; sourceTree = "<group>"; };
 		4E79C93EA805E87E1137A513 /* PaymentMethodCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodCell.swift; sourceTree = "<group>"; };
 		52F54EC3C1ACE19DF48BD6E2 /* tr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = tr; path = tr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		56DC4D15CE6ABC94F13AAB1A /* RadioSelectionDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RadioSelectionDemo.swift; sourceTree = "<group>"; };
 		6493EA8D95DDA066DE982B24 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Main.strings; sourceTree = "<group>"; };
+		65FBFDFAC16FA7D24033441F /* BeforePaymentGateDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BeforePaymentGateDemo.swift; sourceTree = "<group>"; };
 		68E2722188A5A2948DB31144 /* Debug App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Debug App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D2261DDEE5DC5D2ED518037 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		6D665EEA8106E51925C3CF2B /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Main.strings; sourceTree = "<group>"; };
+		6DC8194131061281FE50D115 /* DemoCheckout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DemoCheckout.swift; sourceTree = "<group>"; };
 		70D3D6CF0F006A06B7CEC71B /* TransactionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionResponse.swift; sourceTree = "<group>"; };
 		721B75053C8E82756FB8AD0D /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		72845A3010F10A88F2EC7849 /* CheckoutTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckoutTheme.swift; sourceTree = "<group>"; };
 		72E691B9A6A8EBB9F6A6B266 /* MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutAvailablePaymentMethodsViewController.swift; sourceTree = "<group>"; };
 		743E00065B4A8D6C95092A23 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		7480FE5F665CC66C092BC95A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		7E6EBCE1A7344DCFA889529A /* VaultManagementDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultManagementDemo.swift; sourceTree = "<group>"; };
 		876140D42B63F7DB0058CA8C /* MerchantHeadlessCheckoutKlarnaViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutKlarnaViewController.swift; sourceTree = "<group>"; };
 		876140E52B67F3B30058CA8C /* MerchantHeadlessCheckoutKlarnaViewController+Klarna.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MerchantHeadlessCheckoutKlarnaViewController+Klarna.swift"; sourceTree = "<group>"; };
 		876140EE2B6BE8C20058CA8C /* MerchantHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHelpers.swift; sourceTree = "<group>"; };
@@ -164,12 +197,14 @@
 		87FC1ACA2BE5194100C9F474 /* MerchantHeadlessStripeAchFieldsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessStripeAchFieldsViewModel.swift; sourceTree = "<group>"; };
 		87FC1ACC2BE51DCA00C9F474 /* MerchantHeadlessCheckoutStripeAchViewController+StripeAch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MerchantHeadlessCheckoutStripeAchViewController+StripeAch.swift"; sourceTree = "<group>"; };
 		8A3FDC6FE0EB5AB5828D4D80 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		8F6D657944A33EEC8F9575D0 /* CustomNavigationDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomNavigationDemo.swift; sourceTree = "<group>"; };
 		9128566126AA7F571FFECA3A /* Range+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Range+Extensions.swift"; sourceTree = "<group>"; };
 		92BE0A1A904DCEA405A11CC1 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Main.strings; sourceTree = "<group>"; };
 		93F15C1E46C70C3D73B50F31 /* UIStackViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIStackViewExtensions.swift; sourceTree = "<group>"; };
 		942332BD921CBCAFBC77BD6D /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Main.strings; sourceTree = "<group>"; };
 		98079137F3DE1FE6221DA7EC /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Main.strings; sourceTree = "<group>"; };
 		9874F439DA3EA5854A454687 /* MerchantDropInUIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantDropInUIViewController.swift; sourceTree = "<group>"; };
+		9E18104979BD74EED4DC0BFA /* CustomCardFormDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomCardFormDemo.swift; sourceTree = "<group>"; };
 		A1591DF82D51349900DCED69 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		A1591DF92D51349900DCED69 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Main.strings; sourceTree = "<group>"; };
 		A1591DFA2D5134AE00DCED69 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -231,19 +266,28 @@
 		A79D98212EE6DCE70024B330 /* NetworkingUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingUtils.swift; sourceTree = "<group>"; };
 		A79D98222EE6DCE70024B330 /* SimpleCountryPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleCountryPicker.swift; sourceTree = "<group>"; };
 		A7C561352EF2F07100689089 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		AE574B8EE9C6DA41B33F14F8 /* CustomPaymentMethodsDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomPaymentMethodsDemo.swift; sourceTree = "<group>"; };
 		B18D7E7738BF86467B0F1465 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		B1FD8065D40A2D691F643F3B /* UIViewController+API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+API.swift"; sourceTree = "<group>"; };
+		B54E47699C896E3008B15C62 /* PaymentMethodListOnlyDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaymentMethodListOnlyDemo.swift; sourceTree = "<group>"; };
 		B866FF13033A5CB8B4C3388E /* MerchantHeadlessCheckoutRawDataViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantHeadlessCheckoutRawDataViewController.swift; sourceTree = "<group>"; };
 		BA6BF5942E7858A5003D8B3D /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
+		BABEE840922AE6C131F8DBA4 /* ThemedManagedDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThemedManagedDemo.swift; sourceTree = "<group>"; };
+		BCB3519F6711694A79B66BDF /* ManagedCheckoutView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ManagedCheckoutView.swift; sourceTree = "<group>"; };
 		C18C9664115CFDEB59FED19A /* MerchantSessionAndSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MerchantSessionAndSettingsViewController.swift; sourceTree = "<group>"; };
 		C4DFE77F28AB538220A0F6EE /* ka */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ka; path = ka.lproj/Main.strings; sourceTree = "<group>"; };
 		C7BBA501E14E460382627FFF /* Pods-Debug App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.release.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.release.xcconfig"; sourceTree = "<group>"; };
 		C7EB86C62BA46BF51C64ABC2 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		CC866297C6C6470232877807 /* RefreshClientSessionDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RefreshClientSessionDemo.swift; sourceTree = "<group>"; };
 		CD03E9D5965C6840D8546A29 /* Pods-Debug App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Debug App.debug.xcconfig"; path = "Target Support Files/Pods-Debug App/Pods-Debug App.debug.xcconfig"; sourceTree = "<group>"; };
+		CF4EAD7EBF1E314CDD982291 /* CustomResultScreensDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomResultScreensDemo.swift; sourceTree = "<group>"; };
+		D378D99C790B8A0666028BFF /* VaultedPaymentMethodsDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VaultedPaymentMethodsDemo.swift; sourceTree = "<group>"; };
 		D4139D8F153BB399DA67F2EE /* ViewController+PrimerUIHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewController+PrimerUIHelpers.swift"; sourceTree = "<group>"; };
 		D5C1B1F65A9382606A25CE77 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Main.strings; sourceTree = "<group>"; };
 		DAC5687FF32E8661F1A00CE5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DBC8EA85D1CBC1EC4AB3EB8C /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		DC45C031EF64BAD93DBA05ED /* CardFormSheetDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CardFormSheetDemo.swift; sourceTree = "<group>"; };
+		DD5C0644BB3CD9B71864FF0E /* InlineCardFormDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InlineCardFormDemo.swift; sourceTree = "<group>"; };
 		DECCDC4079DC6471CEDDEA84 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		E11F47502B06C5030091C31F /* BanksListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BanksListView.swift; sourceTree = "<group>"; };
 		E11F47512B06C5030091C31F /* BanksListModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BanksListModel.swift; sourceTree = "<group>"; };
@@ -252,12 +296,14 @@
 		E1C3EF0BA039C0A50EDE13A5 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Main.strings; sourceTree = "<group>"; };
 		E7640DB186F9638C2F556F77 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Main.strings; sourceTree = "<group>"; };
 		E8DE1E4FB055B60582977315 /* Networking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
+		E9AEE113E876FC94A73EF601 /* DynamicVaultDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DynamicVaultDemo.swift; sourceTree = "<group>"; };
 		F046FCB92DACE83A00B2A4E7 /* TestSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSettings.swift; sourceTree = "<group>"; };
 		F046FCBB2DACEADA00B2A4E7 /* RNPrimerSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNPrimerSettingsTests.swift; sourceTree = "<group>"; };
 		F04DFC682DAE42390006AEDC /* AppLinkConfigProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLinkConfigProviderTests.swift; sourceTree = "<group>"; };
 		F08F63D92B9B5BC5006EF9A9 /* AppLinkConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLinkConfigProvider.swift; sourceTree = "<group>"; };
 		F09978812D00B7620058E4B5 /* Metadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata.swift; sourceTree = "<group>"; };
 		F0CD61552DACEFB600582D59 /* TestSettings+PrimerSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TestSettings+PrimerSettings.swift"; sourceTree = "<group>"; };
+		F666249B7C8DF8E573426AB1 /* MerchantNavigationDemo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MerchantNavigationDemo.swift; sourceTree = "<group>"; };
 		F816A2444633C4336A7CB071 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		F9023841AFCE8E3205CB713A /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		F96CB43EDFEE9D7117F694EB /* Pods_Debug_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Debug_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -458,6 +504,25 @@
 			isa = PBXGroup;
 			children = (
 				A79D98142EE6DCE70024B330 /* DefaultCheckoutDemo.swift */,
+				DD5C0644BB3CD9B71864FF0E /* InlineCardFormDemo.swift */,
+				04C909229BE1C054E0945B10 /* InlineCheckoutDemo.swift */,
+				DC45C031EF64BAD93DBA05ED /* CardFormSheetDemo.swift */,
+				9E18104979BD74EED4DC0BFA /* CustomCardFormDemo.swift */,
+				65FBFDFAC16FA7D24033441F /* BeforePaymentGateDemo.swift */,
+				B54E47699C896E3008B15C62 /* PaymentMethodListOnlyDemo.swift */,
+				AE574B8EE9C6DA41B33F14F8 /* CustomPaymentMethodsDemo.swift */,
+				18E0026D906CF8660227AC5C /* CustomGridPaymentMethodsDemo.swift */,
+				56DC4D15CE6ABC94F13AAB1A /* RadioSelectionDemo.swift */,
+				7E6EBCE1A7344DCFA889529A /* VaultManagementDemo.swift */,
+				D378D99C790B8A0666028BFF /* VaultedPaymentMethodsDemo.swift */,
+				3E5ADFE02C37750D49E97575 /* VaultModeInlineDemo.swift */,
+				E9AEE113E876FC94A73EF601 /* DynamicVaultDemo.swift */,
+				F666249B7C8DF8E573426AB1 /* MerchantNavigationDemo.swift */,
+				CF4EAD7EBF1E314CDD982291 /* CustomResultScreensDemo.swift */,
+				8F6D657944A33EEC8F9575D0 /* CustomNavigationDemo.swift */,
+				BABEE840922AE6C131F8DBA4 /* ThemedManagedDemo.swift */,
+				2B5EAA9A4030EC74DA2D6B6E /* ThemeDemos.swift */,
+				CC866297C6C6470232877807 /* RefreshClientSessionDemo.swift */,
 			);
 			path = Demos;
 			sourceTree = "<group>";
@@ -468,6 +533,9 @@
 				A79D98162EE6DCE70024B330 /* DemoRow.swift */,
 				A79D98172EE6DCE70024B330 /* ErrorView.swift */,
 				A79D98182EE6DCE70024B330 /* LoadingView.swift */,
+				30384F09A95668DBC42303B5 /* DemoScaffold.swift */,
+				6DC8194131061281FE50D115 /* DemoCheckout.swift */,
+				BCB3519F6711694A79B66BDF /* ManagedCheckoutView.swift */,
 			);
 			path = SharedComponents;
 			sourceTree = "<group>";
@@ -477,6 +545,7 @@
 			children = (
 				A79D98222EE6DCE70024B330 /* SimpleCountryPicker.swift */,
 				A79D98212EE6DCE70024B330 /* NetworkingUtils.swift */,
+				3E47D44F2F427BD319AD4540 /* Color+DemoHex.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -841,6 +910,29 @@
 				34CDCA7B403C001E4C55D26D /* MerchantSessionAndSettingsViewController.swift in Sources */,
 				876140E62B67F3B30058CA8C /* MerchantHeadlessCheckoutKlarnaViewController+Klarna.swift in Sources */,
 				C0115AC7BC96FDF49EF8E530 /* PaymentMethodCell.swift in Sources */,
+				D1917B092D51CF34DE3D18A6 /* DemoScaffold.swift in Sources */,
+				4397441889288D805E68A32F /* DemoCheckout.swift in Sources */,
+				89BBA18318F00021250E10BE /* Color+DemoHex.swift in Sources */,
+				D36BFED6F8219F1AB0F1DACF /* InlineCardFormDemo.swift in Sources */,
+				4818DEC07017CBBB6B4CCB35 /* InlineCheckoutDemo.swift in Sources */,
+				5B05A35525456BF720FC8E29 /* CardFormSheetDemo.swift in Sources */,
+				6F199AA51090D1814EB90860 /* CustomCardFormDemo.swift in Sources */,
+				CDD6648FC9356383B1EE6689 /* BeforePaymentGateDemo.swift in Sources */,
+				89E44F5F6D3AE162E6541FAD /* PaymentMethodListOnlyDemo.swift in Sources */,
+				65192773BC12A325FCC64A45 /* CustomPaymentMethodsDemo.swift in Sources */,
+				716345D2F39D60667F3CDB30 /* CustomGridPaymentMethodsDemo.swift in Sources */,
+				33086A5888B7380A1ED6592F /* RadioSelectionDemo.swift in Sources */,
+				D7C34BCB56FFE5456DCD77D7 /* VaultManagementDemo.swift in Sources */,
+				9396BD9456361876C2DD64DE /* VaultedPaymentMethodsDemo.swift in Sources */,
+				5638450F6F483C36005769B8 /* VaultModeInlineDemo.swift in Sources */,
+				28513A0E74EA69218ACEA172 /* DynamicVaultDemo.swift in Sources */,
+				9B75385C69FE02C251AC1536 /* MerchantNavigationDemo.swift in Sources */,
+				9D3927977BAC95D67856680B /* CustomResultScreensDemo.swift in Sources */,
+				57ED5E41DB6664A6BA04DF9C /* CustomNavigationDemo.swift in Sources */,
+				4B7A4EE11037A10647B01A8C /* ManagedCheckoutView.swift in Sources */,
+				3F5471E1992506698BD8DF47 /* ThemedManagedDemo.swift in Sources */,
+				D06E314F3D6FAF3E291A3EAF /* ThemeDemos.swift in Sources */,
+				A1214B38136DBC3D181786F4 /* RefreshClientSessionDemo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Debug App/Sources/View Controllers/CheckoutComponents/CheckoutComponentsExamplesView.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/CheckoutComponentsExamplesView.swift
@@ -24,9 +24,13 @@ struct CheckoutComponentsExamplesView: View {
 
     var body: some View {
         List {
-            ForEach(DemoRegistry.allMetadata) { metadata in
-                DemoRow(metadata: metadata) {
-                    selectedDemoId = metadata.id
+            ForEach(DemoRegistry.sections, id: \.category) { section in
+                Section(section.category.rawValue) {
+                    ForEach(section.demos) { metadata in
+                        DemoRow(metadata: metadata) {
+                            selectedDemoId = metadata.id
+                        }
+                    }
                 }
             }
         }

--- a/Debug App/Sources/View Controllers/CheckoutComponents/DemoProtocol.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/DemoProtocol.swift
@@ -15,12 +15,22 @@ struct DemoConfiguration {
     let clientToken: String?
 }
 
+enum DemoCategory: String, CaseIterable {
+    case core = "Core"
+    case paymentMethods = "Payment Methods"
+    case vault = "Vault"
+    case navigation = "Navigation & Flows"
+    case themes = "Themes"
+    case utility = "Utility"
+}
+
 struct DemoMetadata: Identifiable {
     let id = UUID()
     let name: String
     let description: String
     let tags: [String]
     let isCustom: Bool
+    let category: DemoCategory
 }
 
 @available(iOS 15.0, *)

--- a/Debug App/Sources/View Controllers/CheckoutComponents/DemoRegistry.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/DemoRegistry.swift
@@ -9,12 +9,20 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 enum DemoRegistry {
-    static let allDemos: [(metadata: DemoMetadata, factory: (DemoConfiguration) -> AnyView)] = [
-        (DefaultCheckoutDemo.metadata, { config in AnyView(DefaultCheckoutDemo(configuration: config)) })
-    ]
+    typealias DemoEntry = (metadata: DemoMetadata, factory: (DemoConfiguration) -> AnyView)
+
+    static let allDemos: [DemoEntry] = flowDemos + themeDemos + utilityDemos
 
     static var allMetadata: [DemoMetadata] {
         allDemos.map(\.metadata)
+    }
+
+    /// Demos grouped by category, in category declaration order, skipping empty categories.
+    static var sections: [(category: DemoCategory, demos: [DemoMetadata])] {
+        DemoCategory.allCases.compactMap { category in
+            let demos = allMetadata.filter { $0.category == category }
+            return demos.isEmpty ? nil : (category, demos)
+        }
     }
 
     static func createDemo(id: UUID, configuration: DemoConfiguration) -> AnyView? {
@@ -23,4 +31,37 @@ enum DemoRegistry {
         }
         return demo.factory(configuration)
     }
+
+    private static let flowDemos: [DemoEntry] = [
+        // Core
+        (DefaultCheckoutDemo.metadata, { AnyView(DefaultCheckoutDemo(configuration: $0)) }),
+        (InlineCheckoutDemo.metadata, { AnyView(InlineCheckoutDemo(configuration: $0)) }),
+        (InlineCardFormDemo.metadata, { AnyView(InlineCardFormDemo(configuration: $0)) }),
+        (CardFormSheetDemo.metadata, { AnyView(CardFormSheetDemo(configuration: $0)) }),
+        (CustomCardFormDemo.metadata, { AnyView(CustomCardFormDemo(configuration: $0)) }),
+        (BeforePaymentGateDemo.metadata, { AnyView(BeforePaymentGateDemo(configuration: $0)) }),
+        // Payment method lists
+        (PaymentMethodListOnlyDemo.metadata, { AnyView(PaymentMethodListOnlyDemo(configuration: $0)) }),
+        (CustomPaymentMethodsDemo.metadata, { AnyView(CustomPaymentMethodsDemo(configuration: $0)) }),
+        (CustomGridPaymentMethodsDemo.metadata, { AnyView(CustomGridPaymentMethodsDemo(configuration: $0)) }),
+        (RadioSelectionDemo.metadata, { AnyView(RadioSelectionDemo(configuration: $0)) }),
+        // Vault
+        (VaultManagementDemo.metadata, { AnyView(VaultManagementDemo(configuration: $0)) }),
+        (VaultedPaymentMethodsDemo.metadata, { AnyView(VaultedPaymentMethodsDemo(configuration: $0)) }),
+        (VaultModeInlineDemo.metadata, { AnyView(VaultModeInlineDemo(configuration: $0)) }),
+        (DynamicVaultDemo.metadata, { AnyView(DynamicVaultDemo(configuration: $0)) }),
+        // Navigation & flows
+        (MerchantNavigationDemo.metadata, { AnyView(MerchantNavigationDemo(configuration: $0)) }),
+        (CustomResultScreensDemo.metadata, { AnyView(CustomResultScreensDemo(configuration: $0)) }),
+        (CustomNavigationDemo.metadata, { AnyView(CustomNavigationDemo(configuration: $0)) })
+    ]
+
+    private static let themeDemos: [DemoEntry] = ThemeDemos.entries.map { entry in
+        (metadata: entry.metadata,
+         factory: { AnyView(ThemedManagedDemo(configuration: $0, title: entry.metadata.name, theme: entry.theme)) })
+    }
+
+    private static let utilityDemos: [DemoEntry] = [
+        (RefreshClientSessionDemo.metadata, { AnyView(RefreshClientSessionDemo(configuration: $0)) })
+    ]
 }

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/BeforePaymentGateDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/BeforePaymentGateDemo.swift
@@ -1,0 +1,101 @@
+//
+//  BeforePaymentGateDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Before Payment Gate — pause the SDK right before it creates the payment to confirm terms and
+/// supply a per-attempt idempotency key. Set `session.onBeforePaymentCreate`; the SDK calls it with a
+/// decision handler to continue (with an idempotency key) or abort.
+@available(iOS 15.0, *)
+struct BeforePaymentGateDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Before Payment Gate",
+            description: "Confirm terms / set idempotency key before payment",
+            tags: ["PAYMENT_CARD"],
+            isCustom: true,
+            category: .core
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            BeforePaymentGateContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct BeforePaymentGateContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+    @StateObject private var gate = PaymentGate()
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Before Payment Gate").font(.title2.weight(.bold))
+                Text("Accept the terms before the payment is created")
+                    .font(.subheadline).foregroundStyle(.secondary)
+
+                switch session.phase {
+                case .initializing:
+                    ProgressView().frame(maxWidth: .infinity).padding(.top, 24)
+                case .ready:
+                    PrimerCardForm().padding(.top, 16)
+                    PrimerPaymentMethods(method: { method, onSelect in
+                        if method.type != "PAYMENT_CARD" {
+                            PaymentMethodsDefaults.method(method, onSelect: onSelect)
+                        }
+                    })
+                }
+            }
+            .padding(16)
+        }
+        .demoCheckout(session)
+        .onAppear {
+            session.onBeforePaymentCreate = { _, decision in
+                // The SDK may call this off the main actor; hop back before touching UI state.
+                DispatchQueue.main.async { gate.pending = decision }
+            }
+        }
+        .alert("Confirm payment", isPresented: gate.isPresented) {
+            Button("Cancel", role: .cancel) {
+                gate.resolve(.abortPaymentCreation(withErrorMessage: "Terms not accepted"))
+            }
+            Button("Accept & Pay") {
+                gate.resolve(.continuePaymentCreation(withIdempotencyKey: UUID().uuidString))
+            }
+        } message: {
+            Text("Accept the terms to continue with your payment.")
+        }
+    }
+}
+
+/// Holds the pending payment-creation decision so a SwiftUI alert can resolve it.
+@available(iOS 15.0, *)
+private final class PaymentGate: ObservableObject {
+    @Published var pending: ((PrimerPaymentCreationDecision) -> Void)?
+
+    var isPresented: Binding<Bool> {
+        Binding(get: { self.pending != nil }, set: { if !$0 { self.pending = nil } })
+    }
+
+    func resolve(_ decision: PrimerPaymentCreationDecision) {
+        pending?(decision)
+        pending = nil
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CardFormSheetDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CardFormSheetDemo.swift
@@ -1,0 +1,62 @@
+//
+//  CardFormSheetDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Card Form Sheet — the default `PrimerCardForm` embedded inline beneath your own heading, showing
+/// that it drops straight into a custom layout.
+@available(iOS 15.0, *)
+struct CardFormSheetDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Card Form Sheet",
+            description: "Card form embedded beneath a custom heading",
+            tags: ["PAYMENT_CARD"],
+            isCustom: true,
+            category: .core
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            CardFormSheetContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CardFormSheetContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text("Card Form")
+                    .font(.title2.weight(.bold))
+
+                switch session.phase {
+                case .initializing:
+                    ProgressView().frame(maxWidth: .infinity)
+                case .ready:
+                    PrimerCardForm()
+                }
+            }
+            .padding(16)
+        }
+        .demoCheckout(session)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomCardFormDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomCardFormDemo.swift
@@ -1,0 +1,148 @@
+//
+//  CustomCardFormDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Fully Custom Card Form — build your own fields and submit button, driven entirely by
+/// ``PrimerCardFormSession``. Read values from `state.data`, push edits through the `update…`
+/// methods, gate the button on `state.isValid`, and call `submit()`.
+@available(iOS 15.0, *)
+struct CustomCardFormDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Fully Custom Card Form",
+            description: "Build your own form with PrimerCardFormSession",
+            tags: ["PAYMENT_CARD"],
+            isCustom: true,
+            category: .core
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            CustomCardFormContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomCardFormContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Custom Card Form").font(.title2.weight(.bold))
+                Text("Fully custom UI driven by PrimerCardFormSession")
+                    .font(.subheadline).foregroundStyle(.secondary)
+
+                switch session.phase {
+                case .initializing:
+                    ProgressView().frame(maxWidth: .infinity).padding(.top, 24)
+                case .ready:
+                    if let cardForm = session.cardForm {
+                        CustomCardFields(cardForm: cardForm).padding(.top, 16)
+                    } else {
+                        Text("Card payment method not available").foregroundStyle(.red)
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .demoCheckout(session)
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomCardFields: View {
+    @ObservedObject var cardForm: PrimerCardFormSession
+
+    var body: some View {
+        let state = cardForm.state
+        VStack(alignment: .leading, spacing: 16) {
+            field("Card Number", placeholder: "4242 4242 4242 4242", text: cardNumber)
+                .keyboardType(.numberPad)
+
+            HStack(spacing: 12) {
+                field("Expiry", placeholder: "MM/YY", text: expiry).keyboardType(.numberPad)
+                field("CVV", placeholder: "123", text: cvv).keyboardType(.numberPad)
+            }
+
+            if state.configuration.cardFields.contains(.cardholderName) {
+                field("Cardholder Name", placeholder: "John Doe", text: cardholderName)
+            }
+
+            Text(state.isValid ? "Form is valid" : "Please complete all fields")
+                .font(.footnote)
+                .foregroundStyle(state.isValid ? .green : .secondary)
+
+            Button(action: cardForm.submit) {
+                Group {
+                    if state.isLoading {
+                        ProgressView().tint(.white)
+                    } else {
+                        Text("Pay Now").font(.headline)
+                    }
+                }
+                .frame(maxWidth: .infinity, minHeight: 56)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!state.isValid || state.isLoading)
+        }
+    }
+
+    private func field(_ label: String, placeholder: String, text: Binding<String>) -> some View {
+        TextField(placeholder, text: text)
+            .textFieldStyle(.roundedBorder)
+            .autocorrectionDisabled()
+            .accessibilityLabel(label)
+    }
+
+    private var cardNumber: Binding<String> {
+        Binding(
+            get: { cardForm.state.data[.cardNumber] },
+            set: { cardForm.updateCardNumber(String($0.filter(\.isNumber).prefix(19))) }
+        )
+    }
+
+    private var cvv: Binding<String> {
+        Binding(
+            get: { cardForm.state.data[.cvv] },
+            set: { cardForm.updateCvv(String($0.filter(\.isNumber).prefix(4))) }
+        )
+    }
+
+    private var cardholderName: Binding<String> {
+        Binding(
+            get: { cardForm.state.data[.cardholderName] },
+            set: { cardForm.updateCardholderName($0) }
+        )
+    }
+
+    private var expiry: Binding<String> {
+        Binding(
+            get: { cardForm.state.data[.expiryDate] },
+            set: { value in
+                let digits = String(value.filter(\.isNumber).prefix(4))
+                let formatted = digits.count > 2
+                    ? "\(digits.prefix(2))/\(digits.dropFirst(2))"
+                    : digits
+                cardForm.updateExpiryDate(formatted)
+            }
+        )
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomGridPaymentMethodsDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomGridPaymentMethodsDemo.swift
@@ -1,0 +1,97 @@
+//
+//  CustomGridPaymentMethodsDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Custom Grid — lay the payment methods out in a two-column grid built from the selection session's
+/// own `state.paymentMethods`, calling `select(_:)` on tap.
+@available(iOS 15.0, *)
+struct CustomGridPaymentMethodsDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Custom Grid",
+            description: "Two-column grid of payment methods",
+            tags: ["PAYMENT_CARD", "APM"],
+            isCustom: true,
+            category: .paymentMethods
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            CustomGridContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomGridContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Choose Payment Method").font(.title2.weight(.bold))
+                Text("Custom 2-column grid via PrimerSelectionSession")
+                    .font(.subheadline).foregroundStyle(.secondary)
+
+                switch session.phase {
+                case .initializing:
+                    ProgressView().frame(maxWidth: .infinity).padding(.top, 24)
+                case .ready:
+                    if let selection = session.selection {
+                        PaymentMethodGrid(selection: selection).padding(.top, 16)
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .demoCheckout(session)
+    }
+}
+
+@available(iOS 15.0, *)
+private struct PaymentMethodGrid: View {
+    @ObservedObject var selection: PrimerSelectionSession
+
+    private let columns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(selection.state.paymentMethods) { method in
+                Button { selection.select(method) } label: {
+                    VStack(spacing: 12) {
+                        Text(method.type.prefix(2).uppercased())
+                            .font(.headline)
+                            .frame(width: 48, height: 48)
+                            .background(Color(.systemBackground))
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                        Text(method.name)
+                            .font(.subheadline.weight(.medium))
+                            .multilineTextAlignment(.center)
+                            .lineLimit(2)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .aspectRatio(1.2, contentMode: .fit)
+                    .background(Color(.secondarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomNavigationDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomNavigationDemo.swift
@@ -1,0 +1,161 @@
+//
+//  CustomNavigationDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Custom Navigation — a custom success screen whose "View Order Details" button navigates to an
+/// in-app order details view, pushed onto the surrounding navigation stack.
+@available(iOS 15.0, *)
+struct CustomNavigationDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Custom Navigation",
+            description: "Success screen navigates to order details",
+            tags: ["PAYMENT_CARD"],
+            isCustom: true,
+            category: .navigation
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            CustomNavigationContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomNavigationContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+    @State private var outcome: PrimerCheckoutState?
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        Group {
+            switch outcome {
+            case let .success(result):
+                SuccessWithNavigation(result: result)
+            case let .failure(error):
+                ErrorWithSupport(error: error)
+            default:
+                checkout
+            }
+        }
+        .primerCheckoutSession(session) { state in
+            switch state {
+            case .success, .failure: outcome = state
+            default: break
+            }
+        }
+    }
+
+    @ViewBuilder private var checkout: some View {
+        switch session.phase {
+        case .initializing:
+            ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .ready:
+            ScrollView {
+                VStack(spacing: 24) {
+                    PrimerPaymentMethods()
+                    PrimerCardForm()
+                }
+                .padding(16)
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct SuccessWithNavigation: View {
+    let result: PaymentResult
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 36, weight: .bold)).foregroundStyle(.white)
+                .frame(width: 80, height: 80).background(.green).clipShape(Circle())
+            Text("Payment Successful!").font(.title2.weight(.bold)).foregroundStyle(.green)
+            Text("Order #\(result.paymentId.prefix(8))").foregroundStyle(.secondary)
+
+            NavigationLink {
+                OrderDetailsScreen(orderId: result.paymentId)
+            } label: {
+                Text("View Order Details").frame(maxWidth: .infinity, minHeight: 50)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Button("Continue Shopping") {}
+                .frame(maxWidth: .infinity, minHeight: 50)
+                .buttonStyle(.bordered)
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}
+
+@available(iOS 15.0, *)
+private struct ErrorWithSupport: View {
+    let error: PrimerError
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "xmark")
+                .font(.system(size: 36, weight: .bold)).foregroundStyle(.white)
+                .frame(width: 80, height: 80).background(.red).clipShape(Circle())
+            Text("Payment Failed").font(.title2.weight(.bold)).foregroundStyle(.red)
+            Text(error.localizedDescription)
+                .multilineTextAlignment(.center).foregroundStyle(.secondary)
+            Button("Contact Support") {}
+                .frame(maxWidth: .infinity, minHeight: 50)
+                .buttonStyle(.bordered)
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}
+
+@available(iOS 15.0, *)
+private struct OrderDetailsScreen: View {
+    let orderId: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text("Order Details").font(.title.weight(.bold))
+                VStack(alignment: .leading, spacing: 16) {
+                    labeled("Order ID", orderId)
+                    labeled("Status", "✓ Payment Confirmed")
+                    Text("Navigated here from the custom success screen.")
+                        .font(.subheadline).foregroundStyle(.secondary)
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .padding(16)
+        }
+        .navigationTitle("Order")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func labeled(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            Text(value).fontWeight(.medium)
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomPaymentMethodsDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomPaymentMethodsDemo.swift
@@ -1,0 +1,81 @@
+//
+//  CustomPaymentMethodsDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Custom Payment Methods — replace each row with your own view through the `method` slot, while the
+/// SDK still owns the list, loading, and selection.
+@available(iOS 15.0, *)
+struct CustomPaymentMethodsDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Custom Payment Methods",
+            description: "Custom row via the method slot",
+            tags: ["PAYMENT_CARD", "APM"],
+            isCustom: true,
+            category: .paymentMethods
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            CustomPaymentMethodsContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomPaymentMethodsContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            switch session.phase {
+            case .initializing:
+                ProgressView().frame(maxWidth: .infinity).padding(.top, 40)
+            case .ready:
+                PrimerPaymentMethods(method: { method, onSelect in
+                    CustomPaymentMethodRow(name: method.name, onSelect: onSelect)
+                })
+                .padding(16)
+            }
+        }
+        .demoCheckout(session)
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomPaymentMethodRow: View {
+    let name: String
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack {
+                Text(name).fontWeight(.medium)
+                Spacer()
+                Text("→")
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 6)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomResultScreensDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/CustomResultScreensDemo.swift
@@ -1,0 +1,154 @@
+//
+//  CustomResultScreensDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Custom Result Screens — replace the loading, success, and error UI with your own. The inline
+/// session drives a custom loading view while initializing, the SDK checkout when ready, and a custom
+/// success/error screen from the terminal state delivered to `onCompletion`.
+@available(iOS 15.0, *)
+struct CustomResultScreensDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Custom Result Screens",
+            description: "Custom loading, success, and error screens",
+            tags: ["PAYMENT_CARD"],
+            isCustom: true,
+            category: .navigation
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            CustomResultScreensContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomResultScreensContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+    @State private var outcome: PrimerCheckoutState?
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        Group {
+            switch outcome {
+            case let .success(result):
+                CustomSuccessScreen(result: result)
+            case let .failure(error):
+                CustomErrorScreen(error: error)
+            default:
+                checkout
+            }
+        }
+        .primerCheckoutSession(session) { state in
+            switch state {
+            case .success, .failure: outcome = state
+            default: break
+            }
+        }
+    }
+
+    @ViewBuilder private var checkout: some View {
+        switch session.phase {
+        case .initializing:
+            CustomLoadingScreen()
+        case .ready:
+            ScrollView {
+                VStack(spacing: 24) {
+                    PrimerPaymentMethods()
+                    PrimerCardForm()
+                }
+                .padding(16)
+            }
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomLoadingScreen: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            ProgressView().controlSize(.large).tint(Color(red: 0.38, green: 0, blue: 0.93))
+            Text("Preparing your checkout…").font(.headline)
+            Text("This will only take a moment").font(.subheadline).foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(32)
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomSuccessScreen: View {
+    let result: PaymentResult
+
+    var body: some View {
+        VStack(spacing: 16) {
+            resultBadge(systemName: "checkmark", color: .green)
+            Text("Payment Successful!").font(.title2.weight(.bold)).foregroundStyle(.green)
+            Text("Thank you for your purchase").foregroundStyle(.secondary)
+
+            VStack(spacing: 8) {
+                row("Payment ID", String(result.paymentId.prefix(12)) + "…")
+                if let amount = result.amount, let currency = result.currencyCode {
+                    row("Amount", "\(amount) \(currency)")
+                }
+                row("Status", "\(result.status)")
+            }
+            .padding(16)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).fontWeight(.medium)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CustomErrorScreen: View {
+    let error: PrimerError
+
+    var body: some View {
+        VStack(spacing: 16) {
+            resultBadge(systemName: "xmark", color: .red)
+            Text("Payment Failed").font(.title2.weight(.bold)).foregroundStyle(.red)
+            Text(error.localizedDescription)
+                .multilineTextAlignment(.center).foregroundStyle(.secondary)
+        }
+        .padding(32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}
+
+@available(iOS 15.0, *)
+@ViewBuilder
+private func resultBadge(systemName: String, color: Color) -> some View {
+    Image(systemName: systemName)
+        .font(.system(size: 36, weight: .bold))
+        .foregroundStyle(.white)
+        .frame(width: 80, height: 80)
+        .background(color)
+        .clipShape(Circle())
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/DefaultCheckoutDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/DefaultCheckoutDemo.swift
@@ -15,7 +15,8 @@ struct DefaultCheckoutDemo: View, CheckoutComponentsDemo {
             name: "Default Checkout",
             description: "Standard CheckoutComponents with SDK-provided UI",
             tags: ["PAYMENT_CARD", "APPLE_PAY"],
-            isCustom: false
+            isCustom: false,
+            category: .core
         )
     }
 

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/DynamicVaultDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/DynamicVaultDemo.swift
@@ -1,0 +1,108 @@
+//
+//  DynamicVaultDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Dynamic Vault — a fully custom single-page checkout layout (a product card with the card form
+/// embedded below). Per-form `vaultOnSuccess` toggling isn't exposed on ``PrimerCardFormSession`` yet,
+/// so the save-card control is shown disabled to mark the gap.
+@available(iOS 15.0, *)
+struct DynamicVaultDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Dynamic Vault",
+            description: "Custom single-page checkout layout",
+            tags: ["VAULT", "PAYMENT_CARD"],
+            isCustom: true,
+            category: .vault
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            DynamicVaultContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct DynamicVaultContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                productCard
+
+                switch session.phase {
+                case .initializing:
+                    ProgressView().frame(maxWidth: .infinity).padding(.top, 24)
+                case .ready:
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Pay with card").font(.headline)
+                        PrimerCardForm()
+                        Toggle("Save card for future payments", isOn: .constant(false))
+                            .disabled(true)
+                        Text("Per-form vault toggling isn't exposed on iOS yet.")
+                            .font(.caption2).foregroundStyle(.secondary)
+                    }
+                    .padding(16)
+                    .background(Color(.secondarySystemBackground))
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                }
+            }
+            .padding(16)
+        }
+        .background(Color(.systemGroupedBackground))
+        .demoCheckout(session)
+    }
+
+    private var productCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("🇷🇴 Romania").font(.largeTitle.weight(.bold))
+            Divider()
+            Text("Package").font(.caption).foregroundStyle(.secondary)
+            infoRow(icon: "location", label: "Coverage", value: "Romania")
+            infoRow(icon: "info.circle", label: "Data", value: "1 GB")
+            infoRow(icon: "calendar", label: "Validity", value: "3 days")
+            HStack {
+                Image(systemName: "star.fill").foregroundStyle(.orange)
+                Text("You'll earn 0.20 € in cashback from this purchase").font(.caption)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.orange.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func infoRow(icon: String, label: String, value: String) -> some View {
+        HStack {
+            Image(systemName: icon)
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).fontWeight(.bold)
+        }
+        .padding(8)
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/InlineCardFormDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/InlineCardFormDemo.swift
@@ -1,0 +1,56 @@
+//
+//  InlineCardFormDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Inline Card Form — just the embedded card form, nothing else. `PrimerCardForm` with its default
+/// slots, wired to an inline ``PrimerCheckoutSession``.
+@available(iOS 15.0, *)
+struct InlineCardFormDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Inline Card Form",
+            description: "Embedded card form via PrimerCheckoutSession",
+            tags: ["PAYMENT_CARD"],
+            isCustom: true,
+            category: .core
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            InlineCardFormContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct InlineCardFormContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            switch session.phase {
+            case .initializing:
+                ProgressView().padding(.top, 40)
+            case .ready:
+                PrimerCardForm().padding(12)
+            }
+        }
+        .demoCheckout(session)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/InlineCheckoutDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/InlineCheckoutDemo.swift
@@ -1,0 +1,66 @@
+//
+//  InlineCheckoutDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Inline Checkout — embed the card form and the remaining payment methods directly in your own
+/// layout instead of presenting the managed sheet. Any Primer composable placed under
+/// `.primerCheckoutSession(_:)` resolves its session from the environment.
+@available(iOS 15.0, *)
+struct InlineCheckoutDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Inline Checkout",
+            description: "Embedded card form with other payment methods",
+            tags: ["PAYMENT_CARD"],
+            isCustom: true,
+            category: .core
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            InlineCheckoutContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct InlineCheckoutContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                switch session.phase {
+                case .initializing:
+                    ProgressView().padding(.top, 40)
+                case .ready:
+                    PrimerCardForm()
+                    // The card form is rendered above, so omit the card row from the list.
+                    PrimerPaymentMethods(method: { method, onSelect in
+                        if method.type != "PAYMENT_CARD" {
+                            PaymentMethodsDefaults.method(method, onSelect: onSelect)
+                        }
+                    })
+                }
+            }
+            .padding(16)
+        }
+        .demoCheckout(session)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/MerchantNavigationDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/MerchantNavigationDemo.swift
@@ -1,0 +1,193 @@
+//
+//  MerchantNavigationDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Merchant Navigation — a tabbed Checkout + Profile experience with screen-to-screen navigation, all
+/// sharing one inline ``PrimerCheckoutSession``.
+@available(iOS 15.0, *)
+struct MerchantNavigationDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Merchant Navigation",
+            description: "Tabbed checkout + profile navigation",
+            tags: ["PAYMENT_CARD", "VAULT"],
+            isCustom: true,
+            category: .navigation
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            MerchantNavigationContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct MerchantNavigationContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+    @State private var tab: Tab = .checkout
+    @State private var checkoutScreen: CheckoutScreen = .methods
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    private enum Tab { case checkout, profile }
+    private enum CheckoutScreen { case methods, cardForm }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+            tabBar
+        }
+        .primerCheckoutSession(session) { state in
+            if case .success = state { checkoutScreen = .methods }
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        switch tab {
+        case .checkout:
+            switch session.phase {
+            case .initializing:
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .ready:
+                switch checkoutScreen {
+                case .methods: methodsScreen
+                case .cardForm: cardFormScreen
+                }
+            }
+        case .profile:
+            profileScreen
+        }
+    }
+
+    private var methodsScreen: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Order #12345").font(.headline)
+                    Text("Total: €10.00").font(.title2.weight(.bold)).foregroundStyle(Color.accentColor)
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                Text("How would you like to pay?").font(.headline)
+
+                PrimerPaymentMethods(method: { method, onSelect in
+                    let isCard = method.type == "PAYMENT_CARD"
+                    Button {
+                        if isCard { checkoutScreen = .cardForm } else { onSelect() }
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(method.name).fontWeight(.medium)
+                                if isCard {
+                                    Text("Enter card details").font(.caption).foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            Text("→").foregroundStyle(.secondary)
+                        }
+                        .padding(16)
+                        .frame(maxWidth: .infinity)
+                        .background(isCard ? Color.accentColor.opacity(0.1) : Color(.secondarySystemBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.vertical, 4)
+                })
+            }
+            .padding(16)
+        }
+    }
+
+    private var cardFormScreen: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Button { checkoutScreen = .methods } label: {
+                    HStack { Image(systemName: "chevron.left"); Text("Back") }
+                }
+                HStack {
+                    Text("🔒")
+                    Text("Your payment is secure and encrypted")
+                        .font(.caption).foregroundStyle(.green)
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.green.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                PrimerCardForm()
+            }
+            .padding(16)
+        }
+    }
+
+    private var profileScreen: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                HStack(spacing: 16) {
+                    Text("JD")
+                        .font(.title2.weight(.bold)).foregroundStyle(.white)
+                        .frame(width: 60, height: 60).background(Color.accentColor).clipShape(Circle())
+                    VStack(alignment: .leading) {
+                        Text("John Doe").font(.headline)
+                        Text("john.doe@example.com").font(.subheadline).foregroundStyle(.secondary)
+                    }
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                Text("Saved Payment Methods").font(.headline)
+
+                if session.phase == .ready {
+                    PrimerVaultedPaymentMethods()
+                } else {
+                    ProgressView()
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private var tabBar: some View {
+        HStack {
+            tabButton(.checkout, "cart", "Checkout")
+            tabButton(.profile, "person", "Profile")
+        }
+        .padding(.top, 8)
+    }
+
+    private func tabButton(_ value: Tab, _ icon: String, _ label: String) -> some View {
+        Button {
+            tab = value
+            if value == .checkout { checkoutScreen = .methods }
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: icon)
+                Text(label).font(.caption)
+            }
+            .frame(maxWidth: .infinity)
+            .foregroundStyle(tab == value ? Color.accentColor : .secondary)
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/PaymentMethodListOnlyDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/PaymentMethodListOnlyDemo.swift
@@ -1,0 +1,63 @@
+//
+//  PaymentMethodListOnlyDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Payment Methods Only — render just the list. Tapping a method (e.g. card) lets the SDK open the
+/// follow-up flow automatically via the inline flow host.
+@available(iOS 15.0, *)
+struct PaymentMethodListOnlyDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Payment Methods Only",
+            description: "Inline list — card form opens automatically",
+            tags: ["PAYMENT_CARD", "APM"],
+            isCustom: true,
+            category: .paymentMethods
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            PaymentMethodListOnlyContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct PaymentMethodListOnlyContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Select Payment Method").font(.title2.weight(.bold))
+                Text("Tap any method — the card form opens automatically")
+                    .font(.subheadline).foregroundStyle(.secondary)
+
+                switch session.phase {
+                case .initializing:
+                    ProgressView().frame(maxWidth: .infinity).padding(.top, 24)
+                case .ready:
+                    PrimerPaymentMethods().padding(.top, 16)
+                }
+            }
+            .padding(16)
+        }
+        .demoCheckout(session)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/RadioSelectionDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/RadioSelectionDemo.swift
@@ -1,0 +1,146 @@
+//
+//  RadioSelectionDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Radio Selection — present the payment methods as a radio group with a floating Pay button that
+/// pays the chosen method only on confirmation. The inline session doesn't surface the order total,
+/// so the summary uses the demo's known sandbox amount.
+@available(iOS 15.0, *)
+struct RadioSelectionDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Radio Selection",
+            description: "Radio group with a floating Pay button",
+            tags: ["PAYMENT_CARD", "APM"],
+            isCustom: true,
+            category: .paymentMethods
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            RadioSelectionContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct RadioSelectionContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        Group {
+            switch session.phase {
+            case .initializing:
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .ready:
+                if let selection = session.selection {
+                    RadioContent(selection: selection)
+                }
+            }
+        }
+        .demoCheckout(session)
+    }
+}
+
+@available(iOS 15.0, *)
+private struct RadioContent: View {
+    @ObservedObject var selection: PrimerSelectionSession
+    @State private var selected: CheckoutPaymentMethod?
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            ScrollView {
+                VStack(spacing: 16) {
+                    summaryCard
+                    Text("Select Payment Method")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    methodsCard
+                }
+                .padding(16)
+                .padding(.bottom, 100)
+            }
+
+            if let selected {
+                payBar(for: selected)
+            }
+        }
+    }
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Order Summary").font(.headline)
+            HStack {
+                Text("Premium Subscription").foregroundStyle(.secondary)
+                Spacer()
+                Text("€10.00")
+            }
+            Divider()
+            HStack {
+                Text("Total due today").fontWeight(.bold)
+                Spacer()
+                Text("€10.00").fontWeight(.bold)
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var methodsCard: some View {
+        VStack(spacing: 0) {
+            ForEach(selection.state.paymentMethods) { method in
+                Button { selected = method } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: selected?.id == method.id ? "largecircle.fill.circle" : "circle")
+                            .foregroundStyle(selected?.id == method.id ? Color.accentColor : .secondary)
+                        VStack(alignment: .leading) {
+                            Text(method.name)
+                                .fontWeight(selected?.id == method.id ? .medium : .regular)
+                            Text(method.type).font(.caption).foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                    }
+                    .padding(16)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                if method.id != selection.state.paymentMethods.last?.id { Divider() }
+            }
+        }
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func payBar(for method: CheckoutPaymentMethod) -> some View {
+        VStack(spacing: 8) {
+            Text("Selected: \(method.name)")
+                .font(.subheadline).foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button { selection.select(method) } label: {
+                Text("Pay with \(method.name)")
+                    .frame(maxWidth: .infinity, minHeight: 50)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(16)
+        .background(.regularMaterial)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/RefreshClientSessionDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/RefreshClientSessionDemo.swift
@@ -1,0 +1,106 @@
+//
+//  RefreshClientSessionDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Refresh Client Session — verify `session.refresh()` re-fetches configuration and updates every
+/// observer (state, payment methods, vault).
+@available(iOS 15.0, *)
+struct RefreshClientSessionDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Refresh Client Session",
+            description: "Verify refresh() updates state, methods, vault",
+            tags: ["PAYMENT_CARD", "VAULT"],
+            isCustom: true,
+            category: .utility
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            RefreshClientSessionContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct RefreshClientSessionContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+    @State private var refreshCount = 0
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    private var isLoading: Bool { session.phase == .initializing }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Refresh Client Session").font(.title2.weight(.bold))
+                Text("Verify that refresh() updates all observers")
+                    .font(.subheadline).foregroundStyle(.secondary)
+
+                stateCard
+
+                Button {
+                    refreshCount += 1
+                    Task { await session.refresh() }
+                } label: {
+                    Text("Refresh Client Session").frame(maxWidth: .infinity, minHeight: 44)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isLoading)
+
+                if session.phase == .ready {
+                    let methodCount = session.selection?.state.paymentMethods.count ?? 0
+                    let vaultedCount = session.selection?.vaultedPaymentMethods.count ?? 0
+
+                    Text("Payment Methods (\(methodCount))").font(.headline)
+                    PrimerPaymentMethods()
+
+                    Text("Vaulted Methods (\(vaultedCount))").font(.headline)
+                    if vaultedCount == 0 {
+                        Text("No saved payment methods").foregroundStyle(.secondary)
+                    } else {
+                        PrimerVaultedPaymentMethods()
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .demoCheckout(session)
+    }
+
+    private var stateCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Checkout State").font(.headline)
+            stateRow("isLoading", "\(isLoading)")
+            stateRow("phase", session.phase == .ready ? "ready" : "initializing")
+            stateRow("refreshCount", "\(refreshCount)")
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.accentColor.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func stateRow(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).fontWeight(.medium)
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/ThemeDemos.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/ThemeDemos.swift
@@ -1,0 +1,95 @@
+//
+//  ThemeDemos.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// The theming catalog: each entry applies a different `PrimerCheckoutTheme` to the managed checkout,
+/// rendered via ``ThemedManagedDemo``. Registered in bulk by ``DemoRegistry``.
+@available(iOS 15.0, *)
+enum ThemeDemos {
+    static let entries: [(metadata: DemoMetadata, theme: PrimerCheckoutTheme)] = [
+        (meta("Custom Theme", "Purple brand, rounded corners, custom type"), customTheme),
+        (meta("Red Theme", "Brand color override"), brandTheme(0xE53E3E)),
+        (meta("Green Theme", "Brand color override"), brandTheme(0x38A169)),
+        (meta("Purple Theme", "Brand color override"), brandTheme(0x805AD5)),
+        (meta("No Radius", "Sharp rectangular design via radius tokens"), noRadiusTheme),
+        (meta("Small Sizes", "Compact components via size tokens"), smallSizesTheme),
+        (meta("Large Sizes", "Bold components via size tokens"), largeSizesTheme),
+        (meta("Light Typography", "Weight-300 typography"), typographyTheme(.init(weight: .light))),
+        (meta("Bold Typography", "Weight-700 typography"), typographyTheme(.init(weight: .bold))),
+        (meta("Large Typography", "32-point typography for accessibility"), typographyTheme(.init(size: 32))),
+        (meta("Custom Font", "Custom font via typography tokens"), typographyTheme(.init(font: "Marker Felt")))
+    ]
+
+    private static func meta(_ name: String, _ description: String) -> DemoMetadata {
+        DemoMetadata(name: name, description: description, tags: ["THEME"], isCustom: false, category: .themes)
+    }
+
+    private static func brandTheme(_ hex: UInt32) -> PrimerCheckoutTheme {
+        PrimerCheckoutTheme(
+            colors: ColorOverrides(
+                primerColorBrand: Color(hex: hex),
+                primerColorBorderOutlinedDefault: Color(hex: hex),
+                primerColorBorderOutlinedFocus: Color(hex: hex)
+            )
+        )
+    }
+
+    /// Applies the same `TypographyStyle` to every text token — the shape shared by the weight, size,
+    /// and font demos.
+    private static func typographyTheme(_ style: TypographyOverrides.TypographyStyle) -> PrimerCheckoutTheme {
+        PrimerCheckoutTheme(
+            typography: TypographyOverrides(
+                titleXlarge: style,
+                titleLarge: style,
+                bodyLarge: style,
+                bodyMedium: style,
+                bodySmall: style
+            )
+        )
+    }
+
+    private static let customTheme = PrimerCheckoutTheme(
+        colors: ColorOverrides(
+            primerColorBrand: Color(hex: 0x6B46C1),
+            primerColorBorderOutlinedDefault: Color(hex: 0xD6BCFA),
+            primerColorBorderOutlinedFocus: Color(hex: 0x6B46C1)
+        ),
+        radius: RadiusOverrides(
+            primerRadiusXsmall: 8, primerRadiusSmall: 12, primerRadiusMedium: 16,
+            primerRadiusLarge: 24, primerRadiusBase: 12
+        ),
+        typography: TypographyOverrides(
+            titleXlarge: .init(weight: .semibold),
+            titleLarge: .init(weight: .semibold),
+            bodyLarge: .init(weight: .regular),
+            bodyMedium: .init(weight: .regular),
+            bodySmall: .init(weight: .regular)
+        )
+    )
+
+    private static let noRadiusTheme = PrimerCheckoutTheme(
+        radius: RadiusOverrides(
+            primerRadiusXsmall: 0, primerRadiusSmall: 0, primerRadiusMedium: 0,
+            primerRadiusLarge: 0, primerRadiusBase: 0
+        )
+    )
+
+    private static let smallSizesTheme = PrimerCheckoutTheme(
+        sizes: SizeOverrides(
+            primerSizeSmall: 12, primerSizeMedium: 16, primerSizeLarge: 18,
+            primerSizeXlarge: 22, primerSizeXxlarge: 28, primerSizeXxxlarge: 34
+        )
+    )
+
+    private static let largeSizesTheme = PrimerCheckoutTheme(
+        sizes: SizeOverrides(
+            primerSizeSmall: 24, primerSizeMedium: 32, primerSizeLarge: 40,
+            primerSizeXlarge: 48, primerSizeXxlarge: 64, primerSizeXxxlarge: 80
+        )
+    )
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/ThemedManagedDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/ThemedManagedDemo.swift
@@ -1,0 +1,23 @@
+//
+//  ThemedManagedDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// A managed-checkout demo that only varies by its theme. The theme catalog lives in ``ThemeDemos``;
+/// each entry is registered with this view so the theming variants don't each need their own file.
+@available(iOS 15.0, *)
+struct ThemedManagedDemo: View {
+    let configuration: DemoConfiguration
+    let title: String
+    let theme: PrimerCheckoutTheme
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: title) { clientToken in
+            ManagedCheckoutView(clientToken: clientToken, settings: configuration.settings, theme: theme)
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/VaultManagementDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/VaultManagementDemo.swift
@@ -1,0 +1,63 @@
+//
+//  VaultManagementDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Vault Management — show saved (vaulted) payment methods above the available payment methods, both
+/// with their default Primer components.
+@available(iOS 15.0, *)
+struct VaultManagementDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Vault Management",
+            description: "Display and manage saved payment methods",
+            tags: ["VAULT", "PAYMENT_CARD"],
+            isCustom: false,
+            category: .vault
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            VaultManagementContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct VaultManagementContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Saved Payment Methods").font(.title2.weight(.bold))
+
+                switch session.phase {
+                case .initializing:
+                    ProgressView().frame(maxWidth: .infinity).padding(.top, 24)
+                case .ready:
+                    PrimerVaultedPaymentMethods()
+                    Divider()
+                    PrimerPaymentMethods()
+                }
+            }
+            .padding(16)
+        }
+        .demoCheckout(session)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/VaultModeInlineDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/VaultModeInlineDemo.swift
@@ -1,0 +1,145 @@
+//
+//  VaultModeInlineDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Vault Mode Inline — custom navigation that saves a new method: pick a method, enter card details
+/// on a dedicated screen, and show the resulting token.
+@available(iOS 15.0, *)
+struct VaultModeInlineDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Vault Mode Inline",
+            description: "Select card → enter details → token shown",
+            tags: ["VAULT", "PAYMENT_CARD"],
+            isCustom: true,
+            category: .vault
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            VaultModeInlineContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct VaultModeInlineContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+    @State private var screen: Screen = .list
+    @State private var lastToken: String?
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    private enum Screen { case list, cardForm }
+
+    var body: some View {
+        Group {
+            switch session.phase {
+            case .initializing:
+                ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .ready:
+                switch screen {
+                case .list: listScreen
+                case .cardForm: cardFormScreen
+                }
+            }
+        }
+        .primerCheckoutSession(session) { state in
+            switch state {
+            case let .success(result):
+                lastToken = result.paymentId
+                screen = .list
+            case .failure:
+                screen = .list
+            default:
+                break
+            }
+        }
+    }
+
+    private var listScreen: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Vault Mode").font(.title2.weight(.bold))
+                Text("Save a new payment method to your vault")
+                    .font(.subheadline).foregroundStyle(.secondary)
+
+                if let lastToken {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Token Created Successfully!").font(.headline).foregroundStyle(.green)
+                        Text("Token: \(lastToken.prefix(20))…").font(.caption).foregroundStyle(.secondary)
+                    }
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.green.opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+
+                Text("Select a payment method to save:").font(.headline)
+
+                PrimerPaymentMethods(method: { method, onSelect in
+                    let isCard = method.type == "PAYMENT_CARD"
+                    Button {
+                        if isCard { screen = .cardForm } else { onSelect() }
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(method.name).fontWeight(.medium)
+                                if isCard {
+                                    Text("Tap to enter card details")
+                                        .font(.caption).foregroundStyle(.secondary)
+                                }
+                            }
+                            Spacer()
+                            Text("→").font(.title3)
+                                .foregroundStyle(isCard ? Color.accentColor : .secondary)
+                        }
+                        .padding(16)
+                        .frame(maxWidth: .infinity)
+                        .background(isCard ? Color.accentColor.opacity(0.1) : Color(.secondarySystemBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.vertical, 4)
+                })
+            }
+            .padding(16)
+        }
+    }
+
+    private var cardFormScreen: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Button { screen = .list } label: {
+                    HStack {
+                        Image(systemName: "chevron.left")
+                        Text("Back to Payment Methods").fontWeight(.medium)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Enter Card Details").font(.title2.weight(.bold))
+                    Text("Your card will be saved for future payments")
+                        .font(.subheadline).foregroundStyle(.secondary)
+                }
+
+                PrimerCardForm()
+            }
+            .padding(16)
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Demos/VaultedPaymentMethodsDemo.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Demos/VaultedPaymentMethodsDemo.swift
@@ -1,0 +1,120 @@
+//
+//  VaultedPaymentMethodsDemo.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Vaulted Methods (Custom) — the default vaulted list alongside a fully custom row built through the
+/// `item` slot, reading masked card data from the vaulted method.
+@available(iOS 15.0, *)
+struct VaultedPaymentMethodsDemo: View, CheckoutComponentsDemo {
+    static var metadata: DemoMetadata {
+        DemoMetadata(
+            name: "Vaulted Methods (Custom)",
+            description: "Custom vaulted-card rows",
+            tags: ["VAULT", "PAYMENT_CARD"],
+            isCustom: true,
+            category: .vault
+        )
+    }
+
+    let configuration: DemoConfiguration
+
+    init(configuration: DemoConfiguration) {
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        DemoScaffold(configuration: configuration, title: Self.metadata.name) { clientToken in
+            VaultedPaymentMethodsContent(clientToken: clientToken, settings: configuration.settings)
+        }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct VaultedPaymentMethodsContent: View {
+    @StateObject private var session: PrimerCheckoutSession
+
+    init(clientToken: String, settings: PrimerSettings) {
+        _session = StateObject(wrappedValue: PrimerCheckoutSession(clientToken: clientToken, settings: settings))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text("Vaulted Payment Methods").font(.title2.weight(.bold))
+
+                switch session.phase {
+                case .initializing:
+                    ProgressView().frame(maxWidth: .infinity).padding(.top, 24)
+                case .ready:
+                    section("1. Default Component", "Default styling") {
+                        PrimerVaultedPaymentMethods()
+                    }
+                    section("2. Custom Rows", "Custom card UI via the item slot") {
+                        PrimerVaultedPaymentMethods(item: { method, isSelected, onSelect in
+                            AnyView(VaultedCardRow(method: method, isSelected: isSelected, onSelect: onSelect))
+                        })
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .demoCheckout(session)
+    }
+
+    private func section(_ title: String, _ subtitle: String, @ViewBuilder content: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title).font(.headline)
+            Text(subtitle).font(.caption).foregroundStyle(.secondary)
+            content()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+@available(iOS 15.0, *)
+private struct VaultedCardRow: View {
+    let method: PrimerVaultedPaymentMethods.VaultedMethod
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 12) {
+                Image(systemName: "creditcard")
+                    .font(.title2).foregroundStyle(.secondary)
+                VStack(alignment: .leading) {
+                    Text("•••• \(method.paymentInstrumentData.last4Digits ?? "****")")
+                        .fontWeight(.medium)
+                    Text(method.paymentInstrumentData.network ?? method.paymentMethodType)
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+                if let month = method.paymentInstrumentData.expirationMonth,
+                   let year = method.paymentInstrumentData.expirationYear {
+                    Text("\(month)/\(year)").font(.caption).foregroundStyle(.secondary)
+                }
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill").foregroundStyle(Color.accentColor)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity)
+            .background(Color(.systemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? Color.accentColor : .clear, lineWidth: 2)
+            )
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, 4)
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/DemoCheckout.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/DemoCheckout.swift
@@ -1,0 +1,56 @@
+//
+//  DemoCheckout.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+extension View {
+    /// Wires an inline ``PrimerCheckoutSession`` and surfaces its terminal outcome as an alert that
+    /// dismisses the demo — the minimal completion handling most inline demos need.
+    @available(iOS 15.0, *)
+    func demoCheckout(_ session: PrimerCheckoutSession) -> some View {
+        modifier(DemoCheckoutModifier(session: session))
+    }
+}
+
+@available(iOS 15.0, *)
+private struct DemoCheckoutModifier: ViewModifier {
+    let session: PrimerCheckoutSession
+    @SwiftUI.Environment(\.dismiss) private var dismiss
+    @State private var result: DemoCheckoutResult?
+
+    func body(content: Content) -> some View {
+        content
+            .primerCheckoutSession(session) { result = DemoCheckoutResult($0) }
+            .alert(result?.title ?? "", isPresented: presented, presenting: result) { _ in
+                Button("Done") { dismiss() }
+            } message: { Text($0.message) }
+    }
+
+    private var presented: Binding<Bool> {
+        Binding(get: { result != nil }, set: { if !$0 { result = nil } })
+    }
+}
+
+/// A terminal checkout outcome rendered as an alert. `nil` for non-terminal states.
+@available(iOS 15.0, *)
+private struct DemoCheckoutResult {
+    let title: String
+    let message: String
+
+    init?(_ state: PrimerCheckoutState) {
+        switch state {
+        case let .success(result):
+            title = "Payment complete"
+            message = "Payment \(result.paymentId) succeeded."
+        case let .failure(error):
+            title = "Payment failed"
+            message = error.localizedDescription
+        default:
+            return nil
+        }
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/DemoScaffold.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/DemoScaffold.swift
@@ -1,0 +1,72 @@
+//
+//  DemoScaffold.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Resolves a client token for a demo — reusing one supplied in the configuration, otherwise
+/// requesting a session — then renders the demo content inside a dismissable navigation container.
+/// Factored out so each demo only describes its checkout UI, not the loading boilerplate.
+@available(iOS 15.0, *)
+struct DemoScaffold<Content: View>: View {
+    let configuration: DemoConfiguration
+    let title: String
+    @ViewBuilder let content: (String) -> Content
+
+    @SwiftUI.Environment(\.dismiss) private var dismiss
+    @State private var clientToken: String?
+    @State private var isLoading = true
+    @State private var error: String?
+
+    var body: some View {
+        NavigationView {
+            contentView
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Cancel") { dismiss() }
+                    }
+                }
+        }
+        .task { await loadToken() }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        if isLoading {
+            LoadingView()
+        } else if let error {
+            ErrorView(error: error, onRetry: { Task { await loadToken() } })
+        } else if let clientToken {
+            content(clientToken)
+        }
+    }
+
+    private func loadToken() async {
+        isLoading = true
+        error = nil
+
+        if let existing = configuration.clientToken, !existing.isEmpty {
+            clientToken = existing
+            isLoading = false
+            return
+        }
+
+        guard let clientSession = configuration.clientSession else {
+            error = "No session configuration provided - configure a session in the main settings screen"
+            isLoading = false
+            return
+        }
+
+        do {
+            clientToken = try await NetworkingUtils.requestClientSession(body: clientSession, apiVersion: configuration.apiVersion)
+        } catch {
+            self.error = error.localizedDescription
+        }
+        isLoading = false
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/ManagedCheckoutView.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/SharedComponents/ManagedCheckoutView.swift
@@ -1,0 +1,28 @@
+//
+//  ManagedCheckoutView.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerSDK
+import SwiftUI
+
+/// Renders the managed ``PrimerCheckout`` with the given settings and theme, dismissing the demo on
+/// completion. Shared by the theme demos, which differ only by their `PrimerCheckoutTheme`.
+@available(iOS 15.0, *)
+struct ManagedCheckoutView: View {
+    let clientToken: String
+    let settings: PrimerSettings
+    let theme: PrimerCheckoutTheme
+
+    @SwiftUI.Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        PrimerCheckout(
+            clientToken: clientToken,
+            primerSettings: settings,
+            primerTheme: theme,
+            onCompletion: { _ in dismiss() }
+        )
+    }
+}

--- a/Debug App/Sources/View Controllers/CheckoutComponents/Utils/Color+DemoHex.swift
+++ b/Debug App/Sources/View Controllers/CheckoutComponents/Utils/Color+DemoHex.swift
@@ -1,0 +1,18 @@
+//
+//  Color+DemoHex.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import SwiftUI
+
+extension Color {
+    /// Creates a color from a `0xRRGGBB` integer, matching the hex literals used by the theme demos.
+    init(hex: UInt32) {
+        self.init(
+            red: Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8) & 0xFF) / 255,
+            blue: Double(hex & 0xFF) / 255
+        )
+    }
+}


### PR DESCRIPTION
# Description

[ORC-7415](https://primerapi.atlassian.net/browse/ORC-7415)

Consolidates the CheckoutComponents demo catalog into the **Debug App** instead of a separate standalone app. The Debug App's **CheckoutComponents → SwiftUI Examples** section grows from the single *Default* demo to **28 demos** covering the breadth of the CC SwiftUI surface, so the SDK can be exercised and bug-hunted from the app we already ship and build in CI.

### What's added

**28 demos**, sectioned by category in the examples list:

| Category | Demos |
|----------|-------|
| **Core** (6) | Default · Inline Checkout · Inline Card Form · Card Form Sheet · Fully Custom Card Form · Before Payment Gate |
| **Payment Methods** (4) | Payment Methods Only · Custom Payment Methods · Custom Grid · Radio Selection |
| **Vault** (4) | Vault Management · Vaulted Methods (Custom) · Vault Mode Inline · Dynamic Vault |
| **Navigation & Flows** (3) | Merchant Navigation · Custom Result Screens · Custom Navigation |
| **Themes** (11) | Custom · Red · Green · Purple · No Radius · Small/Large Sizes · Light/Bold/Large Typography · Custom Font |
| **Utility** (1) | Refresh Client Session |

They exercise every SwiftUI entry point and customization surface: managed `PrimerCheckout`, inline `PrimerCheckoutSession` + composables (`PrimerCardForm`, `PrimerPaymentMethods`, `PrimerVaultedPaymentMethods`), the low-level `PrimerCardFormSession`, slot overrides, theming via `PrimerCheckoutTheme`, the before-payment hook, and `session.refresh()`.

### How it's structured

- Each demo conforms to the existing `CheckoutComponentsDemo` protocol and is registered in `DemoRegistry`.
- A shared **`DemoScaffold`** resolves the client token (via `NetworkingUtils.requestClientSession`, reusing `DemoConfiguration.clientSession`) and hosts each demo in a dismissable navigation container — so individual demos only describe their checkout UI.
- **`demoCheckout`** modifier surfaces terminal outcomes as an alert that dismisses the demo.
- The 11 theme variants are **data-driven** via `ThemeDemos` + `ThemedManagedDemo` rather than 11 near-identical files.
- `DemoMetadata` gains a `category`, and the examples list is now sectioned by `DemoCategory`.
- All files are registered in **both** the CocoaPods (`Debug App`) and SPM (`Debug App SPM`) targets.

**No SDK changes** — this only touches the Debug App demo layer.

# Other Notes

- Demos requiring specific session config (billing, surcharge, CVV recapture, restricted networks) can use the Debug App's existing `ClientSessionRequestBody`, which already models those fields — a follow-up can wire per-demo sessions and add the remaining GA-gap demos (declines, 3DS, co-badged, etc.).
- The standalone Primer Studio scaffold is being retired now that the catalog lives here.

# Manual Testing

- `Debug App` scheme builds green on the iOS 16 simulator (0 errors); each batch was verified incrementally.
- SwiftFormat + SwiftLint clean on all new files.
- **Runtime smoke passed** on the iPhone 16 simulator: the **sectioned examples list** renders every category; a **managed themed demo** (Custom Theme) applies the purple brand / rounded corners; and an **inline demo** (Custom Result Screens) loads a client token and renders the payment-method list + card form. Both the managed and inline `DemoScaffold` paths are verified.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge


[ORC-7415]: https://primerapi.atlassian.net/browse/ORC-7415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ