### PR TITLE
fix: Validate phone numbers via lookup service (ORC-7907)

### DIFF
--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
@@ -88,6 +88,13 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
 
         let input = rawData.phoneNumber
 
+        // New input supersedes any lookup still in flight, including when it is rejected below —
+        // otherwise the old lookup lands afterwards and reports valid for a number that has gone.
+        // Clearing first also means the cancelled task no longer sees itself as current.
+        let superseded = validationTask
+        validationTask = nil
+        await superseded?.cancel(with: PrimerError.cancelled(paymentMethodType: paymentMethodType))
+
         guard !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw invalidated(PrimerValidationError.invalidPhoneNumber(message: "Phone number cannot be blank."))
         }
@@ -102,10 +109,7 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
                 paymentRequestBody: Request.Body.PhoneMetadata.PhoneMetadataDataRequest(phoneNumber: input)
             )
         }
-        // Register before cancelling, or the cancelled task still sees itself as current.
-        let superseded = validationTask
         validationTask = task
-        await superseded?.cancel(with: handled(primerError: .cancelled(paymentMethodType: paymentMethodType)))
 
         let response: Response.Body.PhoneMetadata.PhoneMetadataDataResponse
         do {

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
@@ -42,8 +42,8 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
     // string is what gets submitted, so both platforms send the same value.
     private var approvedInput: String?
 
-    // One lookup per keystroke, so responses can land out of order.
-    private var currentGeneration = 0
+    // One lookup per keystroke; the newest supersedes any still in flight.
+    private var validationTask: CancellableTask<Response.Body.PhoneMetadata.PhoneMetadataDataResponse>?
 
     required init(paymentMethodType: String) {
         self.paymentMethodType = paymentMethodType
@@ -99,23 +99,31 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
             throw invalidated(PrimerError.invalidClientToken())
         }
 
-        currentGeneration += 1
-        let generation = currentGeneration
-
-        let response: Response.Body.PhoneMetadata.PhoneMetadataDataResponse
-        do {
-            response = try await apiClient.getPhoneMetadata(
+        let task = CancellableTask {
+            try await self.apiClient.getPhoneMetadata(
                 clientToken: clientToken,
                 paymentRequestBody: Request.Body.PhoneMetadata.PhoneMetadataDataRequest(phoneNumber: input)
             )
+        }
+        // Register before cancelling: the cancelled task resumes immediately, and if it still saw
+        // itself as current it would report a verdict instead of standing down.
+        let superseded = validationTask
+        validationTask = task
+        await superseded?.cancel(with: handled(primerError: .cancelled(paymentMethodType: paymentMethodType)))
+
+        let response: Response.Body.PhoneMetadata.PhoneMetadataDataResponse
+        do {
+            response = try await task.wait()
         } catch {
-            guard generation == currentGeneration else { return }
+            // A newer keystroke replaced us, so there is no verdict to report.
+            guard validationTask === task else { return }
+            validationTask = nil
             // asPrimerError also keeps InternalError out of merchant callbacks.
             throw invalidated(error.asPrimerError)
         }
 
-        // Superseded by a newer input.
-        guard generation == currentGeneration else { return }
+        guard validationTask === task else { return }
+        validationTask = nil
 
         // Android requires the parsed parts too before treating a number as valid, even though
         // neither platform submits them.
@@ -133,11 +141,11 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
         notifyDelegateOfValidationResult(isValid: false, errors: [error])
     }
 
-    // Single specific errors are not wrapped in `underlyingErrors` — that hid error types in
-    // monitoring and was undone repo-wide in #1299.
-    private func invalidated(_ error: Error) -> Error {
+    // Generic so the concrete type survives: `asPrimerError` would turn a PrimerValidationError
+    // into PrimerError.unknown, and wrapping in `underlyingErrors` hid types in monitoring.
+    private func invalidated<E: Error>(_ error: E) -> E {
         invalidate(with: error)
-        return handled(primerError: error.asPrimerError)
+        return handled(error: error)
     }
 
     private func notifyDelegateOfValidationResult(isValid: Bool, errors: [Error]?) {

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
@@ -38,11 +38,9 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
 
     private let apiClient: PrimerAPIClientProtocol
 
-    // The input the lookup approved. Like Android, the lookup is a yes/no — the shopper's own
-    // string is what gets submitted, so both platforms send the same value.
+    // Android submits the shopper's own string too — the lookup is only a yes/no.
     private var approvedInput: String?
 
-    // One lookup per keystroke; the newest supersedes any still in flight.
     private var validationTask: CancellableTask<Response.Body.PhoneMetadata.PhoneMetadataDataResponse>?
 
     required init(paymentMethodType: String) {
@@ -68,7 +66,6 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
             throw handled(primerError: .invalidValue(key: "rawData"))
         }
 
-        // Only submit a number the lookup approved, and only while it is still what's on screen.
         guard approvedInput == rawData.phoneNumber else {
             throw handled(primerError: .invalidValue(key: "phoneNumber"))
         }
@@ -105,8 +102,7 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
                 paymentRequestBody: Request.Body.PhoneMetadata.PhoneMetadataDataRequest(phoneNumber: input)
             )
         }
-        // Register before cancelling: the cancelled task resumes immediately, and if it still saw
-        // itself as current it would report a verdict instead of standing down.
+        // Register before cancelling, or the cancelled task still sees itself as current.
         let superseded = validationTask
         validationTask = task
         await superseded?.cancel(with: handled(primerError: .cancelled(paymentMethodType: paymentMethodType)))
@@ -115,18 +111,15 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
         do {
             response = try await task.wait()
         } catch {
-            // A newer keystroke replaced us, so there is no verdict to report.
             guard validationTask === task else { return }
             validationTask = nil
-            // asPrimerError also keeps InternalError out of merchant callbacks.
             throw invalidated(error.asPrimerError)
         }
 
         guard validationTask === task else { return }
         validationTask = nil
 
-        // Android requires the parsed parts too before treating a number as valid, even though
-        // neither platform submits them.
+        // Android requires the parsed parts too, though neither platform submits them.
         guard response.isValid, response.countryCode != nil, response.nationalNumber != nil else {
             throw invalidated(PrimerValidationError.invalidPhoneNumber(message: "Phone number is not valid."))
         }
@@ -141,8 +134,7 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
         notifyDelegateOfValidationResult(isValid: false, errors: [error])
     }
 
-    // Generic so the concrete type survives: `asPrimerError` would turn a PrimerValidationError
-    // into PrimerError.unknown, and wrapping in `underlyingErrors` hid types in monitoring.
+    // Generic: `asPrimerError` would flatten a PrimerValidationError to PrimerError.unknown.
     private func invalidated<E: Error>(_ error: E) -> E {
         invalidate(with: error)
         return handled(error: error)

--- a/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/Core/PrimerHeadlessUniversalCheckout/Managers/PrimerRawPhoneNumberDataTokenizationBuilder.swift
@@ -11,7 +11,6 @@ import Foundation
 @_spi(PrimerInternal) import PrimerFoundation
 @_spi(PrimerInternal) import PrimerNetworking
 
-// MARK: MISSING_TESTS
 final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizationBuilderProtocol {
 
     var rawData: PrimerRawData? {
@@ -37,8 +36,23 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
         [.phoneNumber]
     }
 
+    private let apiClient: PrimerAPIClientProtocol
+
+    // The input the lookup approved. Like Android, the lookup is a yes/no — the shopper's own
+    // string is what gets submitted, so both platforms send the same value.
+    private var approvedInput: String?
+
+    // One lookup per keystroke, so responses can land out of order.
+    private var currentGeneration = 0
+
     required init(paymentMethodType: String) {
         self.paymentMethodType = paymentMethodType
+        apiClient = PrimerAPIClient()
+    }
+
+    init(paymentMethodType: String, apiClient: PrimerAPIClientProtocol) {
+        self.paymentMethodType = paymentMethodType
+        self.apiClient = apiClient
     }
 
     func configure(withRawDataManager rawDataManager: PrimerHeadlessUniversalCheckout.RawDataManager) {
@@ -54,6 +68,11 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
             throw handled(primerError: .invalidValue(key: "rawData"))
         }
 
+        // Only submit a number the lookup approved, and only while it is still what's on screen.
+        guard approvedInput == rawData.phoneNumber else {
+            throw handled(primerError: .invalidValue(key: "phoneNumber"))
+        }
+
         return Request.Body.Tokenization(
             paymentInstrument: OffSessionPaymentInstrument(
                 paymentMethodConfigId: paymentMethodId,
@@ -64,27 +83,61 @@ final class PrimerRawPhoneNumberDataTokenizationBuilder: PrimerRawDataTokenizati
     }
 
     func validateRawData(_ data: PrimerRawData) async throws {
-        var errors: [PrimerValidationError] = []
-
         guard let rawData = data as? PrimerPhoneNumberData else {
             let err = PrimerValidationError.invalidRawData()
-            errors.append(err)
-            notifyDelegateOfValidationResult(isValid: false, errors: errors)
+            invalidate(with: err)
             throw handled(error: err)
         }
 
-        if let paymentMethodType = PrimerPaymentMethodType(rawValue: paymentMethodType),
-           !rawData.phoneNumber.isValidPhoneNumberForPaymentMethodType(paymentMethodType) {
-            errors.append(PrimerValidationError.invalidPhoneNumber(message: "Phone number is not valid."))
+        let input = rawData.phoneNumber
+
+        guard !input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw invalidated(PrimerValidationError.invalidPhoneNumber(message: "Phone number cannot be blank."))
         }
 
-        guard errors.isEmpty else {
-            let err = PrimerError.underlyingErrors(errors: errors)
-            notifyDelegateOfValidationResult(isValid: false, errors: errors)
-            throw handled(primerError: err)
+        guard let clientToken = PrimerAPIConfigurationModule.decodedJWTToken else {
+            throw invalidated(PrimerError.invalidClientToken())
         }
+
+        currentGeneration += 1
+        let generation = currentGeneration
+
+        let response: Response.Body.PhoneMetadata.PhoneMetadataDataResponse
+        do {
+            response = try await apiClient.getPhoneMetadata(
+                clientToken: clientToken,
+                paymentRequestBody: Request.Body.PhoneMetadata.PhoneMetadataDataRequest(phoneNumber: input)
+            )
+        } catch {
+            guard generation == currentGeneration else { return }
+            // asPrimerError also keeps InternalError out of merchant callbacks.
+            throw invalidated(error.asPrimerError)
+        }
+
+        // Superseded by a newer input.
+        guard generation == currentGeneration else { return }
+
+        // Android requires the parsed parts too before treating a number as valid, even though
+        // neither platform submits them.
+        guard response.isValid, response.countryCode != nil, response.nationalNumber != nil else {
+            throw invalidated(PrimerValidationError.invalidPhoneNumber(message: "Phone number is not valid."))
+        }
+
+        approvedInput = input
 
         notifyDelegateOfValidationResult(isValid: true, errors: nil)
+    }
+
+    private func invalidate(with error: Error) {
+        approvedInput = nil
+        notifyDelegateOfValidationResult(isValid: false, errors: [error])
+    }
+
+    // Single specific errors are not wrapped in `underlyingErrors` — that hid error types in
+    // monitoring and was undone repo-wide in #1299.
+    private func invalidated(_ error: Error) -> Error {
+        invalidate(with: error)
+        return handled(primerError: error.asPrimerError)
     }
 
     private func notifyDelegateOfValidationResult(isValid: Bool, errors: [Error]?) {

--- a/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
+++ b/Sources/PrimerSDK/Classes/Extensions & Utilities/StringExtension.swift
@@ -139,21 +139,6 @@ extension String {
         return String((0..<length).map { _ in letters.randomElement()! })
     }
 
-    func isValidPhoneNumberForPaymentMethodType(_ paymentMethodType: PrimerPaymentMethodType) -> Bool {
-
-        var regex = ""
-
-        switch paymentMethodType {
-        case .xenditOvo:
-            regex = "^(^\\+628|628)(\\d{8,10})"
-        default:
-            regex = "^(^\\+)(\\d){9,14}$"
-        }
-
-        let phoneNumber = NSPredicate(format: "SELF MATCHES %@", regex)
-        return phoneNumber.evaluate(with: self)
-    }
-
     /// Validates expiry date string in MM/YY or MM/YYYY format
     /// - Throws: PrimerValidationError if the date format is invalid or the date is expired
     /// - Note: This function accepts both MM/YY and MM/YYYY formats to maintain compatibility

--- a/Tests/Primer/Extensions/StringExtensionTests.swift
+++ b/Tests/Primer/Extensions/StringExtensionTests.swift
@@ -208,25 +208,6 @@ final class StringExtensionTests: XCTestCase {
         XCTAssertEqual(string3.separate(every: 1, with: "#"), "a")
     }
 
-    func testIsValidPhoneNumberForPaymentType() {
-        // Generic case
-        XCTAssertTrue("+447890123456".isValidPhoneNumberForPaymentMethodType(.paymentCard))
-        XCTAssertTrue("+447890123456".isValidPhoneNumberForPaymentMethodType(.adyenDotPay))
-        XCTAssertTrue("+447890123456".isValidPhoneNumberForPaymentMethodType(.applePay))
-        XCTAssertTrue("+447890123456".isValidPhoneNumberForPaymentMethodType(.googlePay))
-        XCTAssertTrue("+129876543210".isValidPhoneNumberForPaymentMethodType(.googlePay))
-        XCTAssertFalse("+12987654".isValidPhoneNumberForPaymentMethodType(.googlePay))
-        XCTAssertFalse("+12987654301010101".isValidPhoneNumberForPaymentMethodType(.googlePay))
-
-        // XenditOvo (special case)
-        XCTAssertTrue("+62812345678".isValidPhoneNumberForPaymentMethodType(.xenditOvo))
-        XCTAssertTrue("+628123456789".isValidPhoneNumberForPaymentMethodType(.xenditOvo))
-        XCTAssertTrue("+6281234567890".isValidPhoneNumberForPaymentMethodType(.xenditOvo))
-        XCTAssertFalse("+62812345678901".isValidPhoneNumberForPaymentMethodType(.xenditOvo))
-        XCTAssertFalse("+6281234567".isValidPhoneNumberForPaymentMethodType(.xenditOvo))
-        XCTAssertFalse("+5281234567890".isValidPhoneNumberForPaymentMethodType(.xenditOvo))
-    }
-
     func testIsValidExpiryDateString() {
         XCTAssertThrowsError(try "".validateExpiryDateString())
         XCTAssertThrowsError(try "01/2022".validateExpiryDateString())

--- a/Tests/Primer/Managers/PrimerRawPhoneNumberDataTokenizationBuilderTests.swift
+++ b/Tests/Primer/Managers/PrimerRawPhoneNumberDataTokenizationBuilderTests.swift
@@ -14,12 +14,16 @@ import XCTest
 /// explicitly rather than by sleeping.
 private final class Gate {
     private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
 
     func wait() async {
+        // open() can land first — without this the continuation is never installed and we hang.
+        guard !isOpen else { return }
         await withCheckedContinuation { continuation = $0 }
     }
 
     func open() {
+        isOpen = true
         continuation?.resume()
         continuation = nil
     }

--- a/Tests/Primer/Managers/PrimerRawPhoneNumberDataTokenizationBuilderTests.swift
+++ b/Tests/Primer/Managers/PrimerRawPhoneNumberDataTokenizationBuilderTests.swift
@@ -1,0 +1,287 @@
+//
+//  PrimerRawPhoneNumberDataTokenizationBuilderTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+import PrimerFoundation
+@testable import PrimerSDK
+import XCTest
+@_spi(PrimerInternal) @testable import PrimerCore
+@_spi(PrimerInternal) @testable import PrimerNetworking
+
+/// Holds a mocked lookup open until the test releases it, so response ordering is controlled
+/// explicitly rather than by sleeping.
+private final class Gate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func open() {
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+final class PrimerRawPhoneNumberDataTokenizationBuilderTests: XCTestCase {
+
+    private static let paymentMethodType = "XENDIT_OVO"
+    private static let validResponse = Response.Body.PhoneMetadata.PhoneMetadataDataResponse(
+        isValid: true,
+        countryCode: "62",
+        nationalNumber: "81234567890"
+    )
+    private static let invalidResponse = Response.Body.PhoneMetadata.PhoneMetadataDataResponse(
+        isValid: false,
+        countryCode: nil,
+        nationalNumber: nil
+    )
+    private static let validNumber = "+6281234567890"
+    private static let ovoPaymentMethod = PrimerPaymentMethod(
+        id: "payment_method_id",
+        implementationType: .nativeSdk,
+        type: paymentMethodType,
+        name: "Xendit OVO",
+        processorConfigId: nil,
+        surcharge: nil,
+        options: nil,
+        displayMetadata: nil
+    )
+
+    private var mockApiClient: MockPrimerAPIClient!
+
+    override func setUp() {
+        super.setUp()
+        SDKSessionHelper.setUp(withPaymentMethods: [Self.ovoPaymentMethod])
+        mockApiClient = MockPrimerAPIClient()
+        mockApiClient.mockedNetworkDelay = 0
+        mockApiClient.getPhoneMetadataResult = .success(Self.validResponse)
+    }
+
+    override func tearDown() {
+        mockApiClient = nil
+        SDKSessionHelper.tearDown()
+        super.tearDown()
+    }
+
+    // MARK: - requiredInputElementTypes
+
+    func test_requiredInputElementTypes_shouldReturnPhoneNumberType() {
+        XCTAssertEqual(makeBuilder().requiredInputElementTypes, [.phoneNumber])
+    }
+
+    // MARK: - validateRawData
+
+    func test_validateRawData_withInvalidDataType_shouldFail() async {
+        let builder = makeBuilder()
+        let invalidRawData = PrimerOTPData(otp: "123456")
+
+        do {
+            try await builder.validateRawData(invalidRawData)
+            XCTFail("Expected validation to fail with a non-phone raw data type")
+        } catch {
+            XCTAssert(error is PrimerValidationError)
+        }
+        XCTAssertFalse(builder.isDataValid)
+    }
+
+    func test_validateRawData_withBlankNumber_shouldFailWithoutCallingLookup() async {
+        let builder = makeBuilder()
+
+        do {
+            try await builder.validateRawData(PrimerPhoneNumberData(phoneNumber: "   "))
+            XCTFail("Expected validation to fail for a blank phone number")
+        } catch {
+            // Expected
+        }
+        XCTAssertFalse(builder.isDataValid)
+        XCTAssertEqual(mockApiClient.getPhoneMetadataCallCount, 0)
+    }
+
+    func test_validateRawData_shouldLookUpTheNumberAsTyped() async throws {
+
+        try await makeBuilder().validateRawData(PrimerPhoneNumberData(phoneNumber: "+6281234567890"))
+
+        XCTAssertEqual(mockApiClient.getPhoneMetadataRequestedNumbers, ["+6281234567890"])
+    }
+
+    func test_validateRawData_whenLookupSaysValid_shouldSucceed() async throws {
+        let builder = makeBuilder()
+
+        try await builder.validateRawData(PrimerPhoneNumberData(phoneNumber: "+6281234567890"))
+
+        XCTAssertTrue(builder.isDataValid)
+    }
+
+    func test_validateRawData_whenLookupSaysInvalid_shouldFail() async {
+        mockApiClient.getPhoneMetadataResult = .success(Self.invalidResponse)
+        let builder = makeBuilder()
+
+        do {
+            try await builder.validateRawData(PrimerPhoneNumberData(phoneNumber: "+6281"))
+            XCTFail("Expected validation to fail when the lookup reports the number invalid")
+        } catch {
+            // Expected
+        }
+        XCTAssertFalse(builder.isDataValid)
+    }
+
+    func test_validateRawData_whenLookupIsValidButPartsMissing_shouldFail() async {
+        mockApiClient.getPhoneMetadataResult = .success(.init(isValid: true, countryCode: nil, nationalNumber: nil))
+        let builder = makeBuilder()
+
+        do {
+            try await builder.validateRawData(PrimerPhoneNumberData(phoneNumber: "+6281234567890"))
+            XCTFail("Expected validation to fail when the lookup returns no parsed number")
+        } catch {
+            // Expected
+        }
+        XCTAssertFalse(builder.isDataValid)
+    }
+
+    func test_validateRawData_whenLookupFails_shouldThrow() async {
+        mockApiClient.getPhoneMetadataResult = .failure(PrimerError.unknown(message: "network down"))
+        let builder = makeBuilder()
+
+        do {
+            try await builder.validateRawData(PrimerPhoneNumberData(phoneNumber: "+6281234567890"))
+            XCTFail("Expected the lookup failure to propagate")
+        } catch {
+            XCTAssert(error is PrimerError)
+        }
+    }
+
+    // MARK: - makeRequestBodyWithRawData
+
+    // Android submits the shopper's own string, so iOS must too — the lookup is only a yes/no.
+    func test_makeRequestBody_shouldSubmitTheApprovedInputVerbatim() async throws {
+        let builder = makeBuilder()
+        let typed = "+62 812 3456 7890"
+        let rawData = PrimerPhoneNumberData(phoneNumber: typed)
+
+        try await builder.validateRawData(rawData)
+        let requestBody = try await builder.makeRequestBodyWithRawData(rawData)
+
+        XCTAssertEqual(submittedPhoneNumber(in: requestBody), typed)
+    }
+
+    func test_makeRequestBody_withoutPriorValidation_shouldThrow() async {
+        let builder = makeBuilder()
+
+        do {
+            _ = try await builder.makeRequestBodyWithRawData(PrimerPhoneNumberData(phoneNumber: "+6281234567890"))
+            XCTFail("Expected failure when no verified number is held")
+        } catch {
+            XCTAssert(error is PrimerError)
+        }
+    }
+
+    func test_makeRequestBody_whenInputChangedAfterValidation_shouldThrow() async throws {
+        let builder = makeBuilder()
+        try await builder.validateRawData(PrimerPhoneNumberData(phoneNumber: "+6281234567890"))
+
+        do {
+            _ = try await builder.makeRequestBodyWithRawData(PrimerPhoneNumberData(phoneNumber: "+6289999999999"))
+            XCTFail("Expected failure when the verified number belongs to different input")
+        } catch {
+            guard case let PrimerError.invalidValue(key, _, _, _) = error else {
+                return XCTFail("Expected invalidValue, got \(error)")
+            }
+            XCTAssertEqual(key, "phoneNumber")
+        }
+    }
+
+    // The older lookup answers last; its verdict must not win.
+    func test_supersededLookupFailure_shouldNotOverwriteNewerSuccess() async throws {
+        let partial = "+6281"
+        let staleGate = Gate()
+        let staleStarted = expectation(description: "superseded lookup reached the network")
+        mockApiClient.getPhoneMetadataHandler = { number in
+            guard number == partial else {
+                return Self.validResponse
+            }
+            staleStarted.fulfill()
+            await staleGate.wait()
+            return Self.invalidResponse
+        }
+        let builder = makeBuilder()
+        let completeData = PrimerPhoneNumberData(phoneNumber: Self.validNumber)
+
+        let stale = Task { try? await builder.validateRawData(PrimerPhoneNumberData(phoneNumber: partial)) }
+        await fulfillment(of: [staleStarted], timeout: 2)
+
+        try await builder.validateRawData(completeData)
+        XCTAssertTrue(builder.isDataValid)
+
+        staleGate.open()
+        _ = await stale.value
+
+        XCTAssertTrue(builder.isDataValid, "A superseded lookup must not flip validity")
+        let requestBody = try await builder.makeRequestBodyWithRawData(completeData)
+        XCTAssertEqual(submittedPhoneNumber(in: requestBody), Self.validNumber)
+    }
+
+    func test_lookupFailureAfterSuccess_shouldDiscardVerifiedNumber() async throws {
+        let builder = makeBuilder()
+        let rawData = PrimerPhoneNumberData(phoneNumber: Self.validNumber)
+        try await builder.validateRawData(rawData)
+        XCTAssertTrue(builder.isDataValid)
+
+        mockApiClient.getPhoneMetadataResult = .failure(PrimerError.unknown(message: "network down"))
+        try? await builder.validateRawData(rawData)
+
+        XCTAssertFalse(builder.isDataValid)
+        do {
+            _ = try await builder.makeRequestBodyWithRawData(rawData)
+            XCTFail("Expected failure after the verified number was discarded")
+        } catch {
+            XCTAssert(error is PrimerError)
+        }
+    }
+
+    func test_makeRequestBody_withInvalidDataType_shouldFail() async {
+        let builder = makeBuilder()
+
+        do {
+            _ = try await builder.makeRequestBodyWithRawData(PrimerOTPData(otp: "123456"))
+            XCTFail("Expected failure when raw data is not a phone number")
+        } catch {
+            XCTAssert(error is PrimerError)
+        }
+    }
+
+    func test_makeRequestBody_withUnknownPaymentMethodType_shouldFail() async {
+        let builder = PrimerRawPhoneNumberDataTokenizationBuilder(
+            paymentMethodType: "NOT_A_PAYMENT_METHOD",
+            apiClient: mockApiClient
+        )
+
+        do {
+            _ = try await builder.makeRequestBodyWithRawData(PrimerPhoneNumberData(phoneNumber: "+6281234567890"))
+            XCTFail("Expected failure for an unknown payment method type")
+        } catch {
+            XCTAssert(error is PrimerError)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeBuilder() -> PrimerRawPhoneNumberDataTokenizationBuilder {
+        PrimerRawPhoneNumberDataTokenizationBuilder(
+            paymentMethodType: Self.paymentMethodType,
+            apiClient: mockApiClient
+        )
+    }
+
+    private func submittedPhoneNumber(in requestBody: Request.Body.Tokenization) -> String? {
+        guard let instrument = requestBody.paymentInstrument as? OffSessionPaymentInstrument,
+              let sessionInfo = instrument.sessionInfo as? InputPhonenumberSessionInfo else {
+            XCTFail("Expected an OffSessionPaymentInstrument carrying InputPhonenumberSessionInfo")
+            return nil
+        }
+        return sessionInfo.phoneNumber
+    }
+
+}

--- a/Tests/Primer/Managers/PrimerRawPhoneNumberDataTokenizationBuilderTests.swift
+++ b/Tests/Primer/Managers/PrimerRawPhoneNumberDataTokenizationBuilderTests.swift
@@ -195,6 +195,37 @@ final class PrimerRawPhoneNumberDataTokenizationBuilderTests: XCTestCase {
         }
     }
 
+    // Rejecting locally must still supersede the in-flight lookup, or it lands afterwards and
+    // reports valid for a number the shopper has already cleared.
+    func test_clearingFieldMidLookup_shouldNotBeReValidatedByIt() async throws {
+        let gate = Gate()
+        let started = expectation(description: "lookup reached the network")
+        mockApiClient.getPhoneMetadataHandler = { _ in
+            started.fulfill()
+            await gate.wait()
+            return Self.validResponse
+        }
+        let builder = makeBuilder()
+        let typed = PrimerPhoneNumberData(phoneNumber: Self.validNumber)
+
+        let inFlight = Task { try? await builder.validateRawData(typed) }
+        await fulfillment(of: [started], timeout: 2)
+
+        try? await builder.validateRawData(PrimerPhoneNumberData(phoneNumber: ""))
+        XCTAssertFalse(builder.isDataValid)
+
+        gate.open()
+        _ = await inFlight.value
+
+        XCTAssertFalse(builder.isDataValid, "A cleared field must not be re-validated by the old lookup")
+        do {
+            _ = try await builder.makeRequestBodyWithRawData(typed)
+            XCTFail("Expected submit to be refused after the field was cleared")
+        } catch {
+            XCTAssert(error is PrimerError)
+        }
+    }
+
     // The older lookup answers last; its verdict must not win.
     func test_supersededLookupFailure_shouldNotOverwriteNewerSuccess() async throws {
         let partial = "+6281"

--- a/Tests/Primer/Managers/PrimerRawPhoneNumberDataTokenizationBuilderTests.swift
+++ b/Tests/Primer/Managers/PrimerRawPhoneNumberDataTokenizationBuilderTests.swift
@@ -10,14 +10,13 @@ import XCTest
 @_spi(PrimerInternal) @testable import PrimerCore
 @_spi(PrimerInternal) @testable import PrimerNetworking
 
-/// Holds a mocked lookup open until the test releases it, so response ordering is controlled
-/// explicitly rather than by sleeping.
+/// Holds a mocked lookup open so response ordering is explicit rather than timing-based.
 private final class Gate {
     private var continuation: CheckedContinuation<Void, Never>?
     private var isOpen = false
 
     func wait() async {
-        // open() can land first — without this the continuation is never installed and we hang.
+        // open() can land first; without this we never install the continuation and hang.
         guard !isOpen else { return }
         await withCheckedContinuation { continuation = $0 }
     }
@@ -105,7 +104,6 @@ final class PrimerRawPhoneNumberDataTokenizationBuilderTests: XCTestCase {
     }
 
     func test_validateRawData_shouldLookUpTheNumberAsTyped() async throws {
-
         try await makeBuilder().validateRawData(PrimerPhoneNumberData(phoneNumber: "+6281234567890"))
 
         XCTAssertEqual(mockApiClient.getPhoneMetadataRequestedNumbers, ["+6281234567890"])

--- a/Tests/Utilities/Mocks/Services/MockAPIClient.swift
+++ b/Tests/Utilities/Mocks/Services/MockAPIClient.swift
@@ -41,6 +41,10 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
     private var currentPollingIteration: Int = 0
     var fetchNolSdkSecretResult: (() -> Result<Response.Body.NolPay.NolPaySecretDataResponse, Error>)?
     var getPhoneMetadataResult: Result<Response.Body.PhoneMetadata.PhoneMetadataDataResponse, Error>?
+    // Per-number response and timing, for forcing lookups to answer out of order.
+    var getPhoneMetadataHandler: ((String) async throws -> Response.Body.PhoneMetadata.PhoneMetadataDataResponse)?
+    private(set) var getPhoneMetadataRequestedNumbers: [String] = []
+    var getPhoneMetadataCallCount: Int { getPhoneMetadataRequestedNumbers.count }
     var sdkCompleteUrlResult: (Response.Body.Complete?, Error?)?
     var responseHeaders: [String: String]?
 
@@ -1067,13 +1071,19 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
         clientToken: DecodedJWTToken,
         paymentRequestBody: Request.Body.PhoneMetadata.PhoneMetadataDataRequest
     ) async throws -> Response.Body.PhoneMetadata.PhoneMetadataDataResponse {
+        getPhoneMetadataRequestedNumbers.append(paymentRequestBody.phoneNumber)
+
+        try await Task.sleep(nanoseconds: UInt64(mockedNetworkDelay * 1_000_000_000))
+
+        if let getPhoneMetadataHandler {
+            return try await getPhoneMetadataHandler(paymentRequestBody.phoneNumber)
+        }
+
         guard let result = getPhoneMetadataResult else {
-            XCTAssert(false, "Set 'getPhoneMetadataResult' on your MockPrimerAPIClient")
+            XCTAssert(false, "Set 'getPhoneMetadataResult' or 'getPhoneMetadataHandler' on your MockPrimerAPIClient")
             throw NSError(domain: "MockPrimerAPIClient", code: 1, userInfo: nil)
         }
 
-        try await Task.sleep(nanoseconds: UInt64(mockedNetworkDelay * 1_000_000_000))
-        
         switch result {
         case let .success(success): return success
         case let .failure(failure): throw failure


### PR DESCRIPTION
# Description

ORC-7907

Phone numbers for OVO and MB WAY were checked against a regex hardcoded in the SDK. It capped the length at a guessed value, so a valid longer Indonesian mobile was refused outright — `+62812345678901` could not be paid with. It also required the number to look Indonesian, which is the backend's call rather than the client's.

Validity now comes from `/phone-number-lookups/`, the same service Android already uses. The shopper's own string is what gets submitted, so both platforms send the same value.

`isValidPhoneNumberForPaymentMethodType` and its test are deleted — nothing else used it.

# Other Notes

Two details worth a reviewer's eye:

- `validateRawData` is now async and hits the network. It fires once per keystroke via `rawData.didSet`, and those responses can land out of order, so each lookup carries a generation token and a superseded answer is dropped rather than allowed to overwrite a newer one. Without that, a late "invalid" for a half-typed number wiped a good result and showed an error under a correct number.
- The approved value is stored tagged with the input it came from. `makeRequestBodyWithRawData` throws unless that tag still matches what is on screen, so a number the lookup never approved cannot be submitted.

Deliberately **not** included, for discussion rather than omission:

- **No debounce.** Both existing remote validators debounce (`NolPayPhoneMetadataService` 0.275s on this same endpoint, `CardValidationService` 0.35s). This one does not, to match Android, which also validates per keystroke. That decision means one request per character.
- **No country restriction.** The old regex enforced Indonesian numbers for OVO. Whether a number is a real OVO account is the backend's call, so it is gone. A non-Indonesian number now passes client-side validation, as it already did on Android.
- **`0812…` still fails**, on both platforms. Neither SDK converts a local number to international form and the lookup cannot infer a country without a leading `+`. Only `+628…` works. Not fixed here — nobody has reported it, and the clean fix is the lookup accepting a country rather than each SDK guessing dialling rules.

Found by driving the simulator, and fixed here rather than left as notes:

- **A cancelled lookup reported a verdict.** The cancelled task's `catch` could run before the replacement was registered, so it still saw itself as current and pushed `dataIsValid: false` with a meaningless `cancelled` error. Every superseded keystroke did this.
- **Rejecting locally did not supersede the lookup in flight.** Clearing the field returned before `validationTask` was touched, so the previous number's lookup landed afterwards, set `approvedInput` and reported valid — on an empty field. Submit was then accepted for a number no longer on screen. Both are pinned by tests that fail if the guards are removed.
- **Superseded lookups logged error-severity analytics.** `.cancelled` is not in `shouldFilterError` and severity defaults to `.error`, so with no debounce each keystroke that superseded a lookup wrote an error event to disk. The cancellation no longer goes through `handled()`.

Two things found by driving the simulator that are worth a reviewer's judgement rather than a silent fix:

- **The lookup accepts trailing junk.** `+628789789789go` comes back `isValid: true, countryCode: 62` — it parses the leading digits and ignores the rest. Because the shopper's string is submitted verbatim, those letters reach tokenization. The old regex refused anything non-numeric, so this is new. Android behaves the same way, so it is parity, but on something neither platform handles well. Stripping non-phone characters before submitting would fix it and diverge from Android.
- **Cancellation does not reach the network.** Superseded lookups are cancelled so their verdict is discarded, but `DefaultNetworkService`'s async wrapper drops the `PrimerCancellable` the dispatcher returns, so the HTTP request still runs to completion. Making that actually cancel is a change in the API client, not here.

One thing to raise separately: because the number sits in the URL path, it now reaches analytics events, which are stored on disk and uploaded. Every recipient already has the number, so this is data governance rather than a vulnerability, but URLs fan out into access and APM logs.

# Manual Testing

Sandbox ID/IDR session via RN Checkout Components, iOS 26.5 simulator:

| Input | Result |
| --- | --- |
| `+6281234567890` | approved, submitted verbatim, tokenized, payment created |
| `+62812345678901` | approved — **the old regex rejected this** |
| `+6281` | rejected, error shown, Pay stays disabled |
| `081234567890` | rejected (unchanged, see above) |

Payments then fail at the processor because the numbers are fictitious and Xendit's sandbox approves OVO through a mock connector URL, not the phone number.

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added

