### PR TITLE
fix: Move SDK file cache into Library/Caches/primer

### DIFF
--- a/Modules/PrimerCore/Sources/PrimerCore/Models/File.swift
+++ b/Modules/PrimerCore/Sources/PrimerCore/Models/File.swift
@@ -18,18 +18,24 @@ public typealias FileExtension = String
 
 @_spi(PrimerInternal) open class File: LogReporter {
 
+    /// Directory holding all SDK-cached files, namespaced away from the host app's data.
+    /// Lives under Caches: the contents are re-downloadable and should not be backed up.
+    public static var cacheDirectoryUrl: URL? {
+        FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("primer", isDirectory: true)
+    }
+
     public var fileName: FileName
     public var fileExtension: FileExtension?
     public var localUrl: URL? {
-        guard let documentDirectoryUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else { return nil }
+        guard let cacheDirectoryUrl = Self.cacheDirectoryUrl else { return nil }
 
         var tmpFilename: String = self.fileName
         if let fileExtension = self.fileExtension {
             tmpFilename += "." + fileExtension
         }
 
-        let fileLocalUrl = documentDirectoryUrl.appendingPathComponent(tmpFilename)
-        return fileLocalUrl
+        return cacheDirectoryUrl.appendingPathComponent(tmpFilename)
     }
     public private(set) var remoteUrl: URL?
     private var base64Data: Data?
@@ -51,21 +57,18 @@ public typealias FileExtension = String
         self.base64Data = base64Data
 
         if let base64Data = self.base64Data,
-           let documentDirectoryUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+           let localUrl {
             do {
-                var tmpFilename: String = self.fileName
-                if let fileExtension = self.fileExtension {
-                    tmpFilename += "." + fileExtension
-                }
-
-                let fileLocalUrl = documentDirectoryUrl
-                    .appendingPathComponent("primer", isDirectory: true)
-                    .appendingPathComponent(tmpFilename)
-                try base64Data.write(to: fileLocalUrl)
-
+                Self.ensureCacheDirectoryExists()
+                try base64Data.write(to: localUrl)
             } catch {
                 logger.error(message: "Write failed")
             }
         }
+    }
+
+    public static func ensureCacheDirectoryExists() {
+        guard let url = cacheDirectoryUrl else { return }
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     }
 }

--- a/Sources/PrimerSDK/Classes/Modules/Downloader.swift
+++ b/Sources/PrimerSDK/Classes/Modules/Downloader.swift
@@ -66,6 +66,7 @@ final class Downloader: NSObject, DownloaderModule {
     }
 
     private func downloadData(from url: URL, to localUrl: URL) async throws {
+        File.ensureCacheDirectoryExists()
         let session = URLSession.shared
         session.configuration.urlCache = URLCache.shared
         let request = URLRequest(url: url, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 2)

--- a/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
+++ b/Sources/PrimerSDK/Classes/Modules/ImageManager.swift
@@ -210,18 +210,16 @@ final class ImageManager: LogReporter {
     }
 
     static func clean() {
-        guard let documentDirectoryUrl = FileManager.default.urls(
-            for: .documentDirectory,
-            in: .userDomainMask
-        ).first
+        guard let cacheDirectoryUrl = File.cacheDirectoryUrl,
+              FileManager.default.fileExists(atPath: cacheDirectoryUrl.path)
         else { return }
-        let documentsPath = documentDirectoryUrl.path
+        let cachePath = cacheDirectoryUrl.path
 
         do {
-            let fileNames = try FileManager.default.contentsOfDirectory(atPath: "\(documentsPath)")
+            let fileNames = try FileManager.default.contentsOfDirectory(atPath: cachePath)
 
             for fileName in fileNames where fileName.hasSuffix(".png") {
-                let filePathName = "\(documentsPath)/\(fileName)"
+                let filePathName = "\(cachePath)/\(fileName)"
                 try FileManager.default.removeItem(atPath: filePathName)
             }
 

--- a/Tests/Primer/Modules/ImageManagerTests.swift
+++ b/Tests/Primer/Modules/ImageManagerTests.swift
@@ -57,68 +57,71 @@ final class ImageManagerTests: XCTestCase {
     }
     
     func testGetImage_WithCachedImage() async throws {
-        var imageFile = ImageFile(
-            fileName: "test-image",
+        guard let testImage = UIImage(systemName: "star"),
+              let imageData = testImage.pngData() else {
+            return XCTFail("Could not create test image data")
+        }
+
+        // base64Data is written to localUrl on init, so getImage returns the cache without network
+        let imageFile = ImageFile(
+            fileName: "test-image-\(UUID().uuidString)",
             fileExtension: "png",
-            remoteUrl: URL(string: "https://example.com/image.png")
+            remoteUrl: URL(string: "https://example.com/image.png"),
+            base64Data: imageData
         )
-        
-        // Create with base64 data to simulate cached image
-        if let testImage = UIImage(systemName: "star"),
-           let imageData = testImage.pngData()
-        {
-            imageFile = ImageFile(
-                fileName: imageFile.fileName,
-                fileExtension: imageFile.fileExtension,
-                remoteUrl: imageFile.remoteUrl,
-                base64Data: imageData
-            )
+        defer {
+            if let localUrl = imageFile.localUrl {
+                try? FileManager.default.removeItem(at: localUrl)
+            }
         }
-        
-        do {
-            _ = try await sut.getImage(file: imageFile)
-        } catch {
-            // Expected to fail without proper mocking
-        }
+
+        XCTAssertNotNil(imageFile.cachedImage, "base64Data should be readable back as the cached image")
+
+        let result = try await sut.getImage(file: imageFile)
+        XCTAssertNotNil(result.cachedImage)
     }
     
     // MARK: - clean Tests
     
     func testClean_RemovesPNGFiles() {
-        // Create a test PNG file in documents directory
-        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            XCTFail("Could not get documents directory")
+        guard let cacheURL = File.cacheDirectoryUrl,
+              let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            XCTFail("Could not get cache/documents directory")
             return
         }
-        
-        let testFileName = "test-image-\(UUID().uuidString).png"
-        let testFileURL = documentsURL.appendingPathComponent(testFileName)
-        
-        // Create test file
+        File.ensureCacheDirectoryExists()
+
+        let cachedFileURL = cacheURL.appendingPathComponent("test-image-\(UUID().uuidString).png")
+        let hostAppFileURL = documentsURL.appendingPathComponent("host-image-\(UUID().uuidString).png")
+
         let testData = Data("test".utf8)
         do {
-            try testData.write(to: testFileURL)
-            XCTAssertTrue(FileManager.default.fileExists(atPath: testFileURL.path))
-            
-            // Clean
+            try testData.write(to: cachedFileURL)
+            try testData.write(to: hostAppFileURL)
+
             ImageManager.clean()
-            
-            // Verify file is removed
-            XCTAssertFalse(FileManager.default.fileExists(atPath: testFileURL.path))
+
+            // SDK cache is swept
+            XCTAssertFalse(FileManager.default.fileExists(atPath: cachedFileURL.path))
+            // The host app's own files are out of bounds
+            XCTAssertTrue(FileManager.default.fileExists(atPath: hostAppFileURL.path))
+
+            try FileManager.default.removeItem(at: hostAppFileURL)
         } catch {
             XCTFail("Failed to create test file: \(error)")
         }
     }
     
     func testClean_DoesNotRemoveNonPNGFiles() {
-        // Create a test non-PNG file in documents directory
-        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            XCTFail("Could not get documents directory")
+        // Create a test non-PNG file in the SDK cache directory
+        guard let cacheURL = File.cacheDirectoryUrl else {
+            XCTFail("Could not get cache directory")
             return
         }
-        
+        File.ensureCacheDirectoryExists()
+
         let testFileName = "test-file-\(UUID().uuidString).txt"
-        let testFileURL = documentsURL.appendingPathComponent(testFileName)
+        let testFileURL = cacheURL.appendingPathComponent(testFileName)
         
         // Create test file
         let testData = Data("test".utf8)


### PR DESCRIPTION
# Description

Stacked on #1851 — merge that one first. This PR's own diff is the last commit (4 files); it sits on #1851 because `AnalyticsStorageTests` is flaky on master (it uses the production analytics file) and #1851 is what fixes it.

The SDK caches downloaded payment-method images loose in the host app's documents directory. Three problems:

- **The base64 write path is broken.** `File.init(base64Data:)` writes to a `primer/` subdirectory of documents that is never created, so the write fails silently, while `localUrl`/`data` read from the documents root. Icons delivered inline as base64 (via `ImageFileProcessor`) therefore never cache. The download path was unaffected — it writes to `localUrl` and reads back correctly.
- **Filename collisions with the host app.** Cache filenames are unscoped in a directory the host app also owns, and `Downloader` returns early when a file already exists — so a host-app file of the same name can be served as a cached SDK image.
- **`ImageManager.clean()` deletes every `.png` in the documents directory**, including files the SDK does not own. Latent today: `ImageManager` is internal and nothing calls `clean()` outside tests — but it is a loaded gun.

Documents is also iCloud-backed, and re-downloadable icons shouldn't be.

Changes:

- `File.localUrl` now points into `Library/Caches/primer/`
- the base64 write targets `localUrl`, so it lands where reads look
- `File` and `Downloader` create the directory before writing
- `ImageManager.clean()` sweeps only `Caches/primer/`; the test now proves a host-app `.png` in documents survives it
- the cached-image test is hermetic and asserts the cache hit (it previously swallowed all errors, asserted nothing, and attempted a real download of example.com on every run)

Migration: files cached at the old location by earlier versions are orphaned and re-downloaded once into the new location. The old location is deliberately not swept — scanning the host app's documents directory is the behavior being removed here.

No breaking changes (`ImageManager` and `File` caching are internal / SPI).

Verification: `ImageManagerTests` ×3 in isolation, full suite ×2 (923 passed, 0 failures, 0 crashes each).

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)
