### PR TITLE
fix: Correct Polish BLIK typo and drop-in copy (ESC-1105)

### DIFF
--- a/Modules/PrimerResources/Sources/PrimerResources/Resources/Localizable/pl.lproj/Localizable.strings
+++ b/Modules/PrimerResources/Sources/PrimerResources/Resources/Localizable/pl.lproj/Localizable.strings
@@ -1,31 +1,31 @@
 /* An error message displayed when the Address line 1 is not correct */
-"addressLine1ErrorInvalid" = "Nieprawidłowa pierwsza linia adresu";
+"addressLine1ErrorInvalid" = "Nieprawidłowy adres (linia 1)";
 
-/* State, Region or County is required - Form Validation */
-"addressLine1ErrorRequired" = "Pierwsza linia adresu jest wymagana";
+/* Address line 1 is required - Form Validation */
+"addressLine1ErrorRequired" = "Adres (linia 1) jest wymagany";
 
 /* The billing address Address line 1 container view label */
-"addressLine1Label" = "Pierwsza linia adresu";
+"addressLine1Label" = "Adres (linia 1)";
 
 /* Form Text Field Placeholder (Address line 1) */
 "addressLine1Placeholder" = "Pierwsza linia adresu";
 
 /* An error message displayed when the Address line 2 is not correct */
-"addressLine2ErrorInvalid" = "Nieprawidłowa druga linia adresu";
+"addressLine2ErrorInvalid" = "Nieprawidłowy adres (linia 2)";
 
-/* State, Region or County is required - Form Validation */
-"addressLine2ErrorRequired" = "Druga linia adresu jest wymagana";
+/* Address line 2 is required - Form Validation */
+"addressLine2ErrorRequired" = "Adres (linia 2) jest wymagany";
 
 /* The billing address Address line 2 container view label */
-"addressLine2Label" = "Druga linia adresu";
+"addressLine2Label" = "Adres (linia 2)";
 
 /* Form Text Field Placeholder (Address line 2) */
 "addressLine2Placeholder" = "Druga linia adresu";
 
 "card_expiry_date" = "MM/RR";
 
-/* An error message displayed when the city field is not correct */
-"cardholderErrorInvalid" = "Nieprawidłowe imię i nazwisko posiadacza karty";
+/* An error message displayed when the Cardholder name is not correct */
+"cardholderErrorInvalid" = "Nieprawidłowe imię i nazwisko na karcie";
 
 /* Choose your bank - Choose your bank title label */
 "choose-your-bank-title-label" = "Wybierz bank";
@@ -83,7 +83,7 @@
 "form_error_card_type_not_supported" = "Nieobsługiwany typ karty";
 
 /* Get the code from your banking app - Blik descriptor */
-"input_description_otp" = "Otrzymaj kod z aplikacji bankowej";
+"input_description_otp" = "Wpisz kod z aplikacji bankowej";
 
 /* 6 digit code - Text field top placeholder */
 "input_hint_form_blik_otp" = "6-cyfrowy kod";
@@ -287,7 +287,7 @@
 "shipping" = "Wysyłka";
 
 /* An error message displayed when the State, Region or County field is not correct */
-"stateErrorInvalid" = "Nieprawidłowy stan, region lub województwo";
+"stateErrorInvalid" = "Nieprawidłowy region";
 
 /* State, Region or County is required - Form Validation */
 "stateErrorRequired" = "Stan, region lub województwo jest wymagane";

--- a/Modules/PrimerResources/Sources/PrimerResources/Resources/Localizable/pl.lproj/Localizable.strings
+++ b/Modules/PrimerResources/Sources/PrimerResources/Resources/Localizable/pl.lproj/Localizable.strings
@@ -8,7 +8,7 @@
 "addressLine1Label" = "Adres (linia 1)";
 
 /* Form Text Field Placeholder (Address line 1) */
-"addressLine1Placeholder" = "Pierwsza linia adresu";
+"addressLine1Placeholder" = "Adres (linia 1)";
 
 /* An error message displayed when the Address line 2 is not correct */
 "addressLine2ErrorInvalid" = "Nieprawidłowy adres (linia 2)";
@@ -20,7 +20,7 @@
 "addressLine2Label" = "Adres (linia 2)";
 
 /* Form Text Field Placeholder (Address line 2) */
-"addressLine2Placeholder" = "Druga linia adresu";
+"addressLine2Placeholder" = "Adres (linia 2)";
 
 "card_expiry_date" = "MM/RR";
 
@@ -290,7 +290,7 @@
 "stateErrorInvalid" = "Nieprawidłowy region";
 
 /* State, Region or County is required - Form Validation */
-"stateErrorRequired" = "Stan, region lub województwo jest wymagane";
+"stateErrorRequired" = "Region jest wymagany";
 
 /* The billing address state container view label */
 "stateLabel" = "Stan / Region / Województwo";

--- a/Modules/PrimerResources/Sources/PrimerResources/Resources/Localizable/pl.lproj/Localizable.strings
+++ b/Modules/PrimerResources/Sources/PrimerResources/Resources/Localizable/pl.lproj/Localizable.strings
@@ -1,23 +1,23 @@
 /* An error message displayed when the Address line 1 is not correct */
-"addressLine1ErrorInvalid" = "Invalid Address Line 1";
+"addressLine1ErrorInvalid" = "Nieprawidłowa pierwsza linia adresu";
 
 /* State, Region or County is required - Form Validation */
-"addressLine1ErrorRequired" = "Wymagana jest 1. linia adresowa";
+"addressLine1ErrorRequired" = "Pierwsza linia adresu jest wymagana";
 
 /* The billing address Address line 1 container view label */
-"addressLine1Label" = "Address line 1";
+"addressLine1Label" = "Pierwsza linia adresu";
 
 /* Form Text Field Placeholder (Address line 1) */
 "addressLine1Placeholder" = "Pierwsza linia adresu";
 
 /* An error message displayed when the Address line 2 is not correct */
-"addressLine2ErrorInvalid" = "Invalid Address Line 2";
+"addressLine2ErrorInvalid" = "Nieprawidłowa druga linia adresu";
 
 /* State, Region or County is required - Form Validation */
-"addressLine2ErrorRequired" = "Wymagana jest 2. linia adresowa";
+"addressLine2ErrorRequired" = "Druga linia adresu jest wymagana";
 
 /* The billing address Address line 2 container view label */
-"addressLine2Label" = "Address line 2";
+"addressLine2Label" = "Druga linia adresu";
 
 /* Form Text Field Placeholder (Address line 2) */
 "addressLine2Placeholder" = "Druga linia adresu";
@@ -25,13 +25,13 @@
 "card_expiry_date" = "MM/RR";
 
 /* An error message displayed when the city field is not correct */
-"cardholderErrorInvalid" = "Invalid Cardholder name";
+"cardholderErrorInvalid" = "Nieprawidłowe imię i nazwisko posiadacza karty";
 
 /* Choose your bank - Choose your bank title label */
 "choose-your-bank-title-label" = "Wybierz bank";
 
 /* An error message displayed when the city field is not correct */
-"cityErrorInvalid" = "Invalid city";
+"cityErrorInvalid" = "Nieprawidłowe miasto";
 
 /* City is required - Form Validation */
 "cityErrorRequired" = "Wymagane jest miasto";
@@ -49,7 +49,7 @@
 "continue" = "Kontynuuj";
 
 /* An error message displayed when the Country is not correct */
-"countryCodeErrorInvalid" = "Invalid Country";
+"countryCodeErrorInvalid" = "Nieprawidłowy kraj";
 
 /* Country is required - Form Validation */
 "countryCodeErrorRequired" = "Kraj jest wymagany";
@@ -67,7 +67,7 @@
 "dueAt" = "Termin:";
 
 /* An error message displayed when the First Name is not correct */
-"firstNameErrorInvalid" = "Invalid First Name";
+"firstNameErrorInvalid" = "Nieprawidłowe imię";
 
 /* First name is required - Form Validation */
 "firstNameErrorRequired" = "Imię jest wymagane";
@@ -78,18 +78,18 @@
 /* Form Text Field Placeholder (First name) */
 "firstNamePlaceholder" = "Imię";
 
-"form_error_card_holder_name_length" = "Nazwa musi zawierać od 2 do 45 znaków";
+"form_error_card_holder_name_length" = "Wpisz od 2 do 45 znaków";
 
-"form_error_card_type_not_supported" = "Nieobsługiwane typy kart";
+"form_error_card_type_not_supported" = "Nieobsługiwany typ karty";
 
 /* Get the code from your banking app - Blik descriptor */
-"input_description_otp" = "Otrymaj kod z aplikacji bankowej";
+"input_description_otp" = "Otrzymaj kod z aplikacji bankowej";
 
 /* 6 digit code - Text field top placeholder */
 "input_hint_form_blik_otp" = "6-cyfrowy kod";
 
 /* An error message displayed when the Last Name is not correct */
-"lastNameErrorInvalid" = "Invalid Last Name";
+"lastNameErrorInvalid" = "Nieprawidłowe nazwisko";
 
 /* Last name is required - Form Validation */
 "lastNameErrorRequired" = "Nazwisko jest wymagane";
@@ -104,7 +104,7 @@
 "no_additional_fee" = "Żadnych dodatkowych opłat";
 
 /* Enter your one time password - Text field placeholder */
-"payment_method_blik_loading_placeholder" = "Dokończ płatność w aplikacji Blik";
+"payment_method_blik_loading_placeholder" = "Dokończ płatność w aplikacji BLIK";
 
 /* Pay with card - Payment Method Type (Card Not Vaulted */
 "payment-method-type-card-not-vaulted" = "Zapłać kartą";
@@ -113,7 +113,7 @@
 "pleaseTransferFunds" = "Przelej środki na podane konto DBS z Twojego konta bankowego w Singapurze, wybierając metodę FAST (zalecana), MEPS lub GIRO.";
 
 /* An error message displayed when the postal code field is not correct */
-"postalCodeErrorInvalid" = "Invalid postal code";
+"postalCodeErrorInvalid" = "Nieprawidłowy kod pocztowy";
 
 /* Postal code is required - Form Validation */
 "postalCodeErrorRequired" = "Wymagany jest kod pocztowy";
@@ -203,7 +203,7 @@
 "primer-form-text-field-title-card-number" = "Numer karty";
 
 /* Expiry date - Form Text Field Title (Expiry date) */
-"primer-form-text-field-title-expiry-date" = "Data wygaśnięcia";
+"primer-form-text-field-title-expiry-date" = "Data ważności";
 
 /* Enter your card details - Form Type Main Title (Card) */
 "primer-form-type-main-title-card-form" = "Wpisz dane karty";
@@ -287,7 +287,7 @@
 "shipping" = "Wysyłka";
 
 /* An error message displayed when the State, Region or County field is not correct */
-"stateErrorInvalid" = "Nieprawidłowy stan, region lub hrabstwo";
+"stateErrorInvalid" = "Nieprawidłowy stan, region lub województwo";
 
 /* State, Region or County is required - Form Validation */
 "stateErrorRequired" = "Stan, region lub województwo jest wymagane";


### PR DESCRIPTION
# Description

ESC-1105

The Polish BLIK OTP descriptor read "Otrymaj kod z aplikacji bankowej". "Otrymaj" is not a Polish word. The imperative of "otrzymać" is "otrzymaj". A merchant reported it on the drop-in BLIK flow, where the string is the label under the OTP field.

Render path: `Strings.Blik.inputDescriptor` (`Strings.swift:1092`) -> `FormPaymentMethodTokenizationViewModel.swift:158` -> `inputTextFieldsStackViews` -> `PrimerInputViewController`. Only drop-in shows it. Headless routes BLIK through `PrimerRawOTPDataTokenizationBuilder`, where the merchant builds the field, and CheckoutComponents uses its own keys.

# Other Notes

The rest of the Polish drop-in copy is fixed in the same file:

- Eight strings were still in English: the invalid-value errors for both address lines, cardholder name, city, country, first name, last name and postal code, plus both address line labels.
- The address lines are now named the same way everywhere. Labels, placeholders and both error kinds all say "pierwsza/druga linia adresu", matching CheckoutComponents.
- The cardholder field is called by its real name. "Nazwa" names a thing, not a person, so the length error becomes "Wpisz od 2 do 45 znaków" and the invalid error names the cardholder.
- The unsupported-card-type error is singular, since it fires for the one card being entered.
- BLIK is written in capitals, as the brand does and as every other BLIK string already did.
- The card expiry date uses "data ważności", the term printed on Polish cards.
- "Hrabstwo" is gone from the state error. It is the British county and appears nowhere on the field's own label.

## Phrase is already updated

These files are Phrase-managed, and Phrase held the same typo. `Manual Translation Update` runs `phrase pull`, which overwrites the repo, so this PR alone would regress on the next pull.

I pushed the 18 corrected Polish values to the drop-in Phrase project on 2026-08-31, and verified them by downloading the locale again. Phrase now matches this branch exactly. The other 85 Polish keys were not touched, and no keys were created or deleted.

Two things are worth knowing about that push:

- A plain `phrase push` cannot do this. `update_translations` is off by default, so a push only creates what is missing. PR #1872 adds a `Manual Translation Push` workflow so the next person does not have to work this out again.
- Five of these keys also carry the `android-sdk` tag, and a shared key has one Polish translation. So the push also corrected the Android drop-in copy, including the escalated `input_description_otp`. The Android team gets it on their next translation pull. Their `upload-to-phrase.yml` runs on every PR but only uploads the English source with `update_translations: false`, so it cannot overwrite this.

CheckoutComponents has its own Phrase project and is not affected by this PR. The same Polish fixes are on `bn/feature/checkout-components` as commits `673ca715d` and `31c7d55c2`.

# Manual Testing

Not yet run on a device. To verify: open the drop-in checkout with the device language set to Polish, choose BLIK, and read the label under the OTP field. It should read "Otrzymaj kod z aplikacji bankowej".

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

