### PR TITLE
fix(components): let the card network badge follow the brand font (ORC-8277)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/PrimerFont.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/PrimerFont.swift
@@ -147,9 +147,10 @@ enum PrimerFont {
     return uiFont(family: "Inter", weight: 400, size: size)
   }
 
-  /// Small badge font (10pt, weight 500) - for compact badge text
-  static func uiFontSmallBadge(tokens _: DesignTokens?) -> UIFont {
-    uiFont(family: "Inter", weight: 500, size: 10)
+  /// Small badge font (10pt, weight 500) - for compact badge text.
+  /// No typography token defines a 10pt style, so only the family follows the theme.
+  static func uiFontSmallBadge(tokens: DesignTokens?) -> UIFont {
+    uiFont(family: tokens?.primerTypographyBrand ?? "Inter", weight: 500, size: 10)
   }
 
   // MARK: - SwiftUI Typography Helpers

--- a/Tests/Primer/CheckoutComponents/Tokens/PrimerFontTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/PrimerFontTests.swift
@@ -51,7 +51,8 @@ final class PrimerFontTests: XCTestCase {
             PrimerFont.uiFontBodyLarge(tokens: tokens),
             PrimerFont.uiFontBodyMedium(tokens: tokens),
             PrimerFont.uiFontBodySmall(tokens: tokens),
-            PrimerFont.uiFontError(tokens: tokens)
+            PrimerFont.uiFontError(tokens: tokens),
+            PrimerFont.uiFontSmallBadge(tokens: tokens)
         ]
 
         // Then
@@ -85,10 +86,12 @@ final class PrimerFontTests: XCTestCase {
         // When
         let title = PrimerFont.uiFontTitleXLarge(tokens: tokens)
         let body = PrimerFont.uiFontBodyMedium(tokens: tokens)
+        let badge = PrimerFont.uiFontSmallBadge(tokens: tokens)
 
         // Then
         XCTAssertTrue(title.familyName.contains("Inter"), "got \(title.familyName)")
         XCTAssertTrue(body.familyName.contains("Inter"), "got \(body.familyName)")
+        XCTAssertTrue(badge.familyName.contains("Inter"), "got \(badge.familyName)")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
# Description

[ORC-8277](https://primerapi.atlassian.net/browse/ORC-8277)

When a card has no logo, Checkout Components draws a two-letter abbreviation of the network name instead. `uiFontSmallBadge` hardcoded Inter and discarded the `tokens` it was handed, so that label stayed Inter while every other text style followed the merchant's brand font.

The family comes from `primerTypographyBrand` now. Size and weight stay at 10pt/500, since no typography token defines a 10pt style.

`test_brandFont_everyTextStyleUsesTheBrandFamily` already asserted this property but listed six helpers and left this one out, which is how it survived. It includes the badge now.

`uiFontLargeIcon` beside it has the same shape and is left alone: all nine of its call sites are SF Symbols, which ignore the font family.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [ ]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable




[ORC-8277]: https://primerapi.atlassian.net/browse/ORC-8277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ