### PR TITLE
feat(components): let merchants colour input fields separately from the sheet (ORC-8118)

### DIFF
--- a/DesignTokens/tokens/base.json
+++ b/DesignTokens/tokens/base.json
@@ -2,11 +2,21 @@
   "primer": {
     "color": {
       "background": {
+        "primary": {
+          "description": "",
+          "type": "color",
+          "value": "{primer.color.gray.000}"
+        },
+        "secondary": {
+          "description": "",
+          "type": "color",
+          "value": "{primer.color.gray.100}"
+        },
         "outlined": {
           "default": {
             "description": "",
             "type": "color",
-            "value": "{primer.color.background}"
+            "value": "{primer.color.background.secondary}"
           },
           "disabled": {
             "description": "",
@@ -70,10 +80,7 @@
             "type": "color",
             "value": "{primer.color.gray.100}"
           }
-        },
-        "description": "",
-        "type": "color",
-        "value": "{primer.color.gray.000}"
+        }
       },
       "text": {
         "primary": {
@@ -105,6 +112,13 @@
           "description": "",
           "type": "color",
           "value": "{primer.color.gray.600}"
+        },
+        "outlined": {
+          "default": {
+            "description": "",
+            "type": "color",
+            "value": "{primer.color.gray.900}"
+          }
         }
       },
       "border": {

--- a/DesignTokens/tokens/base.json
+++ b/DesignTokens/tokens/base.json
@@ -16,7 +16,7 @@
           "default": {
             "description": "",
             "type": "color",
-            "value": "{primer.color.background.secondary}"
+            "value": "{primer.color.background.primary}"
           },
           "disabled": {
             "description": "",
@@ -117,7 +117,7 @@
           "default": {
             "description": "",
             "type": "color",
-            "value": "{primer.color.gray.900}"
+            "value": "{primer.color.text.primary}"
           }
         }
       },

--- a/Modules/PrimerResources/Sources/PrimerResources/Resources/JSONs/base.json
+++ b/Modules/PrimerResources/Sources/PrimerResources/Resources/JSONs/base.json
@@ -2,11 +2,21 @@
   "primer": {
     "color": {
       "background": {
+        "primary": {
+          "description": "",
+          "type": "color",
+          "value": "{primer.color.gray.000}"
+        },
+        "secondary": {
+          "description": "",
+          "type": "color",
+          "value": "{primer.color.gray.100}"
+        },
         "outlined": {
           "default": {
             "description": "",
             "type": "color",
-            "value": "{primer.color.background}"
+            "value": "{primer.color.background.secondary}"
           },
           "disabled": {
             "description": "",
@@ -70,10 +80,7 @@
             "type": "color",
             "value": "{primer.color.gray.100}"
           }
-        },
-        "description": "",
-        "type": "color",
-        "value": "{primer.color.gray.000}"
+        }
       },
       "text": {
         "primary": {
@@ -105,6 +112,13 @@
           "description": "",
           "type": "color",
           "value": "{primer.color.gray.600}"
+        },
+        "outlined": {
+          "default": {
+            "description": "",
+            "type": "color",
+            "value": "{primer.color.gray.900}"
+          }
         }
       },
       "border": {

--- a/Modules/PrimerResources/Sources/PrimerResources/Resources/JSONs/base.json
+++ b/Modules/PrimerResources/Sources/PrimerResources/Resources/JSONs/base.json
@@ -16,7 +16,7 @@
           "default": {
             "description": "",
             "type": "color",
-            "value": "{primer.color.background.secondary}"
+            "value": "{primer.color.background.primary}"
           },
           "disabled": {
             "description": "",
@@ -117,7 +117,7 @@
           "default": {
             "description": "",
             "type": "color",
-            "value": "{primer.color.gray.900}"
+            "value": "{primer.color.text.primary}"
           }
         }
       },

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Rendering.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Rendering.swift
@@ -46,7 +46,7 @@ extension PrimerInputFieldContainer {
 
   func makeTextFieldContainerBackgroundBackground() -> some View {
     RoundedRectangle(cornerRadius: fieldCornerRadius)
-      .fill(CheckoutColors.background(tokens: tokens))
+      .fill(CheckoutColors.inputBackground(tokens: tokens))
   }
 
   func makeTextFieldContainerWarning() -> some View {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
@@ -117,7 +117,7 @@ extension UITextField {
     let textFont = PrimerFont.uiFontBodyLarge(tokens: tokens)
     font = textFont
     adjustsFontForContentSizeCategory = true
-    textColor = UIColor(CheckoutColors.textPrimary(tokens: tokens))
+    textColor = UIColor(CheckoutColors.inputText(tokens: tokens))
 
     // Placeholder styling with design tokens
     let placeholderColor = UIColor(CheckoutColors.textPlaceholder(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
@@ -34,7 +34,7 @@ struct CountryInputField: View, LogReporter {
     guard !countryName.isEmpty else {
       return CheckoutColors.textPlaceholder(tokens: tokens)
     }
-    return CheckoutColors.textPrimary(tokens: tokens)
+    return CheckoutColors.inputText(tokens: tokens)
   }
 
   private var selectedCountryFromScope: PrimerCountry? {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/OTPCodeInputField/OTPCodeInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/OTPCodeInputField/OTPCodeInputField.swift
@@ -77,7 +77,7 @@ struct OTPCodeInputField: View, LogReporter {
           .foregroundColor(CheckoutColors.textPlaceholder(tokens: tokens))
       )
       .font(fieldFont)
-      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      .foregroundColor(CheckoutColors.inputText(tokens: tokens))
       .keyboardType(.numberPad)
       .textContentType(.oneTimeCode)
       .frame(height: PrimerSize.xxlarge(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
@@ -99,7 +99,7 @@ struct VaultedCardCVVInput: View {
       .frame(width: PrimerComponentWidth.cvvFieldMax, height: PrimerSize.xxlarge(tokens: tokens))
       .background(
         RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-          .fill(CheckoutColors.background(tokens: tokens))
+          .fill(CheckoutColors.inputBackground(tokens: tokens))
       )
       .overlay(
         RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
@@ -94,7 +94,7 @@ struct VaultedCardCVVInput: View {
       .focused($isFocused)
       .multilineTextAlignment(.leading)
       .font(PrimerFont.bodyLarge(tokens: tokens))
-      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      .foregroundColor(CheckoutColors.inputText(tokens: tokens))
       .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
       .frame(width: PrimerComponentWidth.cvvFieldMax, height: PrimerSize.xxlarge(tokens: tokens))
       .background(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -226,7 +226,7 @@ struct BillingAddressRedirectScreen: View {
 
   private func fieldBorderColor(for fieldType: PrimerInputElementType) -> Color {
     billingState.errors[fieldType] != nil
-      ? CheckoutColors.textNegative(tokens: tokens)
+      ? CheckoutColors.borderError(tokens: tokens)
       : CheckoutColors.borderDefault(tokens: tokens)
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -158,7 +158,7 @@ struct BillingAddressRedirectScreen: View {
         HStack {
           if let selected = CountryCode(rawValue: countryCode) {
             Text("\(selected.flag ?? "") \(selected.country)")
-              .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+              .foregroundColor(CheckoutColors.inputText(tokens: tokens))
           } else {
             Text(CheckoutComponentsStrings.countrySelectorPlaceholder)
               .foregroundColor(CheckoutColors.textPlaceholder(tokens: tokens))
@@ -170,7 +170,7 @@ struct BillingAddressRedirectScreen: View {
         .font(PrimerFont.bodyLarge(tokens: tokens))
         .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
         .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
-        .background(CheckoutColors.background(tokens: tokens))
+        .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
             .stroke(fieldBorderColor(for: .countryCode), lineWidth: PrimerBorderWidth.standard(tokens: tokens))
@@ -201,10 +201,10 @@ struct BillingAddressRedirectScreen: View {
 
       TextField(placeholder, text: text)
         .font(PrimerFont.bodyLarge(tokens: tokens))
-        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .foregroundColor(CheckoutColors.inputText(tokens: tokens))
         .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
         .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
-        .background(CheckoutColors.background(tokens: tokens))
+        .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
             .stroke(fieldBorderColor(for: fieldType), lineWidth: PrimerBorderWidth.standard(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -184,7 +184,7 @@ private struct FormFieldView: View {
             if let errorMessage = field.errorMessage {
                 Text(errorMessage)
                     .font(PrimerFont.caption(tokens: tokens))
-                    .foregroundColor(CheckoutColors.error(tokens: tokens))
+                    .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
             } else if let helperText = field.helperText {
                 Text(helperText)
                     .font(PrimerFont.caption(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -207,6 +207,7 @@ private struct FormFieldView: View {
                 set: { onValueChanged($0) }
             ))
             .font(PrimerFont.bodyLarge(tokens: tokens))
+            .foregroundColor(CheckoutColors.inputText(tokens: tokens))
             .keyboardType(field.keyboardType.uiKeyboardType)
             .textContentType(field.fieldType.textContentType)
             .focused($isFocused)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -198,7 +198,7 @@ private struct FormFieldView: View {
             if let prefix = field.countryCodePrefix, field.fieldType == .phoneNumber {
                 Text(prefix)
                     .font(PrimerFont.bodyLarge(tokens: tokens))
-                    .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+                    .foregroundColor(CheckoutColors.inputText(tokens: tokens))
                     .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.phonePrefix)
             }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
@@ -91,7 +91,7 @@ struct SelectCountryScreen: View, LogReporter {
     }
     .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
     .padding(.vertical, PrimerSpacing.small(tokens: tokens))
-    .background(CheckoutColors.inputBackground(tokens: tokens))
+    .background(CheckoutColors.backgroundSecondary(tokens: tokens))
     .cornerRadius(PrimerRadius.small(tokens: tokens))
     .padding(PrimerSpacing.large(tokens: tokens))
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
@@ -91,7 +91,7 @@ struct SelectCountryScreen: View, LogReporter {
     }
     .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
     .padding(.vertical, PrimerSpacing.small(tokens: tokens))
-    .background(CheckoutColors.gray100(tokens: tokens))
+    .background(CheckoutColors.inputBackground(tokens: tokens))
     .cornerRadius(PrimerRadius.small(tokens: tokens))
     .padding(PrimerSpacing.large(tokens: tokens))
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
@@ -18,6 +18,19 @@ final class DesignTokens: Decodable {
     red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
   var primerColorTextOutlinedDefault: Color? = Color(
     red: 0.129, green: 0.129, blue: 0.129, opacity: 1)
+  var primerColorBackgroundSecondary: Color? = Color(red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
+  var primerColorBackgroundOutlinedHover: Color? = Color(red: 1.000, green: 1.000, blue: 1.000, opacity: 1)
+  var primerColorBackgroundOutlinedActive: Color? = Color(red: 1.000, green: 1.000, blue: 1.000, opacity: 1)
+  var primerColorBackgroundOutlinedDisabled: Color? = Color(red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
+  var primerColorBackgroundOutlinedLoading: Color? = Color(red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
+  var primerColorBackgroundOutlinedSelected: Color? = Color(red: 1.000, green: 1.000, blue: 1.000, opacity: 1)
+  var primerColorBackgroundOutlinedError: Color? = Color(red: 1.000, green: 1.000, blue: 1.000, opacity: 1)
+  var primerColorBackgroundTransparentDefault: Color? = Color(red: 1.000, green: 1.000, blue: 1.000, opacity: 0)
+  var primerColorBackgroundTransparentHover: Color? = Color(red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
+  var primerColorBackgroundTransparentActive: Color? = Color(red: 0.933, green: 0.933, blue: 0.933, opacity: 1)
+  var primerColorBackgroundTransparentDisabled: Color? = Color(red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
+  var primerColorBackgroundTransparentLoading: Color? = Color(red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
+  var primerColorBackgroundTransparentSelected: Color? = Color(red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
   var primerColorTextPrimary: Color? = Color(
     red: 0.129, green: 0.129, blue: 0.129, opacity: 1)
   var primerColorTextPlaceholder: Color? = Color(
@@ -138,6 +151,19 @@ final class DesignTokens: Decodable {
     case primerColorBackgroundPrimary
     case primerColorBackgroundOutlinedDefault
     case primerColorTextOutlinedDefault
+    case primerColorBackgroundSecondary
+    case primerColorBackgroundOutlinedHover
+    case primerColorBackgroundOutlinedActive
+    case primerColorBackgroundOutlinedDisabled
+    case primerColorBackgroundOutlinedLoading
+    case primerColorBackgroundOutlinedSelected
+    case primerColorBackgroundOutlinedError
+    case primerColorBackgroundTransparentDefault
+    case primerColorBackgroundTransparentHover
+    case primerColorBackgroundTransparentActive
+    case primerColorBackgroundTransparentDisabled
+    case primerColorBackgroundTransparentLoading
+    case primerColorBackgroundTransparentSelected
     case primerColorTextPrimary
     case primerColorTextPlaceholder
     case primerColorTextDisabled
@@ -241,6 +267,19 @@ final class DesignTokens: Decodable {
     primerColorBackgroundPrimary = try container.decodeColorIfPresent(forKey: .primerColorBackgroundPrimary) ?? primerColorBackgroundPrimary
     primerColorBackgroundOutlinedDefault = try container.decodeColorIfPresent(forKey: .primerColorBackgroundOutlinedDefault) ?? primerColorBackgroundOutlinedDefault
     primerColorTextOutlinedDefault = try container.decodeColorIfPresent(forKey: .primerColorTextOutlinedDefault) ?? primerColorTextOutlinedDefault
+    primerColorBackgroundSecondary = try container.decodeColorIfPresent(forKey: .primerColorBackgroundSecondary) ?? primerColorBackgroundSecondary
+    primerColorBackgroundOutlinedHover = try container.decodeColorIfPresent(forKey: .primerColorBackgroundOutlinedHover) ?? primerColorBackgroundOutlinedHover
+    primerColorBackgroundOutlinedActive = try container.decodeColorIfPresent(forKey: .primerColorBackgroundOutlinedActive) ?? primerColorBackgroundOutlinedActive
+    primerColorBackgroundOutlinedDisabled = try container.decodeColorIfPresent(forKey: .primerColorBackgroundOutlinedDisabled) ?? primerColorBackgroundOutlinedDisabled
+    primerColorBackgroundOutlinedLoading = try container.decodeColorIfPresent(forKey: .primerColorBackgroundOutlinedLoading) ?? primerColorBackgroundOutlinedLoading
+    primerColorBackgroundOutlinedSelected = try container.decodeColorIfPresent(forKey: .primerColorBackgroundOutlinedSelected) ?? primerColorBackgroundOutlinedSelected
+    primerColorBackgroundOutlinedError = try container.decodeColorIfPresent(forKey: .primerColorBackgroundOutlinedError) ?? primerColorBackgroundOutlinedError
+    primerColorBackgroundTransparentDefault = try container.decodeColorIfPresent(forKey: .primerColorBackgroundTransparentDefault) ?? primerColorBackgroundTransparentDefault
+    primerColorBackgroundTransparentHover = try container.decodeColorIfPresent(forKey: .primerColorBackgroundTransparentHover) ?? primerColorBackgroundTransparentHover
+    primerColorBackgroundTransparentActive = try container.decodeColorIfPresent(forKey: .primerColorBackgroundTransparentActive) ?? primerColorBackgroundTransparentActive
+    primerColorBackgroundTransparentDisabled = try container.decodeColorIfPresent(forKey: .primerColorBackgroundTransparentDisabled) ?? primerColorBackgroundTransparentDisabled
+    primerColorBackgroundTransparentLoading = try container.decodeColorIfPresent(forKey: .primerColorBackgroundTransparentLoading) ?? primerColorBackgroundTransparentLoading
+    primerColorBackgroundTransparentSelected = try container.decodeColorIfPresent(forKey: .primerColorBackgroundTransparentSelected) ?? primerColorBackgroundTransparentSelected
     primerColorTextPrimary = try container.decodeColorIfPresent(forKey: .primerColorTextPrimary) ?? primerColorTextPrimary
     primerColorTextPlaceholder = try container.decodeColorIfPresent(forKey: .primerColorTextPlaceholder) ?? primerColorTextPlaceholder
     primerColorTextDisabled = try container.decodeColorIfPresent(forKey: .primerColorTextDisabled) ?? primerColorTextDisabled

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
@@ -12,8 +12,12 @@ import SwiftUI
 // This class is generated automatically by Style Dictionary.
 // It represents the design tokens for the Light theme.
 final class DesignTokens: Decodable {
-  var primerColorBackground: Color? = Color(
+  var primerColorBackgroundPrimary: Color? = Color(
     red: 1.000, green: 1.000, blue: 1.000, opacity: 1)
+  var primerColorBackgroundOutlinedDefault: Color? = Color(
+    red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
+  var primerColorTextOutlinedDefault: Color? = Color(
+    red: 0.129, green: 0.129, blue: 0.129, opacity: 1)
   var primerColorTextPrimary: Color? = Color(
     red: 0.129, green: 0.129, blue: 0.129, opacity: 1)
   var primerColorTextPlaceholder: Color? = Color(
@@ -131,7 +135,9 @@ final class DesignTokens: Decodable {
 
   // Coding keys to map JSON keys to properties.
   enum CodingKeys: String, CodingKey {
-    case primerColorBackground
+    case primerColorBackgroundPrimary
+    case primerColorBackgroundOutlinedDefault
+    case primerColorTextOutlinedDefault
     case primerColorTextPrimary
     case primerColorTextPlaceholder
     case primerColorTextDisabled
@@ -232,7 +238,9 @@ final class DesignTokens: Decodable {
   required init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
 
-    primerColorBackground = try container.decodeColorIfPresent(forKey: .primerColorBackground) ?? primerColorBackground
+    primerColorBackgroundPrimary = try container.decodeColorIfPresent(forKey: .primerColorBackgroundPrimary) ?? primerColorBackgroundPrimary
+    primerColorBackgroundOutlinedDefault = try container.decodeColorIfPresent(forKey: .primerColorBackgroundOutlinedDefault) ?? primerColorBackgroundOutlinedDefault
+    primerColorTextOutlinedDefault = try container.decodeColorIfPresent(forKey: .primerColorTextOutlinedDefault) ?? primerColorTextOutlinedDefault
     primerColorTextPrimary = try container.decodeColorIfPresent(forKey: .primerColorTextPrimary) ?? primerColorTextPrimary
     primerColorTextPlaceholder = try container.decodeColorIfPresent(forKey: .primerColorTextPlaceholder) ?? primerColorTextPlaceholder
     primerColorTextDisabled = try container.decodeColorIfPresent(forKey: .primerColorTextDisabled) ?? primerColorTextDisabled

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
@@ -15,7 +15,7 @@ final class DesignTokens: Decodable {
   var primerColorBackgroundPrimary: Color? = Color(
     red: 1.000, green: 1.000, blue: 1.000, opacity: 1)
   var primerColorBackgroundOutlinedDefault: Color? = Color(
-    red: 0.961, green: 0.961, blue: 0.961, opacity: 1)
+    red: 1.000, green: 1.000, blue: 1.000, opacity: 1)
   var primerColorTextOutlinedDefault: Color? = Color(
     red: 0.129, green: 0.129, blue: 0.129, opacity: 1)
   var primerColorBackgroundSecondary: Color? = Color(red: 0.961, green: 0.961, blue: 0.961, opacity: 1)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
@@ -111,6 +111,19 @@ final class DesignTokensManager: ObservableObject {
     if let value = colors.primerColorBackgroundPrimary { tokens.primerColorBackgroundPrimary = value }
     if let value = colors.primerColorBackgroundOutlinedDefault { tokens.primerColorBackgroundOutlinedDefault = value }
     if let value = colors.primerColorTextOutlinedDefault { tokens.primerColorTextOutlinedDefault = value }
+    if let value = colors.primerColorBackgroundSecondary { tokens.primerColorBackgroundSecondary = value }
+    if let value = colors.primerColorBackgroundOutlinedHover { tokens.primerColorBackgroundOutlinedHover = value }
+    if let value = colors.primerColorBackgroundOutlinedActive { tokens.primerColorBackgroundOutlinedActive = value }
+    if let value = colors.primerColorBackgroundOutlinedDisabled { tokens.primerColorBackgroundOutlinedDisabled = value }
+    if let value = colors.primerColorBackgroundOutlinedLoading { tokens.primerColorBackgroundOutlinedLoading = value }
+    if let value = colors.primerColorBackgroundOutlinedSelected { tokens.primerColorBackgroundOutlinedSelected = value }
+    if let value = colors.primerColorBackgroundOutlinedError { tokens.primerColorBackgroundOutlinedError = value }
+    if let value = colors.primerColorBackgroundTransparentDefault { tokens.primerColorBackgroundTransparentDefault = value }
+    if let value = colors.primerColorBackgroundTransparentHover { tokens.primerColorBackgroundTransparentHover = value }
+    if let value = colors.primerColorBackgroundTransparentActive { tokens.primerColorBackgroundTransparentActive = value }
+    if let value = colors.primerColorBackgroundTransparentDisabled { tokens.primerColorBackgroundTransparentDisabled = value }
+    if let value = colors.primerColorBackgroundTransparentLoading { tokens.primerColorBackgroundTransparentLoading = value }
+    if let value = colors.primerColorBackgroundTransparentSelected { tokens.primerColorBackgroundTransparentSelected = value }
   }
 
   private func applyTextColorOverrides(to tokens: DesignTokens, from colors: ColorOverrides) {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
@@ -26,22 +26,57 @@ final class DesignTokensManager: ObservableObject {
   // MARK: - Token Loading
 
   func fetchTokens(for colorScheme: ColorScheme) async throws {
-    let loadedTokens = try Self.makeTokens(for: colorScheme)
+    let loadedTokens = try Self.makeTokens(for: colorScheme, paletteOverrides: palettePairs())
 
-    // Apply merchant theme overrides on top of loaded tokens
+    // Semantic overrides are applied last so an explicit token always wins over a
+    // palette value it happens to alias.
     applyThemeOverrides(to: loadedTokens)
 
     tokens = loadedTokens
   }
 
-  /// Resolves the shipped token JSON for a colour scheme, without merchant overrides.
-  /// Previews and tests use this so they see the same values production does.
-  nonisolated static func makeTokens(for colorScheme: ColorScheme) throws -> DesignTokens {
+  /// Merchant overrides for the raw palette, keyed by flattened token name.
+  /// These are injected before references resolve so tokens that alias a palette entry
+  /// (border.outlined.default -> gray.300, and the rest) follow the override, matching Android.
+  private func palettePairs() -> [String: Color] {
+    guard let colors = themeOverrides?.colors else { return [:] }
+    let pairs: [(String, Color?)] = [
+      ("primerColorBrand", colors.primerColorBrand),
+      ("primerColorGray000", colors.primerColorGray000),
+      ("primerColorGray100", colors.primerColorGray100),
+      ("primerColorGray200", colors.primerColorGray200),
+      ("primerColorGray300", colors.primerColorGray300),
+      ("primerColorGray400", colors.primerColorGray400),
+      ("primerColorGray500", colors.primerColorGray500),
+      ("primerColorGray600", colors.primerColorGray600),
+      ("primerColorGray900", colors.primerColorGray900),
+      ("primerColorGreen500", colors.primerColorGreen500),
+      ("primerColorRed100", colors.primerColorRed100),
+      ("primerColorRed500", colors.primerColorRed500),
+      ("primerColorRed900", colors.primerColorRed900),
+      ("primerColorBlue500", colors.primerColorBlue500),
+      ("primerColorBlue900", colors.primerColorBlue900),
+    ]
+    return pairs.reduce(into: [:]) { result, pair in
+      if let value = pair.1 { result[pair.0] = value }
+    }
+  }
+
+  /// Resolves the shipped token JSON for a colour scheme.
+  /// Previews and tests call this with no overrides so they see the same values production does.
+  nonisolated static func makeTokens(
+    for colorScheme: ColorScheme,
+    paletteOverrides: [String: Color] = [:]
+  ) throws -> DesignTokens {
     let baseDict = try loadJSON(named: "base")
-    let mergedDict =
+    var mergedDict =
       colorScheme == .dark
       ? DesignTokensProcessor.mergeDictionaries(baseDict, with: try loadJSON(named: "dark"))
       : baseDict
+
+    if !paletteOverrides.isEmpty {
+      mergedDict = applyPaletteOverrides(paletteOverrides, to: mergedDict)
+    }
 
     var processedDict = DesignTokensProcessor.resolveReferences(in: mergedDict)
     processedDict = DesignTokensProcessor.convertHexColors(in: processedDict)
@@ -51,6 +86,38 @@ final class DesignTokensManager: ObservableObject {
 
     let data = try JSONSerialization.data(withJSONObject: flatDict)
     return try JSONDecoder().decode(DesignTokens.self, from: data)
+  }
+
+  /// Replaces the value of every leaf whose flattened name matches an override, in place in the
+  /// nested dictionary, so the existing reference-resolution pass picks the new value up.
+  private nonisolated static func applyPaletteOverrides(
+    _ overrides: [String: Color],
+    to dict: [String: Any],
+    prefix: String = ""
+  ) -> [String: Any] {
+    dict.reduce(into: [String: Any]()) { result, pair in
+      let (key, value) = pair
+      let path = prefix.isEmpty ? key : "\(prefix).\(key)"
+      guard var nested = value as? [String: Any] else {
+        result[key] = value
+        return
+      }
+      if nested["value"] != nil,
+         let override = overrides[DesignTokensProcessor.flattenedName(for: path)],
+         let components = colorComponents(override) {
+        nested["value"] = components
+      }
+      result[key] = applyPaletteOverrides(overrides, to: nested, prefix: path)
+    }
+  }
+
+  private nonisolated static func colorComponents(_ color: Color) -> [CGFloat]? {
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    guard UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return nil }
+    return [red, green, blue, alpha]
   }
 
   // MARK: - Apply Theme Overrides

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
@@ -170,7 +170,13 @@ final class DesignTokensManager: ObservableObject {
     if let value = colors.primerColorRed900 { tokens.primerColorRed900 = value }
     if let value = colors.primerColorBlue500 { tokens.primerColorBlue500 = value }
     if let value = colors.primerColorBlue900 { tokens.primerColorBlue900 = value }
-    if let value = colors.primerColorBackgroundPrimary { tokens.primerColorBackgroundPrimary = value }
+    if let value = colors.primerColorBackgroundPrimary {
+      tokens.primerColorBackgroundPrimary = value
+      // the input fill aliases the sheet, so it follows unless the merchant names it too
+      if colors.primerColorBackgroundOutlinedDefault == nil {
+        tokens.primerColorBackgroundOutlinedDefault = value
+      }
+    }
     if let value = colors.primerColorBackgroundOutlinedDefault { tokens.primerColorBackgroundOutlinedDefault = value }
     if let value = colors.primerColorTextOutlinedDefault { tokens.primerColorTextOutlinedDefault = value }
     if let value = colors.primerColorBackgroundSecondary { tokens.primerColorBackgroundSecondary = value }
@@ -189,7 +195,12 @@ final class DesignTokensManager: ObservableObject {
   }
 
   private func applyTextColorOverrides(to tokens: DesignTokens, from colors: ColorOverrides) {
-    if let value = colors.primerColorTextPrimary { tokens.primerColorTextPrimary = value }
+    if let value = colors.primerColorTextPrimary {
+      tokens.primerColorTextPrimary = value
+      if colors.primerColorTextOutlinedDefault == nil {
+        tokens.primerColorTextOutlinedDefault = value
+      }
+    }
     if let value = colors.primerColorTextSecondary { tokens.primerColorTextSecondary = value }
     if let value = colors.primerColorTextPlaceholder { tokens.primerColorTextPlaceholder = value }
     if let value = colors.primerColorTextDisabled { tokens.primerColorTextDisabled = value }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
@@ -28,16 +28,13 @@ final class DesignTokensManager: ObservableObject {
   func fetchTokens(for colorScheme: ColorScheme) async throws {
     let loadedTokens = try Self.makeTokens(for: colorScheme, paletteOverrides: palettePairs())
 
-    // Semantic overrides are applied last so an explicit token always wins over a
-    // palette value it happens to alias.
+    // applied last so an explicit token wins over a palette value it aliases
     applyThemeOverrides(to: loadedTokens)
 
     tokens = loadedTokens
   }
 
-  /// Merchant overrides for the raw palette, keyed by flattened token name.
-  /// These are injected before references resolve so tokens that alias a palette entry
-  /// (border.outlined.default -> gray.300, and the rest) follow the override, matching Android.
+  /// Injected before references resolve, so tokens aliasing a palette entry follow the override.
   private func palettePairs() -> [String: Color] {
     guard let colors = themeOverrides?.colors else { return [:] }
     let pairs: [(String, Color?)] = [
@@ -62,8 +59,7 @@ final class DesignTokensManager: ObservableObject {
     }
   }
 
-  /// Resolves the shipped token JSON for a colour scheme.
-  /// Previews and tests call this with no overrides so they see the same values production does.
+  /// Previews and tests call this with no overrides so they resolve what production resolves.
   nonisolated static func makeTokens(
     for colorScheme: ColorScheme,
     paletteOverrides: [String: Color] = [:]
@@ -88,8 +84,7 @@ final class DesignTokensManager: ObservableObject {
     return try JSONDecoder().decode(DesignTokens.self, from: data)
   }
 
-  /// Replaces the value of every leaf whose flattened name matches an override, in place in the
-  /// nested dictionary, so the existing reference-resolution pass picks the new value up.
+  /// Replaces matching leaves in place so the existing reference pass picks the new value up.
   private nonisolated static func applyPaletteOverrides(
     _ overrides: [String: Color],
     to dict: [String: Any],

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
@@ -108,7 +108,9 @@ final class DesignTokensManager: ObservableObject {
     if let value = colors.primerColorRed900 { tokens.primerColorRed900 = value }
     if let value = colors.primerColorBlue500 { tokens.primerColorBlue500 = value }
     if let value = colors.primerColorBlue900 { tokens.primerColorBlue900 = value }
-    if let value = colors.primerColorBackground { tokens.primerColorBackground = value }
+    if let value = colors.primerColorBackgroundPrimary { tokens.primerColorBackgroundPrimary = value }
+    if let value = colors.primerColorBackgroundOutlinedDefault { tokens.primerColorBackgroundOutlinedDefault = value }
+    if let value = colors.primerColorTextOutlinedDefault { tokens.primerColorTextOutlinedDefault = value }
   }
 
   private func applyTextColorOverrides(to tokens: DesignTokens, from colors: ColorOverrides) {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
@@ -74,8 +74,7 @@ final class DesignTokensManager: ObservableObject {
       mergedDict = applyPaletteOverrides(paletteOverrides, to: mergedDict)
     }
 
-    var processedDict = DesignTokensProcessor.resolveReferences(in: mergedDict)
-    processedDict = DesignTokensProcessor.convertHexColors(in: processedDict)
+    let processedDict = DesignTokensProcessor.convertHexColors(in: mergedDict)
     var flatDict = DesignTokensProcessor.flattenTokenDictionary(processedDict)
     flatDict = DesignTokensProcessor.resolveFlattenedReferences(in: flatDict, source: processedDict)
     flatDict = DesignTokensProcessor.evaluateMath(in: flatDict)
@@ -111,7 +110,11 @@ final class DesignTokensManager: ObservableObject {
     var green: CGFloat = 0
     var blue: CGFloat = 0
     var alpha: CGFloat = 0
-    guard UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha) else { return nil }
+    guard UIColor(color).getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+      PrimerLogging.shared.logger.error(
+        message: "[DesignTokens] Palette override ignored: colour has no readable RGB components.")
+      return nil
+    }
     return [red, green, blue, alpha]
   }
 
@@ -407,7 +410,7 @@ final class DesignTokensManager: ObservableObject {
 
   // MARK: - JSON Loading
 
-  private nonisolated static func loadJSON(named fileName: String) throws -> [String: Any] {
+  nonisolated static func loadJSON(named fileName: String) throws -> [String: Any] {
     guard let url = Bundle.primerResources.url(forResource: fileName, withExtension: "json"),
       let data = try? Data(contentsOf: url),
       let dictionary = try? JSONSerialization.jsonObject(with: data) as? [String: Any]

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensProcessor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensProcessor.swift
@@ -32,35 +32,6 @@ enum DesignTokensProcessor {
 
   // MARK: - Token Reference Resolution
 
-  static func resolveReferences(in dict: [String: Any]) -> [String: Any] {
-    (0..<10).reduce(dict) { current, _ in
-      var hasUnresolved = false
-      let resolved = resolvePass(current, root: current, hasUnresolved: &hasUnresolved)
-      return hasUnresolved ? resolved : current
-    }
-  }
-
-  private static func resolvePass(
-    _ dict: [String: Any], root: [String: Any], hasUnresolved: inout Bool
-  ) -> [String: Any] {
-    dict.reduce(into: [String: Any]()) { result, pair in
-      let (key, value) = pair
-      if let nested = value as? [String: Any] {
-        result[key] = resolvePass(nested, root: root, hasUnresolved: &hasUnresolved)
-      } else if let ref = value as? String, ref.hasPrefix("{"), ref.hasSuffix("}") {
-        let reference = String(ref.dropFirst().dropLast())
-        if let resolved = resolveReference(reference, in: root) {
-          result[key] = resolved
-        } else {
-          result[key] = value
-          hasUnresolved = true
-        }
-      } else {
-        result[key] = value
-      }
-    }
-  }
-
   private static func resolveReference(_ reference: String, in root: [String: Any]) -> Any? {
     let parts = reference.split(separator: ".").map(String.init)
     var current: Any = root

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensProcessor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensProcessor.swift
@@ -158,6 +158,9 @@ enum DesignTokensProcessor {
     }
   }
 
+  /// The flattened key a dotted token path collapses to, e.g. primer.color.gray.300 -> primerColorGray300.
+  static func flattenedName(for path: String) -> String { toCamelCase(path) }
+
   private static func toCamelCase(_ path: String) -> String {
     let parts = path.split(separator: ".").map(String.init)
     return parts.enumerated().map { index, part in

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -93,7 +93,7 @@ enum CheckoutColors {
   }
 
   static func inputBackground(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackgroundOutlinedDefault ?? Color(.systemGray6)
+    tokens?.primerColorBackgroundOutlinedDefault ?? .white
   }
 
   static func inputText(tokens: DesignTokens?) -> Color {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -108,10 +108,6 @@ enum CheckoutColors {
     tokens?.primerColorBorderOutlinedFocus ?? .blue
   }
 
-  static func error(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorTextNegative ?? .red
-  }
-
   // MARK: - Button Colors
 
   static func buttonPrimary(tokens: DesignTokens?) -> Color {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -48,6 +48,10 @@ enum CheckoutColors {
     tokens?.primerColorBackgroundPrimary ?? .white
   }
 
+  static func backgroundSecondary(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBackgroundSecondary ?? Color(red: 0.961, green: 0.961, blue: 0.961)
+  }
+
   static func gray100(tokens: DesignTokens?) -> Color {
     tokens?.primerColorGray100 ?? Color(.systemGray6)
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -45,7 +45,7 @@ enum CheckoutColors {
   }
 
   static func background(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackground ?? .white
+    tokens?.primerColorBackgroundPrimary ?? .white
   }
 
   static func gray100(tokens: DesignTokens?) -> Color {
@@ -85,11 +85,15 @@ enum CheckoutColors {
   // MARK: - Screen & Input Colors
 
   static func screenBackground(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackground ?? Color(.systemBackground)
+    tokens?.primerColorBackgroundPrimary ?? Color(.systemBackground)
   }
 
   static func inputBackground(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorGray100 ?? Color(.systemGray6)
+    tokens?.primerColorBackgroundOutlinedDefault ?? Color(.systemGray6)
+  }
+
+  static func inputText(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorTextOutlinedDefault ?? .primary
   }
 
   static func inputBorder(tokens: DesignTokens?) -> Color {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockDesignTokens.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Utilities/MockDesignTokens.swift
@@ -19,10 +19,9 @@
 
     // MARK: - Static Instances
 
-    /// Light theme design tokens with default Primer values
+    /// Resolved through the production pipeline so previews can't drift from real light values.
     static let light: DesignTokens = {
-      // Create instance with default values
-      DesignTokens()
+      (try? DesignTokensManager.makeTokens(for: .light)) ?? DesignTokens()
     }()
 
     /// Resolved through the production pipeline so previews can't drift from real dark values.

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckout.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckout.swift
@@ -197,7 +197,7 @@ struct InternalCheckout: View, LogReporter {
   /// This ensures the background color is correct from the first render.
   private var backgroundColor: Color {
     // Priority 1: Theme override (available immediately)
-    if let themeBackground = theme.colors?.primerColorBackground {
+    if let themeBackground = theme.colors?.primerColorBackgroundPrimary {
       return themeBackground
     }
     // Priority 2: Loaded design tokens (available after async load)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
@@ -94,6 +94,19 @@ public struct ColorOverrides: Equatable {
   public let primerColorBackgroundPrimary: Color?
   public let primerColorBackgroundOutlinedDefault: Color?
   public let primerColorTextOutlinedDefault: Color?
+  public let primerColorBackgroundSecondary: Color?
+  public let primerColorBackgroundOutlinedHover: Color?
+  public let primerColorBackgroundOutlinedActive: Color?
+  public let primerColorBackgroundOutlinedDisabled: Color?
+  public let primerColorBackgroundOutlinedLoading: Color?
+  public let primerColorBackgroundOutlinedSelected: Color?
+  public let primerColorBackgroundOutlinedError: Color?
+  public let primerColorBackgroundTransparentDefault: Color?
+  public let primerColorBackgroundTransparentHover: Color?
+  public let primerColorBackgroundTransparentActive: Color?
+  public let primerColorBackgroundTransparentDisabled: Color?
+  public let primerColorBackgroundTransparentLoading: Color?
+  public let primerColorBackgroundTransparentSelected: Color?
   public let primerColorTextPrimary: Color?
   public let primerColorTextSecondary: Color?
   public let primerColorTextPlaceholder: Color?
@@ -153,6 +166,19 @@ public struct ColorOverrides: Equatable {
     primerColorBackgroundPrimary: Color? = nil,
     primerColorBackgroundOutlinedDefault: Color? = nil,
     primerColorTextOutlinedDefault: Color? = nil,
+    primerColorBackgroundSecondary: Color? = nil,
+    primerColorBackgroundOutlinedHover: Color? = nil,
+    primerColorBackgroundOutlinedActive: Color? = nil,
+    primerColorBackgroundOutlinedDisabled: Color? = nil,
+    primerColorBackgroundOutlinedLoading: Color? = nil,
+    primerColorBackgroundOutlinedSelected: Color? = nil,
+    primerColorBackgroundOutlinedError: Color? = nil,
+    primerColorBackgroundTransparentDefault: Color? = nil,
+    primerColorBackgroundTransparentHover: Color? = nil,
+    primerColorBackgroundTransparentActive: Color? = nil,
+    primerColorBackgroundTransparentDisabled: Color? = nil,
+    primerColorBackgroundTransparentLoading: Color? = nil,
+    primerColorBackgroundTransparentSelected: Color? = nil,
     primerColorTextPrimary: Color? = nil,
     primerColorTextSecondary: Color? = nil,
     primerColorTextPlaceholder: Color? = nil,
@@ -199,6 +225,19 @@ public struct ColorOverrides: Equatable {
     self.primerColorBackgroundPrimary = primerColorBackgroundPrimary
     self.primerColorBackgroundOutlinedDefault = primerColorBackgroundOutlinedDefault
     self.primerColorTextOutlinedDefault = primerColorTextOutlinedDefault
+    self.primerColorBackgroundSecondary = primerColorBackgroundSecondary
+    self.primerColorBackgroundOutlinedHover = primerColorBackgroundOutlinedHover
+    self.primerColorBackgroundOutlinedActive = primerColorBackgroundOutlinedActive
+    self.primerColorBackgroundOutlinedDisabled = primerColorBackgroundOutlinedDisabled
+    self.primerColorBackgroundOutlinedLoading = primerColorBackgroundOutlinedLoading
+    self.primerColorBackgroundOutlinedSelected = primerColorBackgroundOutlinedSelected
+    self.primerColorBackgroundOutlinedError = primerColorBackgroundOutlinedError
+    self.primerColorBackgroundTransparentDefault = primerColorBackgroundTransparentDefault
+    self.primerColorBackgroundTransparentHover = primerColorBackgroundTransparentHover
+    self.primerColorBackgroundTransparentActive = primerColorBackgroundTransparentActive
+    self.primerColorBackgroundTransparentDisabled = primerColorBackgroundTransparentDisabled
+    self.primerColorBackgroundTransparentLoading = primerColorBackgroundTransparentLoading
+    self.primerColorBackgroundTransparentSelected = primerColorBackgroundTransparentSelected
     self.primerColorTextPrimary = primerColorTextPrimary
     self.primerColorTextSecondary = primerColorTextSecondary
     self.primerColorTextPlaceholder = primerColorTextPlaceholder

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
@@ -92,9 +92,8 @@ public struct ColorOverrides: Equatable {
   // MARK: Semantic UI Colors (matching internal DesignTokens)
 
   public let primerColorBackgroundPrimary: Color?
-  public let primerColorBackgroundOutlinedDefault: Color?
-  public let primerColorTextOutlinedDefault: Color?
   public let primerColorBackgroundSecondary: Color?
+  public let primerColorBackgroundOutlinedDefault: Color?
   public let primerColorBackgroundOutlinedHover: Color?
   public let primerColorBackgroundOutlinedActive: Color?
   public let primerColorBackgroundOutlinedDisabled: Color?
@@ -113,6 +112,7 @@ public struct ColorOverrides: Equatable {
   public let primerColorTextDisabled: Color?
   public let primerColorTextNegative: Color?
   public let primerColorTextLink: Color?
+  public let primerColorTextOutlinedDefault: Color?
 
   // MARK: Border Colors (matching internal DesignTokens)
 
@@ -164,9 +164,8 @@ public struct ColorOverrides: Equatable {
     primerColorBlue500: Color? = nil,
     primerColorBlue900: Color? = nil,
     primerColorBackgroundPrimary: Color? = nil,
-    primerColorBackgroundOutlinedDefault: Color? = nil,
-    primerColorTextOutlinedDefault: Color? = nil,
     primerColorBackgroundSecondary: Color? = nil,
+    primerColorBackgroundOutlinedDefault: Color? = nil,
     primerColorBackgroundOutlinedHover: Color? = nil,
     primerColorBackgroundOutlinedActive: Color? = nil,
     primerColorBackgroundOutlinedDisabled: Color? = nil,
@@ -185,6 +184,7 @@ public struct ColorOverrides: Equatable {
     primerColorTextDisabled: Color? = nil,
     primerColorTextNegative: Color? = nil,
     primerColorTextLink: Color? = nil,
+    primerColorTextOutlinedDefault: Color? = nil,
     primerColorBorderOutlinedDefault: Color? = nil,
     primerColorBorderOutlinedHover: Color? = nil,
     primerColorBorderOutlinedActive: Color? = nil,
@@ -223,9 +223,8 @@ public struct ColorOverrides: Equatable {
     self.primerColorBlue500 = primerColorBlue500
     self.primerColorBlue900 = primerColorBlue900
     self.primerColorBackgroundPrimary = primerColorBackgroundPrimary
-    self.primerColorBackgroundOutlinedDefault = primerColorBackgroundOutlinedDefault
-    self.primerColorTextOutlinedDefault = primerColorTextOutlinedDefault
     self.primerColorBackgroundSecondary = primerColorBackgroundSecondary
+    self.primerColorBackgroundOutlinedDefault = primerColorBackgroundOutlinedDefault
     self.primerColorBackgroundOutlinedHover = primerColorBackgroundOutlinedHover
     self.primerColorBackgroundOutlinedActive = primerColorBackgroundOutlinedActive
     self.primerColorBackgroundOutlinedDisabled = primerColorBackgroundOutlinedDisabled
@@ -244,6 +243,7 @@ public struct ColorOverrides: Equatable {
     self.primerColorTextDisabled = primerColorTextDisabled
     self.primerColorTextNegative = primerColorTextNegative
     self.primerColorTextLink = primerColorTextLink
+    self.primerColorTextOutlinedDefault = primerColorTextOutlinedDefault
     self.primerColorBorderOutlinedDefault = primerColorBorderOutlinedDefault
     self.primerColorBorderOutlinedHover = primerColorBorderOutlinedHover
     self.primerColorBorderOutlinedActive = primerColorBorderOutlinedActive

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
@@ -91,7 +91,9 @@ public struct ColorOverrides: Equatable {
 
   // MARK: Semantic UI Colors (matching internal DesignTokens)
 
-  public let primerColorBackground: Color?
+  public let primerColorBackgroundPrimary: Color?
+  public let primerColorBackgroundOutlinedDefault: Color?
+  public let primerColorTextOutlinedDefault: Color?
   public let primerColorTextPrimary: Color?
   public let primerColorTextSecondary: Color?
   public let primerColorTextPlaceholder: Color?
@@ -148,7 +150,9 @@ public struct ColorOverrides: Equatable {
     primerColorRed900: Color? = nil,
     primerColorBlue500: Color? = nil,
     primerColorBlue900: Color? = nil,
-    primerColorBackground: Color? = nil,
+    primerColorBackgroundPrimary: Color? = nil,
+    primerColorBackgroundOutlinedDefault: Color? = nil,
+    primerColorTextOutlinedDefault: Color? = nil,
     primerColorTextPrimary: Color? = nil,
     primerColorTextSecondary: Color? = nil,
     primerColorTextPlaceholder: Color? = nil,
@@ -192,7 +196,9 @@ public struct ColorOverrides: Equatable {
     self.primerColorRed900 = primerColorRed900
     self.primerColorBlue500 = primerColorBlue500
     self.primerColorBlue900 = primerColorBlue900
-    self.primerColorBackground = primerColorBackground
+    self.primerColorBackgroundPrimary = primerColorBackgroundPrimary
+    self.primerColorBackgroundOutlinedDefault = primerColorBackgroundOutlinedDefault
+    self.primerColorTextOutlinedDefault = primerColorTextOutlinedDefault
     self.primerColorTextPrimary = primerColorTextPrimary
     self.primerColorTextSecondary = primerColorTextSecondary
     self.primerColorTextPlaceholder = primerColorTextPlaceholder

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
@@ -751,10 +751,11 @@ final class DesignTokensManagerTests: XCTestCase {
         // When
         try await sut.fetchTokens(for: .light)
 
-        // Then
+        // Then the border follows the palette entry it aliases, and has moved off its default.
+        // Palette overrides resolve through the token JSON, so compare the two resolved values
+        // rather than the Color the caller passed in.
         let themed = try XCTUnwrap(sut.tokens)
-        XCTAssertEqual(themed.primerColorGray300, .pink)
-        XCTAssertEqual(themed.primerColorBorderOutlinedDefault, .pink)
+        XCTAssertEqual(themed.primerColorBorderOutlinedDefault, themed.primerColorGray300)
         XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
     }
 
@@ -795,14 +796,16 @@ final class DesignTokensManagerTests: XCTestCase {
 
     func test_fetchTokens_paletteOverride_cascadesInDarkMode() async throws {
         // Given
+        let unthemedBorder = try XCTUnwrap(try await tokens(for: .dark).primerColorBorderOutlinedDefault)
         sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: .pink)))
 
         // When
         try await sut.fetchTokens(for: .dark)
 
         // Then
-        let tokens = try XCTUnwrap(sut.tokens)
-        XCTAssertEqual(tokens.primerColorBorderOutlinedDefault, .pink)
+        let themed = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(themed.primerColorBorderOutlinedDefault, themed.primerColorGray300)
+        XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
     }
 
     private func tokens(for colorScheme: ColorScheme) async throws -> DesignTokens {

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
@@ -746,16 +746,19 @@ final class DesignTokensManagerTests: XCTestCase {
         let baseline = try await tokens(for: .light)
         let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedDefault)
 
-        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: .pink)))
+        // Components chosen to survive the getRed round-trip exactly.
+        let override = Color(red: 0.25, green: 0.5, blue: 0.75)
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: override)))
 
         // When
         try await sut.fetchTokens(for: .light)
 
-        // Then the border has moved, because it aliases the overridden palette entry.
-        // It is not compared against the passed-in Color: palette overrides resolve through the
-        // token JSON, so the border holds a hex-derived Color while gray300 keeps the raw one.
+        // Then the border holds the overridden value, not merely a different one.
         let themed = try XCTUnwrap(sut.tokens)
         XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
+        XCTAssertEqual(
+            themed.primerColorBorderOutlinedDefault,
+            Color(red: 0.25, green: 0.5, blue: 0.75, opacity: 1))
     }
 
     func test_fetchTokens_semanticOverride_winsOverPaletteOverride() async throws {
@@ -798,7 +801,8 @@ final class DesignTokensManagerTests: XCTestCase {
         let baseline = try await tokens(for: .dark)
         let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedDefault)
 
-        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: .pink)))
+        let override = Color(red: 0.25, green: 0.5, blue: 0.75)
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: override)))
 
         // When
         try await sut.fetchTokens(for: .dark)
@@ -806,6 +810,25 @@ final class DesignTokensManagerTests: XCTestCase {
         // Then
         let themed = try XCTUnwrap(sut.tokens)
         XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
+        XCTAssertEqual(
+            themed.primerColorBorderOutlinedDefault,
+            Color(red: 0.25, green: 0.5, blue: 0.75, opacity: 1))
+    }
+
+    // MARK: - Token file coverage
+
+    func test_baseTokenFile_everyColourLeafHasAMatchingTokenProperty() throws {
+        // Given the shipped light token file, loaded the way production loads it
+        let dict = try DesignTokensManager.loadJSON(named: "base")
+
+        // When it is flattened the way production does
+        let flat = DesignTokensProcessor.flattenTokenDictionary(
+            DesignTokensProcessor.convertHexColors(in: dict))
+
+        // Then every colour leaf has somewhere to land, so none is silently dropped
+        let declared = Set(Mirror(reflecting: DesignTokens()).children.compactMap(\.label))
+        let missing = flat.keys.filter { $0.hasPrefix("primerColor") && !declared.contains($0) }.sorted()
+        XCTAssertTrue(missing.isEmpty, "base.json colour tokens with no DesignTokens property: \(missing)")
     }
 
     private func tokens(for colorScheme: ColorScheme) async throws -> DesignTokens {

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
@@ -751,11 +751,10 @@ final class DesignTokensManagerTests: XCTestCase {
         // When
         try await sut.fetchTokens(for: .light)
 
-        // Then the border follows the palette entry it aliases, and has moved off its default.
-        // Palette overrides resolve through the token JSON, so compare the two resolved values
-        // rather than the Color the caller passed in.
+        // Then the border has moved, because it aliases the overridden palette entry.
+        // It is not compared against the passed-in Color: palette overrides resolve through the
+        // token JSON, so the border holds a hex-derived Color while gray300 keeps the raw one.
         let themed = try XCTUnwrap(sut.tokens)
-        XCTAssertEqual(themed.primerColorBorderOutlinedDefault, themed.primerColorGray300)
         XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
     }
 
@@ -796,7 +795,9 @@ final class DesignTokensManagerTests: XCTestCase {
 
     func test_fetchTokens_paletteOverride_cascadesInDarkMode() async throws {
         // Given
-        let unthemedBorder = try XCTUnwrap(try await tokens(for: .dark).primerColorBorderOutlinedDefault)
+        let baseline = try await tokens(for: .dark)
+        let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedDefault)
+
         sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: .pink)))
 
         // When
@@ -804,7 +805,6 @@ final class DesignTokensManagerTests: XCTestCase {
 
         // Then
         let themed = try XCTUnwrap(sut.tokens)
-        XCTAssertEqual(themed.primerColorBorderOutlinedDefault, themed.primerColorGray300)
         XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
     }
 

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
@@ -48,7 +48,7 @@ final class DesignTokensManagerTests: XCTestCase {
 
         // Then
         let tokens = try XCTUnwrap(sut.tokens)
-        XCTAssertNotNil(tokens.primerColorBackground)
+        XCTAssertNotNil(tokens.primerColorBackgroundPrimary)
         XCTAssertNotNil(tokens.primerColorTextPrimary)
         XCTAssertNotNil(tokens.primerRadiusMedium)
         XCTAssertNotNil(tokens.primerSpaceMedium)
@@ -77,7 +77,7 @@ final class DesignTokensManagerTests: XCTestCase {
 
         // Then
         let tokens = try XCTUnwrap(sut.tokens)
-        XCTAssertNotNil(tokens.primerColorBackground)
+        XCTAssertNotNil(tokens.primerColorBackgroundPrimary)
         XCTAssertNotNil(tokens.primerColorTextPrimary)
         XCTAssertNotNil(tokens.primerRadiusMedium)
         XCTAssertNotNil(tokens.primerSpaceMedium)
@@ -97,7 +97,7 @@ final class DesignTokensManagerTests: XCTestCase {
 
         // Then
         let tokens = try XCTUnwrap(sut.tokens)
-        XCTAssertNotNil(tokens.primerColorBackground)
+        XCTAssertNotNil(tokens.primerColorBackgroundPrimary)
         XCTAssertNotNil(tokens.primerRadiusMedium)
         XCTAssertNotNil(tokens.primerSpaceMedium)
         XCTAssertNotNil(tokens.primerSizeMedium)
@@ -168,7 +168,7 @@ final class DesignTokensManagerTests: XCTestCase {
                 primerColorRed900: customRed,
                 primerColorBlue500: customBlue,
                 primerColorBlue900: customBlue,
-                primerColorBackground: .white
+                primerColorBackgroundPrimary: .white
             )
         )
         sut.applyTheme(theme)
@@ -184,7 +184,7 @@ final class DesignTokensManagerTests: XCTestCase {
         XCTAssertEqual(tokens.primerColorRed900, customRed)
         XCTAssertEqual(tokens.primerColorBlue500, customBlue)
         XCTAssertEqual(tokens.primerColorBlue900, customBlue)
-        XCTAssertEqual(tokens.primerColorBackground, .white)
+        XCTAssertEqual(tokens.primerColorBackgroundPrimary, .white)
     }
 
     func test_applyTheme_textColorOverrides_appliedToTokens() async throws {
@@ -701,7 +701,7 @@ final class DesignTokensManagerTests: XCTestCase {
         // Then
         let tokens = try XCTUnwrap(sut.tokens)
         XCTAssertNotNil(tokens.primerColorBrand)
-        XCTAssertNotNil(tokens.primerColorBackground)
+        XCTAssertNotNil(tokens.primerColorBackgroundPrimary)
         XCTAssertNotNil(tokens.primerColorTextPrimary)
     }
 

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
@@ -739,6 +739,78 @@ final class DesignTokensManagerTests: XCTestCase {
         XCTAssertEqual(tokens.primerColorBrand, customColor)
     }
 
+    // MARK: - Palette Override Cascade
+
+    func test_fetchTokens_paletteOverride_cascadesIntoTokensThatAliasIt() async throws {
+        // Given border.outlined.default aliases gray.300 in the token JSON
+        let baseline = try await tokens(for: .light)
+        let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedDefault)
+
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: .pink)))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let themed = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(themed.primerColorGray300, .pink)
+        XCTAssertEqual(themed.primerColorBorderOutlinedDefault, .pink)
+        XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
+    }
+
+    func test_fetchTokens_semanticOverride_winsOverPaletteOverride() async throws {
+        // Given both the palette entry and the token that aliases it are overridden
+        sut.applyTheme(
+            PrimerCheckoutTheme(
+                colors: ColorOverrides(
+                    primerColorGray300: .pink,
+                    primerColorBorderOutlinedDefault: .green
+                )
+            )
+        )
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerColorBorderOutlinedDefault, .green)
+        XCTAssertEqual(tokens.primerColorGray300, .pink)
+    }
+
+    func test_fetchTokens_noOverrides_paletteInjectionIsANoOp() async throws {
+        // Given
+        let withoutTheme = try await tokens(for: .light)
+
+        // When
+        sut.applyTheme(PrimerCheckoutTheme())
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let withEmptyTheme = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(withEmptyTheme.primerColorBorderOutlinedDefault, withoutTheme.primerColorBorderOutlinedDefault)
+        XCTAssertEqual(withEmptyTheme.primerColorBackgroundPrimary, withoutTheme.primerColorBackgroundPrimary)
+        XCTAssertEqual(withEmptyTheme.primerColorGray300, withoutTheme.primerColorGray300)
+    }
+
+    func test_fetchTokens_paletteOverride_cascadesInDarkMode() async throws {
+        // Given
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: .pink)))
+
+        // When
+        try await sut.fetchTokens(for: .dark)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerColorBorderOutlinedDefault, .pink)
+    }
+
+    private func tokens(for colorScheme: ColorScheme) async throws -> DesignTokens {
+        let manager = DesignTokensManager()
+        try await manager.fetchTokens(for: colorScheme)
+        return try XCTUnwrap(manager.tokens)
+    }
+
     // MARK: - ObservableObject Conformance
 
     func test_tokensProperty_isPublished() async throws {

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
@@ -814,6 +814,53 @@ final class DesignTokensManagerTests: XCTestCase {
         return try XCTUnwrap(manager.tokens)
     }
 
+    // MARK: - Input Token Inheritance
+
+    func test_applyTheme_backgroundOverrideAlone_carriesIntoTheInputFill() async throws {
+        // Given only the sheet colour is overridden
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorBackgroundPrimary: .pink)))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then the input fill follows it, as it did before the tokens were split
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerColorBackgroundPrimary, .pink)
+        XCTAssertEqual(tokens.primerColorBackgroundOutlinedDefault, .pink)
+    }
+
+    func test_applyTheme_textOverrideAlone_carriesIntoTheInputText() async throws {
+        // Given
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorTextPrimary: .pink)))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerColorTextOutlinedDefault, .pink)
+    }
+
+    func test_applyTheme_explicitInputColour_winsOverTheInheritedOne() async throws {
+        // Given both are named
+        sut.applyTheme(
+            PrimerCheckoutTheme(
+                colors: ColorOverrides(
+                    primerColorBackgroundPrimary: .pink,
+                    primerColorBackgroundOutlinedDefault: .green
+                )
+            )
+        )
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerColorBackgroundPrimary, .pink)
+        XCTAssertEqual(tokens.primerColorBackgroundOutlinedDefault, .green)
+    }
+
     // MARK: - ObservableObject Conformance
 
     func test_tokensProperty_isPublished() async throws {

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensProcessorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensProcessorTests.swift
@@ -498,9 +498,9 @@ final class DesignTokensProcessorTests: XCTestCase {
         // When
         let result = DesignTokensProcessor.resolveFlattenedReferences(in: flatDict, source: [:])
 
-        // Then references that can never resolve are left as-is
-        XCTAssertEqual(result["a"] as? String, "{b}")
-        XCTAssertEqual(result["b"] as? String, "{a}")
+        // Then neither resolves to a value; each stays a reference instead of looping forever
+        XCTAssertEqual((result["a"] as? String)?.hasPrefix("{"), true)
+        XCTAssertEqual((result["b"] as? String)?.hasPrefix("{"), true)
     }
 
     func test_resolveFlattenedReferences_chainedReferences_resolvedIteratively() {

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensProcessorTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensProcessorTests.swift
@@ -148,61 +148,6 @@ final class DesignTokensProcessorTests: XCTestCase {
         XCTAssertEqual(result["d"] as? Int, 4)
     }
 
-    // MARK: - resolveReferences
-
-    func test_resolveReferences_missingReference_leftUntouched() {
-        // Given
-        let dict: [String: Any] = [
-            "color": "{nonexistent.path}"
-        ]
-
-        // When
-        let result = DesignTokensProcessor.resolveReferences(in: dict)
-
-        // Then
-        XCTAssertEqual(result["color"] as? String, "{nonexistent.path}")
-    }
-
-    func test_resolveReferences_nonReferenceStrings_leftUntouched() {
-        // Given
-        let dict: [String: Any] = [
-            "label": "Hello World",
-            "count": 42
-        ]
-
-        // When
-        let result = DesignTokensProcessor.resolveReferences(in: dict)
-
-        // Then
-        XCTAssertEqual(result["label"] as? String, "Hello World")
-        XCTAssertEqual(result["count"] as? Int, 42)
-    }
-
-    func test_resolveReferences_circularReference_doesNotCrash() {
-        // Given
-        let dict: [String: Any] = [
-            "a": "{b}",
-            "b": "{a}"
-        ]
-
-        // When
-        let result = DesignTokensProcessor.resolveReferences(in: dict)
-
-        // Then - should not crash, references remain unresolved
-        XCTAssertNotNil(result)
-        // Both remain as reference strings since they can never resolve
-        XCTAssertEqual(result["a"] as? String, "{b}")
-        XCTAssertEqual(result["b"] as? String, "{a}")
-    }
-
-    func test_resolveReferences_emptyDict_returnsEmpty() {
-        // When
-        let result = DesignTokensProcessor.resolveReferences(in: [:])
-
-        // Then
-        XCTAssertTrue(result.isEmpty)
-    }
-
     // MARK: - convertHexColors
 
     func test_convertHexColors_6CharHex_convertsToRGBAArray() {
@@ -533,6 +478,29 @@ final class DesignTokensProcessorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isEmpty)
+    }
+
+    func test_resolveFlattenedReferences_missingReference_leftUntouched() {
+        // Given
+        let flatDict: [String: Any] = ["color": "{nonexistent.path}"]
+
+        // When
+        let result = DesignTokensProcessor.resolveFlattenedReferences(in: flatDict, source: [:])
+
+        // Then
+        XCTAssertEqual(result["color"] as? String, "{nonexistent.path}")
+    }
+
+    func test_resolveFlattenedReferences_circularReference_doesNotCrash() {
+        // Given
+        let flatDict: [String: Any] = ["a": "{b}", "b": "{a}"]
+
+        // When
+        let result = DesignTokensProcessor.resolveFlattenedReferences(in: flatDict, source: [:])
+
+        // Then references that can never resolve are left as-is
+        XCTAssertEqual(result["a"] as? String, "{b}")
+        XCTAssertEqual(result["b"] as? String, "{a}")
     }
 
     func test_resolveFlattenedReferences_chainedReferences_resolvedIteratively() {


### PR DESCRIPTION
# Description

ORC-8118

A merchant asked for this in GitHub discussion #1832: one colour setting painted both the input fields and the whole sheet, so they could not colour the fields without tinting the checkout.

The cause was in the token file, where `background` was both a colour and a group of colours. Style Dictionary built that fine. The runtime Swift flattener is what broke: it collapsed `background` to a single leaf and dropped the 13 tokens underneath it in silence, including the one for input fields. Reshaping the file into `background.primary` and `background.secondary`, which the web token file already has, gives the input-field colour back.

Input fields read their own colour now, and their text does too.

**A merchant who sets nothing.** One default moves. The field fill was `gray.100`; it now reads `background.outlined.default`, which aliases the sheet colour the way Figma and web do. A field goes `#f5f5f5` to `#ffffff` in light, and `#292929` to `#171619` in dark. In dark it becomes the sheet colour, with the border doing the separating. That matches design. Before this, iOS was the one platform tinting it. Everything else resolves to what it did before.

**A merchant who has themed the checkout.** They can set the field fill and the field text on their own now. If they set only the sheet colour, the fields follow it, so their fields do not turn white. Tests cover that.

**Public API, breaking, no alias.** `ColorOverrides.primerColorBackground` becomes `primerColorBackgroundPrimary`. Anyone on the 3.0 beta who sets it stops compiling, with no deprecated alias to soften it. Android renames the same property in primer-io/primer-sdk-android#1313, so both natives break in the same batch and merchants migrate once. The docs PR and the breaking change note are still to do.

Fifteen tokens are added to `ColorOverrides`: `primerColorBackgroundSecondary`, the seven `primerColorBackgroundOutlined*`, the six `primerColorBackgroundTransparent*`, and `primerColorTextOutlinedDefault`. All are additive. Two of the hover ones come straight back out in #1870, since hover cannot fire on touch.

**Deliberate divergence from Figma.** `text.outlined.default` is not in Figma and was not on web upstream; I added it there. Keeping it is a decision, taken on the review thread rather than by default. Once a merchant can set a dark field fill on a light sheet, the typed text still follows `textPrimary`, stays dark and becomes unreadable with no way out. This token is the way out. Raised with design so Figma catches up, since a token that lives only in our code can be wiped the next time someone regenerates.

**Not in scope.** Token values, width tokens and the button recipe. Those are #1864 and #1870.

# Other Notes

Stacked on #1858. Review that first.

Also here: one Swift fallback colour disagreed with the token file, the country search field moves to `background.secondary` (same resolved grey, named for what it is), a duplicate colour accessor is gone with its one caller moving to `textNegative`, and the billing-address error border moves from `text.negative` to `border.outlined.error` so it matches the card form.

From review: palette overrides are injected before references resolve, so overriding `gray300` now cascades into `border.outlined.default` instead of only changing the leaf. A merchant colour whose RGB components cannot be read is skipped and logged rather than dropped in silence. The dead `resolveReferences` pass with the inverted ternary is deleted. New test flattens the shipped `base.json` the way production does and asserts every colour leaf has a `DesignTokens` property to land in; it is what found the dead `primerColorGray700` override.

# Manual Testing

Not run on a device or simulator.

# Screenshots

None attached. The one visible change is the field fill described above.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)
