### PR TITLE
fix: Fire willCreatePayment after Apple Pay authorization (ORC-8210)

### DIFF
--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -109,7 +109,6 @@ final class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
 
         let clientSessionActionsModule: ClientSessionActionsProtocol = ClientSessionActionsModule()
         try await clientSessionActionsModule.selectPaymentMethodIfNeeded(config.type, cardNetwork: nil)
-        try await handlePrimerWillCreatePaymentEvent(PrimerPaymentMethodData(type: config.type))
         try await presentPaymentMethodUserInterface()
         try await awaitUserInput()
 
@@ -120,6 +119,9 @@ final class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
             mobileNumber: applePayPaymentResponse.mobileNumber,
             emailAddress: applePayPaymentResponse.emailAddress
         )
+
+        // Must run after the client session address updates so merchants can act on them (Android parity)
+        try await handlePrimerWillCreatePaymentEvent(PrimerPaymentMethodData(type: config.type))
     }
 
     override func performTokenizationStep() async throws {

--- a/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
+++ b/Sources/PrimerSDK/Classes/User Interface/TokenizationViewModels/ApplePayTokenizationViewModel.swift
@@ -120,7 +120,6 @@ final class ApplePayTokenizationViewModel: PaymentMethodTokenizationViewModel {
             emailAddress: applePayPaymentResponse.emailAddress
         )
 
-        // Must run after the client session address updates so merchants can act on them (Android parity)
         try await handlePrimerWillCreatePaymentEvent(PrimerPaymentMethodData(type: config.type))
     }
 

--- a/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
+++ b/Tests/Primer/Tokenization/View Models/ApplePayTokenizationViewModelTests.swift
@@ -154,7 +154,42 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
         uiManager = nil
         createResumePaymentService = nil
         tokenizationService = nil
+        PrimerAPIConfigurationModule.apiClient = nil
         SDKSessionHelper.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    /// Mocks the API client so the client session updates the flow performs after Apple Pay
+    /// authorization resolve locally instead of hitting the network.
+    @discardableResult
+    private func setUpMockedClientSessionUpdates() throws -> MockPrimerAPIClient {
+        let config = try XCTUnwrap(PrimerAPIConfiguration.current, "Unable to generate configuration")
+        let apiClient = MockPrimerAPIClient()
+        apiClient.fetchConfigurationWithActionsResult = (config, nil)
+        PrimerAPIConfigurationModule.apiClient = apiClient
+        return apiClient
+    }
+
+    private func makeApplePayPresentationManager(
+        authorizationDelay: TimeInterval = 0.1,
+        onPresented: (() -> Void)? = nil
+    ) -> MockApplePayPresentationManager {
+        let manager = MockApplePayPresentationManager()
+        manager.onPresent = { _, delegate in
+            DispatchQueue.main.asyncAfter(deadline: .now() + authorizationDelay) {
+                let dummyController = PKPaymentAuthorizationController()
+                delegate.paymentAuthorizationController?(
+                    dummyController,
+                    didAuthorizePayment: MockPKPayment(),
+                    handler: { _ in }
+                )
+                delegate.paymentAuthorizationControllerDidFinish(dummyController)
+            }
+            onPresented?()
+            return .success(())
+        }
+        return manager
     }
 
     // MARK: - Validation Tests
@@ -205,11 +240,14 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
         let delegate = MockPrimerHeadlessUniversalCheckoutDelegate()
         PrimerHeadlessUniversalCheckout.current.delegate = delegate
 
+        try setUpMockedClientSessionUpdates()
+        sut.applePayPresentationManager = makeApplePayPresentationManager()
+
         let expectWillCreatePaymentWithData = expectation(description: "Will create payment with data")
         delegate.onWillCreatePaymentWithData = { data, decision in
             XCTAssertEqual(data.paymentMethodType.type, Mocks.Static.Strings.webRedirectPaymentMethodType)
-            decision(.abortPaymentCreation())
             expectWillCreatePaymentWithData.fulfill()
+            decision(.abortPaymentCreation())
         }
 
         let expectDidFail = expectation(description: "Payment flow fails")
@@ -228,7 +266,40 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
         wait(for: [
             expectWillCreatePaymentWithData,
             expectDidFail,
-        ], timeout: 2.0, enforceOrder: true)
+        ], timeout: 5.0, enforceOrder: true)
+    }
+
+    func test_startFlow_shouldUpdateClientSessionBeforeWillCreatePayment() throws {
+        SDKSessionHelper.setUp(order: order)
+        let delegate = MockPrimerHeadlessUniversalCheckoutDelegate()
+        PrimerHeadlessUniversalCheckout.current.delegate = delegate
+
+        try setUpMockedClientSessionUpdates()
+        sut.applePayPresentationManager = makeApplePayPresentationManager()
+
+        let expectDidUpdateClientSession = expectation(description: "Client session updates with the Apple Pay address")
+        delegate.onDidUpdateClientSession = { _ in
+            expectDidUpdateClientSession.fulfill()
+        }
+
+        let expectWillCreatePaymentWithData = expectation(description: "Will create payment with data")
+        delegate.onWillCreatePaymentWithData = { _, decision in
+            expectWillCreatePaymentWithData.fulfill()
+            decision(.abortPaymentCreation())
+        }
+
+        let expectDidFail = expectation(description: "Payment flow fails")
+        delegate.onDidFail = { _ in
+            expectDidFail.fulfill()
+        }
+
+        sut.start()
+
+        wait(for: [
+            expectDidUpdateClientSession,
+            expectWillCreatePaymentWithData,
+            expectDidFail,
+        ], timeout: 5.0, enforceOrder: true)
     }
 
     func test_startFlow_withShippingModules_shouldCompleteSuccessfully() throws {
@@ -255,9 +326,6 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
         PrimerAPIConfigurationModule.apiClient = apiClient
         apiClient.fetchConfigurationWithActionsResult = (config, nil)
 
-        let applePayPresentationManager = MockApplePayPresentationManager()
-        sut.applePayPresentationManager = applePayPresentationManager
-
         let expectWillCreatePaymentWithData = expectation(description: "Will create payment with data")
         delegate.onWillCreatePaymentWithData = { data, decision in
             XCTAssertEqual(data.paymentMethodType.type, Mocks.Static.Strings.webRedirectPaymentMethodType)
@@ -266,18 +334,8 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
         }
 
         let expectDidPresentApplePay = expectation(description: "Apple Pay UI presents")
-        applePayPresentationManager.onPresent = { _, delegate in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                let dummyController = PKPaymentAuthorizationController()
-                delegate.paymentAuthorizationController?(
-                    dummyController,
-                    didAuthorizePayment: MockPKPayment(),
-                    handler: { _ in }
-                )
-                delegate.paymentAuthorizationControllerDidFinish(dummyController)
-            }
+        sut.applePayPresentationManager = makeApplePayPresentationManager(authorizationDelay: 1.5) {
             expectDidPresentApplePay.fulfill()
-            return .success(())
         }
 
         let expectDidTokenize = expectation(description: "Payment method tokenizes")
@@ -306,8 +364,8 @@ final class ApplePayTokenizationViewModelTests: XCTestCase {
         sut.start()
 
         wait(for: [
-            expectWillCreatePaymentWithData,
             expectDidPresentApplePay,
+            expectWillCreatePaymentWithData,
             expectDidTokenize,
             expectDidCreatePayment,
             expectDidCompleteCheckout,


### PR DESCRIPTION
# Description

[ORC-8210](https://primerapi.atlassian.net/browse/ORC-8210)

On Apple Pay, `willCreatePaymentWithData` fired when the shopper tapped the pay button, before the sheet opened. The wallet billing address isn't in the client session yet at that point, so merchants can't use it. It now fires after authorization and after the billing/shipping session updates, matching Android's `onClientSessionUpdated` then `onBeforePaymentCreated` order.

Worth knowing:

- Aborting now happens after the shopper has authorized, so the failure shows after Apple Pay's checkmark. Same as Android.
- An aborted payment leaves the billing address applied to the session. Same as Android.
- Drop-in shares this view model, so its callback timing changes too.

# Other Notes

The abort test now drives a client session update, so it needed a mocked API client. Added that, plus an `apiClient` reset in teardown.

# Manual Testing

Not verified on device, Apple Pay needs real hardware. Unit tests pin the new order.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge


[ORC-8210]: https://primerapi.atlassian.net/browse/ORC-8210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ