### PR TITLE
fix(components): repaint bridged fields on a colour-scheme change (ORC-8178)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/API_REFERENCE.md
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/API_REFERENCE.md
@@ -308,16 +308,26 @@ Design token overrides for the entire checkout UI.
 public struct PrimerCheckoutTheme: Equatable {
   public init(
     colors: ColorOverrides? = nil,
+    darkColors: ColorOverrides? = nil,
     radius: RadiusOverrides? = nil,
     spacing: SpacingOverrides? = nil,
     sizes: SizeOverrides? = nil,
     typography: TypographyOverrides? = nil,
-    borderWidth: BorderWidthOverrides? = nil
+    width: WidthOverrides? = nil
   )
 }
 ```
 
-**Override types**: `ColorOverrides`, `RadiusOverrides`, `SpacingOverrides`, `SizeOverrides`, `TypographyOverrides`, `BorderWidthOverrides`. See `Scope/PrimerCheckoutTheme.swift` for all token names.
+**Override types**: `ColorOverrides`, `RadiusOverrides`, `SpacingOverrides`, `SizeOverrides`, `TypographyOverrides`, `WidthOverrides`. See `Scope/PrimerCheckoutTheme.swift` for all token names.
+
+**Light and dark colours**: `colors` applies in both colour schemes. Add `darkColors` to give dark mode its own values — each one left nil there falls back to the matching `colors` value, so only the colours that differ need naming. `radius`, `spacing`, `sizes`, `typography` and `width` are colour-scheme independent and have no dark counterpart.
+
+```swift
+PrimerCheckoutTheme(
+    colors: ColorOverrides(primerColorBrand: Color(red: 0.10, green: 0.14, blue: 0.49)),
+    darkColors: ColorOverrides(primerColorBrand: Color(red: 0.55, green: 0.62, blue: 1.00))
+)
+```
 
 ---
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Containers/PrimerInputFieldContainer+Styling.swift
@@ -48,7 +48,12 @@ extension PrimerInputFieldContainer {
 @available(iOS 15.0, *)
 extension PrimerInputFieldContainer {
   var fieldCornerRadius: CGFloat { PrimerRadius.small(tokens: tokens) }
-  var textFieldContainerBackgroundLineWidth: CGFloat { PrimerBorderWidth.standard(tokens: tokens) }
+  var textFieldContainerBackgroundLineWidth: CGFloat {
+    if hasError { return PrimerBorderWidth.error(tokens: tokens) }
+    return isFocused
+      ? PrimerBorderWidth.focused(tokens: tokens)
+      : PrimerBorderWidth.standard(tokens: tokens)
+  }
   var errorMessageMinHeight: CGFloat { hasError ? PrimerComponentHeight.errorMessage : 0 }
   var errorMessageTopPadding: CGFloat { hasError ? PrimerSpacing.xsmall(tokens: tokens) : 0 }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Infrastructure/Utilities/PrimerTextFieldExtension.swift
@@ -133,6 +133,22 @@ extension UITextField {
     )
   }
 
+  /// The two token-derived colours a bridged field paints, reapplied after a colour-scheme change.
+  ///
+  /// Deliberately narrow. It does not touch the font, border, fill or `inputAccessoryView`: none of
+  /// those change with the scheme, and writing them on a live field is what broke the two earlier
+  /// attempts at this fix.
+  func repaintPrimerColors(placeholder: String, tokens: DesignTokens?) {
+    textColor = UIColor(CheckoutColors.inputText(tokens: tokens))
+    attributedPlaceholder = NSAttributedString(
+      string: placeholder,
+      attributes: [
+        .foregroundColor: UIColor(CheckoutColors.textPlaceholder(tokens: tokens)),
+        .font: font ?? PrimerFont.uiFontBodyLarge(tokens: tokens)
+      ]
+    )
+  }
+
   /// Auto-sizing keyboard toolbar with a trailing "Done" button.
   private static func makeDoneAccessory(
     tokens: DesignTokens?,
@@ -160,5 +176,26 @@ extension UITextField {
 
     toolbar.items = [.flexibleSpace(), doneItem]
     return toolbar
+  }
+}
+
+/// Holds the token set a bridged field was last painted with, so `updateUIView` repaints on a
+/// colour-scheme change and does nothing on the keystrokes that make up almost every other call.
+///
+/// Identity, not equality: `DesignTokensManager` decodes a fresh `DesignTokens` per scheme, and the
+/// `UIColor`s built from it never compare equal, so a value check would repaint every time.
+@available(iOS 15.0, *)
+final class PrimerFieldRepainter {
+  private var appliedTokens: DesignTokens?
+
+  /// Seeded from `makeUIView`, which has already painted the field.
+  func markApplied(_ tokens: DesignTokens?) {
+    appliedTokens = tokens
+  }
+
+  func repaintIfNeeded(_ textField: UITextField, placeholder: String, tokens: DesignTokens?) {
+    guard appliedTokens !== tokens else { return }
+    appliedTokens = tokens
+    textField.repaintPrimerColors(placeholder: placeholder, tokens: tokens)
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector+Button.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector+Button.swift
@@ -12,7 +12,6 @@ import SwiftUI
 struct InlineCardNetworkButton: View {
   let network: CardNetwork
   let isSelected: Bool
-  let tokens: DesignTokens?
   let onTap: () -> Void
 
   var body: some View {
@@ -23,7 +22,7 @@ struct InlineCardNetworkButton: View {
           height: PrimerCardNetworkSelector.buttonFrameHeight,
           alignment: .center
         )
-        .background(backgroundColor)
+        .contentShape(Rectangle())
     }
     .buttonStyle(PlainButtonStyle())
     .accessibilityIdentifier(
@@ -32,12 +31,6 @@ struct InlineCardNetworkButton: View {
     .accessibilityLabel(network.displayName)
     .accessibilityHint(isSelected ? "" : CheckoutComponentsStrings.a11yInlineNetworkButtonHint)
     .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
-  }
-
-  private var backgroundColor: Color {
-    isSelected
-      ? CheckoutColors.backgroundSecondary(tokens: tokens)
-      : CheckoutColors.background(tokens: tokens)
   }
 }
 
@@ -48,7 +41,6 @@ struct InlineCardNetworkButton: View {
       InlineCardNetworkButton(
         network: .visa,
         isSelected: true,
-        tokens: MockDesignTokens.light,
         onTap: {}
       )
     }
@@ -62,7 +54,6 @@ struct InlineCardNetworkButton: View {
       InlineCardNetworkButton(
         network: .masterCard,
         isSelected: false,
-        tokens: MockDesignTokens.light,
         onTap: {}
       )
     }
@@ -75,20 +66,20 @@ struct InlineCardNetworkButton: View {
     VStack(spacing: 20) {
       HStack(spacing: 0) {
         InlineCardNetworkButton(
-          network: .visa, isSelected: true, tokens: MockDesignTokens.light, onTap: {})
+          network: .visa, isSelected: true, onTap: {})
         InlineCardNetworkButton(
-          network: .masterCard, isSelected: false, tokens: MockDesignTokens.light, onTap: {})
+          network: .masterCard, isSelected: false, onTap: {})
         InlineCardNetworkButton(
-          network: .amex, isSelected: false, tokens: MockDesignTokens.light, onTap: {})
+          network: .amex, isSelected: false, onTap: {})
       }
 
       HStack(spacing: 0) {
         InlineCardNetworkButton(
-          network: .visa, isSelected: false, tokens: MockDesignTokens.light, onTap: {})
+          network: .visa, isSelected: false, onTap: {})
         InlineCardNetworkButton(
-          network: .masterCard, isSelected: true, tokens: MockDesignTokens.light, onTap: {})
+          network: .masterCard, isSelected: true, onTap: {})
         InlineCardNetworkButton(
-          network: .amex, isSelected: false, tokens: MockDesignTokens.light, onTap: {})
+          network: .amex, isSelected: false, onTap: {})
       }
     }
     .padding()

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/InlineCardNetworkSelector/InlineCardNetworkSelector.swift
@@ -27,8 +27,7 @@ struct InlineCardNetworkSelector: View {
       ForEach(Array(availableNetworks.enumerated()), id: \.element.rawValue) { index, network in
         InlineCardNetworkButton(
           network: network,
-          isSelected: selectedNetwork == network,
-          tokens: tokens
+          isSelected: selectedNetwork == network
         ) {
           selectedNetwork = network
           onNetworkSelected?(network)
@@ -39,16 +38,17 @@ struct InlineCardNetworkSelector: View {
           Rectangle()
             .fill(baseBorderColor)
             .frame(
-              width: PrimerBorderWidth.standard, height: PrimerCardNetworkSelector.buttonFrameHeight
+              width: PrimerBorderWidth.standard(tokens: tokens),
+              height: PrimerCardNetworkSelector.buttonFrameHeight
             )
         }
       }
     }
 
-    .padding(PrimerBorderWidth.standard)
+    .padding(PrimerBorderWidth.standard(tokens: tokens))
     .overlay(
       RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-        .strokeBorder(baseBorderColor, lineWidth: PrimerBorderWidth.standard)
+        .strokeBorder(baseBorderColor, lineWidth: PrimerBorderWidth.standard(tokens: tokens))
     )
     .accessibilityIdentifier(AccessibilityIdentifiers.CardForm.inlineNetworkSelectorContainer)
     .overlay(
@@ -64,7 +64,7 @@ struct InlineCardNetworkSelector: View {
             bottomRight: selectedIndex == availableNetworks.count - 1
               ? PrimerRadius.small(tokens: tokens) : 0
           )
-          .strokeBorder(selectedBorderColor, lineWidth: PrimerBorderWidth.standard)
+          .strokeBorder(selectedBorderColor, lineWidth: PrimerBorderWidth.standard(tokens: tokens))
           .frame(width: buttonWidth, height: PrimerCardNetworkSelector.selectedBorderHeight)
           .offset(x: xOffset)
         }
@@ -80,7 +80,7 @@ struct InlineCardNetworkSelector: View {
   }
 
   private var borderWidth: CGFloat {
-    PrimerBorderWidth.standard
+    PrimerBorderWidth.standard(tokens: tokens)
   }
 
   private var buttonWidth: CGFloat {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/AddressLineInputField/AddressLineInputField+UIViewRepresentable.swift
@@ -36,10 +36,14 @@ struct AddressLineTextField: UIViewRepresentable, LogReporter {
       doneButtonAction: #selector(Coordinator.doneButtonTapped)
     )
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: UITextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     if textField.text != addressLine {
       textField.text = addressLine
     }
@@ -61,6 +65,7 @@ struct AddressLineTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     private let validationService: ValidationService
     @Binding private var addressLine: String
     @Binding private var isValid: Bool

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CVVInputField/CVVInputField+UIViewRepresentable.swift
@@ -34,10 +34,14 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
       doneButtonAction: #selector(Coordinator.doneButtonTapped)
     )
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: SecureTextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     if textField.internalText != cvv {
       textField.internalText = cvv
     }
@@ -56,6 +60,7 @@ struct CVVTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     private let validationService: ValidationService
     private let cardNetwork: CardNetwork
     @Binding private var cvv: String

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardNumberInputField/CardNumberInputField+UIViewRepresentable.swift
@@ -34,10 +34,14 @@ struct CardNumberTextField: UIViewRepresentable, LogReporter {
       doneButtonAction: #selector(Coordinator.doneButtonTapped)
     )
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: SecureTextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     let formatted = CardNumberFormatter.format(cardNumber, for: cardNetwork)
     if textField.internalText != formatted {
       textField.internalText = formatted
@@ -57,6 +61,7 @@ struct CardNumberTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     // MARK: - Properties
 
     @Binding private var cardNumber: String

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CardholderNameInputField/CardholderNameInputField+UIViewRepresentable.swift
@@ -34,10 +34,14 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
 
     textField.font = PrimerFont.uiFontBodyLarge(tokens: tokens)
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: UITextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     if textField.text != cardholderName {
       textField.text = cardholderName
     }
@@ -55,6 +59,7 @@ struct CardholderNameTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     private let validationService: ValidationService
     @Binding private var cardholderName: String
     @Binding private var isValid: Bool

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/CityInputField/CityInputField+UIViewRepresentable.swift
@@ -33,10 +33,14 @@ struct CityTextField: UIViewRepresentable, LogReporter {
       doneButtonAction: #selector(Coordinator.doneButtonTapped)
     )
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: UITextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     if textField.text != city {
       textField.text = city
     }
@@ -54,6 +58,7 @@ struct CityTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     private let validationService: ValidationService
     @Binding private var city: String
     @Binding private var isValid: Bool

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/EmailInputField/EmailInputField+UIViewRepresentable.swift
@@ -35,10 +35,14 @@ struct EmailTextField: UIViewRepresentable, LogReporter {
       doneButtonAction: #selector(Coordinator.doneButtonTapped)
     )
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: UITextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     if textField.text != email {
       textField.text = email
     }
@@ -58,6 +62,7 @@ struct EmailTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     private let validationService: ValidationService
     @Binding private var email: String
     @Binding private var isValid: Bool

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/ExpiryDateInputField/ExpiryDateInputField+UIViewRepresentable.swift
@@ -35,10 +35,14 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
       doneButtonAction: #selector(Coordinator.doneButtonTapped)
     )
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: UITextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     if textField.text != expiryDate {
       textField.text = expiryDate
     }
@@ -58,6 +62,7 @@ struct ExpiryDateTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     private let validationService: ValidationService
     @Binding private var expiryDate: String
     @Binding private var month: String

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/NameInputField/NameInputField+UIViewRepresentable.swift
@@ -36,10 +36,14 @@ struct NameTextField: UIViewRepresentable, LogReporter {
       doneButtonAction: #selector(Coordinator.doneButtonTapped)
     )
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: UITextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     if textField.text != name {
       textField.text = name
     }
@@ -60,6 +64,7 @@ struct NameTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     private let validationService: ValidationService
     @Binding private var name: String
     @Binding private var isValid: Bool

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/PostalCodeInputField/PostalCodeInputField+UIViewRepresentable.swift
@@ -45,10 +45,14 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
       doneButtonAction: #selector(Coordinator.doneButtonTapped)
     )
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: UITextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     if textField.text != postalCode {
       textField.text = postalCode
     }
@@ -67,6 +71,7 @@ struct PostalCodeTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     private let validationService: ValidationService
     @Binding private var postalCode: String
     @Binding private var isValid: Bool

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField+UIViewRepresentable.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/Inputs/StateInputField/StateInputField+UIViewRepresentable.swift
@@ -33,10 +33,14 @@ struct StateTextField: UIViewRepresentable, LogReporter {
       doneButtonAction: #selector(Coordinator.doneButtonTapped)
     )
 
+    context.coordinator.repainter.markApplied(tokens)
+
     return textField
   }
 
   func updateUIView(_ textField: UITextField, context: Context) {
+    context.coordinator.repainter.repaintIfNeeded(textField, placeholder: placeholder, tokens: tokens)
+
     if textField.text != state {
       textField.text = state
     }
@@ -54,6 +58,7 @@ struct StateTextField: UIViewRepresentable, LogReporter {
   }
 
   final class Coordinator: NSObject, UITextFieldDelegate, LogReporter {
+    let repainter = PrimerFieldRepainter()
     private let validationService: ValidationService
     @Binding private var state: String
     @Binding private var isValid: Bool

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
@@ -74,7 +74,7 @@ struct PaymentMethodButton: View {
       return width
     }
     guard !hasVisibleBackground else { return 0 }
-    return PrimerBorderWidth.standard
+    return PrimerBorderWidth.standard(tokens: tokens)
   }
 
   @ViewBuilder

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodsSection.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodsSection.swift
@@ -43,7 +43,7 @@ struct PaymentMethodsSection: View {
   private func makeLoadingView() -> some View {
     ProgressView()
       .progressViewStyle(
-        CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+        CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
       )
       .scaleEffect(PrimerScale.large)
       .frame(maxWidth: .infinity, minHeight: PrimerComponentHeight.emptyStateMinHeight)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/VaultedCardCVVInput.swift
@@ -94,19 +94,19 @@ struct VaultedCardCVVInput: View {
       .focused($isFocused)
       .multilineTextAlignment(.leading)
       .font(PrimerFont.bodyLarge(tokens: tokens))
-      .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
+      .foregroundColor(CheckoutColors.inputText(tokens: tokens))
       .padding(.horizontal, PrimerSpacing.medium(tokens: tokens))
       .frame(width: PrimerComponentWidth.cvvFieldMax, height: PrimerSize.xxlarge(tokens: tokens))
       .background(
         RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-          .fill(CheckoutColors.background(tokens: tokens))
+          .fill(CheckoutColors.inputBackground(tokens: tokens))
       )
       .overlay(
         RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
           .stroke(
             cvvBorderColor,
             lineWidth: isFocused
-              ? PrimerBorderWidth.selected(tokens: tokens) : PrimerBorderWidth.standard(tokens: tokens))
+              ? PrimerBorderWidth.focused(tokens: tokens) : PrimerBorderWidth.standard(tokens: tokens))
       )
       .accessibility(
         config: AccessibilityConfiguration(
@@ -121,7 +121,7 @@ struct VaultedCardCVVInput: View {
 
   private func makeErrorLabel(_ message: String) -> some View {
     Text(message)
-      .font(PrimerFont.bodySmall(tokens: tokens))
+      .font(PrimerFont.error(tokens: tokens))
       .foregroundColor(CheckoutColors.textNegative(tokens: tokens))
   }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchMandateView.swift
@@ -32,7 +32,7 @@ struct AchMandateView: View, LogReporter {
           .frame(maxWidth: .infinity, alignment: .leading)
           .background(
             RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-              .fill(CheckoutColors.backgroundSecondary(tokens: tokens))
+              .fill(CheckoutColors.gray100(tokens: tokens))
           )
       }
       .frame(maxHeight: Layout.mandateTextMaxHeight)
@@ -58,7 +58,7 @@ struct AchMandateView: View, LogReporter {
         .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
         .frame(maxWidth: .infinity)
         .padding(.vertical, PrimerSpacing.large(tokens: tokens))
-        .background(CheckoutColors.textPrimary(tokens: tokens))
+        .background(CheckoutColors.buttonPrimary(tokens: tokens))
         .cornerRadius(PrimerRadius.small(tokens: tokens))
     }
     .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateAcceptButton)
@@ -75,7 +75,9 @@ struct AchMandateView: View, LogReporter {
         .padding(.vertical, PrimerSpacing.large(tokens: tokens))
         .background(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-            .stroke(CheckoutColors.borderDefault(tokens: tokens), lineWidth: 1)
+            .stroke(
+              CheckoutColors.borderDefault(tokens: tokens),
+              lineWidth: PrimerBorderWidth.standard(tokens: tokens))
         )
     }
     .accessibilityIdentifier(AccessibilityIdentifiers.Ach.mandateDeclineButton)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/Ach/AchView.swift
@@ -139,7 +139,7 @@ struct AchView: View, LogReporter {
         .frame(height: PrimerSpacing.xxlarge(tokens: tokens) * 2)
 
       ProgressView()
-        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.blue(tokens: tokens)))
+        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
         .scaleEffect(PrimerScale.large)
         .frame(width: Layout.spinnerSize, height: Layout.spinnerSize)
         .accessibilityIdentifier(AccessibilityIdentifiers.Ach.loadingIndicator)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
@@ -177,7 +177,7 @@ struct AdyenKlarnaScreen: View {
             Spacer()
             makePaymentMethodLogo()
             ProgressView()
-                .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.textSecondary(tokens: tokens)))
+                .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
                 .scaleEffect(PrimerScale.small)
             Spacer()
         }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/AdyenKlarna/AdyenKlarnaScreen.swift
@@ -140,7 +140,9 @@ struct AdyenKlarnaScreen: View {
             .background(CheckoutColors.background(tokens: tokens))
             .overlay(
                 RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens))
-                    .stroke(CheckoutColors.borderDefault(tokens: tokens), lineWidth: 1)
+                    .stroke(
+                        CheckoutColors.borderDefault(tokens: tokens),
+                        lineWidth: PrimerBorderWidth.standard(tokens: tokens))
             )
             .clipShape(RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens)))
         }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ApplePayScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/ApplePayScreen.swift
@@ -56,6 +56,7 @@ struct ApplePayScreen: View {
 
       Text(CheckoutComponentsStrings.applePayTitle)
         .font(PrimerFont.titleLarge(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
         .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.title)
         .accessibilityAddTraits(.isHeader)
 
@@ -99,7 +100,7 @@ struct ApplePayScreen: View {
   private func makeLoadingView() -> some View {
     HStack(spacing: PrimerSpacing.medium(tokens: tokens)) {
       ProgressView()
-        .progressViewStyle(CircularProgressViewStyle())
+        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
         .accessibilityIdentifier(AccessibilityIdentifiers.ApplePay.processingIndicator)
 
       Text(CheckoutComponentsStrings.applePayProcessing)
@@ -145,7 +146,7 @@ struct ApplePayScreen: View {
             .foregroundColor(CheckoutColors.onBrand(tokens: tokens))
             .frame(maxWidth: .infinity)
             .frame(height: 50)
-            .background(CheckoutColors.blue(tokens: tokens))
+            .background(CheckoutColors.buttonPrimary(tokens: tokens))
             .cornerRadius(PrimerRadius.medium(tokens: tokens))
         }
         .padding(.horizontal, PrimerSpacing.large(tokens: tokens))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/BillingAddressRedirect/BillingAddressRedirectScreen.swift
@@ -37,7 +37,7 @@ struct BillingAddressRedirectScreen: View {
     }
     .frame(maxWidth: .infinity)
     .navigationBarHidden(true)
-    .background(CheckoutColors.inputBackground(tokens: tokens))
+    .background(CheckoutColors.background(tokens: tokens))
     .accessibilityIdentifier(AccessibilityIdentifiers.BillingAddressRedirect.screen)
     .task {
       for await newState in scope.state {
@@ -58,7 +58,7 @@ struct BillingAddressRedirectScreen: View {
                 .font(PrimerFont.bodyMedium(tokens: tokens))
               Text(CheckoutComponentsStrings.backButton)
             }
-            .foregroundColor(CheckoutColors.inputText(tokens: tokens))
+            .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
           }
           .accessibility(config: AccessibilityConfiguration(
             identifier: AccessibilityIdentifiers.BillingAddressRedirect.backButton,
@@ -77,13 +77,13 @@ struct BillingAddressRedirectScreen: View {
 
       Text(paymentMethodDisplayName)
         .font(PrimerFont.titleXLarge(tokens: tokens))
-        .foregroundColor(CheckoutColors.inputText(tokens: tokens))
+        .foregroundColor(CheckoutColors.textPrimary(tokens: tokens))
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityAddTraits(.isHeader)
 
       if let surcharge = billingState.surchargeAmount {
         Text(surcharge)
-          .font(PrimerFont.error(tokens: tokens))
+          .font(PrimerFont.bodySmall(tokens: tokens))
           .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
       }
     }
@@ -142,7 +142,7 @@ struct BillingAddressRedirectScreen: View {
   private func makeCountryField() -> some View {
     VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
       Text(CheckoutComponentsStrings.countryLabel)
-        .font(PrimerFont.error(tokens: tokens))
+        .font(PrimerFont.bodySmall(tokens: tokens))
         .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
 
       Menu {
@@ -173,7 +173,8 @@ struct BillingAddressRedirectScreen: View {
         .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-            .stroke(fieldBorderColor(for: .countryCode), lineWidth: PrimerBorderWidth.standard(tokens: tokens))
+            .stroke(
+              fieldBorderColor(for: .countryCode), lineWidth: fieldBorderWidth(for: .countryCode))
         )
       }
       .accessibilityIdentifier(AccessibilityIdentifiers.BillingAddressRedirect.countryCodeField)
@@ -196,7 +197,7 @@ struct BillingAddressRedirectScreen: View {
   ) -> some View {
     VStack(alignment: .leading, spacing: PrimerSpacing.xsmall(tokens: tokens)) {
       Text(label)
-        .font(PrimerFont.error(tokens: tokens))
+        .font(PrimerFont.bodySmall(tokens: tokens))
         .foregroundColor(CheckoutColors.textSecondary(tokens: tokens))
 
       TextField(placeholder, text: text)
@@ -207,7 +208,7 @@ struct BillingAddressRedirectScreen: View {
         .background(CheckoutColors.inputBackground(tokens: tokens))
         .overlay(
           RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-            .stroke(fieldBorderColor(for: fieldType), lineWidth: PrimerBorderWidth.standard(tokens: tokens))
+            .stroke(fieldBorderColor(for: fieldType), lineWidth: fieldBorderWidth(for: fieldType))
         )
         .autocapitalization(.words)
         .disableAutocorrection(true)
@@ -230,6 +231,12 @@ struct BillingAddressRedirectScreen: View {
       : CheckoutColors.borderDefault(tokens: tokens)
   }
 
+  private func fieldBorderWidth(for fieldType: PrimerInputElementType) -> CGFloat {
+    billingState.errors[fieldType] != nil
+      ? PrimerBorderWidth.error(tokens: tokens)
+      : PrimerBorderWidth.standard(tokens: tokens)
+  }
+
   // MARK: - Submit Button
 
   @ViewBuilder
@@ -245,12 +252,11 @@ struct BillingAddressRedirectScreen: View {
   }
 
   private func makeSubmitButtonContent() -> some View {
-    let isLoading = [.submitting, .redirecting, .polling].contains(billingState.status)
-
-    return HStack {
-      if isLoading {
+    HStack {
+      if isSubmitInFlight {
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isButtonActive)))
+          .progressViewStyle(
+            CircularProgressViewStyle(tint: CheckoutColors.onBrand(tokens: tokens, isEnabled: isButtonActive)))
           .scaleEffect(PrimerScale.small)
       } else {
         Text(submitButtonText)
@@ -279,7 +285,7 @@ struct BillingAddressRedirectScreen: View {
       : CheckoutColors.buttonDisabled(tokens: tokens)
   }
 
-  /// The button keeps its brand fill while submitting; only an invalid form greys it out.
+  /// The button keeps its brand fill while the payment is in flight; only an invalid form greys it out.
   private var isButtonActive: Bool {
     billingState.isFormValid || isSubmitInFlight
   }
@@ -289,7 +295,7 @@ struct BillingAddressRedirectScreen: View {
   }
 
   private var isButtonDisabled: Bool {
-    !billingState.isFormValid || [.submitting, .redirecting, .polling].contains(billingState.status)
+    !billingState.isFormValid || isSubmitInFlight
   }
 
   private var paymentMethodDisplayName: String {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DefaultLoadingScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/DefaultLoadingScreen.swift
@@ -16,7 +16,7 @@ struct DefaultLoadingScreen: View {
     VStack(spacing: PrimerSpacing.small(tokens: tokens)) {
       ProgressView()
         .progressViewStyle(
-          CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+          CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
         )
         .scaleEffect(PrimerScale.large)
         .accessibility(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectPendingScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectPendingScreen.swift
@@ -51,7 +51,7 @@ struct FormRedirectPendingScreen: View {
 
                 ProgressView()
                     .progressViewStyle(
-                        CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+                        CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
                     )
                     .scaleEffect(PrimerScale.large)
                     .accessibilityIdentifier(AccessibilityIdentifiers.FormRedirect.loadingIndicator)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/FormRedirect/FormRedirectScreen.swift
@@ -214,6 +214,7 @@ private struct FormFieldView: View {
                 set: { onValueChanged($0) }
             ))
             .font(PrimerFont.bodyLarge(tokens: tokens))
+            .foregroundColor(CheckoutColors.inputText(tokens: tokens))
             .keyboardType(field.keyboardType.uiKeyboardType)
             .textContentType(field.fieldType.textContentType)
             .focused($isFocused)
@@ -232,12 +233,19 @@ private struct FormFieldView: View {
         .padding(.vertical, PrimerSpacing.medium(tokens: tokens))
         .background(
             RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-                .stroke(borderColor, lineWidth: PrimerBorderWidth.standard(tokens: tokens))
+                .stroke(borderColor, lineWidth: borderWidth)
                 .background(
                     RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
                         .fill(CheckoutColors.inputBackground(tokens: tokens))
                 )
         )
+    }
+
+    private var borderWidth: CGFloat {
+        if field.errorMessage != nil { return PrimerBorderWidth.error(tokens: tokens) }
+        return isFocused
+            ? PrimerBorderWidth.focused(tokens: tokens)
+            : PrimerBorderWidth.standard(tokens: tokens)
     }
 
     private var borderColor: Color {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -150,7 +150,7 @@ struct KlarnaView: View, LogReporter {
         .frame(height: PrimerSpacing.xxlarge(tokens: tokens) * 2)
 
       ProgressView()
-        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.blue(tokens: tokens)))
+        .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
         .scaleEffect(PrimerScale.large)
         .frame(width: Layout.spinnerSize, height: Layout.spinnerSize)
         .accessibilityIdentifier(AccessibilityIdentifiers.Klarna.loadingIndicator)
@@ -242,7 +242,7 @@ struct KlarnaView: View, LogReporter {
           .accessibilityLabel(CheckoutComponentsStrings.a11yKlarnaPaymentView)
       } else if isSelected, scope.paymentView == nil, klarnaState.step != .viewReady {
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.blue(tokens: tokens)))
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
           .frame(maxWidth: .infinity, minHeight: Layout.inlineLoadingMinHeight)
           .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
       }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/KlarnaView.swift
@@ -26,8 +26,6 @@ struct KlarnaView: View, LogReporter {
     static let badgeHeight: CGFloat = 40
     static let paymentViewMinHeight: CGFloat = 200
     static let inlineLoadingMinHeight: CGFloat = 100
-    static let selectedBorderWidth: CGFloat = 2
-    static let defaultBorderWidth: CGFloat = 1
     static let badgeCornerRadius: CGFloat = 2
     static let placeholderOpacity: Double = 0.8
   }
@@ -256,7 +254,8 @@ struct KlarnaView: View, LogReporter {
         .stroke(
           isSelected
             ? CheckoutColors.borderSelected(tokens: tokens) : CheckoutColors.borderDefault(tokens: tokens),
-          lineWidth: isSelected ? Layout.selectedBorderWidth : Layout.defaultBorderWidth
+          lineWidth: isSelected
+            ? PrimerBorderWidth.selected(tokens: tokens) : PrimerBorderWidth.standard(tokens: tokens)
         )
     )
     .clipShape(RoundedRectangle(cornerRadius: PrimerRadius.medium(tokens: tokens)))

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/QRCodeView.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/QRCodeView.swift
@@ -102,7 +102,7 @@ struct QRCodeView: View, LogReporter {
       case .loading:
         Spacer()
         ProgressView()
-          .progressViewStyle(CircularProgressViewStyle())
+          .progressViewStyle(CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens)))
           .scaleEffect(PrimerScale.large)
           .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.loadingIndicator)
           .accessibilityLabel(CheckoutComponentsStrings.a11yLoading)
@@ -178,7 +178,9 @@ struct QRCodeView: View, LogReporter {
           .padding(Layout.qrCodePadding)
           .overlay(
             RoundedRectangle(cornerRadius: PrimerRadius.small(tokens: tokens))
-              .stroke(Color.gray.opacity(0.5), lineWidth: PrimerBorderWidth.standard)
+              .stroke(
+                CheckoutColors.borderDefault(tokens: tokens),
+                lineWidth: PrimerBorderWidth.standard(tokens: tokens))
           )
           .frame(maxWidth: .infinity)
           .accessibilityIdentifier(AccessibilityIdentifiers.QRCode.qrCodeImage)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SelectCountryScreen.swift
@@ -113,7 +113,7 @@ struct SelectCountryScreen: View, LogReporter {
       Spacer()
       ProgressView()
         .progressViewStyle(
-          CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+          CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
         )
         .scaleEffect(PrimerScale.small)
         .accessibility(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SplashScreen.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Screens/SplashScreen.swift
@@ -20,7 +20,7 @@ struct SplashScreen: View {
       VStack(spacing: PrimerSpacing.large(tokens: tokens)) {
         ProgressView()
           .progressViewStyle(
-            CircularProgressViewStyle(tint: CheckoutColors.borderFocus(tokens: tokens))
+            CircularProgressViewStyle(tint: CheckoutColors.loader(tokens: tokens))
           )
           .scaleEffect(PrimerScale.large)
           .frame(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
@@ -26,7 +26,8 @@ final class DesignTokensManager: ObservableObject {
   // MARK: - Token Loading
 
   func fetchTokens(for colorScheme: ColorScheme) async throws {
-    let colors = themeOverrides?.colors
+    // the only place the colour scheme picks a set, so everything below works off one resolved set
+    let colors = themeOverrides?.resolvedColors(for: colorScheme)
     let loadedTokens = try Self.makeTokens(
       for: colorScheme, valueOverrides: tokenValueOverrides(colors: colors))
 
@@ -36,9 +37,18 @@ final class DesignTokensManager: ObservableObject {
     tokens = loadedTokens
   }
 
-  /// Injected before references resolve, so tokens aliasing a palette entry follow the override.
+  /// Injected before references resolve, so tokens aliasing a palette entry or the brand font follow the override.
   private func tokenValueOverrides(colors: ColorOverrides?) -> [String: Any] {
     var overrides: [String: Any] = [:]
+    if let brandFont = themeOverrides?.typography?.brand {
+      // rejected here rather than downstream: a value the passes rewrite fails the whole decode
+      if DesignTokensProcessor.isTokenAuthoringSyntax(brandFont) {
+        PrimerLogging.shared.logger.error(
+          message: "[DesignTokens] Brand font override ignored: '\(brandFont)' is not a font family name.")
+      } else {
+        overrides["primerTypographyBrand"] = brandFont
+      }
+    }
     guard let colors else { return overrides }
     let pairs: [(String, Color?)] = [
       ("primerColorBrand", colors.primerColorBrand),

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensProcessor.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensProcessor.swift
@@ -237,4 +237,10 @@ enum DesignTokensProcessor {
 
   // MARK: - Merchant Value Validation
 
+  /// True when a string carries token authoring syntax that the passes expand into another type: a
+  /// `#RRGGBB[AA]` literal, a `{token.reference}`, or a single arithmetic expression.
+  static func isTokenAuthoringSyntax(_ value: String) -> Bool {
+    value.hasPrefix("#") || value.contains("{") || value.contains("}")
+      || evaluateExpression(value) != nil
+  }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/PrimerFont.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/PrimerFont.swift
@@ -47,25 +47,19 @@ enum PrimerFont {
     let fontSize = size ?? 14
     let fontWeight = weight ?? 400
 
-    let baseFont: UIFont = if fontFamily == "Inter" {
-      if let customUIFont = variableInterFont(weight: fontWeight, size: fontSize) {
-        customUIFont
-      } else {
-        // Fallback to system font
-        .systemFont(ofSize: fontSize, weight: uiFontWeightFromNumber(fontWeight))
-      }
-    } else {
-      // Attempt to load custom font family
-      if let customFont = UIFont(name: fontFamily, size: fontSize) {
-        customFont
-      } else {
-        // Fallback to system font if custom font is not available
-        .systemFont(ofSize: fontSize, weight: uiFontWeightFromNumber(fontWeight))
-      }
+    let namedFont: UIFont? =
+      fontFamily == "Inter"
+      ? variableInterFont(weight: fontWeight, size: fontSize)
+      : customFont(family: fontFamily, weight: fontWeight, size: fontSize)
+
+    if namedFont == nil {
+      PrimerLogging.shared.logger.warn(
+        message: "[Typography] Font '\(fontFamily)' is not registered in the app, using the system font instead.")
     }
 
     // Apply Dynamic Type scaling
-    return UIFontMetrics.default.scaledFont(for: baseFont)
+    return UIFontMetrics.default.scaledFont(
+      for: namedFont ?? .systemFont(ofSize: fontSize, weight: uiFontWeightFromNumber(fontWeight)))
   }
 
   // MARK: - UIKit Typography Helpers
@@ -265,6 +259,29 @@ enum PrimerFont {
     }
 
     return nil
+  }
+
+  /// Resolves a merchant brand font at the requested weight.
+  ///
+  /// `UIFont(name:size:)` carries no weight, so on its own every text style resolves to the same face.
+  /// A family lookup carrying a weight trait keeps each style's weight; a PostScript face name
+  /// (e.g. "Georgia-Bold") matches no family, so it is normalised to its own family first and only
+  /// falls back to that single face when the family cannot be re-resolved.
+  private static func customFont(family: String, weight: CGFloat, size: CGFloat) -> UIFont? {
+    if let font = weightedFont(family: family, weight: weight, size: size) { return font }
+    guard let namedFace = UIFont(name: family, size: size) else { return nil }
+    return weightedFont(family: namedFace.familyName, weight: weight, size: size) ?? namedFace
+  }
+
+  /// A font from `family` at `weight`, or nil when that family is not installed. Descriptor matching
+  /// substitutes Helvetica for an unknown family, so the resolved family is compared back.
+  private static func weightedFont(family: String, weight: CGFloat, size: CGFloat) -> UIFont? {
+    let descriptor = UIFontDescriptor(fontAttributes: [
+      .family: family,
+      .traits: [UIFontDescriptor.TraitKey.weight: uiFontWeightFromNumber(weight).rawValue]
+    ])
+    let font = UIFont(descriptor: descriptor, size: size)
+    return font.familyName.caseInsensitiveCompare(family) == .orderedSame ? font : nil
   }
 
   /// Converts numeric font weight to UIFont.Weight enum.

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -53,15 +53,23 @@ enum CheckoutColors {
   }
 
   static func gray100(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackgroundOutlinedDefault ?? .white
+    tokens?.primerColorGray100 ?? Color(.systemGray6)
   }
 
   static func gray200(tokens: DesignTokens?) -> Color {
     tokens?.primerColorGray200 ?? Color(.systemGray5)
   }
 
+  static func gray300(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorGray300 ?? Color(.systemGray4)
+  }
+
   static func textPlaceholder(tokens: DesignTokens?) -> Color {
     tokens?.primerColorTextPlaceholder ?? Color(.tertiaryLabel)
+  }
+
+  static func loader(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorLoader ?? .blue
   }
 
   static func borderSelected(tokens: DesignTokens?) -> Color {
@@ -70,52 +78,6 @@ enum CheckoutColors {
 
   static func iconPositive(tokens: DesignTokens?) -> Color {
     tokens?.primerColorIconPositive ?? Color(.systemGreen)
-  }
-
-  static func orange(tokens _: DesignTokens?) -> Color { .orange }
-
-  // MARK: - Screen & Input Colors
-
-  static func screenBackground(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackgroundPrimary ?? Color(.systemBackground)
-  }
-
-  static func inputBackground(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackgroundOutlinedDefault ?? .white
-  }
-
-  static func inputBorder(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBorderOutlinedDefault ?? Color(.systemGray4)
-  }
-
-  static func inputBorderFocused(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBorderOutlinedFocus ?? .blue
-  }
-
-  // MARK: - Button Colors
-
-  static func buttonPrimary(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBrand ?? .blue
-  }
-
-  static func gray300(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorGray300 ?? Color(.systemGray4)
-  }
-
-  static func buttonDisabled(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorBackgroundOutlinedDisabled ?? Color(.systemGray6)
-  }
-
-  static func blue(tokens _: DesignTokens?) -> Color { .blue }
-
-  static func green(tokens _: DesignTokens?) -> Color { .green }
-
-  static func error(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorTextNegative ?? .red
-  }
-
-  static func inputText(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorTextOutlinedDefault ?? .primary
   }
 
   /// Label/spinner colour on a surface filled with `textPrimary`, which the label inverts with; a
@@ -132,5 +94,39 @@ enum CheckoutColors {
   /// fill and takes `textDisabled`. A loading button is still brand-filled, so pass `isEnabled: true`.
   static func onBrand(tokens: DesignTokens?, isEnabled: Bool = true) -> Color {
     isEnabled ? .white : (tokens?.primerColorTextDisabled ?? Color(.tertiaryLabel))
+  }
+
+  static func orange(tokens _: DesignTokens?) -> Color { .orange }
+
+  // MARK: - Screen & Input Colors
+
+  static func screenBackground(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBackgroundPrimary ?? Color(.systemBackground)
+  }
+
+  static func inputBackground(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBackgroundOutlinedDefault ?? .white
+  }
+
+  static func inputText(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorTextOutlinedDefault ?? .primary
+  }
+
+  static func inputBorder(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBorderOutlinedDefault ?? Color(.systemGray4)
+  }
+
+  static func inputBorderFocused(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBorderOutlinedFocus ?? .blue
+  }
+
+  // MARK: - Button Colors
+
+  static func buttonPrimary(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBrand ?? .blue
+  }
+
+  static func buttonDisabled(tokens: DesignTokens?) -> Color {
+    tokens?.primerColorBackgroundOutlinedDisabled ?? Color(.systemGray6)
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/PrimerLayout.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/PrimerLayout.swift
@@ -131,11 +131,20 @@ enum PrimerBorderWidth {
     tokens?.primerWidthDefault ?? standard
   }
 
+  /// Emphasised border for a focused field. Maps to the `focus` width token (default 2).
+  static func focused(tokens: DesignTokens?) -> CGFloat {
+    tokens?.primerWidthFocus ?? selected
+  }
+
   /// Emphasised border for a chosen item, such as a saved card. Maps to the `selected` token.
   static func selected(tokens: DesignTokens?) -> CGFloat {
     tokens?.primerWidthSelected ?? selected
   }
 
+  /// Emphasised border for a field in error. Maps to the `error` width token (default 2).
+  static func error(tokens: DesignTokens?) -> CGFloat {
+    tokens?.primerWidthError ?? selected
+  }
 }
 
 // MARK: - Primer Scale Factors

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckout.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckout.swift
@@ -197,7 +197,7 @@ struct InternalCheckout: View, LogReporter {
   /// This ensures the background color is correct from the first render.
   private var backgroundColor: Color {
     // Priority 1: Theme override (available immediately)
-    if let themeBackground = theme.colors?.primerColorBackgroundPrimary {
+    if let themeBackground = theme.resolvedColors(for: colorScheme)?.primerColorBackgroundPrimary {
       return themeBackground
     }
     // Priority 2: Loaded design tokens (available after async load)

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
@@ -21,6 +21,7 @@ import SwiftUI
 public struct PrimerCheckoutTheme: Equatable {
 
   public let colors: ColorOverrides?
+  public let darkColors: ColorOverrides?
   public let radius: RadiusOverrides?
   public let spacing: SpacingOverrides?
   public let sizes: SizeOverrides?
@@ -30,8 +31,17 @@ public struct PrimerCheckoutTheme: Equatable {
   /// Creates a new theme configuration with optional overrides.
   /// - Parameters:
   ///   - colors: Color token overrides, applied in both light and dark mode. Default: nil (uses internal defaults)
+  ///   - darkColors: Color token overrides applied in dark mode only. Each value left nil here falls back to the
+  ///     matching `colors` value, so only the colours that differ in the dark need naming. Default: nil (`colors`
+  ///     applies in both modes)
+  ///   - radius: Radius token overrides. Default: nil (uses internal defaults)
+  ///   - spacing: Spacing token overrides. Default: nil (uses internal defaults)
+  ///   - sizes: Size token overrides. Default: nil (uses internal defaults)
+  ///   - typography: Typography token overrides. Default: nil (uses internal defaults)
+  ///   - width: Border width token overrides. Default: nil (uses internal defaults)
   public init(
     colors: ColorOverrides? = nil,
+    darkColors: ColorOverrides? = nil,
     radius: RadiusOverrides? = nil,
     spacing: SpacingOverrides? = nil,
     sizes: SizeOverrides? = nil,
@@ -39,6 +49,7 @@ public struct PrimerCheckoutTheme: Equatable {
     width: WidthOverrides? = nil
   ) {
     self.colors = colors
+    self.darkColors = darkColors
     self.radius = radius
     self.spacing = spacing
     self.sizes = sizes
@@ -401,6 +412,10 @@ public struct TypographyOverrides: Equatable {
 
   // MARK: - Token Properties
 
+  /// Font family every style below falls back to, so one typeface covers the whole sheet.
+  /// A style naming its own `font` wins over this. Default: nil (Inter).
+  public let brand: String?
+
   /// Title extra large: Inter, -0.6 letter spacing, weight 550, size 24, line height 32
   public let titleXlarge: TypographyStyle?
 
@@ -421,6 +436,7 @@ public struct TypographyOverrides: Equatable {
 
   /// Creates typography overrides with all optional properties.
   public init(
+    brand: String? = nil,
     titleXlarge: TypographyStyle? = nil,
     titleLarge: TypographyStyle? = nil,
     bodyLarge: TypographyStyle? = nil,
@@ -428,6 +444,7 @@ public struct TypographyOverrides: Equatable {
     bodySmall: TypographyStyle? = nil,
     error: TypographyStyle? = nil
   ) {
+    self.brand = brand
     self.titleXlarge = titleXlarge
     self.titleLarge = titleLarge
     self.bodyLarge = bodyLarge
@@ -465,5 +482,82 @@ public struct WidthOverrides: Equatable {
     self.primerWidthFocus = primerWidthFocus
     self.primerWidthError = primerWidthError
     self.primerWidthSelected = primerWidthSelected
+  }
+}
+
+// MARK: - Color Scheme Resolution
+
+@available(iOS 15.0, *)
+extension PrimerCheckoutTheme {
+  /// The colour overrides that apply in one colour scheme.
+  ///
+  /// `darkColors` only participates in dark mode, and only for the properties it names, so a theme
+  /// carrying just `colors` resolves to that same set in both modes.
+  func resolvedColors(for colorScheme: ColorScheme) -> ColorOverrides? {
+    guard colorScheme == .dark, let darkColors else { return colors }
+    return darkColors.merging(over: colors)
+  }
+}
+
+@available(iOS 15.0, *)
+extension ColorOverrides {
+  /// Keeps every colour this set names and takes the rest from `base`.
+  func merging(over base: ColorOverrides?) -> ColorOverrides {
+    guard let base else { return self }
+    return ColorOverrides(
+      primerColorBrand: primerColorBrand ?? base.primerColorBrand,
+      primerColorGray000: primerColorGray000 ?? base.primerColorGray000,
+      primerColorGray100: primerColorGray100 ?? base.primerColorGray100,
+      primerColorGray200: primerColorGray200 ?? base.primerColorGray200,
+      primerColorGray300: primerColorGray300 ?? base.primerColorGray300,
+      primerColorGray400: primerColorGray400 ?? base.primerColorGray400,
+      primerColorGray500: primerColorGray500 ?? base.primerColorGray500,
+      primerColorGray600: primerColorGray600 ?? base.primerColorGray600,
+      primerColorGray900: primerColorGray900 ?? base.primerColorGray900,
+      primerColorGreen500: primerColorGreen500 ?? base.primerColorGreen500,
+      primerColorRed100: primerColorRed100 ?? base.primerColorRed100,
+      primerColorRed500: primerColorRed500 ?? base.primerColorRed500,
+      primerColorRed900: primerColorRed900 ?? base.primerColorRed900,
+      primerColorBlue500: primerColorBlue500 ?? base.primerColorBlue500,
+      primerColorBlue900: primerColorBlue900 ?? base.primerColorBlue900,
+      primerColorBackgroundPrimary: primerColorBackgroundPrimary ?? base.primerColorBackgroundPrimary,
+      primerColorBackgroundSecondary: primerColorBackgroundSecondary ?? base.primerColorBackgroundSecondary,
+      primerColorBackgroundOutlinedDefault: primerColorBackgroundOutlinedDefault ?? base.primerColorBackgroundOutlinedDefault,
+      primerColorBackgroundOutlinedActive: primerColorBackgroundOutlinedActive ?? base.primerColorBackgroundOutlinedActive,
+      primerColorBackgroundOutlinedDisabled: primerColorBackgroundOutlinedDisabled ?? base.primerColorBackgroundOutlinedDisabled,
+      primerColorBackgroundOutlinedLoading: primerColorBackgroundOutlinedLoading ?? base.primerColorBackgroundOutlinedLoading,
+      primerColorBackgroundOutlinedSelected: primerColorBackgroundOutlinedSelected ?? base.primerColorBackgroundOutlinedSelected,
+      primerColorBackgroundOutlinedError: primerColorBackgroundOutlinedError ?? base.primerColorBackgroundOutlinedError,
+      primerColorBackgroundTransparentDefault: primerColorBackgroundTransparentDefault ?? base.primerColorBackgroundTransparentDefault,
+      primerColorBackgroundTransparentActive: primerColorBackgroundTransparentActive ?? base.primerColorBackgroundTransparentActive,
+      primerColorBackgroundTransparentDisabled: primerColorBackgroundTransparentDisabled ?? base.primerColorBackgroundTransparentDisabled,
+      primerColorBackgroundTransparentLoading: primerColorBackgroundTransparentLoading ?? base.primerColorBackgroundTransparentLoading,
+      primerColorBackgroundTransparentSelected: primerColorBackgroundTransparentSelected ?? base.primerColorBackgroundTransparentSelected,
+      primerColorTextPrimary: primerColorTextPrimary ?? base.primerColorTextPrimary,
+      primerColorTextSecondary: primerColorTextSecondary ?? base.primerColorTextSecondary,
+      primerColorTextPlaceholder: primerColorTextPlaceholder ?? base.primerColorTextPlaceholder,
+      primerColorTextDisabled: primerColorTextDisabled ?? base.primerColorTextDisabled,
+      primerColorTextNegative: primerColorTextNegative ?? base.primerColorTextNegative,
+      primerColorTextLink: primerColorTextLink ?? base.primerColorTextLink,
+      primerColorTextOutlinedDefault: primerColorTextOutlinedDefault ?? base.primerColorTextOutlinedDefault,
+      primerColorBorderOutlinedDefault: primerColorBorderOutlinedDefault ?? base.primerColorBorderOutlinedDefault,
+      primerColorBorderOutlinedActive: primerColorBorderOutlinedActive ?? base.primerColorBorderOutlinedActive,
+      primerColorBorderOutlinedFocus: primerColorBorderOutlinedFocus ?? base.primerColorBorderOutlinedFocus,
+      primerColorBorderOutlinedDisabled: primerColorBorderOutlinedDisabled ?? base.primerColorBorderOutlinedDisabled,
+      primerColorBorderOutlinedError: primerColorBorderOutlinedError ?? base.primerColorBorderOutlinedError,
+      primerColorBorderOutlinedSelected: primerColorBorderOutlinedSelected ?? base.primerColorBorderOutlinedSelected,
+      primerColorBorderOutlinedLoading: primerColorBorderOutlinedLoading ?? base.primerColorBorderOutlinedLoading,
+      primerColorBorderTransparentDefault: primerColorBorderTransparentDefault ?? base.primerColorBorderTransparentDefault,
+      primerColorBorderTransparentActive: primerColorBorderTransparentActive ?? base.primerColorBorderTransparentActive,
+      primerColorBorderTransparentFocus: primerColorBorderTransparentFocus ?? base.primerColorBorderTransparentFocus,
+      primerColorBorderTransparentDisabled: primerColorBorderTransparentDisabled ?? base.primerColorBorderTransparentDisabled,
+      primerColorBorderTransparentSelected: primerColorBorderTransparentSelected ?? base.primerColorBorderTransparentSelected,
+      primerColorIconPrimary: primerColorIconPrimary ?? base.primerColorIconPrimary,
+      primerColorIconDisabled: primerColorIconDisabled ?? base.primerColorIconDisabled,
+      primerColorIconNegative: primerColorIconNegative ?? base.primerColorIconNegative,
+      primerColorIconPositive: primerColorIconPositive ?? base.primerColorIconPositive,
+      primerColorFocus: primerColorFocus ?? base.primerColorFocus,
+      primerColorLoader: primerColorLoader ?? base.primerColorLoader
+    )
   }
 }

--- a/Tests/Primer/CheckoutComponents/PrimerFieldRepainterTests.swift
+++ b/Tests/Primer/CheckoutComponents/PrimerFieldRepainterTests.swift
@@ -1,0 +1,96 @@
+//
+//  PrimerFieldRepainterTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import SwiftUI
+import UIKit
+import XCTest
+@_spi(PrimerInternal) @testable import PrimerFoundation
+@_spi(PrimerInternal) @testable import PrimerCore
+
+@available(iOS 15.0, *)
+final class PrimerFieldRepainterTests: XCTestCase {
+    private func makeField(tokens: DesignTokens?) -> UITextField {
+        let field = UITextField()
+        field.repaintPrimerColors(placeholder: "Card number", tokens: tokens)
+        return field
+    }
+
+    // MARK: - What a repaint writes
+
+    func test_repaint_takesTextAndPlaceholderColoursFromTheGivenTokens() throws {
+        let light = try DesignTokensManager.makeTokens(for: .light)
+        let dark = try DesignTokensManager.makeTokens(for: .dark)
+        let field = makeField(tokens: light)
+
+        field.repaintPrimerColors(placeholder: "Card number", tokens: dark)
+
+        XCTAssertEqual(field.textColor, UIColor(CheckoutColors.inputText(tokens: dark)))
+        let placeholderColour = field.attributedPlaceholder?
+            .attribute(.foregroundColor, at: 0, effectiveRange: nil) as? UIColor
+        XCTAssertEqual(placeholderColour, UIColor(CheckoutColors.textPlaceholder(tokens: dark)))
+    }
+
+    /// The two earlier attempts at this fix rewrote these as well, and lost the shopper's input.
+    func test_repaint_leavesText_font_borderAndAccessoryAlone() throws {
+        let light = try DesignTokensManager.makeTokens(for: .light)
+        let dark = try DesignTokensManager.makeTokens(for: .dark)
+        let field = makeField(tokens: light)
+        field.text = "4242 4242"
+        field.font = UIFont.systemFont(ofSize: 21)
+        field.borderStyle = .roundedRect
+        let accessory = UIToolbar()
+        field.inputAccessoryView = accessory
+
+        field.repaintPrimerColors(placeholder: "Card number", tokens: dark)
+
+        XCTAssertEqual(field.text, "4242 4242")
+        XCTAssertEqual(field.font, UIFont.systemFont(ofSize: 21))
+        XCTAssertEqual(field.borderStyle, .roundedRect)
+        XCTAssertTrue(field.inputAccessoryView === accessory)
+    }
+
+    func test_repaint_onASecureField_keepsTheRealValue() throws {
+        let light = try DesignTokensManager.makeTokens(for: .light)
+        let dark = try DesignTokensManager.makeTokens(for: .dark)
+        let field = SecureTextField()
+        field.repaintPrimerColors(placeholder: "Card number", tokens: light)
+        field.internalText = "4242424242424242"
+
+        field.repaintPrimerColors(placeholder: "Card number", tokens: dark)
+
+        XCTAssertEqual(field.internalText, "4242424242424242")
+    }
+
+    // MARK: - When a repaint fires
+
+    func test_repaintIfNeeded_sameTokens_doesNothing() throws {
+        let light = try DesignTokensManager.makeTokens(for: .light)
+        let field = makeField(tokens: light)
+        field.textColor = .magenta
+        let repainter = PrimerFieldRepainter()
+        repainter.markApplied(light)
+
+        repainter.repaintIfNeeded(field, placeholder: "Card number", tokens: light)
+
+        XCTAssertEqual(field.textColor, .magenta, "a keystroke must not trigger a repaint")
+    }
+
+    func test_repaintIfNeeded_newTokens_repaintsOnceAndThenStops() throws {
+        let light = try DesignTokensManager.makeTokens(for: .light)
+        let dark = try DesignTokensManager.makeTokens(for: .dark)
+        let field = makeField(tokens: light)
+        let repainter = PrimerFieldRepainter()
+        repainter.markApplied(light)
+
+        repainter.repaintIfNeeded(field, placeholder: "Card number", tokens: dark)
+        XCTAssertEqual(field.textColor, UIColor(CheckoutColors.inputText(tokens: dark)))
+
+        field.textColor = .magenta
+        repainter.repaintIfNeeded(field, placeholder: "Card number", tokens: dark)
+        XCTAssertEqual(field.textColor, .magenta, "the same token set must not repaint twice")
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
@@ -601,6 +601,79 @@ final class DesignTokensManagerTests: XCTestCase {
         }
     }
 
+    // MARK: - Brand Font
+
+    func test_applyTheme_brandFont_appliedToEveryTextStyle() async throws {
+        // Given
+        sut.applyTheme(PrimerCheckoutTheme(typography: TypographyOverrides(brand: "Georgia")))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerTypographyBrand, "Georgia")
+        XCTAssertEqual(tokens.primerTypographyTitleXlargeFont, "Georgia")
+        XCTAssertEqual(tokens.primerTypographyTitleLargeFont, "Georgia")
+        XCTAssertEqual(tokens.primerTypographyBodyLargeFont, "Georgia")
+        XCTAssertEqual(tokens.primerTypographyBodyMediumFont, "Georgia")
+        XCTAssertEqual(tokens.primerTypographyBodySmallFont, "Georgia")
+        XCTAssertEqual(tokens.primerTypographyErrorFont, "Georgia")
+    }
+
+    func test_applyTheme_perStyleFont_winsOverBrandFont() async throws {
+        // Given
+        sut.applyTheme(PrimerCheckoutTheme(
+            typography: TypographyOverrides(brand: "Georgia", bodyMedium: .init(font: "Menlo"))
+        ))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerTypographyBodyMediumFont, "Menlo")
+        XCTAssertEqual(tokens.primerTypographyBodyLargeFont, "Georgia")
+    }
+
+    func test_fetchTokens_noTypographyOverride_everyTextStyleStaysInter() async throws {
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerTypographyBrand, "Inter")
+        XCTAssertEqual(tokens.primerTypographyTitleXlargeFont, "Inter")
+        XCTAssertEqual(tokens.primerTypographyTitleLargeFont, "Inter")
+        XCTAssertEqual(tokens.primerTypographyBodyLargeFont, "Inter")
+        XCTAssertEqual(tokens.primerTypographyBodyMediumFont, "Inter")
+        XCTAssertEqual(tokens.primerTypographyBodySmallFont, "Inter")
+        XCTAssertEqual(tokens.primerTypographyErrorFont, "Inter")
+    }
+
+    func test_applyTheme_brandFontUsingTokenSyntax_isIgnoredAndEveryOtherOverrideStillApplies() async throws {
+        // A hex, a reference and an arithmetic expression are the three shapes the token passes rewrite.
+        for badValue in ["#ff0000", "{primer.size.base}", "8-2"] {
+            // Given
+            let manager = DesignTokensManager()
+            manager.applyTheme(PrimerCheckoutTheme(
+                colors: ColorOverrides(primerColorBrand: .purple),
+                radius: RadiusOverrides(primerRadiusMedium: 30),
+                typography: TypographyOverrides(brand: badValue)
+            ))
+
+            // When
+            try await manager.fetchTokens(for: .light)
+
+            // Then
+            let tokens = try XCTUnwrap(manager.tokens, "'\(badValue)' discarded the whole token set")
+            XCTAssertEqual(tokens.primerColorBrand, .purple, "'\(badValue)' discarded the colour override")
+            XCTAssertEqual(tokens.primerRadiusMedium, 30, "'\(badValue)' discarded the radius override")
+            XCTAssertEqual(tokens.primerTypographyBrand, "Inter")
+            XCTAssertEqual(tokens.primerTypographyBodyMediumFont, "Inter")
+        }
+    }
+
     // MARK: - Combined Overrides
 
     func test_applyTheme_allOverrideCategories_appliedTogether() async throws {
@@ -731,6 +804,312 @@ final class DesignTokensManagerTests: XCTestCase {
         // Then
         let tokens = try XCTUnwrap(sut.tokens)
         XCTAssertEqual(tokens.primerColorBrand, customColor)
+    }
+
+    // MARK: - Light and Dark Colour Sets
+
+    func test_applyTheme_lightColoursOnly_areUsedInBothColourSchemes() async throws {
+        // Given the single colours parameter every existing integration passes
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorBrand: .pink)))
+
+        // When both schemes are loaded
+        try await sut.fetchTokens(for: .light)
+        let light = try XCTUnwrap(sut.tokens?.primerColorBrand)
+        try await sut.fetchTokens(for: .dark)
+        let dark = try XCTUnwrap(sut.tokens?.primerColorBrand)
+
+        // Then the one colour applies in both, exactly as it did before darkColors existed
+        XCTAssertEqual(light, .pink)
+        XCTAssertEqual(dark, .pink)
+    }
+
+    func test_applyTheme_darkColours_winInDarkModeAndFallBackPerProperty() async throws {
+        // Given a dark set that names the brand and leaves the text colour to the light set
+        sut.applyTheme(
+            PrimerCheckoutTheme(
+                colors: ColorOverrides(primerColorBrand: .pink, primerColorTextPrimary: .green),
+                darkColors: ColorOverrides(primerColorBrand: .blue)
+            )
+        )
+
+        // When both schemes are loaded
+        try await sut.fetchTokens(for: .light)
+        let lightBrand = try XCTUnwrap(sut.tokens?.primerColorBrand)
+        let lightText = try XCTUnwrap(sut.tokens?.primerColorTextPrimary)
+        try await sut.fetchTokens(for: .dark)
+        let dark = try XCTUnwrap(sut.tokens)
+
+        // Then light ignores the dark set, and dark takes what it names plus the light rest
+        XCTAssertEqual(lightBrand, .pink)
+        XCTAssertEqual(lightText, .green)
+        XCTAssertEqual(dark.primerColorBrand, .blue)
+        XCTAssertEqual(dark.primerColorTextPrimary, .green)
+    }
+
+    func test_applyTheme_noColourOverrides_matchesAnUnthemedLoad() async throws {
+        // Given a theme that names no colours at all
+        sut.applyTheme(PrimerCheckoutTheme())
+
+        // When
+        try await sut.fetchTokens(for: .dark)
+        let loaded = try XCTUnwrap(sut.tokens)
+        let unthemed = try DesignTokensManager.makeTokens(for: .dark)
+
+        // Then every colour token equals an unthemed dark load, so the resolution costs nothing
+        let themed = colorTokens(of: loaded)
+        XCTAssertFalse(themed.isEmpty)
+        XCTAssertEqual(themed, colorTokens(of: unthemed))
+    }
+
+    func test_applyTheme_darkColoursOnly_leaveLightModeAlone() async throws {
+        // Given a dark set with no light set beside it
+        let shippedBrand = try await tokens(for: .light).primerColorBrand
+        sut.applyTheme(PrimerCheckoutTheme(darkColors: ColorOverrides(primerColorBrand: .blue)))
+
+        // When both schemes are loaded
+        try await sut.fetchTokens(for: .light)
+        let light = try XCTUnwrap(sut.tokens?.primerColorBrand)
+        try await sut.fetchTokens(for: .dark)
+        let dark = try XCTUnwrap(sut.tokens?.primerColorBrand)
+
+        // Then light keeps the shipped colour and only dark moves
+        XCTAssertEqual(light, shippedBrand)
+        XCTAssertEqual(dark, .blue)
+    }
+
+    private func colorTokens(of tokens: DesignTokens) -> [String: Color] {
+        Mirror(reflecting: tokens).children.reduce(into: [String: Color]()) { result, child in
+            guard let label = child.label, label.hasPrefix("primerColor"),
+                  let color = child.value as? Color else { return }
+            result[label] = color
+        }
+    }
+
+    // MARK: - Palette Override Cascade
+
+    func test_fetchTokens_paletteOverride_cascadesIntoTokensThatAliasIt() async throws {
+        // Given border.outlined.default aliases gray.300 in the token JSON
+        let baseline = try await tokens(for: .light)
+        let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedDefault)
+
+        // Components chosen to survive the getRed round-trip exactly.
+        let override = Color(red: 0.25, green: 0.5, blue: 0.75)
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: override)))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then the border holds the overridden value, not merely a different one.
+        let themed = try XCTUnwrap(sut.tokens)
+        XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
+        XCTAssertEqual(
+            themed.primerColorBorderOutlinedDefault,
+            Color(red: 0.25, green: 0.5, blue: 0.75, opacity: 1))
+    }
+
+    func test_fetchTokens_semanticOverride_winsOverPaletteOverride() async throws {
+        // Given both the palette entry and the token that aliases it are overridden
+        sut.applyTheme(
+            PrimerCheckoutTheme(
+                colors: ColorOverrides(
+                    primerColorGray300: .pink,
+                    primerColorBorderOutlinedDefault: .green
+                )
+            )
+        )
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerColorBorderOutlinedDefault, .green)
+        XCTAssertEqual(tokens.primerColorGray300, .pink)
+    }
+
+    func test_fetchTokens_noOverrides_paletteInjectionIsANoOp() async throws {
+        // Given
+        let withoutTheme = try await tokens(for: .light)
+
+        // When
+        sut.applyTheme(PrimerCheckoutTheme())
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let withEmptyTheme = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(withEmptyTheme.primerColorBorderOutlinedDefault, withoutTheme.primerColorBorderOutlinedDefault)
+        XCTAssertEqual(withEmptyTheme.primerColorBackgroundPrimary, withoutTheme.primerColorBackgroundPrimary)
+        XCTAssertEqual(withEmptyTheme.primerColorGray300, withoutTheme.primerColorGray300)
+    }
+
+    func test_fetchTokens_paletteOverride_cascadesInDarkMode() async throws {
+        // Given
+        let baseline = try await tokens(for: .dark)
+        let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedDefault)
+
+        let override = Color(red: 0.25, green: 0.5, blue: 0.75)
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: override)))
+
+        // When
+        try await sut.fetchTokens(for: .dark)
+
+        // Then
+        let themed = try XCTUnwrap(sut.tokens)
+        XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
+        XCTAssertEqual(
+            themed.primerColorBorderOutlinedDefault,
+            Color(red: 0.25, green: 0.5, blue: 0.75, opacity: 1))
+    }
+
+    // MARK: - Width overrides
+
+    func test_applyTheme_widthOverrides_appliedToTokens() async throws {
+        // Given
+        let theme = PrimerCheckoutTheme(
+            width: WidthOverrides(
+                primerWidthDefault: 3,
+                primerWidthFocus: 5,
+                primerWidthError: 7
+            )
+        )
+        sut.applyTheme(theme)
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerWidthDefault, 3)
+        XCTAssertEqual(tokens.primerWidthFocus, 5)
+        XCTAssertEqual(tokens.primerWidthError, 7)
+    }
+
+    func test_widthTokens_defaultToDesignValues() async throws {
+        // When no override is applied
+        let tokens = try await tokens(for: .light)
+
+        // Then the values match the design tokens: 1 at rest, 2 for focus and error
+        XCTAssertEqual(tokens.primerWidthDefault, 1)
+        XCTAssertEqual(tokens.primerWidthFocus, 2)
+        XCTAssertEqual(tokens.primerWidthSelected, 2)
+        XCTAssertEqual(tokens.primerWidthError, 2)
+    }
+
+    func test_borderWidthHelper_readsTheMatchingToken() async throws {
+        // Given each width token is overridden with a distinct value
+        sut.applyTheme(
+            PrimerCheckoutTheme(
+                width: WidthOverrides(
+                    primerWidthDefault: 3,
+                    primerWidthFocus: 5,
+                    primerWidthError: 7,
+                    primerWidthSelected: 9)))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then the helper each renderer calls resolves to its own token
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(PrimerBorderWidth.standard(tokens: tokens), 3)
+        XCTAssertEqual(PrimerBorderWidth.focused(tokens: tokens), 5)
+        XCTAssertEqual(PrimerBorderWidth.error(tokens: tokens), 7)
+        XCTAssertEqual(PrimerBorderWidth.selected(tokens: tokens), 9)
+    }
+
+    // MARK: - Error typography
+
+    func test_applyTheme_errorTypographyOverride_doesNotMoveBodySmall() async throws {
+        // Given only the error style is overridden
+        sut.applyTheme(
+            PrimerCheckoutTheme(
+                typography: TypographyOverrides(error: .init(size: 20))))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then error moves and the body-small label it used to share stays put
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerTypographyErrorSize, 20)
+        XCTAssertEqual(tokens.primerTypographyBodySmallSize, 12)
+    }
+
+    func test_errorTypography_defaultsToBodySmall() async throws {
+        // When nothing is overridden
+        let tokens = try await tokens(for: .light)
+
+        // Then error carries the body-small values, so nothing looks different out of the box
+        XCTAssertEqual(tokens.primerTypographyErrorSize, tokens.primerTypographyBodySmallSize)
+        XCTAssertEqual(tokens.primerTypographyErrorWeight, tokens.primerTypographyBodySmallWeight)
+        XCTAssertEqual(tokens.primerTypographyErrorLineHeight, tokens.primerTypographyBodySmallLineHeight)
+    }
+
+    // MARK: - Token file coverage
+
+    func test_baseTokenFile_everyColourLeafHasAMatchingTokenProperty() throws {
+        // Given the shipped light token file, loaded the way production loads it
+        let dict = try DesignTokensManager.loadJSON(named: "base")
+
+        // When it is flattened the way production does
+        let flat = DesignTokensProcessor.flattenTokenDictionary(
+            DesignTokensProcessor.convertHexColors(in: dict))
+
+        // Then every colour leaf has somewhere to land, so none is silently dropped
+        let declared = Set(Mirror(reflecting: DesignTokens()).children.compactMap(\.label))
+        let missing = flat.keys.filter { $0.hasPrefix("primerColor") && !declared.contains($0) }.sorted()
+        XCTAssertTrue(missing.isEmpty, "base.json colour tokens with no DesignTokens property: \(missing)")
+    }
+
+    private func tokens(for colorScheme: ColorScheme) async throws -> DesignTokens {
+        let manager = DesignTokensManager()
+        try await manager.fetchTokens(for: colorScheme)
+        return try XCTUnwrap(manager.tokens)
+    }
+
+    // MARK: - Input Token Inheritance
+
+    func test_applyTheme_backgroundOverrideAlone_carriesIntoTheInputFill() async throws {
+        // Given only the sheet colour is overridden
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorBackgroundPrimary: .pink)))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then the input fill follows it, as it did before the tokens were split
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerColorBackgroundPrimary, .pink)
+        XCTAssertEqual(tokens.primerColorBackgroundOutlinedDefault, .pink)
+    }
+
+    func test_applyTheme_textOverrideAlone_carriesIntoTheInputText() async throws {
+        // Given
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorTextPrimary: .pink)))
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerColorTextOutlinedDefault, .pink)
+    }
+
+    func test_applyTheme_explicitInputColour_winsOverTheInheritedOne() async throws {
+        // Given both are named
+        sut.applyTheme(
+            PrimerCheckoutTheme(
+                colors: ColorOverrides(
+                    primerColorBackgroundPrimary: .pink,
+                    primerColorBackgroundOutlinedDefault: .green
+                )
+            )
+        )
+
+        // When
+        try await sut.fetchTokens(for: .light)
+
+        // Then
+        let tokens = try XCTUnwrap(sut.tokens)
+        XCTAssertEqual(tokens.primerColorBackgroundPrimary, .pink)
+        XCTAssertEqual(tokens.primerColorBackgroundOutlinedDefault, .green)
     }
 
     // MARK: - ObservableObject Conformance

--- a/Tests/Primer/CheckoutComponents/Tokens/PrimerFontTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/PrimerFontTests.swift
@@ -1,0 +1,102 @@
+//
+//  PrimerFontTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import SwiftUI
+import UIKit
+import XCTest
+
+@available(iOS 15.0, *)
+@MainActor
+final class PrimerFontTests: XCTestCase {
+
+    /// Ships several weights on every iOS version, so a weight trait resolves visibly different faces.
+    private let brandFamily = "Helvetica Neue"
+
+    override func setUp() {
+        super.setUp()
+        FontRegistration.registerFonts()
+    }
+
+    // MARK: - Brand Font Weights
+
+    func test_brandFont_titleAndBodyResolveToDifferentFaces() async throws {
+        // Given
+        let tokens = try await loadTokens(brand: brandFamily)
+
+        // When
+        let title = PrimerFont.uiFontTitleXLarge(tokens: tokens)
+        let body = PrimerFont.uiFontBodyMedium(tokens: tokens)
+
+        // Then
+        XCTAssertEqual(title.familyName, brandFamily)
+        XCTAssertEqual(body.familyName, brandFamily)
+        XCTAssertNotEqual(
+            title.fontName, body.fontName,
+            "weight 550 and weight 400 collapsed onto the same face"
+        )
+    }
+
+    func test_brandFont_everyTextStyleUsesTheBrandFamily() async throws {
+        // Given
+        let tokens = try await loadTokens(brand: brandFamily)
+
+        // When
+        let fonts = [
+            PrimerFont.uiFontTitleXLarge(tokens: tokens),
+            PrimerFont.uiFontTitleLarge(tokens: tokens),
+            PrimerFont.uiFontBodyLarge(tokens: tokens),
+            PrimerFont.uiFontBodyMedium(tokens: tokens),
+            PrimerFont.uiFontBodySmall(tokens: tokens),
+            PrimerFont.uiFontError(tokens: tokens)
+        ]
+
+        // Then
+        for font in fonts {
+            XCTAssertEqual(font.familyName, brandFamily)
+        }
+    }
+
+    func test_brandFont_postScriptFaceName_stillVariesByWeight() async throws {
+        // Given a merchant naming a face rather than a family
+        let tokens = try await loadTokens(brand: "Georgia-Bold")
+
+        // When
+        let title = PrimerFont.uiFontTitleXLarge(tokens: tokens)
+        let body = PrimerFont.uiFontBodyMedium(tokens: tokens)
+
+        // Then the face is normalised to its family, so each style keeps its own weight
+        XCTAssertEqual(title.familyName, "Georgia")
+        XCTAssertEqual(body.familyName, "Georgia")
+        XCTAssertNotEqual(title.fontName, body.fontName)
+    }
+
+    // MARK: - Default Font
+
+    func test_noBrandFont_everyTextStyleResolvesInter() async throws {
+        // Given
+        let manager = DesignTokensManager()
+        try await manager.fetchTokens(for: .light)
+        let tokens = try XCTUnwrap(manager.tokens)
+
+        // When
+        let title = PrimerFont.uiFontTitleXLarge(tokens: tokens)
+        let body = PrimerFont.uiFontBodyMedium(tokens: tokens)
+
+        // Then
+        XCTAssertTrue(title.familyName.contains("Inter"), "got \(title.familyName)")
+        XCTAssertTrue(body.familyName.contains("Inter"), "got \(body.familyName)")
+    }
+
+    // MARK: - Helpers
+
+    private func loadTokens(brand: String) async throws -> DesignTokens {
+        let manager = DesignTokensManager()
+        manager.applyTheme(PrimerCheckoutTheme(typography: TypographyOverrides(brand: brand)))
+        try await manager.fetchTokens(for: .light)
+        return try XCTUnwrap(manager.tokens)
+    }
+}


### PR DESCRIPTION
# Description

[ORC-8178](https://primerapi.atlassian.net/browse/ORC-8178)

The ten bridged input fields keep their light colours when the phone switches to dark mid-checkout, leaving near-black digits on a dark fill. They're `UIViewRepresentable`s over `UITextField`: `makeUIView` styles once, `updateUIView` only syncs text, and the token colours are resolved hex so the `UIColor` can't adapt on its own.

`repaintPrimerColors` writes the two colours that change, `textColor` and `attributedPlaceholder`. A `PrimerFieldRepainter` per coordinator gates it so it fires on a scheme change, not every keystroke.

Two earlier attempts were reverted, and this avoids what broke them. It touches no font, border, fill or `inputAccessoryView`: the first repainted all of those on every keystroke and emptied the card form, and the second restyled the keyboard toolbar while the keyboard was up and crashed. The Done toolbar keeps its old tint until the keyboard is re-presented. That is deliberate.

# Manual Testing

Card form tested: typed a partial number, switched to dark and back, value survived; then again with the keyboard up, backgrounding and returning, which is what crashed the previous attempt. Billing address and ACH not yet checked.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable




[ORC-8178]: https://primerapi.atlassian.net/browse/ORC-8178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ