### PR TITLE
fix(components): draw borders at the width the state calls for (ORC-8178)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
@@ -48,7 +48,12 @@ extension PrimerInputFieldContainer {
 @available(iOS 15.0, *)
 extension PrimerInputFieldContainer {
   var fieldCornerRadius: CGFloat { PrimerRadius.small(tokens: tokens) }
-  var textFieldContainerBackgroundLineWidth: CGFloat { PrimerBorderWidth.standard(tokens: tokens) }
+  var textFieldContainerBackgroundLineWidth: CGFloat {
+    if hasError { return PrimerBorderWidth.error(tokens: tokens) }
+    return isFocused
+      ? PrimerBorderWidth.focused(tokens: tokens)
+      : PrimerBorderWidth.standard(tokens: tokens)
+  }
   var errorMessageMinHeight: CGFloat { hasError ? PrimerComponentHeight.errorMessage : 0 }
   var errorMessageTopPadding: CGFloat { hasError ? PrimerSpacing.xsmall(tokens: tokens) : 0 }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
@@ -74,7 +74,7 @@ struct PaymentMethodButton: View {
       return width
     }
     guard !hasVisibleBackground else { return 0 }
-    return PrimerBorderWidth.standard
+    return PrimerBorderWidth.standard(tokens: tokens)
   }
 
   @ViewBuilder

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
@@ -94,19 +94,19 @@ struct VaultedCardCVVInput: View {
       .focused($isFocused)
       .multilineTextAlignment(.leading)
       .font(PrimerFont.bodyLarge(tokens: tokens))
-      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      .foregroundColor(CheckoutColors.inputText(tokens: tokens))
       .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
       .frame(width: PrimerComponentWidth.cvvFieldMax, height: PrimerSize.xxlarge(tokens: tokens))
       .background(
         RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-          .fill(CheckoutColors.background(tokens: tokens))
+          .fill(CheckoutColors.inputBackground(tokens: tokens))
       )
       .overlay(
         RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
           .stroke(
             cvvBorderColor,
             lineWidth: isFocused
-              ? PrimerBorderWidth.selected(tokens: tokens) : PrimerBorderWidth.standard(tokens: tokens))
+              ? PrimerBorderWidth.focused(tokens: tokens) : PrimerBorderWidth.standard(tokens: tokens))
       )
       .accessibility(
         config: AccessibilityConfiguration(
@@ -121,7 +121,7 @@ struct VaultedCardCVVInput: View {
 
   private func makeErrorLabel(_ message: String) -> some View {
     Text(message)
-      .font(PrimerFont.bodySmall(tokens: tokens))
+      .font(PrimerFont.error(tokens: tokens))
       .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
@@ -32,7 +32,7 @@ struct AchMandateView: View, LogReporter {
           .frame(maxWidth: .infinity, alignment: .leading)
           .background(
             RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-              .fill(CheckoutColors.backgroundSecondary(tokens: tokens))
+              .fill(CheckoutColors.gray100(tokens: tokens))
           )
       }
       .frame(maxHeight: Layout.mandateTextMaxHeight)
@@ -58,7 +58,7 @@ struct AchMandateView: View, LogReporter {
         .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
         .frame(maxWidth: .infinity)
         .padding(.vertical, PrimerSpacing.large(tokens: tokens))
-        .background(CheckoutColors.textPrimary(tokens: tokens))
+        .background(CheckoutColors.buttonPrimary(tokens: tokens))
         .cornerRadius(PrimerRadius.small(tokens: tokens))
     }
     .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateAcceptButton)
@@ -75,7 +75,9 @@ struct AchMandateView: View, LogReporter {
         .padding(.vertical, PrimerSpacing.large(tokens: tokens))
         .background(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-            .stroke(CheckoutColors.borderDefault(tokens: tokens), lineWidth: 1)
+            .stroke(
+              CheckoutColors.borderDefault(tokens: tokens),
+              lineWidth: PrimerBorderWidth.standard(tokens: tokens))
         )
     }
     .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateDeclineButton)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
@@ -140,7 +140,9 @@ struct AdyenKlarnaScreen: View {
             .background(CheckoutColors.background(tokens: tokens))
             .overlay(
                 RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
-                    .stroke(CheckoutColors.borderDefault(tokens: tokens), lineWidth: 1)
+                    .stroke(
+                        CheckoutColors.borderDefault(tokens: tokens),
+                        lineWidth: PrimerBorderWidth.standard(tokens: tokens))
             )
             .clipShape(RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens)))
         }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -37,7 +37,7 @@ struct BillingAddressRedirectScreen: View {
     }
     .frame(maxWidth: .infinity)
     .navigationBarHidden(true)
-    .background(CheckoutColors.inputBackground(tokens: tokens))
+    .background(CheckoutColors.background(tokens: tokens))
     .accessibilityIdentifier(AccessibilityIdentifiers.BillingAddressRedirect.screen)
     .task {
       for await newState in scope.state {
@@ -58,7 +58,7 @@ struct BillingAddressRedirectScreen: View {
                 .font(PrimerFont.bodyMedium(tokens: tokens))
               Text(CheckoutComponentsStrings.backButton)
             }
-            .foregroundColor(CheckoutColors.inputText(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
           }
           .accessibility(config: AccessibilityConfiguration(
             identifier: AccessibilityIdentifiers.BillingAddressRedirect.backButton,
@@ -77,13 +77,13 @@ struct BillingAddressRedirectScreen: View {
 
       Text(paymentMethodDisplayName)
         .font(PrimerFont.titleXLarge(tokens: tokens))
-        .foregroundColor(CheckoutColors.inputText(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityAddTraits(.isHeader)
 
       if let surcharge = billingState.surchargeAmount {
         Text(surcharge)
-          .font(PrimerFont.error(tokens: tokens))
+          .font(PrimerFont.bodySmall(tokens: tokens))
           .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
       }
     }
@@ -142,7 +142,7 @@ struct BillingAddressRedirectScreen: View {
   private func makeCountryField() -> some View {
     VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
       Text(CheckoutComponentsStrings.countryLabel)
-        .font(PrimerFont.error(tokens: tokens))
+        .font(PrimerFont.bodySmall(tokens: tokens))
         .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
 
       Menu {
@@ -173,7 +173,8 @@ struct BillingAddressRedirectScreen: View {
         .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-            .stroke(fieldBorderColor(for: .countryCode), lineWidth: PrimerBorderWidth.standard(tokens: tokens))
+            .stroke(
+              fieldBorderColor(for: .countryCode), lineWidth: fieldBorderWidth(for: .countryCode))
         )
       }
       .accessibilityIdentifier(AccessibilityIdentifiers.BillingAddressRedirect.countryCodeField)
@@ -196,7 +197,7 @@ struct BillingAddressRedirectScreen: View {
   ) -> some View {
     VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
       Text(label)
-        .font(PrimerFont.error(tokens: tokens))
+        .font(PrimerFont.bodySmall(tokens: tokens))
         .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
 
       TextField(placeholder, text: text)
@@ -207,7 +208,7 @@ struct BillingAddressRedirectScreen: View {
         .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-            .stroke(fieldBorderColor(for: fieldType), lineWidth: PrimerBorderWidth.standard(tokens: tokens))
+            .stroke(fieldBorderColor(for: fieldType), lineWidth: fieldBorderWidth(for: fieldType))
         )
         .autocapitalization(.words)
         .disableAutocorrection(true)
@@ -230,6 +231,12 @@ struct BillingAddressRedirectScreen: View {
       : CheckoutColors.borderDefault(tokens: tokens)
   }
 
+  private func fieldBorderWidth(for fieldType: PrimerInputElementType) -> CGFloat {
+    billingState.errors[fieldType] != nil
+      ? PrimerBorderWidth.error(tokens: tokens)
+      : PrimerBorderWidth.standard(tokens: tokens)
+  }
+
   // MARK: - Submit Button
 
   @ViewBuilder
@@ -245,12 +252,11 @@ struct BillingAddressRedirectScreen: View {
   }
 
   private func makeSubmitButtonContent() -> some View {
-    let isLoading = [.submitting, .redirecting, .polling].contains(billingState.status)
-
-    return HStack {
-      if isLoading {
+    HStack {
+      if isSubmitInFlight {
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isButtonActive)))
+          .progressViewStyle(
+            CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isButtonActive)))
           .scaleEffect(PrimerScale.small)
       } else {
         Text(submitButtonText)
@@ -279,7 +285,7 @@ struct BillingAddressRedirectScreen: View {
       : CheckoutColors.buttonDisabled(tokens: tokens)
   }
 
-  /// The button keeps its brand fill while submitting; only an invalid form greys it out.
+  /// The button keeps its brand fill while the payment is in flight; only an invalid form greys it out.
   private var isButtonActive: Bool {
     billingState.isFormValid || isSubmitInFlight
   }
@@ -289,7 +295,7 @@ struct BillingAddressRedirectScreen: View {
   }
 
   private var isButtonDisabled: Bool {
-    !billingState.isFormValid || [.submitting, .redirecting, .polling].contains(billingState.status)
+    !billingState.isFormValid || isSubmitInFlight
   }
 
   private var paymentMethodDisplayName: String {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -214,6 +214,7 @@ private struct FormFieldView: View {
                 set: { onValueChanged($0) }
             ))
             .font(PrimerFont.bodyLarge(tokens: tokens))
+            .foregroundColor(CheckoutColors.inputText(tokens: tokens))
             .keyboardType(field.keyboardType.uiKeyboardType)
             .textContentType(field.fieldType.textContentType)
             .focused($isFocused)
@@ -232,12 +233,19 @@ private struct FormFieldView: View {
         .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
         .background(
             RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-                .stroke(borderColor, lineWidth: PrimerBorderWidth.standard(tokens: tokens))
+                .stroke(borderColor, lineWidth: borderWidth)
                 .background(
                     RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
                         .fill(CheckoutColors.inputBackground(tokens: tokens))
                 )
         )
+    }
+
+    private var borderWidth: CGFloat {
+        if field.errorMessage != nil { return PrimerBorderWidth.error(tokens: tokens) }
+        return isFocused
+            ? PrimerBorderWidth.focused(tokens: tokens)
+            : PrimerBorderWidth.standard(tokens: tokens)
     }
 
     private var borderColor: Color {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -26,8 +26,6 @@ struct KlarnaView: View, LogReporter {
     static let badgeHeight: CGFloat = 40
     static let paymentViewMinHeight: CGFloat = 200
     static let inlineLoadingMinHeight: CGFloat = 100
-    static let selectedBorderWidth: CGFloat = 2
-    static let defaultBorderWidth: CGFloat = 1
     static let badgeCornerRadius: CGFloat = 2
     static let placeholderOpacity: Double = 0.8
   }
@@ -256,7 +254,8 @@ struct KlarnaView: View, LogReporter {
         .stroke(
           isSelected
             ? CheckoutColors.borderSelected(tokens: tokens) : CheckoutColors.borderDefault(tokens: tokens),
-          lineWidth: isSelected ? Layout.selectedBorderWidth : Layout.defaultBorderWidth
+          lineWidth: isSelected
+            ? PrimerBorderWidth.selected(tokens: tokens) : PrimerBorderWidth.standard(tokens: tokens)
         )
     )
     .clipShape(RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens)))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/PrimerLayout.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/PrimerLayout.swift
@@ -131,11 +131,20 @@ enum PrimerBorderWidth {
     tokens?.primerWidthDefault ?? standard
   }
 
+  /// Emphasised border for a focused field. Maps to the `focus` width token (default 2).
+  static func focused(tokens: DesignTokens?) -> CGFloat {
+    tokens?.primerWidthFocus ?? selected
+  }
+
   /// Emphasised border for a chosen item, such as a saved card. Maps to the `selected` token.
   static func selected(tokens: DesignTokens?) -> CGFloat {
     tokens?.primerWidthSelected ?? selected
   }
 
+  /// Emphasised border for a field in error. Maps to the `error` width token (default 2).
+  static func error(tokens: DesignTokens?) -> CGFloat {
+    tokens?.primerWidthError ?? selected
+  }
 }
 
 // MARK: - Primer Scale Factors


### PR DESCRIPTION
# Description

[ORC-8178](https://primerapi.atlassian.net/browse/ORC-8178)

A field showing an error drew at the resting width. Error, focus and resting each get their own width token now, and the remaining hardcoded strokes across the sheet move onto the tokens too.

`PrimerBorderWidth` gains `focused()` and `error()` alongside `standard()` and `selected()`.

# Manual Testing

Put a field into error and type into it. The border should stay at the error width.

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [x] I have manually tested newly added UX



[ORC-8178]: https://primerapi.atlassian.net/browse/ORC-8178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ