### PR TITLE
fix(components): give brand-filled buttons an on-brand label (ORC-8179)

### DIFF
--- a/DesignTokens/tokens/base.json
+++ b/DesignTokens/tokens/base.json
@@ -456,6 +456,28 @@
             "value": 16
           }
         }
+      },
+      "error": {
+        "font": {
+          "type": "color",
+          "value": "{primer.typography.body.small.font}"
+        },
+        "weight": {
+          "type": "dimension",
+          "value": "{primer.typography.body.small.weight}"
+        },
+        "size": {
+          "type": "dimension",
+          "value": "{primer.typography.body.small.size}"
+        },
+        "lineHeight": {
+          "type": "dimension",
+          "value": "{primer.typography.body.small.lineHeight}"
+        },
+        "letterSpacing": {
+          "type": "dimension",
+          "value": "{primer.typography.body.small.letterSpacing}"
+        }
       }
     },
     "space": {

--- a/Modules/PrimerResources/Sources/PrimerResources/Resources/JSONs/base.json
+++ b/Modules/PrimerResources/Sources/PrimerResources/Resources/JSONs/base.json
@@ -438,6 +438,28 @@
             "value": 16
           }
         }
+      },
+      "error": {
+        "font": {
+          "type": "color",
+          "value": "{primer.typography.body.small.font}"
+        },
+        "weight": {
+          "type": "dimension",
+          "value": "{primer.typography.body.small.weight}"
+        },
+        "size": {
+          "type": "dimension",
+          "value": "{primer.typography.body.small.size}"
+        },
+        "lineHeight": {
+          "type": "dimension",
+          "value": "{primer.typography.body.small.lineHeight}"
+        },
+        "letterSpacing": {
+          "type": "dimension",
+          "value": "{primer.typography.body.small.letterSpacing}"
+        }
       }
     },
     "space": {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Defaults/PaymentMethodsDefaults.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Defaults/PaymentMethodsDefaults.swift
@@ -214,13 +214,13 @@ private struct VaultedSubmitContent: View {
       Group {
         if isLoading {
           ProgressView()
-            .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.white(tokens: tokens)))
+            .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens)))
         } else {
           Text(CheckoutComponentsStrings.payButton)
         }
       }
       .font(PrimerFont.body(tokens: tokens))
-      .foregroundColor(CheckoutColors.white(tokens: tokens))
+      .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
       .frame(maxWidth: .infinity)
       .padding(.vertical, PrimerSpacing.large(tokens: tokens))
       .background(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Rendering.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Rendering.swift
@@ -46,7 +46,7 @@ extension PrimerInputFieldContainer {
 
   func makeTextFieldContainerBackgroundBackground() -> some View {
     RoundedRectangle(cornerRadius: fieldCornerRadius)
-      .fill(CheckoutColors.background(tokens: tokens))
+      .fill(CheckoutColors.inputBackground(tokens: tokens))
   }
 
   func makeTextFieldContainerWarning() -> some View {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
@@ -41,7 +41,7 @@ extension PrimerInputFieldContainer {
 
 @available(iOS 15.0, *)
 extension PrimerInputFieldContainer {
-  var errorMessageFont: Font { PrimerFont.bodySmall(tokens: tokens) }
+  var errorMessageFont: Font { PrimerFont.error(tokens: tokens) }
   var labelFont: Font { PrimerFont.bodySmall(tokens: tokens) }
 }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
@@ -117,7 +117,7 @@ extension UITextField {
     let textFont = PrimerFont.uiFontBodyLarge(tokens: tokens)
     font = textFont
     adjustsFontForContentSizeCategory = true
-    textColor = UIColor(CheckoutColors.textPrimary(tokens: tokens))
+    textColor = UIColor(CheckoutColors.inputText(tokens: tokens))
 
     // Placeholder styling with design tokens
     let placeholderColor = UIColor(CheckoutColors.textPlaceholder(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CountryInputField/CountryInputField.swift
@@ -34,7 +34,7 @@ struct CountryInputField: View, LogReporter {
     guard !countryName.isEmpty else {
       return CheckoutColors.textPlaceholder(tokens: tokens)
     }
-    return CheckoutColors.textPrimary(tokens: tokens)
+    return CheckoutColors.inputText(tokens: tokens)
   }
 
   private var selectedCountryFromScope: PrimerCountry? {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/OTPCodeInputField/OTPCodeInputField.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/OTPCodeInputField/OTPCodeInputField.swift
@@ -77,7 +77,7 @@ struct OTPCodeInputField: View, LogReporter {
           .foregroundColor(CheckoutColors.textPlaceholder(tokens: tokens))
       )
       .font(fieldFont)
-      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      .foregroundColor(CheckoutColors.inputText(tokens: tokens))
       .keyboardType(.numberPad)
       .textContentType(.oneTimeCode)
       .frame(height: PrimerSize.xxlarge(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
@@ -55,7 +55,7 @@ struct AchMandateView: View, LogReporter {
     Button(action: scope.acceptMandate) {
       Text(CheckoutComponentsStrings.achMandateAcceptButton)
         .font(PrimerFont.body(tokens: tokens))
-        .foregroundColor(CheckoutColors.white(tokens: tokens))
+        .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
         .frame(maxWidth: .infinity)
         .padding(.vertical, PrimerSpacing.large(tokens: tokens))
         .background(CheckoutColors.textPrimary(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchUserDetailsView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchUserDetailsView.swift
@@ -89,7 +89,7 @@ struct AchUserDetailsView: View, LogReporter {
       Button(action: scope.submitUserDetails) {
         Text(CheckoutComponentsStrings.achContinueButton)
           .font(PrimerFont.body(tokens: tokens))
-          .foregroundColor(CheckoutColors.white(tokens: tokens))
+          .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
           .frame(maxWidth: .infinity)
           .padding(.vertical, PrimerSpacing.large(tokens: tokens))
           .background(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ApplePayScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ApplePayScreen.swift
@@ -142,7 +142,7 @@ struct ApplePayScreen: View {
           Text(CheckoutComponentsStrings.applePayChooseOther)
             .font(PrimerFont.bodyMedium(tokens: tokens))
             .fontWeight(.medium)
-            .foregroundColor(CheckoutColors.white(tokens: tokens))
+            .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
             .frame(maxWidth: .infinity)
             .frame(height: 50)
             .background(CheckoutColors.blue(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -83,7 +83,7 @@ struct BillingAddressRedirectScreen: View {
 
       if let surcharge = billingState.surchargeAmount {
         Text(surcharge)
-          .font(PrimerFont.bodySmall(tokens: tokens))
+          .font(PrimerFont.error(tokens: tokens))
           .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
       }
     }
@@ -142,7 +142,7 @@ struct BillingAddressRedirectScreen: View {
   private func makeCountryField() -> some View {
     VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
       Text(CheckoutComponentsStrings.countryLabel)
-        .font(PrimerFont.bodySmall(tokens: tokens))
+        .font(PrimerFont.error(tokens: tokens))
         .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
 
       Menu {
@@ -180,7 +180,7 @@ struct BillingAddressRedirectScreen: View {
 
       if let error = billingState.errors[.countryCode] {
         Text(error.message)
-          .font(PrimerFont.bodySmall(tokens: tokens))
+          .font(PrimerFont.error(tokens: tokens))
           .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
       }
     }
@@ -196,7 +196,7 @@ struct BillingAddressRedirectScreen: View {
   ) -> some View {
     VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
       Text(label)
-        .font(PrimerFont.bodySmall(tokens: tokens))
+        .font(PrimerFont.error(tokens: tokens))
         .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
 
       TextField(placeholder, text: text)
@@ -218,7 +218,7 @@ struct BillingAddressRedirectScreen: View {
 
       if let error = billingState.errors[fieldType] {
         Text(error.message)
-          .font(PrimerFont.bodySmall(tokens: tokens))
+          .font(PrimerFont.error(tokens: tokens))
           .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
       }
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -37,7 +37,7 @@ struct BillingAddressRedirectScreen: View {
     }
     .frame(maxWidth: .infinity)
     .navigationBarHidden(true)
-    .background(CheckoutColors.background(tokens: tokens))
+    .background(CheckoutColors.inputBackground(tokens: tokens))
     .accessibilityIdentifier(AccessibilityIdentifiers.BillingAddressRedirect.screen)
     .task {
       for await newState in scope.state {
@@ -58,7 +58,7 @@ struct BillingAddressRedirectScreen: View {
                 .font(PrimerFont.bodyMedium(tokens: tokens))
               Text(CheckoutComponentsStrings.backButton)
             }
-            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+            .foregroundColor(CheckoutColors.inputText(tokens: tokens))
           }
           .accessibility(config: AccessibilityConfiguration(
             identifier: AccessibilityIdentifiers.BillingAddressRedirect.backButton,
@@ -77,7 +77,7 @@ struct BillingAddressRedirectScreen: View {
 
       Text(paymentMethodDisplayName)
         .font(PrimerFont.titleXLarge(tokens: tokens))
-        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .foregroundColor(CheckoutColors.inputText(tokens: tokens))
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityAddTraits(.isHeader)
 
@@ -158,7 +158,7 @@ struct BillingAddressRedirectScreen: View {
         HStack {
           if let selected = CountryCode(rawValue: countryCode) {
             Text("\(selected.flag ?? "") \(selected.country)")
-              .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+              .foregroundColor(CheckoutColors.inputText(tokens: tokens))
           } else {
             Text(CheckoutComponentsStrings.countrySelectorPlaceholder)
               .foregroundColor(CheckoutColors.textPlaceholder(tokens: tokens))
@@ -170,7 +170,7 @@ struct BillingAddressRedirectScreen: View {
         .font(PrimerFont.bodyLarge(tokens: tokens))
         .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
         .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
-        .background(CheckoutColors.background(tokens: tokens))
+        .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
             .stroke(fieldBorderColor(for: .countryCode), lineWidth: PrimerBorderWidth.standard(tokens: tokens))
@@ -201,10 +201,10 @@ struct BillingAddressRedirectScreen: View {
 
       TextField(placeholder, text: text)
         .font(PrimerFont.bodyLarge(tokens: tokens))
-        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+        .foregroundColor(CheckoutColors.inputText(tokens: tokens))
         .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
         .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
-        .background(CheckoutColors.background(tokens: tokens))
+        .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
             .stroke(fieldBorderColor(for: fieldType), lineWidth: PrimerBorderWidth.standard(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -250,14 +250,14 @@ struct BillingAddressRedirectScreen: View {
     return HStack {
       if isLoading {
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.white(tokens: tokens)))
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens)))
           .scaleEffect(PrimerScale.small)
       } else {
         Text(submitButtonText)
       }
     }
     .font(PrimerFont.body(tokens: tokens))
-    .foregroundColor(CheckoutColors.white(tokens: tokens))
+    .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
     .frame(maxWidth: .infinity)
     .padding(.vertical, PrimerSpacing.large(tokens: tokens))
     .background(submitButtonBackground)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
@@ -114,14 +114,14 @@ struct CardFormScreen: View, LogReporter {
     return HStack {
       if cardFormState.isLoading {
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.white(tokens: tokens)))
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens)))
           .scaleEffect(PrimerScale.small)
       } else {
         Text(payTitle(accessible: false))
       }
     }
     .font(PrimerFont.body(tokens: tokens))
-    .foregroundColor(CheckoutColors.white(tokens: tokens))
+    .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
     .frame(maxWidth: .infinity)
     .padding(.vertical, PrimerSpacing.large(tokens: tokens))
     .background(submitButtonBackground)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ErrorScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ErrorScreen.swift
@@ -73,7 +73,7 @@ struct ErrorScreen: View {
       Text(CheckoutComponentsStrings.retryButton)
         .font(PrimerFont.bodyMedium(tokens: tokens))
         .fontWeight(.semibold)
-        .foregroundColor(CheckoutColors.white(tokens: tokens))
+        .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
         .frame(maxWidth: .infinity)
         .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
         .background(CheckoutColors.buttonPrimary(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -141,7 +141,7 @@ struct FormRedirectScreen: View {
             }
             .frame(maxWidth: .infinity)
             .frame(height: PrimerComponentHeight.button)
-            .foregroundColor(CheckoutColors.buttonTextPrimary(tokens: tokens))
+            .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
             .background(
                 RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
                     .fill(currentState.isSubmitEnabled && !currentState.isLoading

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -198,7 +198,7 @@ private struct FormFieldView: View {
             if let prefix = field.countryCodePrefix, field.fieldType == .phoneNumber {
                 Text(prefix)
                     .font(PrimerFont.bodyLarge(tokens: tokens))
-                    .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+                    .foregroundColor(CheckoutColors.inputText(tokens: tokens))
                     .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.phonePrefix)
             }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -183,8 +183,8 @@ private struct FormFieldView: View {
 
             if let errorMessage = field.errorMessage {
                 Text(errorMessage)
-                    .font(PrimerFont.caption(tokens: tokens))
-                    .foregroundColor(CheckoutColors.borderError(tokens: tokens))
+                    .font(PrimerFont.error(tokens: tokens))
+                    .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
             } else if let helperText = field.helperText {
                 Text(helperText)
                     .font(PrimerFont.caption(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -288,7 +288,7 @@ struct KlarnaView: View, LogReporter {
     Button(action: action) {
       Text(title)
         .font(PrimerFont.body(tokens: tokens))
-        .foregroundColor(CheckoutColors.white(tokens: tokens))
+        .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
         .frame(maxWidth: .infinity)
         .padding(.vertical, PrimerSpacing.large(tokens: tokens))
         .background(CheckoutColors.textPrimary(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokens.swift
@@ -124,6 +124,11 @@ final class DesignTokens: Decodable {
   var primerTypographyBodySmallWeight: CGFloat? = 400
   var primerTypographyBodySmallSize: CGFloat? = 12
   var primerTypographyBodySmallLineHeight: CGFloat? = 16
+  var primerTypographyErrorFont: String? = "Inter"
+  var primerTypographyErrorLetterSpacing: CGFloat? = 0
+  var primerTypographyErrorWeight: CGFloat? = 400
+  var primerTypographyErrorSize: CGFloat? = 12
+  var primerTypographyErrorLineHeight: CGFloat? = 16
   var primerSpaceXxsmall: CGFloat? = 2
   var primerSpaceXsmall: CGFloat? = 4
   var primerSpaceSmall: CGFloat? = 8
@@ -230,6 +235,11 @@ final class DesignTokens: Decodable {
     case primerTypographyBodySmallWeight
     case primerTypographyBodySmallSize
     case primerTypographyBodySmallLineHeight
+    case primerTypographyErrorFont
+    case primerTypographyErrorLetterSpacing
+    case primerTypographyErrorWeight
+    case primerTypographyErrorSize
+    case primerTypographyErrorLineHeight
     case primerSpaceXxsmall
     case primerSpaceXsmall
     case primerSpaceSmall
@@ -370,6 +380,11 @@ final class DesignTokens: Decodable {
       CGFloat.self, forKey: .primerTypographyBodySmallSize) ?? primerTypographyBodySmallSize
     primerTypographyBodySmallLineHeight = try container.decodeIfPresent(
       CGFloat.self, forKey: .primerTypographyBodySmallLineHeight) ?? primerTypographyBodySmallLineHeight
+    primerTypographyErrorFont = try container.decodeIfPresent(String.self, forKey: .primerTypographyErrorFont) ?? primerTypographyErrorFont
+    primerTypographyErrorLetterSpacing = try container.decodeIfPresent(CGFloat.self, forKey: .primerTypographyErrorLetterSpacing) ?? primerTypographyErrorLetterSpacing
+    primerTypographyErrorWeight = try container.decodeIfPresent(CGFloat.self, forKey: .primerTypographyErrorWeight) ?? primerTypographyErrorWeight
+    primerTypographyErrorSize = try container.decodeIfPresent(CGFloat.self, forKey: .primerTypographyErrorSize) ?? primerTypographyErrorSize
+    primerTypographyErrorLineHeight = try container.decodeIfPresent(CGFloat.self, forKey: .primerTypographyErrorLineHeight) ?? primerTypographyErrorLineHeight
     primerSpaceXxsmall = try container.decodeIfPresent(
       CGFloat.self, forKey: .primerSpaceXxsmall) ?? primerSpaceXxsmall
     primerSpaceXsmall = try container.decodeIfPresent(CGFloat.self, forKey: .primerSpaceXsmall) ?? primerSpaceXsmall

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
@@ -386,6 +386,20 @@ final class DesignTokensManager: ObservableObject {
       }
     }
 
+    // Error
+    if let style = typography.error {
+      if let font = style.font { tokens.primerTypographyErrorFont = font }
+      if let size = style.size { tokens.primerTypographyErrorSize = size }
+      if let weight = style.weight {
+        tokens.primerTypographyErrorWeight = fontWeightToCGFloat(weight)
+      }
+      if let letterSpacing = style.letterSpacing {
+        tokens.primerTypographyErrorLetterSpacing = letterSpacing
+      }
+      if let lineHeight = style.lineHeight {
+        tokens.primerTypographyErrorLineHeight = lineHeight
+      }
+    }
   }
 
   private func fontWeightToCGFloat(_ weight: Font.Weight) -> CGFloat {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/PrimerFont.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/PrimerFont.swift
@@ -130,6 +130,18 @@ enum PrimerFont {
     )
   }
 
+  /// Field error text (12pt, weight 400) - defaults to the body small values
+  static func uiFontError(tokens: DesignTokens?) -> UIFont {
+    guard let tokens else {
+      return uiFont(family: "Inter", weight: 400, size: 12)
+    }
+    return uiFont(
+      family: tokens.primerTypographyErrorFont,
+      weight: tokens.primerTypographyErrorWeight,
+      size: tokens.primerTypographyErrorSize
+    )
+  }
+
   /// Large icon font (48pt, weight 400) - for large icon displays
   static func uiFontLargeIcon(tokens _: DesignTokens?) -> UIFont {
     uiFont(family: "Inter", weight: 400, size: 48)
@@ -174,6 +186,11 @@ enum PrimerFont {
   /// Body small (12pt, weight 400) - for small body text and captions
   static func bodySmall(tokens: DesignTokens?) -> Font {
     Font(uiFontBodySmall(tokens: tokens))
+  }
+
+  /// Field error text. Styled on its own so it does not move with every body-small label.
+  static func error(tokens: DesignTokens?) -> Font {
+    Font(uiFontError(tokens: tokens))
   }
 
   /// Large icon font (48pt, weight 400) - for large icon displays

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -106,8 +106,6 @@ enum CheckoutColors {
     tokens?.primerColorGray300 ?? Color(.systemGray4)
   }
 
-  static func white(tokens _: DesignTokens?) -> Color { .white }
-
   static func blue(tokens _: DesignTokens?) -> Color { .blue }
 
   static func green(tokens _: DesignTokens?) -> Color { .green }
@@ -116,11 +114,23 @@ enum CheckoutColors {
     tokens?.primerColorTextNegative ?? .red
   }
 
-  static func buttonTextPrimary(tokens _: DesignTokens?) -> Color {
-    .white
-  }
-
   static func inputText(tokens: DesignTokens?) -> Color {
     tokens?.primerColorTextOutlinedDefault ?? .primary
+  }
+
+  /// Label/spinner colour on a surface filled with `textPrimary`, which the label inverts with; a
+  /// disabled surface is light, so the label follows web and Android onto `textDisabled`.
+  /// Primary buttons are brand-filled and use `onBrand` instead.
+  static func onPrimary(tokens: DesignTokens?, isEnabled: Bool = true) -> Color {
+    isEnabled
+      ? (tokens?.primerColorBackgroundPrimary ?? .white)
+      : (tokens?.primerColorTextDisabled ?? Color(.tertiaryLabel))
+  }
+
+  /// Label/spinner colour on a brand-filled surface, which is every primary button. Brand is a fixed
+  /// blue in both modes, so the enabled label is fixed white too; a disabled button loses the brand
+  /// fill and takes `textDisabled`. A loading button is still brand-filled, so pass `isEnabled: true`.
+  static func onBrand(tokens: DesignTokens?, isEnabled: Bool = true) -> Color {
+    isEnabled ? .white : (tokens?.primerColorTextDisabled ?? Color(.tertiaryLabel))
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -53,7 +53,7 @@ enum CheckoutColors {
   }
 
   static func gray100(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorGray100 ?? Color(.systemGray6)
+    tokens?.primerColorBackgroundOutlinedDefault ?? .white
   }
 
   static func gray200(tokens: DesignTokens?) -> Color {
@@ -85,7 +85,7 @@ enum CheckoutColors {
   }
 
   static func inputBackground(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorGray100 ?? Color(.systemGray6)
+    tokens?.primerColorBackgroundOutlinedDefault ?? .white
   }
 
   static func inputBorder(tokens: DesignTokens?) -> Color {
@@ -118,5 +118,9 @@ enum CheckoutColors {
 
   static func buttonTextPrimary(tokens _: DesignTokens?) -> Color {
     .white
+  }
+
+  static func inputText(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorTextOutlinedDefault ?? .primary
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
@@ -416,19 +416,24 @@ public struct TypographyOverrides: Equatable {
   /// Body small: Inter, 0 letter spacing, weight 400, size 12, line height 16
   public let bodySmall: TypographyStyle?
 
+  /// Field error text. Defaults to the body small values, so it can be styled on its own.
+  public let error: TypographyStyle?
+
   /// Creates typography overrides with all optional properties.
   public init(
     titleXlarge: TypographyStyle? = nil,
     titleLarge: TypographyStyle? = nil,
     bodyLarge: TypographyStyle? = nil,
     bodyMedium: TypographyStyle? = nil,
-    bodySmall: TypographyStyle? = nil
+    bodySmall: TypographyStyle? = nil,
+    error: TypographyStyle? = nil
   ) {
     self.titleXlarge = titleXlarge
     self.titleLarge = titleLarge
     self.bodyLarge = bodyLarge
     self.bodyMedium = bodyMedium
     self.bodySmall = bodySmall
+    self.error = error
   }
 }
 


### PR DESCRIPTION
# Description

[ORC-8179](https://primerapi.atlassian.net/browse/ORC-8179)

Labels and spinners on a brand-filled button were a plain white that ignored the disabled state, so a disabled Pay button read at 1.15:1 in dark mode. They take `onBrand(tokens:isEnabled:)` now.

`white` and `buttonTextPrimary` are retired; twelve call sites across nine files move across.

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [x] I have manually tested newly added UX



[ORC-8179]: https://primerapi.atlassian.net/browse/ORC-8179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ