### PR TITLE
fix(components): stop the country list covering the sheet colour (ORC-8178)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -223,7 +223,7 @@ struct KlarnaView: View, LogReporter {
           // Checkmark for selected
           if isSelected {
             Image(systemName: "checkmark")
-              .foregroundColor(CheckoutColors.blue(tokens: tokens))
+              .foregroundColor(CheckoutColors.borderSelected(tokens: tokens))
               .font(PrimerFont.bodyMedium(tokens: tokens))
           }
         }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
@@ -159,9 +159,11 @@ struct SelectCountryScreen: View, LogReporter {
             )
           }
         }
+        .listRowBackground(Color.clear)
       }
     }
     .listStyle(PlainListStyle())
+    .primerClearListBackground()
   }
 
   private func selectCountry(_ country: PrimerCountry) {
@@ -211,7 +213,7 @@ private struct CountryItemView: View {
         // Selection indicator
         if isSelected {
           Image(systemName: "checkmark")
-            .foregroundColor(CheckoutColors.blue(tokens: tokens))
+            .foregroundColor(CheckoutColors.borderSelected(tokens: tokens))
         }
       }
       .padding(.vertical, PrimerSpacing.small(tokens: tokens))
@@ -219,5 +221,19 @@ private struct CountryItemView: View {
       .contentShape(Rectangle())
     }
     .buttonStyle(PlainButtonStyle())
+  }
+}
+
+@available(iOS 15.0, *)
+extension View {
+  /// `List` paints its own background on top of the sheet colour. Only iOS 16 can turn that off;
+  /// on 15 the clear row backgrounds still remove most of it.
+  @ViewBuilder
+  func primerClearListBackground() -> some View {
+    if #available(iOS 16.0, *) {
+      scrollContentBackground(.hidden)
+    } else {
+      self
+    }
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -95,8 +95,6 @@ enum CheckoutColors {
     isEnabled ? .white : (tokens?.primerColorTextDisabled ?? Color(.tertiaryLabel))
   }
 
-  static func blue(tokens _: DesignTokens?) -> Color { .blue }
-
   static func orange(tokens _: DesignTokens?) -> Color { .orange }
 
   // MARK: - Screen & Input Colors


### PR DESCRIPTION
# Description

ORC-8178

Two colour bugs on iOS.

**The country list ignored the theme.** It is a SwiftUI `List`, which paints its own background on top of the sheet colour, so a merchant's background never showed on that screen. Rows are transparent now, and on iOS 16 and up the list background is hidden.

**Two selection ticks were hardcoded blue.** The country picker's and Klarna's checkmarks used an accessor that took the theme and threw it away. They read `border.outlined.selected` now, which leaves that accessor unused, so it is removed.

**A merchant who sets nothing.** The two ticks go from the system blue `#007AFF` to brand `#2f98ff`. That trades light for dark: on the white sheet contrast drops from 4.02:1 to 2.98:1, and in dark mode it improves from 4.94:1 to 6.06:1. The brand value is what design specifies, and the sub-3:1 number is on the same question already raised with design about the error border. No pixel moves and no layout changes.

**A merchant who has themed the checkout.** The country screen finally takes their background colour, on iOS 16 and up. Their selected-border colour now paints the two ticks.

**iOS 15.** The fix does not reach it. `scrollContentBackground` is iOS 16 only, and on iOS 15 the rows and the underlying `UITableView` share one system background, so the transparent rows do nothing on their own. The country screen keeps the system background there.

**Public API.** No change.

**Not in scope.** Two items on this ticket turned out not to be bugs, and are noted on the ticket rather than changed: switching the phone to dark mode mid-checkout already reloads the tokens, and the "white flash on open" falls back to a dark colour in dark mode, not white. Two warning triangles keep a hardcoded orange, deliberately: there is no warning colour in the token set at all, the same gap web hit with its BLIK note, so there is nowhere themed to point them.

# Other Notes

Stacked on #1864. Review that first.

The red Unit Tests run was a flake. The same SHA passed on 2026-08-21 in run 32536917307 and failed on the 2026-08-22 re-run in run 32575648070, both with 3022 tests. Re-run since.

# Manual Testing

Not run on a device or simulator. Worth opening the country picker on a dark theme to confirm the background.

# Screenshots

None.

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)
