### PR TITLE
chore: Add a Phrase push workflow for one locale (ESC-1105)

### DIFF
--- a/.github/scripts/diff_phrase_locale.py
+++ b/.github/scripts/diff_phrase_locale.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Report how a locale's .strings file differs from what Phrase currently holds.
+
+Used by Manual Translation Push to record the blast radius of an upload in the run log,
+and runnable by hand before deciding to push:
+
+    phrase locales download --id Polish --file_format strings --tags ios-sdk > current.strings
+    python3 .github/scripts/diff_phrase_locale.py current.strings path/to/pl.lproj/Localizable.strings
+
+Phrase serves .strings as UTF-16; the files in this repo are UTF-8, so both encodings are
+tried on each side rather than assumed.
+"""
+
+import re
+import sys
+
+ENTRY = re.compile(r'^"((?:[^"\\]|\\.)*)" = "((?:[^"\\]|\\.)*)";', re.M)
+
+
+def read(path):
+    for encoding in ("utf-16", "utf-8-sig", "utf-8"):
+        try:
+            with open(path, encoding=encoding) as handle:
+                text = handle.read()
+        except (UnicodeDecodeError, UnicodeError):
+            continue
+        # A UTF-8 file decoded as UTF-16 yields mojibake rather than an error, so require
+        # that the result actually parses as .strings entries.
+        if ENTRY.search(text):
+            return text
+    sys.exit(f"error: could not parse {path} as a .strings file")
+
+
+def entries(text):
+    return {key: value for key, value in ENTRY.findall(text)}
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit(f"usage: {sys.argv[0]} <phrase.strings> <repo.strings>")
+
+    remote, local = entries(read(sys.argv[1])), entries(read(sys.argv[2]))
+
+    changed = sorted(k for k in remote.keys() & local.keys() if remote[k] != local[k])
+    added = sorted(local.keys() - remote.keys())
+    missing = sorted(remote.keys() - local.keys())
+
+    print(f"Phrase holds {len(remote)} keys, the repo file has {len(local)}.\n")
+
+    if changed:
+        print(f"{len(changed)} value(s) would be overwritten in Phrase:")
+        for key in changed:
+            print(f"  {key}")
+            print(f"    phrase: {remote[key]}")
+            print(f"    repo  : {local[key]}")
+        print()
+
+    if added:
+        # update_translation_keys is pinned to false, so these are reported, not created.
+        print(f"{len(added)} key(s) exist only in the repo and will NOT be created:")
+        for key in added:
+            print(f"  {key}")
+        print()
+
+    if missing:
+        print(f"{len(missing)} key(s) exist only in Phrase and are left untouched:")
+        for key in missing:
+            print(f"  {key}")
+        print()
+
+    if not changed:
+        print("No existing translation would change. The push would be a no-op.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/manual-translation-push.yml
+++ b/.github/workflows/manual-translation-push.yml
@@ -1,0 +1,124 @@
+name: 'Manual Translation Push'
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to read the .strings files from'
+        required: true
+        default: 'master'
+      locale:
+        description: 'Phrase locale name to push, e.g. Polish. One locale per run.'
+        required: true
+      dry_run:
+        description: 'Report what would change without uploading'
+        required: true
+        type: boolean
+        default: true
+
+# Phrase is the source of truth for the .strings files, and Manual Translation Update
+# overwrites the repo from it. This workflow is the other direction: it sends one
+# locale's corrected values back, so a repo-side fix is not undone by the next pull.
+#
+# Scope is deliberately narrow. It pushes ONE locale of the drop-in project per run.
+# The repo's phrase_config.yml push block covers every locale at once and is not reused.
+#
+# CheckoutComponents is intentionally NOT supported here. That Phrase project is shared
+# with the Android SDK and its source strings use Android format specifiers (%s), while
+# this repo uses %@. Uploading the iOS files would rewrite those specifiers and break
+# Android formatting at runtime. Correct CheckoutComponents strings in the Phrase editor.
+
+jobs:
+  push-translations:
+    name: "Push one locale's translations to Phrase.com"
+    runs-on: ubuntu-latest
+
+    env:
+      PHRASE_ACCESS_KEY: ${{ secrets.PHRASE_ACCESS_KEY }}
+      PROJECT_ID: ${{ secrets.PHRASE_PROJECT_ID }}
+      LOCALE: ${{ inputs.locale }}
+      TAGS: ios-sdk
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Install Phrase CLI
+        uses: phrase/setup-cli@884b5c75c4f61b8888a3ff30d34eb7111d20fa86
+        with:
+          version: '2.35.5'
+
+      - name: Write Phrase configuration
+        run: |
+          # The locale is resolved to a directory name so the source path names exactly
+          # one file. A <locale_code> placeholder would glob every .lproj on disk.
+          code=$(phrase locales list \
+            --access_token "$PHRASE_ACCESS_KEY" \
+            --project_id "$PROJECT_ID" \
+            --per_page 100 -B \
+            | jq -r --arg n "$LOCALE" '.[] | select(.name == $n) | .code')
+
+          if [ -z "$code" ]; then
+            echo "::error::No locale named '$LOCALE' in this Phrase project."
+            exit 1
+          fi
+          echo "Resolved locale '$LOCALE' to code '$code'"
+
+          path="Modules/PrimerResources/Sources/PrimerResources/Resources/Localizable/$code.lproj/Localizable.strings"
+          if [ ! -f "$path" ]; then
+            echo "::error::$path does not exist on ${{ inputs.branch }}."
+            exit 1
+          fi
+          echo "SOURCE_PATH=$path" >> "$GITHUB_ENV"
+
+          # update_translations is the only flag that makes existing translations change;
+          # it is off by default, which is why a plain `phrase push` cannot fix a typo.
+          # The rest are pinned rather than left to their defaults: update_translation_keys
+          # and update_custom_metadata both default to true.
+          {
+            echo "phrase:"
+            echo "  access_token: $PHRASE_ACCESS_KEY"
+            echo "  project_id: $PROJECT_ID"
+            echo "  file_format: strings"
+            echo "  push:"
+            echo "    sources:"
+            echo "      - file: $path"
+            echo "        params:"
+            echo "          file_format: strings"
+            echo "          locale_id: $LOCALE"
+            echo "          tags: $TAGS"
+            echo "          update_translations: true"
+            echo "          update_translation_keys: false"
+            echo "          update_descriptions: false"
+            echo "          update_custom_metadata: false"
+            echo "          tag_only_affected_keys: true"
+            echo "          autotranslate: false"
+            echo "          mark_reviewed: false"
+          } > .phrase.yml
+
+      - name: Show what would change
+        run: |
+          # The repo is checked out at inputs.branch, so the script is read from there
+          # rather than from the branch this workflow file lives on.
+          if [ ! -f .github/scripts/diff_phrase_locale.py ]; then
+            echo "::error::.github/scripts/diff_phrase_locale.py is missing on ${{ inputs.branch }}. Land it there first."
+            exit 1
+          fi
+
+          phrase locales download \
+            --access_token "$PHRASE_ACCESS_KEY" \
+            --project_id "$PROJECT_ID" \
+            --id "$LOCALE" \
+            --file_format strings \
+            --tags "$TAGS" > phrase_current.strings
+
+          python3 .github/scripts/diff_phrase_locale.py phrase_current.strings "$SOURCE_PATH"
+
+      - name: Push to Phrase
+        if: ${{ !inputs.dry_run }}
+        run: phrase push --wait
+
+      - name: Remove generated files
+        if: always()
+        run: rm -f .phrase.yml phrase_current.strings


### PR DESCRIPTION
# Description

ESC-1105

Phrase is the source of truth for the `.strings` files. `Manual Translation Update` runs `phrase pull`, which overwrites the repo from Phrase, so a copy fix made in the repo is undone the next time anyone dispatches it. There was no way to send a correction the other way — `phrase_config.yml:1` says push "is currently not being used", and nothing in CI ran it.

This adds `Manual Translation Push`. It takes a branch, a Phrase locale name and a dry-run flag, and uploads that one locale of the drop-in project. It defaults to a dry run. Either way it downloads what Phrase currently holds and prints a key-by-key diff first, so the run log records exactly which values an upload would overwrite before it happens.

# Other Notes

Two Phrase behaviours are pinned rather than left to their defaults, because both are surprising:

- `update_translations` is **off** by default. That is why a plain `phrase push` cannot correct an existing translation — it only creates what is missing. Confirmed against Phrase's OpenAPI spec (`paths/uploads/create.yaml`), where the parameter carries no `default` while its siblings do. The workflow turns it on; that is the whole point of the workflow.
- `update_translation_keys` and `update_custom_metadata` both default to **true**, so a push can create keys and drop key metadata as a side effect. Both are pinned off here, along with `update_descriptions`, `autotranslate` and `mark_reviewed`.

`--cleanup` deletes keys that are absent from the upload and is never passed.

The repo's own `phrase_config.yml` push block lists every locale, so it is deliberately not reused — the workflow writes a throwaway config naming exactly one file, resolved from the locale name, with no `<locale_code>` placeholder that could glob other locales.

**CheckoutComponents is deliberately unsupported.** That Phrase project is shared with the Android SDK: its English source uses Android format specifiers (14 occurrences of `%s`, none of `%@`) where this repo uses `%@`. Uploading the iOS files would rewrite those specifiers and break Android formatting at runtime, create 78 keys that exist only in the iOS repo, and overwrite translator edits that were never pulled. Those strings should be corrected in the Phrase editor instead.

One finding from the same investigation:

- `manual-translation-update-checkout-components.yml` prepends a `phrase:` root block onto `phrase_config_checkout_components.yml`, which already declares its own `phrase:` root with `access_token: ${PHRASE_ACCESS_TOKEN}`. The result is a duplicate YAML mapping key, so the injected `PHRASE_ACCESS_KEY` secret is discarded in favour of an environment variable the workflow never sets. That workflow has never landed a commit, which is consistent with it being broken. It lives on `bn/feature/checkout-components`, and I fixed it there in `3e40ebde3`: the workflow now substitutes the secrets into the config's own placeholders instead of prepending a second root, and fails early if either secret is empty.

# Manual Testing

`.github/scripts/diff_phrase_locale.py` was run against the live Polish locale downloaded from Phrase and the corrected file from #1871. It reported 18 values that would be overwritten, 0 keys created and 0 keys missing, matching that PR's diff exactly.

The workflow itself has not been dispatched yet. I ran the equivalent `phrase push` by hand on 2026-08-31 to correct the escalated Polish values, with the same parameters this workflow pins. Downloading the locale again afterwards showed Phrase matching the repo exactly, with the other 85 keys untouched and no keys created or deleted. That is the behaviour this workflow automates.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable


