### PR TITLE
fix(components): let the co-badge chips inherit the field (ORC-8267)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
@@ -48,7 +48,12 @@ extension PrimerInputFieldContainer {
 @available(iOS 15.0, *)
 extension PrimerInputFieldContainer {
   var fieldCornerRadius: CGFloat { PrimerRadius.small(tokens: tokens) }
-  var textFieldContainerBackgroundLineWidth: CGFloat { PrimerBorderWidth.standard(tokens: tokens) }
+  var textFieldContainerBackgroundLineWidth: CGFloat {
+    if hasError { return PrimerBorderWidth.error(tokens: tokens) }
+    return isFocused
+      ? PrimerBorderWidth.focused(tokens: tokens)
+      : PrimerBorderWidth.standard(tokens: tokens)
+  }
   var errorMessageMinHeight: CGFloat { hasError ? PrimerComponentHeight.errorMessage : 0 }
   var errorMessageTopPadding: CGFloat { hasError ? PrimerSpacing.xsmall(tokens: tokens) : 0 }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector+Button.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector+Button.swift
@@ -12,7 +12,6 @@ import SwiftUI
 struct InlineCardNetworkButton: View {
   let network: CardNetwork
   let isSelected: Bool
-  let tokens: DesignTokens?
   let onTap: () -> Void
 
   var body: some View {
@@ -23,7 +22,7 @@ struct InlineCardNetworkButton: View {
           height: PrimerCardNetworkSelector.buttonFrameHeight,
           alignment: .center
         )
-        .background(backgroundColor)
+        .contentShape(Rectangle())
     }
     .buttonStyle(PlainButtonStyle())
     .accessibilityIdentifier(
@@ -32,12 +31,6 @@ struct InlineCardNetworkButton: View {
     .accessibilityLabel(network.displayName)
     .accessibilityHint(isSelected ? "" : CheckoutComponentsStrings.a11yInlineNetworkButtonHint)
     .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
-  }
-
-  private var backgroundColor: Color {
-    isSelected
-      ? CheckoutColors.backgroundSecondary(tokens: tokens)
-      : CheckoutColors.background(tokens: tokens)
   }
 }
 
@@ -48,7 +41,6 @@ struct InlineCardNetworkButton: View {
       InlineCardNetworkButton(
         network: .visa,
         isSelected: true,
-        tokens: MockDesignTokens.light,
         onTap: {}
       )
     }
@@ -62,7 +54,6 @@ struct InlineCardNetworkButton: View {
       InlineCardNetworkButton(
         network: .masterCard,
         isSelected: false,
-        tokens: MockDesignTokens.light,
         onTap: {}
       )
     }
@@ -75,20 +66,20 @@ struct InlineCardNetworkButton: View {
     VStack(spacing: 20) {
       HStack(spacing: 0) {
         InlineCardNetworkButton(
-          network: .visa, isSelected: true, tokens: MockDesignTokens.light, onTap: {})
+          network: .visa, isSelected: true, onTap: {})
         InlineCardNetworkButton(
-          network: .masterCard, isSelected: false, tokens: MockDesignTokens.light, onTap: {})
+          network: .masterCard, isSelected: false, onTap: {})
         InlineCardNetworkButton(
-          network: .amex, isSelected: false, tokens: MockDesignTokens.light, onTap: {})
+          network: .amex, isSelected: false, onTap: {})
       }
 
       HStack(spacing: 0) {
         InlineCardNetworkButton(
-          network: .visa, isSelected: false, tokens: MockDesignTokens.light, onTap: {})
+          network: .visa, isSelected: false, onTap: {})
         InlineCardNetworkButton(
-          network: .masterCard, isSelected: true, tokens: MockDesignTokens.light, onTap: {})
+          network: .masterCard, isSelected: true, onTap: {})
         InlineCardNetworkButton(
-          network: .amex, isSelected: false, tokens: MockDesignTokens.light, onTap: {})
+          network: .amex, isSelected: false, onTap: {})
       }
     }
     .padding()

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector.swift
@@ -27,8 +27,7 @@ struct InlineCardNetworkSelector: View {
       ForEach(Array(availableNetworks.enumerated()), id: \.element.rawValue) { index, network in
         InlineCardNetworkButton(
           network: network,
-          isSelected: selectedNetwork == network,
-          tokens: tokens
+          isSelected: selectedNetwork == network
         ) {
           selectedNetwork = network
           onNetworkSelected?(network)
@@ -39,16 +38,17 @@ struct InlineCardNetworkSelector: View {
           Rectangle()
             .fill(baseBorderColor)
             .frame(
-              width: PrimerBorderWidth.standard, height: PrimerCardNetworkSelector.buttonFrameHeight
+              width: PrimerBorderWidth.standard(tokens: tokens),
+              height: PrimerCardNetworkSelector.buttonFrameHeight
             )
         }
       }
     }
 
-    .padding(PrimerBorderWidth.standard)
+    .padding(PrimerBorderWidth.standard(tokens: tokens))
     .overlay(
       RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-        .strokeBorder(baseBorderColor, lineWidth: PrimerBorderWidth.standard)
+        .strokeBorder(baseBorderColor, lineWidth: PrimerBorderWidth.standard(tokens: tokens))
     )
     .accessibilityIdentifier(AccessibilityIdentifiers.CardForm.inlineNetworkSelectorContainer)
     .overlay(
@@ -64,7 +64,7 @@ struct InlineCardNetworkSelector: View {
             bottomRight: selectedIndex == availableNetworks.count - 1
               ? PrimerRadius.small(tokens: tokens) : 0
           )
-          .strokeBorder(selectedBorderColor, lineWidth: PrimerBorderWidth.standard)
+          .strokeBorder(selectedBorderColor, lineWidth: PrimerBorderWidth.standard(tokens: tokens))
           .frame(width: buttonWidth, height: PrimerCardNetworkSelector.selectedBorderHeight)
           .offset(x: xOffset)
         }
@@ -80,7 +80,7 @@ struct InlineCardNetworkSelector: View {
   }
 
   private var borderWidth: CGFloat {
-    PrimerBorderWidth.standard
+    PrimerBorderWidth.standard(tokens: tokens)
   }
 
   private var buttonWidth: CGFloat {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
@@ -74,7 +74,7 @@ struct PaymentMethodButton: View {
       return width
     }
     guard !hasVisibleBackground else { return 0 }
-    return PrimerBorderWidth.standard
+    return PrimerBorderWidth.standard(tokens: tokens)
   }
 
   @ViewBuilder

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodsSection.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodsSection.swift
@@ -43,7 +43,7 @@ struct PaymentMethodsSection: View {
   private func makeLoadingView() -> some View {
     ProgressView()
       .progressViewStyle(
-        CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+        CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
       )
       .scaleEffect(PrimerScale.large)
       .frame(maxWidth: .infinity, minHeight: PrimerComponentHeight.emptyStateMinHeight)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
@@ -94,19 +94,19 @@ struct VaultedCardCVVInput: View {
       .focused($isFocused)
       .multilineTextAlignment(.leading)
       .font(PrimerFont.bodyLarge(tokens: tokens))
-      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      .foregroundColor(CheckoutColors.inputText(tokens: tokens))
       .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
       .frame(width: PrimerComponentWidth.cvvFieldMax, height: PrimerSize.xxlarge(tokens: tokens))
       .background(
         RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-          .fill(CheckoutColors.background(tokens: tokens))
+          .fill(CheckoutColors.inputBackground(tokens: tokens))
       )
       .overlay(
         RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
           .stroke(
             cvvBorderColor,
             lineWidth: isFocused
-              ? PrimerBorderWidth.selected(tokens: tokens) : PrimerBorderWidth.standard(tokens: tokens))
+              ? PrimerBorderWidth.focused(tokens: tokens) : PrimerBorderWidth.standard(tokens: tokens))
       )
       .accessibility(
         config: AccessibilityConfiguration(
@@ -121,7 +121,7 @@ struct VaultedCardCVVInput: View {
 
   private func makeErrorLabel(_ message: String) -> some View {
     Text(message)
-      .font(PrimerFont.bodySmall(tokens: tokens))
+      .font(PrimerFont.error(tokens: tokens))
       .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
@@ -32,7 +32,7 @@ struct AchMandateView: View, LogReporter {
           .frame(maxWidth: .infinity, alignment: .leading)
           .background(
             RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-              .fill(CheckoutColors.backgroundSecondary(tokens: tokens))
+              .fill(CheckoutColors.gray100(tokens: tokens))
           )
       }
       .frame(maxHeight: Layout.mandateTextMaxHeight)
@@ -58,7 +58,7 @@ struct AchMandateView: View, LogReporter {
         .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
         .frame(maxWidth: .infinity)
         .padding(.vertical, PrimerSpacing.large(tokens: tokens))
-        .background(CheckoutColors.textPrimary(tokens: tokens))
+        .background(CheckoutColors.buttonPrimary(tokens: tokens))
         .cornerRadius(PrimerRadius.small(tokens: tokens))
     }
     .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateAcceptButton)
@@ -75,7 +75,9 @@ struct AchMandateView: View, LogReporter {
         .padding(.vertical, PrimerSpacing.large(tokens: tokens))
         .background(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-            .stroke(CheckoutColors.borderDefault(tokens: tokens), lineWidth: 1)
+            .stroke(
+              CheckoutColors.borderDefault(tokens: tokens),
+              lineWidth: PrimerBorderWidth.standard(tokens: tokens))
         )
     }
     .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateDeclineButton)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchView.swift
@@ -139,7 +139,7 @@ struct AchView: View, LogReporter {
         .frame(height: PrimerSpacing.xxlarge(tokens: tokens) * 2)
 
       ProgressView()
-        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.blue(tokens: tokens)))
+        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
         .scaleEffect(PrimerScale.large)
         .frame(width: Layout.spinnerSize, height: Layout.spinnerSize)
         .accessibilityIdentifier(AccessibilityIdentifiers.Ach.loadingIndicator)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
@@ -177,7 +177,7 @@ struct AdyenKlarnaScreen: View {
             Spacer()
             makePaymentMethodLogo()
             ProgressView()
-                .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.textSecondary(tokens: tokens)))
+                .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
                 .scaleEffect(PrimerScale.small)
             Spacer()
         }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
@@ -140,7 +140,9 @@ struct AdyenKlarnaScreen: View {
             .background(CheckoutColors.background(tokens: tokens))
             .overlay(
                 RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
-                    .stroke(CheckoutColors.borderDefault(tokens: tokens), lineWidth: 1)
+                    .stroke(
+                        CheckoutColors.borderDefault(tokens: tokens),
+                        lineWidth: PrimerBorderWidth.standard(tokens: tokens))
             )
             .clipShape(RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens)))
         }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ApplePayScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ApplePayScreen.swift
@@ -56,6 +56,7 @@ struct ApplePayScreen: View {
 
       Text(CheckoutComponentsStrings.applePayTitle)
         .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
         .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.title)
         .accessibilityAddTraits(.isHeader)
 
@@ -99,7 +100,7 @@ struct ApplePayScreen: View {
   private func makeLoadingView() -> some View {
     HStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
       ProgressView()
-        .progressViewStyle(CircularProgressViewStyle())
+        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
         .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.processingIndicator)
 
       Text(CheckoutComponentsStrings.applePayProcessing)
@@ -145,7 +146,7 @@ struct ApplePayScreen: View {
             .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
             .frame(maxWidth: .infinity)
             .frame(height: 50)
-            .background(CheckoutColors.blue(tokens: tokens))
+            .background(CheckoutColors.buttonPrimary(tokens: tokens))
             .cornerRadius(PrimerRadius.medium(tokens: tokens))
         }
         .padding(.horizontal, PrimerSpacing.large(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -37,7 +37,7 @@ struct BillingAddressRedirectScreen: View {
     }
     .frame(maxWidth: .infinity)
     .navigationBarHidden(true)
-    .background(CheckoutColors.inputBackground(tokens: tokens))
+    .background(CheckoutColors.background(tokens: tokens))
     .accessibilityIdentifier(AccessibilityIdentifiers.BillingAddressRedirect.screen)
     .task {
       for await newState in scope.state {
@@ -58,7 +58,7 @@ struct BillingAddressRedirectScreen: View {
                 .font(PrimerFont.bodyMedium(tokens: tokens))
               Text(CheckoutComponentsStrings.backButton)
             }
-            .foregroundColor(CheckoutColors.inputText(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
           }
           .accessibility(config: AccessibilityConfiguration(
             identifier: AccessibilityIdentifiers.BillingAddressRedirect.backButton,
@@ -77,13 +77,13 @@ struct BillingAddressRedirectScreen: View {
 
       Text(paymentMethodDisplayName)
         .font(PrimerFont.titleXLarge(tokens: tokens))
-        .foregroundColor(CheckoutColors.inputText(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityAddTraits(.isHeader)
 
       if let surcharge = billingState.surchargeAmount {
         Text(surcharge)
-          .font(PrimerFont.error(tokens: tokens))
+          .font(PrimerFont.bodySmall(tokens: tokens))
           .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
       }
     }
@@ -142,7 +142,7 @@ struct BillingAddressRedirectScreen: View {
   private func makeCountryField() -> some View {
     VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
       Text(CheckoutComponentsStrings.countryLabel)
-        .font(PrimerFont.error(tokens: tokens))
+        .font(PrimerFont.bodySmall(tokens: tokens))
         .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
 
       Menu {
@@ -173,7 +173,8 @@ struct BillingAddressRedirectScreen: View {
         .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-            .stroke(fieldBorderColor(for: .countryCode), lineWidth: PrimerBorderWidth.standard(tokens: tokens))
+            .stroke(
+              fieldBorderColor(for: .countryCode), lineWidth: fieldBorderWidth(for: .countryCode))
         )
       }
       .accessibilityIdentifier(AccessibilityIdentifiers.BillingAddressRedirect.countryCodeField)
@@ -196,7 +197,7 @@ struct BillingAddressRedirectScreen: View {
   ) -> some View {
     VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
       Text(label)
-        .font(PrimerFont.error(tokens: tokens))
+        .font(PrimerFont.bodySmall(tokens: tokens))
         .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
 
       TextField(placeholder, text: text)
@@ -207,7 +208,7 @@ struct BillingAddressRedirectScreen: View {
         .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-            .stroke(fieldBorderColor(for: fieldType), lineWidth: PrimerBorderWidth.standard(tokens: tokens))
+            .stroke(fieldBorderColor(for: fieldType), lineWidth: fieldBorderWidth(for: fieldType))
         )
         .autocapitalization(.words)
         .disableAutocorrection(true)
@@ -230,6 +231,12 @@ struct BillingAddressRedirectScreen: View {
       : CheckoutColors.borderDefault(tokens: tokens)
   }
 
+  private func fieldBorderWidth(for fieldType: PrimerInputElementType) -> CGFloat {
+    billingState.errors[fieldType] != nil
+      ? PrimerBorderWidth.error(tokens: tokens)
+      : PrimerBorderWidth.standard(tokens: tokens)
+  }
+
   // MARK: - Submit Button
 
   @ViewBuilder
@@ -245,12 +252,11 @@ struct BillingAddressRedirectScreen: View {
   }
 
   private func makeSubmitButtonContent() -> some View {
-    let isLoading = [.submitting, .redirecting, .polling].contains(billingState.status)
-
-    return HStack {
-      if isLoading {
+    HStack {
+      if isSubmitInFlight {
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isButtonActive)))
+          .progressViewStyle(
+            CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isButtonActive)))
           .scaleEffect(PrimerScale.small)
       } else {
         Text(submitButtonText)
@@ -279,7 +285,7 @@ struct BillingAddressRedirectScreen: View {
       : CheckoutColors.buttonDisabled(tokens: tokens)
   }
 
-  /// The button keeps its brand fill while submitting; only an invalid form greys it out.
+  /// The button keeps its brand fill while the payment is in flight; only an invalid form greys it out.
   private var isButtonActive: Bool {
     billingState.isFormValid || isSubmitInFlight
   }
@@ -289,7 +295,7 @@ struct BillingAddressRedirectScreen: View {
   }
 
   private var isButtonDisabled: Bool {
-    !billingState.isFormValid || [.submitting, .redirecting, .polling].contains(billingState.status)
+    !billingState.isFormValid || isSubmitInFlight
   }
 
   private var paymentMethodDisplayName: String {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DefaultLoadingScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DefaultLoadingScreen.swift
@@ -16,7 +16,7 @@ struct DefaultLoadingScreen: View {
     VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
       ProgressView()
         .progressViewStyle(
-          CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+          CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
         )
         .scaleEffect(PrimerScale.large)
         .accessibility(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectPendingScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectPendingScreen.swift
@@ -51,7 +51,7 @@ struct FormRedirectPendingScreen: View {
 
                 ProgressView()
                     .progressViewStyle(
-                        CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+                        CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
                     )
                     .scaleEffect(PrimerScale.large)
                     .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.loadingIndicator)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -214,6 +214,7 @@ private struct FormFieldView: View {
                 set: { onValueChanged($0) }
             ))
             .font(PrimerFont.bodyLarge(tokens: tokens))
+            .foregroundColor(CheckoutColors.inputText(tokens: tokens))
             .keyboardType(field.keyboardType.uiKeyboardType)
             .textContentType(field.fieldType.textContentType)
             .focused($isFocused)
@@ -232,12 +233,19 @@ private struct FormFieldView: View {
         .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
         .background(
             RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-                .stroke(borderColor, lineWidth: PrimerBorderWidth.standard(tokens: tokens))
+                .stroke(borderColor, lineWidth: borderWidth)
                 .background(
                     RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
                         .fill(CheckoutColors.inputBackground(tokens: tokens))
                 )
         )
+    }
+
+    private var borderWidth: CGFloat {
+        if field.errorMessage != nil { return PrimerBorderWidth.error(tokens: tokens) }
+        return isFocused
+            ? PrimerBorderWidth.focused(tokens: tokens)
+            : PrimerBorderWidth.standard(tokens: tokens)
     }
 
     private var borderColor: Color {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -150,7 +150,7 @@ struct KlarnaView: View, LogReporter {
         .frame(height: PrimerSpacing.xxlarge(tokens: tokens) * 2)
 
       ProgressView()
-        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.blue(tokens: tokens)))
+        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
         .scaleEffect(PrimerScale.large)
         .frame(width: Layout.spinnerSize, height: Layout.spinnerSize)
         .accessibilityIdentifier(AccessibilityIdentifiers.Klarna.loadingIndicator)
@@ -242,7 +242,7 @@ struct KlarnaView: View, LogReporter {
           .accessibilityLabel(CheckoutComponentsStrings.a11yKlarnaPaymentView)
       } else if isSelected, scope.paymentView == nil, klarnaState.step != .viewReady {
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.blue(tokens: tokens)))
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
           .frame(maxWidth: .infinity, minHeight: Layout.inlineLoadingMinHeight)
           .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
       }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -26,8 +26,6 @@ struct KlarnaView: View, LogReporter {
     static let badgeHeight: CGFloat = 40
     static let paymentViewMinHeight: CGFloat = 200
     static let inlineLoadingMinHeight: CGFloat = 100
-    static let selectedBorderWidth: CGFloat = 2
-    static let defaultBorderWidth: CGFloat = 1
     static let badgeCornerRadius: CGFloat = 2
     static let placeholderOpacity: Double = 0.8
   }
@@ -256,7 +254,8 @@ struct KlarnaView: View, LogReporter {
         .stroke(
           isSelected
             ? CheckoutColors.borderSelected(tokens: tokens) : CheckoutColors.borderDefault(tokens: tokens),
-          lineWidth: isSelected ? Layout.selectedBorderWidth : Layout.defaultBorderWidth
+          lineWidth: isSelected
+            ? PrimerBorderWidth.selected(tokens: tokens) : PrimerBorderWidth.standard(tokens: tokens)
         )
     )
     .clipShape(RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens)))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/QRCodeView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/QRCodeView.swift
@@ -102,7 +102,7 @@ struct QRCodeView: View, LogReporter {
       case .loading:
         Spacer()
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle())
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
           .scaleEffect(PrimerScale.large)
           .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.loadingIndicator)
           .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
@@ -178,7 +178,9 @@ struct QRCodeView: View, LogReporter {
           .padding(Layout.qrCodePadding)
           .overlay(
             RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-              .stroke(Color.gray.opacity(0.5), lineWidth: PrimerBorderWidth.standard)
+              .stroke(
+                CheckoutColors.borderDefault(tokens: tokens),
+                lineWidth: PrimerBorderWidth.standard(tokens: tokens))
           )
           .frame(maxWidth: .infinity)
           .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.qrCodeImage)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
@@ -113,7 +113,7 @@ struct SelectCountryScreen: View, LogReporter {
       Spacer()
       ProgressView()
         .progressViewStyle(
-          CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+          CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
         )
         .scaleEffect(PrimerScale.small)
         .accessibility(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SplashScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SplashScreen.swift
@@ -20,7 +20,7 @@ struct SplashScreen: View {
       VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
         ProgressView()
           .progressViewStyle(
-            CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+            CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
           )
           .scaleEffect(PrimerScale.large)
           .frame(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -53,15 +53,23 @@ enum CheckoutColors {
   }
 
   static func gray100(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackgroundOutlinedDefault ?? .white
+    tokens?.primerColorGray100 ?? Color(.systemGray6)
   }
 
   static func gray200(tokens: DesignTokens?) -> Color {
     tokens?.primerColorGray200 ?? Color(.systemGray5)
   }
 
+  static func gray300(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorGray300 ?? Color(.systemGray4)
+  }
+
   static func textPlaceholder(tokens: DesignTokens?) -> Color {
     tokens?.primerColorTextPlaceholder ?? Color(.tertiaryLabel)
+  }
+
+  static func loader(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorLoader ?? .blue
   }
 
   static func borderSelected(tokens: DesignTokens?) -> Color {
@@ -70,52 +78,6 @@ enum CheckoutColors {
 
   static func iconPositive(tokens: DesignTokens?) -> Color {
     tokens?.primerColorIconPositive ?? Color(.systemGreen)
-  }
-
-  static func orange(tokens _: DesignTokens?) -> Color { .orange }
-
-  // MARK: - Screen & Input Colors
-
-  static func screenBackground(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackgroundPrimary ?? Color(.systemBackground)
-  }
-
-  static func inputBackground(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackgroundOutlinedDefault ?? .white
-  }
-
-  static func inputBorder(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBorderOutlinedDefault ?? Color(.systemGray4)
-  }
-
-  static func inputBorderFocused(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBorderOutlinedFocus ?? .blue
-  }
-
-  // MARK: - Button Colors
-
-  static func buttonPrimary(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBrand ?? .blue
-  }
-
-  static func gray300(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorGray300 ?? Color(.systemGray4)
-  }
-
-  static func buttonDisabled(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackgroundOutlinedDisabled ?? Color(.systemGray6)
-  }
-
-  static func blue(tokens _: DesignTokens?) -> Color { .blue }
-
-  static func green(tokens _: DesignTokens?) -> Color { .green }
-
-  static func error(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorTextNegative ?? .red
-  }
-
-  static func inputText(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorTextOutlinedDefault ?? .primary
   }
 
   /// Label/spinner colour on a surface filled with `textPrimary`, which the label inverts with; a
@@ -132,5 +94,39 @@ enum CheckoutColors {
   /// fill and takes `textDisabled`. A loading button is still brand-filled, so pass `isEnabled: true`.
   static func onBrand(tokens: DesignTokens?, isEnabled: Bool = true) -> Color {
     isEnabled ? .white : (tokens?.primerColorTextDisabled ?? Color(.tertiaryLabel))
+  }
+
+  static func orange(tokens _: DesignTokens?) -> Color { .orange }
+
+  // MARK: - Screen & Input Colors
+
+  static func screenBackground(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBackgroundPrimary ?? Color(.systemBackground)
+  }
+
+  static func inputBackground(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBackgroundOutlinedDefault ?? .white
+  }
+
+  static func inputText(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorTextOutlinedDefault ?? .primary
+  }
+
+  static func inputBorder(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBorderOutlinedDefault ?? Color(.systemGray4)
+  }
+
+  static func inputBorderFocused(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBorderOutlinedFocus ?? .blue
+  }
+
+  // MARK: - Button Colors
+
+  static func buttonPrimary(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBrand ?? .blue
+  }
+
+  static func buttonDisabled(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBackgroundOutlinedDisabled ?? Color(.systemGray6)
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/PrimerLayout.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/PrimerLayout.swift
@@ -131,11 +131,20 @@ enum PrimerBorderWidth {
     tokens?.primerWidthDefault ?? standard
   }
 
+  /// Emphasised border for a focused field. Maps to the `focus` width token (default 2).
+  static func focused(tokens: DesignTokens?) -> CGFloat {
+    tokens?.primerWidthFocus ?? selected
+  }
+
   /// Emphasised border for a chosen item, such as a saved card. Maps to the `selected` token.
   static func selected(tokens: DesignTokens?) -> CGFloat {
     tokens?.primerWidthSelected ?? selected
   }
 
+  /// Emphasised border for a field in error. Maps to the `error` width token (default 2).
+  static func error(tokens: DesignTokens?) -> CGFloat {
+    tokens?.primerWidthError ?? selected
+  }
 }
 
 // MARK: - Primer Scale Factors


### PR DESCRIPTION
# Description

[ORC-8267](https://primerapi.atlassian.net/browse/ORC-8267)

The co-badge network chips painted the sheet colour behind themselves, so once a merchant coloured the field differently they showed as pale rectangles on top of it. They're transparent now and inherit the field; selection reads from the border alone, as in Figma and on Android.

They no longer need a `tokens` parameter, which is why the diff is mostly deletion.

# Contributor Checklist

- [x] All status checks have passed prior to code review
- [x] I have added unit tests to a reasonable level of coverage where suitable
- [x] I have manually tested newly added UX



[ORC-8267]: https://primerapi.atlassian.net/browse/ORC-8267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ