### PR TITLE
fix(components): keep the pay button brand-filled while paying (ORC-8265)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Defaults/PaymentMethodsDefaults.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Defaults/PaymentMethodsDefaults.swift
@@ -185,7 +185,7 @@ private struct VaultedMethodRowContent: View {
         Spacer()
         if isSelected {
           Image(systemName: "checkmark.circle.fill")
-            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+            .foregroundColor(CheckoutColors.borderSelected(tokens: tokens))
         }
       }
       .padding(PrimerSpacing.medium(tokens: tokens))
@@ -210,23 +210,28 @@ private struct VaultedSubmitContent: View {
   @Environment(\.designTokens) private var tokens
 
   var body: some View {
-    Button(action: onSubmit) {
+    // The button keeps its brand fill while submitting; only a disabled button greys out.
+    let isActive = isEnabled || isLoading
+
+    return Button(action: onSubmit) {
       Group {
         if isLoading {
           ProgressView()
-            .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens)))
+            .progressViewStyle(
+              CircularProgressViewStyle(
+                tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isActive)))
         } else {
           Text(CheckoutComponentsStrings.payButton)
         }
       }
       .font(PrimerFont.body(tokens: tokens))
-      .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
+      .foregroundColor(CheckoutColors.onBrand(tokens: tokens, isEnabled: isActive))
       .frame(maxWidth: .infinity)
       .padding(.vertical, PrimerSpacing.large(tokens: tokens))
       .background(
-        isEnabled && !isLoading
-          ? CheckoutColors.textPrimary(tokens: tokens)
-          : CheckoutColors.gray300(tokens: tokens)
+        isActive
+          ? CheckoutColors.buttonPrimary(tokens: tokens)
+          : CheckoutColors.buttonDisabled(tokens: tokens)
       )
       .cornerRadius(PrimerRadius.small(tokens: tokens))
     }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultSection.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultSection.swift
@@ -52,7 +52,7 @@ struct VaultSection: View {
     .padding(PrimerSpacing.small(tokens: tokens))
     .background(
       RoundedRectangle(cornerRadius: PrimerRadius.large(tokens: tokens))
-        .fill(CheckoutColors.backgroundSecondary(tokens: tokens))
+        .fill(CheckoutColors.gray100(tokens: tokens))
     )
   }
 
@@ -68,21 +68,23 @@ struct VaultSection: View {
         if isLoading {
           ProgressView()
             .progressViewStyle(
-              CircularProgressViewStyle(tint: CheckoutColors.background(tokens: tokens)))
+              CircularProgressViewStyle(
+                tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isPayButtonActive)))
             .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
         } else {
           Text(CheckoutComponentsStrings.payButton)
         }
       }
       .font(PrimerFont.titleLarge(tokens: tokens))
-      .foregroundColor(CheckoutColors.background(tokens: tokens))
+      .foregroundColor(CheckoutColors.onBrand(tokens: tokens, isEnabled: isPayButtonActive))
       .frame(maxWidth: .infinity)
       .padding(PrimerSpacing.medium(tokens: tokens))
       .background(
         RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
           .fill(
-            isPayButtonEnabled
-              ? CheckoutColors.borderFocus(tokens: tokens) : CheckoutColors.gray300(tokens: tokens))
+            isPayButtonActive
+              ? CheckoutColors.buttonPrimary(tokens: tokens)
+              : CheckoutColors.buttonDisabled(tokens: tokens))
       )
     }
     .disabled(!isPayButtonEnabled)
@@ -95,6 +97,11 @@ struct VaultSection: View {
   }
 
   // MARK: - Helpers
+
+  /// The button keeps its brand fill while paying; only an invalid CVV greys it out.
+  private var isPayButtonActive: Bool {
+    isPayButtonEnabled || isLoading
+  }
 
   private var isPayButtonEnabled: Bool {
     if isLoading {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchUserDetailsView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchUserDetailsView.swift
@@ -89,13 +89,13 @@ struct AchUserDetailsView: View, LogReporter {
       Button(action: scope.submitUserDetails) {
         Text(CheckoutComponentsStrings.achContinueButton)
           .font(PrimerFont.body(tokens: tokens))
-          .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
+          .foregroundColor(CheckoutColors.onBrand(tokens: tokens, isEnabled: achState.isSubmitEnabled))
           .frame(maxWidth: .infinity)
           .padding(.vertical, PrimerSpacing.large(tokens: tokens))
           .background(
             achState.isSubmitEnabled
-              ? CheckoutColors.textPrimary(tokens: tokens)
-              : CheckoutColors.textSecondary(tokens: tokens)
+              ? CheckoutColors.buttonPrimary(tokens: tokens)
+              : CheckoutColors.buttonDisabled(tokens: tokens)
           )
           .cornerRadius(PrimerRadius.small(tokens: tokens))
       }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -250,14 +250,14 @@ struct BillingAddressRedirectScreen: View {
     return HStack {
       if isLoading {
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens)))
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isButtonActive)))
           .scaleEffect(PrimerScale.small)
       } else {
         Text(submitButtonText)
       }
     }
     .font(PrimerFont.body(tokens: tokens))
-    .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
+    .foregroundColor(CheckoutColors.onBrand(tokens: tokens, isEnabled: isButtonActive))
     .frame(maxWidth: .infinity)
     .padding(.vertical, PrimerSpacing.large(tokens: tokens))
     .background(submitButtonBackground)
@@ -274,9 +274,18 @@ struct BillingAddressRedirectScreen: View {
   }
 
   private var submitButtonBackground: Color {
-    isButtonDisabled
-      ? CheckoutColors.gray300(tokens: tokens)
-      : CheckoutColors.textPrimary(tokens: tokens)
+    isButtonActive
+      ? CheckoutColors.buttonPrimary(tokens: tokens)
+      : CheckoutColors.buttonDisabled(tokens: tokens)
+  }
+
+  /// The button keeps its brand fill while submitting; only an invalid form greys it out.
+  private var isButtonActive: Bool {
+    billingState.isFormValid || isSubmitInFlight
+  }
+
+  private var isSubmitInFlight: Bool {
+    [.submitting, .redirecting, .polling].contains(billingState.status)
   }
 
   private var isButtonDisabled: Bool {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/CardFormScreen.swift
@@ -114,14 +114,16 @@ struct CardFormScreen: View, LogReporter {
     return HStack {
       if cardFormState.isLoading {
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens)))
+          .progressViewStyle(
+            CircularProgressViewStyle(
+              tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isSubmitButtonActive)))
           .scaleEffect(PrimerScale.small)
       } else {
         Text(payTitle(accessible: false))
       }
     }
     .font(PrimerFont.body(tokens: tokens))
-    .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
+    .foregroundColor(CheckoutColors.onBrand(tokens: tokens, isEnabled: isSubmitButtonActive))
     .frame(maxWidth: .infinity)
     .padding(.vertical, PrimerSpacing.large(tokens: tokens))
     .background(submitButtonBackground)
@@ -172,9 +174,14 @@ struct CardFormScreen: View, LogReporter {
   }
 
   private var submitButtonBackground: Color {
-    cardFormState.isValid && !cardFormState.isLoading
-      ? CheckoutColors.textPrimary(tokens: tokens)
-      : CheckoutColors.gray300(tokens: tokens)
+    isSubmitButtonActive
+      ? CheckoutColors.buttonPrimary(tokens: tokens)
+      : CheckoutColors.buttonDisabled(tokens: tokens)
+  }
+
+  /// The button keeps its brand fill while submitting; only an invalid form greys it out.
+  private var isSubmitButtonActive: Bool {
+    cardFormState.isValid || cardFormState.isLoading
   }
 
   private func submitAction() {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DeleteVaultedPaymentMethodConfirmationScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DeleteVaultedPaymentMethodConfirmationScreen.swift
@@ -121,18 +121,18 @@ struct DeleteVaultedPaymentMethodConfirmationScreen: View, LogReporter {
         if isDeleting {
           ProgressView()
             .progressViewStyle(
-              CircularProgressViewStyle(tint: CheckoutColors.background(tokens: tokens)))
+              CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens)))
         } else {
           Text(CheckoutComponentsStrings.deleteButton)
             .font(PrimerFont.titleLarge(tokens: tokens))
         }
       }
-      .foregroundColor(CheckoutColors.background(tokens: tokens))
+      .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
       .frame(maxWidth: .infinity)
       .padding(PrimerSpacing.medium(tokens: tokens))
       .background(
         RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
-          .fill(CheckoutColors.borderFocus(tokens: tokens))
+          .fill(CheckoutColors.buttonPrimary(tokens: tokens))
       )
     }
     .buttonStyle(PlainButtonStyle())

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -128,6 +128,11 @@ struct FormRedirectScreen: View {
         }
     }
 
+    /// The button keeps its brand fill while submitting; only an invalid form greys it out.
+    private var isButtonActive: Bool {
+        currentState.isSubmitEnabled || currentState.isLoading
+    }
+
     private func makeDefaultSubmitButton() -> some View {
         Button(action: scope.submit) {
             HStack(spacing: PrimerSpacing.small(tokens: tokens)) {
@@ -141,10 +146,12 @@ struct FormRedirectScreen: View {
             }
             .frame(maxWidth: .infinity)
             .frame(height: PrimerComponentHeight.button)
-            .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
+            .foregroundColor(CheckoutColors.onBrand(
+                tokens: tokens,
+                isEnabled: isButtonActive))
             .background(
                 RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
-                    .fill(currentState.isSubmitEnabled && !currentState.isLoading
+                    .fill(isButtonActive
                           ? CheckoutColors.buttonPrimary(tokens: tokens)
                           : CheckoutColors.buttonDisabled(tokens: tokens))
             )

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -291,7 +291,7 @@ struct KlarnaView: View, LogReporter {
         .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
         .frame(maxWidth: .infinity)
         .padding(.vertical, PrimerSpacing.large(tokens: tokens))
-        .background(CheckoutColors.textPrimary(tokens: tokens))
+        .background(CheckoutColors.buttonPrimary(tokens: tokens))
         .cornerRadius(PrimerRadius.small(tokens: tokens))
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -60,10 +60,6 @@ enum CheckoutColors {
     tokens?.primerColorGray200 ?? Color(.systemGray5)
   }
 
-  static func gray300(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorGray300 ?? Color(.systemGray4)
-  }
-
   static func textPlaceholder(tokens: DesignTokens?) -> Color {
     tokens?.primerColorTextPlaceholder ?? Color(.tertiaryLabel)
   }
@@ -102,8 +98,12 @@ enum CheckoutColors {
     tokens?.primerColorBrand ?? .blue
   }
 
-  static func buttonDisabled(tokens: DesignTokens?) -> Color {
+  static func gray300(tokens: DesignTokens?) -> Color {
     tokens?.primerColorGray300 ?? Color(.systemGray4)
+  }
+
+  static func buttonDisabled(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBackgroundOutlinedDisabled ?? Color(.systemGray6)
   }
 
   static func blue(tokens _: DesignTokens?) -> Color { .blue }


### PR DESCRIPTION
# Description

[ORC-8265](https://primerapi.atlassian.net/browse/ORC-8265)

Primary buttons were filled with `textPrimary`, which reads near-black rather than brand, and greyed out the moment the shopper tapped Pay. They fill with brand, keep that fill while loading, and grey only when genuinely disabled.

`isButtonActive = isEnabled || isLoading`, applied on the card form, the vault section, the ACH details screen, the delete confirmation and both redirect forms. `.disabled(!isEnabled)` is untouched, so a loading button still can't be tapped twice. It just doesn't look disabled.

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [x] I have manually tested newly added UX



[ORC-8265]: https://primerapi.atlassian.net/browse/ORC-8265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ