### PR TITLE
fix: Resolve flaky unit tests and their root causes

### DIFF
--- a/Modules/PrimerNetworking/Sources/PrimerNetworking/Classes/PollingModule.swift
+++ b/Modules/PrimerNetworking/Sources/PrimerNetworking/Classes/PollingModule.swift
@@ -95,6 +95,7 @@ protocol Module {
                 } else {
                     let err = PrimerError.unknown(message: "Received unexpected polling status for id '\(res.id)'")
                     ErrorHandler.handle(error: err)
+                    completion(nil, err)
                 }
             case let .failure(err):
                 ErrorHandler.handle(error: err)

--- a/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
+++ b/Sources/PrimerSDK/Classes/Core/Analytics/AnalyticsService.swift
@@ -147,7 +147,15 @@ extension Analytics {
 
             let remainingEvents = storage.loadEvents()
             logger.debug(message: "📚 Analytics: \(syncType.capitalized) completed. \(remainingEvents.count) events remain")
-            if remainingEvents.count >= batchSize { try? await sync(events: remainingEvents) }
+            // Only recurse when this pass actually drained something: a send can report
+            // success without deleting (events needing a client token when none is set),
+            // and recursing on an unchanged store would never terminate.
+            if remainingEvents.count >= batchSize, remainingEvents.count < events.count {
+                // Release the flag we took, or the recursive call trips its own guard
+                // and no-ops. A flush never took it, so it must not clear it either.
+                if !isFlush { isSyncing = false }
+                try? await sync(events: remainingEvents)
+            }
         }
 
         func clear() {

--- a/Tests/Klarna/KlarnaTokenizationComponentTests.swift
+++ b/Tests/Klarna/KlarnaTokenizationComponentTests.swift
@@ -18,6 +18,10 @@
             ErrorHandler.fire = { Analytics.Service.fire(event: Analytics.event(for: $0)) }
         }
 
+        override class func tearDown() {
+            ErrorHandler.fire = nil
+        }
+
         override func setUp() {
             super.setUp()
             paymentMethod = Mocks.PaymentMethods.klarnaPaymentMethod

--- a/Tests/Primer/Analytics/AnalyticsServiceTests.swift
+++ b/Tests/Primer/Analytics/AnalyticsServiceTests.swift
@@ -15,6 +15,7 @@ final class AnalyticsServiceTests: XCTestCase {
     var storage: MockAnalyticsStorage!
 
     override func setUp() {
+        PrimerAPIConfigurationModule.clientToken = nil
         apiClient = MockPrimerAPIAnalyticsClient()
         storage = MockAnalyticsStorage()
         sut = Analytics.Service(
@@ -220,17 +221,13 @@ final class AnalyticsServiceTests: XCTestCase {
             expectation.fulfill()
         }
 
-        let expectation2 = self.expectation(description: "Wait for all events to be sent")
-        Task {
-            do {
-                try await sendEvents(numberOfEvents: 5, eventType: .sdkEvent)
-                try await sendEvents(numberOfEvents: 5, eventType: .sdkEvent)
-                try await sendEvents(numberOfEvents: 5, eventType: .sdkEvent)
-            } catch {}
-            expectation2.fulfill()
+        // Batches stay below the auto-sync threshold; the awaited flush() makes each failure deterministic
+        for _ in 0 ..< 3 {
+            try? await sendEvents(numberOfEvents: 4, eventType: .sdkEvent)
+            try? await sut.flush()
         }
 
-        await fulfillment(of: [expectation, expectation2], timeout: 60.0)
+        await fulfillment(of: [expectation], timeout: 60.0)
 
         XCTAssertEqual(storage.loadEvents().count, 0, "Expected all events to be purged after failures.")
     }

--- a/Tests/Primer/Analytics/AnalyticsStorageTests.swift
+++ b/Tests/Primer/Analytics/AnalyticsStorageTests.swift
@@ -12,7 +12,9 @@ final class AnalyticsStorageTests: XCTestCase {
 
     var storage: Analytics.Storage!
 
-    let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("analytics")
+    // Unique temp file per test — other tests write to the production analytics file
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("analytics-tests-\(UUID().uuidString)")
 
     let events: [StoredEvent] = [
         .sdk(.message(message: "Test #1", messageType: .other, severity: .info)),
@@ -25,6 +27,7 @@ final class AnalyticsStorageTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        storage.deleteAnalyticsFile()
         storage = nil
     }
 

--- a/Tests/Primer/Banks/BanksTokenizationComponentTests.swift
+++ b/Tests/Primer/Banks/BanksTokenizationComponentTests.swift
@@ -83,6 +83,7 @@ final class BanksTokenizationComponentTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        PollingModule.apiClient = nil
         PrimerHeadlessUniversalCheckout.current.delegate = nil
         delegate = nil
         validationDelegate = nil

--- a/Tests/Primer/Errors/ErrorHandlerTests.swift
+++ b/Tests/Primer/Errors/ErrorHandlerTests.swift
@@ -21,6 +21,7 @@ final class ErrorHandlerTests: XCTestCase {
 
     override func tearDown() {
         sut = nil
+        ErrorHandler.fire = nil
         super.tearDown()
     }
 

--- a/Tests/Primer/Managers/RawDataManagerTests.swift
+++ b/Tests/Primer/Managers/RawDataManagerTests.swift
@@ -38,6 +38,7 @@ final class RawDataManagerTests: XCTestCase {
     override func tearDownWithError() throws {
         sut = nil
         rawDataManagerDelegate = nil
+        PollingModule.apiClient = nil
 
         SDKSessionHelper.tearDown()
     }

--- a/Tests/Primer/Modules/PollingModuleTests.swift
+++ b/Tests/Primer/Modules/PollingModuleTests.swift
@@ -10,11 +10,18 @@ import PrimerFoundation
 import XCTest
 
 class PollingModuleTests: XCTestCase {
+    override func tearDown() {
+        PollingModule.apiClient = nil
+        PrimerAPIConfigurationModule.clientToken = nil
+        super.tearDown()
+    }
+
     func test_start_withValidTokenAndSuccessfulPolling_shouldSucceed() async throws {
         // Given
         PrimerAPIConfigurationModule.clientToken = MockAppState.mockClientToken
 
         let mockApiClient = MockPrimerAPIClient()
+        mockApiClient.mockedNetworkDelay = 0
         mockApiClient.pollingResults = [
             (PollingResponse(status: .pending, id: "0", source: "src"), nil),
             (PollingResponse(status: .pending, id: "0", source: "src"), nil),
@@ -38,6 +45,7 @@ class PollingModuleTests: XCTestCase {
         PrimerAPIConfigurationModule.clientToken = MockAppState.mockClientToken
 
         let mockApiClient = MockPrimerAPIClient()
+        mockApiClient.mockedNetworkDelay = 0
         mockApiClient.pollingResults = [
             (PollingResponse(status: .pending, id: "0", source: "src"), nil),
             (nil, NSError(domain: "dummy-network-error", code: 100)),
@@ -59,6 +67,7 @@ class PollingModuleTests: XCTestCase {
     func test_start_withMissingClientToken_shouldFail() async throws {
         // Given
         let mockApiClient = MockPrimerAPIClient()
+        mockApiClient.mockedNetworkDelay = 0
         mockApiClient.pollingResults = [
             (PollingResponse(status: .pending, id: "0", source: "src"), nil),
             (PollingResponse(status: .pending, id: "0", source: "src"), nil),

--- a/Tests/Primer/Modules/PrimerAPIConfigurationModuleTests.swift
+++ b/Tests/Primer/Modules/PrimerAPIConfigurationModuleTests.swift
@@ -9,8 +9,20 @@ import XCTest
 @_spi(PrimerInternal) import PrimerNetworking
 
 class PrimerAPIConfigurationModuleTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        resetGlobalState()
+    }
+
     override func tearDown() {
+        resetGlobalState()
+        super.tearDown()
+    }
+
+    private func resetGlobalState() {
         ConfigurationCache.shared.clearCache()
+        PrimerAPIConfigurationModule.resetSession()
+        PrimerAPIConfigurationModule.apiClient = nil
     }
 
     /// Tests that `setupSession` succeeds when provided with a valid configuration.
@@ -433,6 +445,7 @@ extension MockPrimerAPIClient {
     convenience init(responseHeaders: [String: String]) {
         self.init()
         self.responseHeaders = responseHeaders
+        self.mockedNetworkDelay = 0
     }
 }
 

--- a/Tests/Utilities/Mocks/Services/MockAPIClient.swift
+++ b/Tests/Utilities/Mocks/Services/MockAPIClient.swift
@@ -656,6 +656,10 @@ class MockPrimerAPIClient: PrimerAPIClientProtocol {
         }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + mockedNetworkDelay) {
+            guard self.currentPollingIteration < pollingResults.count else {
+                XCTAssert(false, "MockPrimerAPIClient.poll called after 'pollingResults' were exhausted")
+                return completion(.failure(NSError(domain: "MockPrimerAPIClient", code: 2, userInfo: nil)))
+            }
             let pollingResult = pollingResults[self.currentPollingIteration]
             self.currentPollingIteration += 1
 


### PR DESCRIPTION
# Description

Fixes the root causes behind several long-flaky unit tests, two of which are production bugs:

- **AnalyticsService**: the batch catch-up sync never ran — it executed while its own `isSyncing` flag was still set, so it tripped its guard and no-op'd. Events past the first batch could sit in storage indefinitely. Now the flag is released before the catch-up call. This was the mechanism behind the 30s timeout burns in `testSendFailurePurgeAllEvents` / `testComplexMultiBatchFastSend`.
- **PollingModule**: an unexpected polling status logged an error and never called `completion`, leaving `await start()` suspended forever. Ported the `completion(nil, err)` fix from `bn/feature/checkout-components`, which also removes a divergence between the branches.

Test-side, the flakes were shared mutable state that nothing reset:

- `PollingModule.apiClient` was set by three test classes with no teardown — a later polling test reused the exhausted mock and crashed the runner via index-out-of-range. Teardowns added, and the mock is now bounds-checked so this fails one test instead of the process.
- `ErrorHandler.fire` was set by two classes and never cleared — every handled error in later tests wrote analytics to the real file and real network client. Teardowns added.
- `AnalyticsStorageTests` used the production analytics file (`documents/analytics`); now a per-test temp file.
- `PrimerAPIConfigurationModuleTests` now resets cache/session/apiClient in both setUp and tearDown, and drops the 0.5s mocked network delay.
- `testSendFailurePurgeAllEvents` now drives exactly three failures through awaited `flush()` calls instead of racing fire-and-forget threshold syncs.

No breaking changes.

Verification: full suite ×4 (923 passed, 0 failures, 0 crashes each) and the affected classes ×5 in isolation.

# Other Notes

- Companion PR #1852 (independent, either merge order): moves the SDK file cache into `Library/Caches/primer/` and fixes the base64 write path plus `ImageManager.clean()` deleting host-app PNGs.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)
