### PR TITLE
fix: Bancontact raw-data tokenization (ORC-7697)

### DIFF
--- a/Debug App/Podfile.lock
+++ b/Debug App/Podfile.lock
@@ -40,41 +40,42 @@ PODS:
   - IQTextView (1.0.5):
     - IQKeyboardToolbar/Placeholderable
   - Primer3DS (2.8.0)
-  - PrimerBDCCore (2.50.0):
-    - PrimerBDCEngine (= 2.50.0)
-    - PrimerFoundation (= 2.50.0)
-    - PrimerStepResolver (= 2.50.0)
-  - PrimerBDCEngine (2.50.0):
-    - PrimerFoundation (= 2.50.0)
-    - PrimerStepResolver (= 2.50.0)
-  - PrimerCore (2.50.0):
+  - PrimerBDCCore (2.51.1):
+    - PrimerBDCEngine (= 2.51.1)
+    - PrimerFoundation (= 2.51.1)
+    - PrimerStepResolver (= 2.51.1)
+  - PrimerBDCEngine (2.51.1):
+    - PrimerFoundation (= 2.51.1)
+    - PrimerStepResolver (= 2.51.1)
+  - PrimerCore (2.51.1):
     - Primer3DS
-    - PrimerFoundation (= 2.50.0)
-  - PrimerFoundation (2.50.0)
+    - PrimerFoundation (= 2.51.1)
+    - PrimerResources (= 2.51.1)
+  - PrimerFoundation (2.51.1)
   - PrimerIPay88MYSDK (0.1.7)
   - PrimerKlarnaSDK (1.4.0)
-  - PrimerNetworking (2.50.0):
-    - PrimerFoundation (= 2.50.0)
+  - PrimerNetworking (2.51.1):
+    - PrimerFoundation (= 2.51.1)
   - PrimerNolPaySDK (1.0.1)
-  - PrimerResources (2.50.0)
-  - PrimerSDK (2.50.0):
-    - PrimerSDK/Core (= 2.50.0)
-  - PrimerSDK/Core (2.50.0):
-    - PrimerBDCCore (= 2.50.0)
-    - PrimerBDCEngine (= 2.50.0)
-    - PrimerCore (= 2.50.0)
-    - PrimerFoundation (= 2.50.0)
-    - PrimerNetworking (= 2.50.0)
-    - PrimerResources (= 2.50.0)
-    - PrimerStepResolver (= 2.50.0)
-    - PrimerUI (= 2.50.0)
-  - PrimerStepResolver (2.50.0):
-    - PrimerFoundation (= 2.50.0)
+  - PrimerResources (2.51.1)
+  - PrimerSDK (2.51.1):
+    - PrimerSDK/Core (= 2.51.1)
+  - PrimerSDK/Core (2.51.1):
+    - PrimerBDCCore (= 2.51.1)
+    - PrimerBDCEngine (= 2.51.1)
+    - PrimerCore (= 2.51.1)
+    - PrimerFoundation (= 2.51.1)
+    - PrimerNetworking (= 2.51.1)
+    - PrimerResources (= 2.51.1)
+    - PrimerStepResolver (= 2.51.1)
+    - PrimerUI (= 2.51.1)
+  - PrimerStepResolver (2.51.1):
+    - PrimerFoundation (= 2.51.1)
   - PrimerStripeSDK (1.0.1)
-  - PrimerUI (2.50.0):
-    - PrimerCore (= 2.50.0)
-    - PrimerFoundation (= 2.50.0)
-    - PrimerResources (= 2.50.0)
+  - PrimerUI (2.51.1):
+    - PrimerCore (= 2.51.1)
+    - PrimerFoundation (= 2.51.1)
+    - PrimerResources (= 2.51.1)
 
 DEPENDENCIES:
   - IQKeyboardManagerSwift
@@ -139,19 +140,19 @@ SPEC CHECKSUMS:
   IQTextInputViewNotification: 3b9fb27a16e7ee8958cc9092cfb07a1a9e1fd559
   IQTextView: ae13b4922f22e6f027f62c557d9f4f236b19d5c7
   Primer3DS: b8b583ef260f703180870358bc55069de74f8f51
-  PrimerBDCCore: a57458b4152c808373473ad5529cd991b4d23327
-  PrimerBDCEngine: 988d0d38584b4d4f95c46bd2834bff9a32ad4309
-  PrimerCore: b59b501daa7b7b9f945025a86b6e06412aff65da
-  PrimerFoundation: f76f4876e9e864ea63360891715a87224bd09d0a
+  PrimerBDCCore: 7f5344b88a2123bda018e8aad84eab97554f640a
+  PrimerBDCEngine: df493c9d3e4712aaea45bbd9c3f1e58a8232b66a
+  PrimerCore: 01568c7aa2da10f0b6f51255d2b9237c5aaa3d8e
+  PrimerFoundation: 78c4a2437577ad06caea15f5d2a619b3b113be48
   PrimerIPay88MYSDK: 436ee0be7e2c97e4e81456ccddee20175e9e3c4d
   PrimerKlarnaSDK: 871d684b3a43d1f0f7cd5c3b19a6f3a23e581d49
-  PrimerNetworking: 184ef15aa8823424b8375ac3142d45c539cdd763
+  PrimerNetworking: 8b80bcca22bea3b0781241c6e7b3f2983a3d0a7d
   PrimerNolPaySDK: 08b140ed39b378a0b33b4f8746544a402175c0cc
-  PrimerResources: e35a939934babea0368f15881f3feed122308494
-  PrimerSDK: 8b58cbb14564a013a798d55200abba107f7afe7c
-  PrimerStepResolver: 07332a18bbabd3416eb167bb694548a064a8306d
+  PrimerResources: 3588c545e393a0e6942aa5b50ff00d7dc0881403
+  PrimerSDK: ed1627c6e576fd60688394ee1da08dfce6a2798e
+  PrimerStepResolver: 27bb5225697aaaf1c0159fb7c2114f9dc1a131ba
   PrimerStripeSDK: dce5e37d10223ee724f33d1cdeaa17235a71ddbb
-  PrimerUI: b8f2771e3718d621a80138621fb3c555a409c595
+  PrimerUI: 61a2acfe539e74e1c6f017d7339749e951ff4f5f
 
 PODFILE CHECKSUM: b33ea0f762b33b7c191f41dd3256e79f47dccc09
 

--- a/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutRawDataViewController.swift
+++ b/Debug App/Sources/View Controllers/MerchantHeadlessCheckoutRawDataViewController.swift
@@ -37,6 +37,16 @@ class MerchantHeadlessCheckoutRawDataViewController: UIViewController {
     var cardholderNameTextField: UITextField?
     var payButton: UIButton!
 
+    /// Bancontact takes its own raw-data type (no CVV) — sending `PrimerCardData` fails validation.
+    var currentRawData: PrimerRawData {
+        guard paymentMethodType == "ADYEN_BANCONTACT_CARD" else { return rawCardData }
+        return PrimerBancontactCardData(
+            cardNumber: rawCardData.cardNumber,
+            expiryDate: rawCardData.expiryDate,
+            cardholderName: rawCardData.cardholderName ?? ""
+        )
+    }
+
     var cardsStackView: UIStackView!
 
     var logs: [String] = []
@@ -72,7 +82,7 @@ class MerchantHeadlessCheckoutRawDataViewController: UIViewController {
 
         let updateCardData = { [self] in
             rawCardData.cardNumber = cardnumberTextField!.text!.replacingOccurrences(of: " ", with: "")
-            primerRawDataManager?.rawData = rawCardData
+            primerRawDataManager?.rawData = currentRawData
         }
 
         let visaButton = UIButton(primaryAction: UIAction(title: "VISA", handler: { _ in
@@ -191,10 +201,8 @@ class MerchantHeadlessCheckoutRawDataViewController: UIViewController {
             return showErrorMessage("Please write expiry date in format MM/YY or MM/YYYY")
         }
 
-        if paymentMethodType == "PAYMENT_CARD" {
-            self.primerRawDataManager!.submit()
-            self.showLoadingOverlay()
-        }
+        self.primerRawDataManager!.submit()
+        self.showLoadingOverlay()
     }
 
     // MARK: - HELPERS
@@ -270,7 +278,7 @@ extension MerchantHeadlessCheckoutRawDataViewController: UITextFieldDelegate {
         }
 
         print("self.rawCardData\ncardNumber: \(self.rawCardData.cardNumber)\nexpiryDate: \(self.rawCardData.expiryDate)\ncvv: \(self.rawCardData.cvv)\ncardholderName: \(self.rawCardData.cardholderName ?? "nil")")
-        self.primerRawDataManager?.rawData = self.rawCardData
+        self.primerRawDataManager?.rawData = self.currentRawData
 
         return true
     }

--- a/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerBancontactRawCardDataRedirectTokenizationBuilder.swift
+++ b/Sources/PrimerSDK/Classes/PCI/Checkout Components/PrimerBancontactRawCardDataRedirectTokenizationBuilder.swift
@@ -81,7 +81,7 @@ final class PrimerBancontactRawCardDataRedirectTokenizationBuilder: PrimerRawDat
             throw err
         }
 
-        guard let rawData = data as? PrimerCardData,
+        guard let rawData = data as? PrimerBancontactCardData,
               (rawData.expiryDate.split(separator: "/")).count == 2 else {
             let err = PrimerError.invalidValue(key: "rawData")
             ErrorHandler.handle(error: err)
@@ -89,7 +89,15 @@ final class PrimerBancontactRawCardDataRedirectTokenizationBuilder: PrimerRawDat
         }
 
         let expiryMonth = String((rawData.expiryDate.split(separator: "/"))[0])
-        let expiryYear = String((rawData.expiryDate.split(separator: "/"))[1])
+        let rawExpiryYear = String((rawData.expiryDate.split(separator: "/"))[1])
+
+        // Validation accepts MM/YY, but the API requires a 4-digit year (`^\d{4}$`).
+        guard let expiryYear = rawExpiryYear.normalizedFourDigitYear() else {
+            throw handled(primerValidationError: .invalidExpiryDate(
+                message: "Expiry year '\(rawExpiryYear)' is not valid. Please provide a 2-digit (YY) or 4-digit (YYYY) year."
+            ))
+        }
+
         let sanitizedCardNumber = (PrimerInputElementType.cardNumber.clearFormatting(value: rawData.cardNumber) as? String) ?? rawData.cardNumber
 
         return Request.Body.Tokenization(
@@ -99,7 +107,7 @@ final class PrimerBancontactRawCardDataRedirectTokenizationBuilder: PrimerRawDat
                 number: sanitizedCardNumber,
                 expirationMonth: expiryMonth,
                 expirationYear: expiryYear,
-                cardholderName: rawData.cardholderName ?? ""
+                cardholderName: rawData.cardholderName
             )
         )
     }

--- a/Tests/Primer/Managers/PrimerBancontactCardDataManagerTests.swift
+++ b/Tests/Primer/Managers/PrimerBancontactCardDataManagerTests.swift
@@ -1,13 +1,191 @@
 //
 //  PrimerBancontactCardDataManagerTests.swift
 //
-//  Copyright © 2025 Primer API Ltd. All rights reserved. 
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
-import XCTest
+import PrimerFoundation
 @testable import PrimerSDK
+import XCTest
 
 class PrimerBancontactCardDataManagerTests: XCTestCase {
+
+    // MARK: - makeRequestBodyWithRawData
+
+    func test_makeRequestBody_withBancontactCardData_shouldBuildInstrument() async throws {
+        try await SDKSessionHelper.test(withPaymentMethods: [Mocks.PaymentMethods.adyenBancontactCardPaymentMethod]) {
+            // Given
+            let rawCardData = PrimerBancontactCardData(
+                cardNumber: "4242 4242 4242 4242",
+                expiryDate: "03/2030",
+                cardholderName: "John Smith"
+            )
+            let tokenizationBuilder = PrimerBancontactRawCardDataRedirectTokenizationBuilder(paymentMethodType: "ADYEN_BANCONTACT_CARD")
+
+            // When
+            let body = try await tokenizationBuilder.makeRequestBodyWithRawData(rawCardData)
+
+            // Then
+            let instrument = try XCTUnwrap(body.paymentInstrument as? CardOffSessionPaymentInstrument)
+            XCTAssertEqual(instrument.number, "4242424242424242")
+            XCTAssertEqual(instrument.expirationMonth, "03")
+            XCTAssertEqual(instrument.expirationYear, "2030")
+            XCTAssertEqual(instrument.cardholderName, "John Smith")
+            XCTAssertEqual(instrument.paymentMethodType, "ADYEN_BANCONTACT_CARD")
+        }
+    }
+
+    func test_makeRequestBody_withTwoDigitYear_shouldNormalizeToFourDigits() async throws {
+        try await SDKSessionHelper.test(withPaymentMethods: [Mocks.PaymentMethods.adyenBancontactCardPaymentMethod]) {
+            // Given - validation accepts MM/YY, so the builder must expand it rather than send "30"
+            let rawCardData = PrimerBancontactCardData(
+                cardNumber: "4242424242424242",
+                expiryDate: "03/30",
+                cardholderName: "John Smith"
+            )
+            let tokenizationBuilder = PrimerBancontactRawCardDataRedirectTokenizationBuilder(paymentMethodType: "ADYEN_BANCONTACT_CARD")
+
+            // When
+            let body = try await tokenizationBuilder.makeRequestBodyWithRawData(rawCardData)
+
+            // Then
+            let instrument = try XCTUnwrap(body.paymentInstrument as? CardOffSessionPaymentInstrument)
+            XCTAssertEqual(instrument.expirationMonth, "03")
+            XCTAssertEqual(instrument.expirationYear, "2030")
+        }
+    }
+
+    func test_makeRequestBody_withPrimerCardData_shouldThrow() async throws {
+        try await SDKSessionHelper.test(withPaymentMethods: [Mocks.PaymentMethods.adyenBancontactCardPaymentMethod]) {
+            // Given - PrimerCardData is a sibling of PrimerBancontactCardData, not an accepted input here
+            let rawCardData = PrimerCardData(
+                cardNumber: "4242424242424242",
+                expiryDate: "03/2030",
+                cvv: "123",
+                cardholderName: "John Smith"
+            )
+            let tokenizationBuilder = PrimerBancontactRawCardDataRedirectTokenizationBuilder(paymentMethodType: "ADYEN_BANCONTACT_CARD")
+
+            // When & Then
+            do {
+                _ = try await tokenizationBuilder.makeRequestBodyWithRawData(rawCardData)
+                XCTFail("Expected makeRequestBodyWithRawData to throw for PrimerCardData")
+            } catch {
+                XCTAssertEqual((error as? PrimerError)?.errorId, "invalid-value")
+            }
+        }
+    }
+
+    func test_makeRequestBody_withMixedCaseAndSpacedCardNumber_shouldSanitize() async throws {
+        try await SDKSessionHelper.test(withPaymentMethods: [Mocks.PaymentMethods.adyenBancontactCardPaymentMethod]) {
+            // Given
+            let rawCardData = PrimerBancontactCardData(
+                cardNumber: "4871 0499 9999 9910",
+                expiryDate: "12/2031",
+                cardholderName: "John Smith"
+            )
+            let tokenizationBuilder = PrimerBancontactRawCardDataRedirectTokenizationBuilder(paymentMethodType: "ADYEN_BANCONTACT_CARD")
+
+            // When
+            let body = try await tokenizationBuilder.makeRequestBodyWithRawData(rawCardData)
+
+            // Then
+            let instrument = try XCTUnwrap(body.paymentInstrument as? CardOffSessionPaymentInstrument)
+            XCTAssertEqual(instrument.number, "4871049999999910")
+            XCTAssertEqual(instrument.expirationMonth, "12")
+            XCTAssertEqual(instrument.expirationYear, "2031")
+        }
+    }
+
+    func test_makeRequestBody_withThreeDigitYear_shouldThrowInvalidExpiryDate() async throws {
+        try await SDKSessionHelper.test(withPaymentMethods: [Mocks.PaymentMethods.adyenBancontactCardPaymentMethod]) {
+            // Given - the API requires a 4-digit year, so a 3-digit one cannot be normalized
+            let rawCardData = PrimerBancontactCardData(
+                cardNumber: "4242424242424242",
+                expiryDate: "03/203",
+                cardholderName: "John Smith"
+            )
+            let tokenizationBuilder = PrimerBancontactRawCardDataRedirectTokenizationBuilder(paymentMethodType: "ADYEN_BANCONTACT_CARD")
+
+            // When & Then
+            do {
+                _ = try await tokenizationBuilder.makeRequestBodyWithRawData(rawCardData)
+                XCTFail("Expected makeRequestBodyWithRawData to throw for a 3-digit year")
+            } catch {
+                XCTAssertEqual((error as? PrimerValidationError)?.errorId, "invalid-expiry-date")
+            }
+        }
+    }
+
+    func test_makeRequestBody_withNonNumericYear_shouldThrowInvalidExpiryDate() async throws {
+        try await SDKSessionHelper.test(withPaymentMethods: [Mocks.PaymentMethods.adyenBancontactCardPaymentMethod]) {
+            // Given
+            let rawCardData = PrimerBancontactCardData(
+                cardNumber: "4242424242424242",
+                expiryDate: "03/2O30",
+                cardholderName: "John Smith"
+            )
+            let tokenizationBuilder = PrimerBancontactRawCardDataRedirectTokenizationBuilder(paymentMethodType: "ADYEN_BANCONTACT_CARD")
+
+            // When & Then
+            do {
+                _ = try await tokenizationBuilder.makeRequestBodyWithRawData(rawCardData)
+                XCTFail("Expected makeRequestBodyWithRawData to throw for a non-numeric year")
+            } catch {
+                XCTAssertEqual((error as? PrimerValidationError)?.errorId, "invalid-expiry-date")
+            }
+        }
+    }
+
+    func test_makeRequestBody_withUnconfiguredPaymentMethod_shouldThrow() async throws {
+        try await SDKSessionHelper.test(withPaymentMethods: [Mocks.PaymentMethods.paymentCardPaymentMethod]) {
+            // Given - Bancontact is absent from the client session
+            let rawCardData = PrimerBancontactCardData(
+                cardNumber: "4242424242424242",
+                expiryDate: "03/2030",
+                cardholderName: "John Smith"
+            )
+            let tokenizationBuilder = PrimerBancontactRawCardDataRedirectTokenizationBuilder(paymentMethodType: "ADYEN_BANCONTACT_CARD")
+
+            // When & Then
+            do {
+                _ = try await tokenizationBuilder.makeRequestBodyWithRawData(rawCardData)
+                XCTFail("Expected makeRequestBodyWithRawData to throw when the method is not configured")
+            } catch {
+                XCTAssertEqual((error as? PrimerError)?.errorId, "unsupported-payment-method-type")
+            }
+        }
+    }
+
+    func test_requiredInputElementTypes_shouldNotIncludeCVV() {
+        // Bancontact has no security code — 3DS is the authentication step instead.
+        let tokenizationBuilder = PrimerBancontactRawCardDataRedirectTokenizationBuilder(paymentMethodType: "ADYEN_BANCONTACT_CARD")
+
+        XCTAssertEqual(tokenizationBuilder.requiredInputElementTypes, [.cardNumber, .expiryDate, .cardholderName])
+        XCTAssertFalse(tokenizationBuilder.requiredInputElementTypes.contains(.cvv))
+    }
+
+    func test_makeRequestBody_withExpiryDateMissingSeparator_shouldThrow() async throws {
+        try await SDKSessionHelper.test(withPaymentMethods: [Mocks.PaymentMethods.adyenBancontactCardPaymentMethod]) {
+            // Given
+            let rawCardData = PrimerBancontactCardData(
+                cardNumber: "4242424242424242",
+                expiryDate: "0330",
+                cardholderName: "John Smith"
+            )
+            let tokenizationBuilder = PrimerBancontactRawCardDataRedirectTokenizationBuilder(paymentMethodType: "ADYEN_BANCONTACT_CARD")
+
+            // When & Then
+            do {
+                _ = try await tokenizationBuilder.makeRequestBodyWithRawData(rawCardData)
+                XCTFail("Expected makeRequestBodyWithRawData to throw for a separator-less expiry date")
+            } catch {
+                XCTAssertEqual((error as? PrimerError)?.errorId, "invalid-value")
+            }
+        }
+    }
+
+    // MARK: - validateRawData
 
     func test_validateRawData_withValidBancontactCardData_shouldSucceed() async throws {
         // Given

--- a/Tests/Utilities/Mocks.swift
+++ b/Tests/Utilities/Mocks.swift
@@ -137,6 +137,7 @@ class Mocks {
             static var adyenIDealPaymentMethodId = "mock_adyen_ideal_payment_method_id"
             static var klarnaPaymentMethodId = "mock_klarna_payment_method_id"
             static var paymentCardPaymentMethodId = "mock_payment_card_payment_method_id"
+            static var adyenBancontactCardPaymentMethodId = "mock_adyen_bancontact_card_payment_method_id"
             static var nolPaymentMethodId = "mock_nol_payment_method_id"
             static var paypalPaymentMethodId = "mock_paypal_method_id"
             static var xenditPaymentMethodId = "mock_xendit_method_id"
@@ -154,6 +155,7 @@ class Mocks {
             static var adyenIDealPaymentMethodName = "Mock iDeal Blik Payment Method"
             static var klarnaPaymentMethodName = "Mock Klarna Payment Method"
             static var paymentCardPaymentMethodName = "Mock Payment Card Payment Method"
+            static var adyenBancontactCardPaymentMethodName = "Mock Adyen Bancontact Card Payment Method"
             static var nolPaymentMethodName = "Mock NOL Payment Method"
             static var xenditPaymentMethodName = "Mock Xendit Payment Method"
 
@@ -181,6 +183,17 @@ class Mocks {
             implementationType: .nativeSdk,
             type: "PAYMENT_CARD", // Mocks.Static.Strings.paymentCardPaymentMethodType,
             name: Mocks.Static.Strings.paymentCardPaymentMethodName,
+            processorConfigId: Mocks.Static.Strings.processorConfigId,
+            surcharge: 0,
+            options: nil,
+            displayMetadata: nil
+        )
+
+        static var adyenBancontactCardPaymentMethod = PrimerPaymentMethod(
+            id: Mocks.Static.Strings.adyenBancontactCardPaymentMethodId,
+            implementationType: .nativeSdk,
+            type: "ADYEN_BANCONTACT_CARD",
+            name: Mocks.Static.Strings.adyenBancontactCardPaymentMethodName,
             processorConfigId: Mocks.Static.Strings.processorConfigId,
             surcharge: 0,
             options: nil,


### PR DESCRIPTION
# Description

ORC-7697

`makeRequestBodyWithRawData` casts to `PrimerCardData`, but Bancontact arrives as `PrimerBancontactCardData` — a sibling class, so the cast is always nil and `submit()` throws `invalidValue("rawData")`. Broken since 2.17.0. Drop-in is unaffected; it never hits this builder.

Also normalizes the expiry year, which was sent verbatim as `"30"` while the API requires `^\d{4}$`.

No breaking changes.

# Other Notes

- Debug App: it built `PrimerCardData` for Bancontact (same bug) and Pay was gated to `PAYMENT_CARD`. Both blocked testing this.
- `Debug App/Podfile.lock` was stale at 2.50.0 vs master's 2.51.1.

# Manual Testing

Sandbox BE/EUR, Headless, card `6703 4444 4444 4449`, expiry `03/30`. Before: no request sent. After: sent with `"expirationYear":"2030"`.

The sandbox then returns `422 "CVV is missing for card payment"`. Unrelated — Drop-in and Android return the same, and Bancontact has no CVV. Raising separately.

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge
