### PR TITLE
fix: Report interactive sheet dismissal to the UIKit presenter delegate

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
@@ -82,6 +82,18 @@ extension PrimerCheckoutPresenterDelegate {
     /// Flag to prevent multiple simultaneous presentations
     private var isPresentingCheckout = false
 
+    /// Navigator of the active checkout. Read on interactive dismissal to learn which screen the shopper
+    /// left, so the delegate hears about a decline the SDK error screen was still showing.
+    var activeNavigator: CheckoutNavigator?
+
+    /// Receives `presentationControllerDidDismiss` for the active sheet without exposing the presenter
+    /// itself as a `UIAdaptivePresentationControllerDelegate`.
+    private var dismissalObserver: SheetDismissalObserver?
+
+    /// Set once a terminal result reached the delegate for the active presentation. A swipe on the
+    /// result screen and the screen's own auto-dismiss must not both report the same outcome.
+    var hasDeliveredResult = false
+
     private let logger = PrimerLogging.shared.logger
 
     public weak var delegate: PrimerCheckoutPresenterDelegate?
@@ -229,11 +241,7 @@ extension PrimerCheckoutPresenterDelegate {
         logger.info(message: "Payment completed: \(result.paymentId)")
 
         dismissDirectly { [weak self] in
-            if let delegate = self?.delegate {
-                delegate.primerCheckoutPresenterDidCompleteWithSuccess(result)
-            } else {
-                self?.logger.error(message: "No delegate set for payment success")
-            }
+            self?.deliverSuccess(result)
         }
     }
 
@@ -241,16 +249,54 @@ extension PrimerCheckoutPresenterDelegate {
         logger.error(message: "Payment failed: \(error)")
 
         dismissDirectly { [weak self] in
-            if let delegate = self?.delegate {
-                delegate.primerCheckoutPresenterDidFailWithError(error)
-            } else {
-                self?.logger.error(message: "No delegate set for payment failure")
-            }
+            self?.deliverFailure(error)
         }
     }
 
     func handleCheckoutDismiss() {
         delegate?.primerCheckoutPresenterDidDismiss()
+    }
+
+    /// The shopper swiped the sheet away. UIKit reports this only for interactive dismissal, so the
+    /// programmatic paths above never race it. The current route decides what the merchant hears: a
+    /// decline still on screen is a failure, a finished payment is a success, anything else a dismiss.
+    func handleInteractiveDismiss() {
+        let route = activeNavigator?.checkoutCoordinator.currentRoute
+        activeCheckoutController = nil
+        activeNavigator = nil
+        dismissalObserver = nil
+        isPresentingCheckout = false
+
+        switch route {
+        case let .failure(error):
+            logger.info(message: "Checkout dismissed on the error screen, reporting the failure")
+            deliverFailure(error)
+        case let .success(result):
+            logger.info(message: "Checkout dismissed on the success screen, reporting the success")
+            deliverSuccess(result)
+        default:
+            handleCheckoutDismiss()
+        }
+    }
+
+    private func deliverSuccess(_ result: PaymentResult) {
+        guard !hasDeliveredResult else { return }
+        hasDeliveredResult = true
+        guard let delegate else {
+            logger.error(message: "No delegate set for payment success")
+            return
+        }
+        delegate.primerCheckoutPresenterDidCompleteWithSuccess(result)
+    }
+
+    private func deliverFailure(_ error: PrimerError) {
+        guard !hasDeliveredResult else { return }
+        hasDeliveredResult = true
+        guard let delegate else {
+            logger.error(message: "No delegate set for payment failure")
+            return
+        }
+        delegate.primerCheckoutPresenterDidFailWithError(error)
     }
 
     private func presentCheckout(
@@ -267,14 +313,18 @@ extension PrimerCheckoutPresenterDelegate {
         }
 
         isPresentingCheckout = true
+        hasDeliveredResult = false
 
         Task { @MainActor in
+            let navigator = CheckoutNavigator()
+            activeNavigator = navigator
+
             // SDK initialization is now handled automatically by PrimerCheckout
             let bridgeController = PrimerSwiftUIBridgeViewController.createForCheckoutComponents(
                 clientToken: clientToken,
                 settings: primerSettings,
                 theme: primerTheme,
-                navigator: CheckoutNavigator(),
+                navigator: navigator,
                 presentationContext: .direct,
                 integrationType: .uiKit,
                 onCompletion: { [weak self] state in
@@ -294,6 +344,12 @@ extension PrimerCheckoutPresenterDelegate {
 
             configureSheetPresentation(for: bridgeController, settings: primerSettings)
 
+            let observer = SheetDismissalObserver { [weak self] in
+                self?.handleInteractiveDismiss()
+            }
+            dismissalObserver = observer
+            bridgeController.presentationController?.delegate = observer
+
             viewController.present(bridgeController, animated: true) { [weak self] in
                 self?.isPresentingCheckout = false
                 completion?()
@@ -307,6 +363,8 @@ extension PrimerCheckoutPresenterDelegate {
         if let controller = activeCheckoutController {
             controller.dismiss(animated: true) { [weak self] in
                 self?.activeCheckoutController = nil
+                self?.activeNavigator = nil
+                self?.dismissalObserver = nil
                 completion?()
             }
         } else {
@@ -425,5 +483,24 @@ extension PrimerCheckoutPresenter {
         }
 
         return viewController
+    }
+}
+
+// MARK: - Sheet Dismissal Observer
+
+/// Forwards interactive sheet dismissal to the presenter. UIKit calls
+/// `presentationControllerDidDismiss` only when the shopper dismisses the sheet, never for
+/// programmatic `dismiss(animated:)`.
+@available(iOS 15.0, *)
+@MainActor
+private final class SheetDismissalObserver: NSObject, UIAdaptivePresentationControllerDelegate {
+    private let onDismiss: () -> Void
+
+    init(onDismiss: @escaping () -> Void) {
+        self.onDismiss = onDismiss
+    }
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        onDismiss()
     }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
@@ -254,6 +254,8 @@ extension PrimerCheckoutPresenterDelegate {
     }
 
     func handleCheckoutDismiss() {
+        guard !hasDeliveredResult else { return }
+        hasDeliveredResult = true
         delegate?.primerCheckoutPresenterDidDismiss()
     }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
@@ -75,6 +75,14 @@ extension PrimerCheckoutPresenterDelegate {
 
     // MARK: - Properties
 
+    /// Navigator of the active checkout. Read on interactive dismissal to learn which screen the shopper
+    /// left, so the delegate hears about a decline the SDK error screen was still showing.
+    var activeNavigator: CheckoutNavigator?
+
+    /// Set once a terminal result reached the delegate for the active presentation. A swipe on the
+    /// result screen and the screen's own auto-dismiss must not both report the same outcome.
+    var hasDeliveredResult = false
+
     /// The currently active UIViewController hosting the SwiftUI checkout view
     /// This will always be a PrimerSwiftUIBridgeViewController that wraps the PrimerCheckout SwiftUI view
     private weak var activeCheckoutController: UIViewController?
@@ -82,17 +90,9 @@ extension PrimerCheckoutPresenterDelegate {
     /// Flag to prevent multiple simultaneous presentations
     private var isPresentingCheckout = false
 
-    /// Navigator of the active checkout. Read on interactive dismissal to learn which screen the shopper
-    /// left, so the delegate hears about a decline the SDK error screen was still showing.
-    var activeNavigator: CheckoutNavigator?
-
     /// Receives `presentationControllerDidDismiss` for the active sheet without exposing the presenter
     /// itself as a `UIAdaptivePresentationControllerDelegate`.
     private var dismissalObserver: SheetDismissalObserver?
-
-    /// Set once a terminal result reached the delegate for the active presentation. A swipe on the
-    /// result screen and the screen's own auto-dismiss must not both report the same outcome.
-    var hasDeliveredResult = false
 
     private let logger = PrimerLogging.shared.logger
 
@@ -282,20 +282,14 @@ extension PrimerCheckoutPresenterDelegate {
     private func deliverSuccess(_ result: PaymentResult) {
         guard !hasDeliveredResult else { return }
         hasDeliveredResult = true
-        guard let delegate else {
-            logger.error(message: "No delegate set for payment success")
-            return
-        }
+        guard let delegate else { return logger.error(message: "No delegate set for payment success") }
         delegate.primerCheckoutPresenterDidCompleteWithSuccess(result)
     }
 
     private func deliverFailure(_ error: PrimerError) {
         guard !hasDeliveredResult else { return }
         hasDeliveredResult = true
-        guard let delegate else {
-            logger.error(message: "No delegate set for payment failure")
-            return
-        }
+        guard let delegate else { return logger.error(message: "No delegate set for payment failure") }
         delegate.primerCheckoutPresenterDidFailWithError(error)
     }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/PrimerCheckoutPresenter.swift
@@ -264,9 +264,7 @@ extension PrimerCheckoutPresenterDelegate {
     /// decline still on screen is a failure, a finished payment is a success, anything else a dismiss.
     func handleInteractiveDismiss() {
         let route = activeNavigator?.checkoutCoordinator.currentRoute
-        activeCheckoutController = nil
-        activeNavigator = nil
-        dismissalObserver = nil
+        clearActiveCheckout()
         isPresentingCheckout = false
 
         switch route {
@@ -362,17 +360,22 @@ extension PrimerCheckoutPresenterDelegate {
     // MARK: - Direct Dismissal
 
     func dismissDirectly(completion: (() -> Void)? = nil) {
-        if let controller = activeCheckoutController {
-            controller.dismiss(animated: true) { [weak self] in
-                self?.activeCheckoutController = nil
-                self?.activeNavigator = nil
-                self?.dismissalObserver = nil
-                completion?()
-            }
-        } else {
-            // No controller to dismiss, call completion immediately
+        guard let controller = activeCheckoutController else {
+            // The controller is held weakly and may already be gone; drop what it left behind.
+            clearActiveCheckout()
+            completion?()
+            return
+        }
+        controller.dismiss(animated: true) { [weak self] in
+            self?.clearActiveCheckout()
             completion?()
         }
+    }
+
+    private func clearActiveCheckout() {
+        activeCheckoutController = nil
+        activeNavigator = nil
+        dismissalObserver = nil
     }
 
     private func dismiss(animated: Bool, completion: (() -> Void)?) {

--- a/Tests/Primer/CheckoutComponents/Presenter/PrimerCheckoutPresenterTests.swift
+++ b/Tests/Primer/CheckoutComponents/Presenter/PrimerCheckoutPresenterTests.swift
@@ -231,4 +231,26 @@ final class PrimerCheckoutPresenterTests: XCTestCase {
         // Then
         XCTAssertNil(sut.activeNavigator)
     }
+
+    func test_handleCheckoutDismiss_afterFailureDelivered_doesNotCallDidDismiss() {
+        // Given
+        sut.activeNavigator = makeNavigator(showing: .failure(makeError()))
+        sut.handleInteractiveDismiss()
+
+        // When - a late dismissal path fires after the outcome already reached the merchant
+        sut.handleCheckoutDismiss()
+
+        // Then
+        XCTAssertEqual(mockDelegate.didFailWithErrorCallCount, 1)
+        XCTAssertEqual(mockDelegate.didDismissCallCount, 0)
+    }
+
+    func test_handleCheckoutDismiss_twice_callsDidDismissOnce() {
+        // When
+        sut.handleCheckoutDismiss()
+        sut.handleCheckoutDismiss()
+
+        // Then
+        XCTAssertEqual(mockDelegate.didDismissCallCount, 1)
+    }
 }

--- a/Tests/Primer/CheckoutComponents/Presenter/PrimerCheckoutPresenterTests.swift
+++ b/Tests/Primer/CheckoutComponents/Presenter/PrimerCheckoutPresenterTests.swift
@@ -19,6 +19,8 @@ final class PrimerCheckoutPresenterTests: XCTestCase {
     override func setUp() {
         super.setUp()
         sut = PrimerCheckoutPresenter.shared
+        sut.activeNavigator = nil
+        sut.hasDeliveredResult = false
         mockDelegate = MockPrimerCheckoutPresenterDelegate()
         sut.delegate = mockDelegate
     }
@@ -141,4 +143,92 @@ final class PrimerCheckoutPresenterTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    // MARK: - handleInteractiveDismiss
+
+    private func makeNavigator(showing route: CheckoutRoute) -> CheckoutNavigator {
+        let coordinator = CheckoutCoordinator()
+        coordinator.navigate(to: route)
+        return CheckoutNavigator(coordinator: coordinator)
+    }
+
+    private func makeError() -> PrimerError {
+        PrimerError.invalidValue(
+            key: TestData.ErrorKeys.test,
+            value: nil,
+            reason: nil,
+            diagnosticsId: TestData.DiagnosticsIds.test
+        )
+    }
+
+    func test_handleInteractiveDismiss_onFailureRoute_callsDidFailWithError() {
+        // Given
+        sut.activeNavigator = makeNavigator(showing: .failure(makeError()))
+
+        // When
+        sut.handleInteractiveDismiss()
+
+        // Then
+        XCTAssertEqual(mockDelegate.didFailWithErrorCallCount, 1)
+        XCTAssertEqual(mockDelegate.capturedError?.diagnosticsId, TestData.DiagnosticsIds.test)
+        XCTAssertEqual(mockDelegate.didDismissCallCount, 0)
+    }
+
+    func test_handleInteractiveDismiss_onSuccessRoute_callsDidCompleteWithSuccess() {
+        // Given
+        let result = PaymentResult(paymentId: TestData.PaymentIds.success, status: .success)
+        sut.activeNavigator = makeNavigator(showing: .success(result))
+
+        // When
+        sut.handleInteractiveDismiss()
+
+        // Then
+        XCTAssertEqual(mockDelegate.didCompleteWithSuccessCallCount, 1)
+        XCTAssertEqual(mockDelegate.capturedSuccessResult?.paymentId, TestData.PaymentIds.success)
+        XCTAssertEqual(mockDelegate.didDismissCallCount, 0)
+    }
+
+    func test_handleInteractiveDismiss_onSelectionRoute_callsDidDismiss() {
+        // Given
+        sut.activeNavigator = makeNavigator(showing: .paymentMethodSelection)
+
+        // When
+        sut.handleInteractiveDismiss()
+
+        // Then
+        XCTAssertEqual(mockDelegate.didDismissCallCount, 1)
+        XCTAssertEqual(mockDelegate.didFailWithErrorCallCount, 0)
+        XCTAssertEqual(mockDelegate.didCompleteWithSuccessCallCount, 0)
+    }
+
+    func test_handleInteractiveDismiss_withoutNavigator_callsDidDismiss() {
+        // Given / When
+        sut.handleInteractiveDismiss()
+
+        // Then
+        XCTAssertEqual(mockDelegate.didDismissCallCount, 1)
+    }
+
+    func test_handleInteractiveDismiss_thenPaymentFailure_reportsFailureOnce() {
+        // Given
+        let error = makeError()
+        sut.activeNavigator = makeNavigator(showing: .failure(error))
+
+        // When - the shopper swipes, then the SDK's own completion path fires for the same outcome
+        sut.handleInteractiveDismiss()
+        sut.handlePaymentFailure(error)
+
+        // Then
+        XCTAssertEqual(mockDelegate.didFailWithErrorCallCount, 1)
+    }
+
+    func test_handleInteractiveDismiss_clearsActiveNavigator() {
+        // Given
+        sut.activeNavigator = makeNavigator(showing: .paymentMethodSelection)
+
+        // When
+        sut.handleInteractiveDismiss()
+
+        // Then
+        XCTAssertNil(sut.activeNavigator)
+    }
 }


### PR DESCRIPTION
# Description

ORC-8311

When the shopper swiped the CheckoutComponents sheet away, `PrimerCheckoutPresenterDelegate` received nothing. Not `primerCheckoutPresenterDidFailWithError`, not `primerCheckoutPresenterDidDismiss`. Nobody observed `UIAdaptivePresentationControllerDelegate` on the presented bridge controller, so an interactive dismissal was invisible to the SDK. A decline left on the error screen never reached the merchant. Jackpot.com reported this on 2026-09-02 as the first blocker for their decline messaging.

The presenter now keeps the `CheckoutNavigator` it creates and installs a private `SheetDismissalObserver` as the sheet's presentation delegate. On interactive dismissal it reads the coordinator's current route:

- `.failure(error)` delivers `primerCheckoutPresenterDidFailWithError`
- `.success(result)` delivers `primerCheckoutPresenterDidCompleteWithSuccess`
- anything else delivers `primerCheckoutPresenterDidDismiss`

`hasDeliveredResult` guards against the result screen's own completion reporting the same outcome a second time. Programmatic dismissal paths are unchanged, UIKit does not call the observer for them.

No public API changes. The SwiftUI `PrimerCheckout` entry is not affected, the merchant owns the sheet there.

# Manual Testing

Debug App, iPhone 17 Pro simulator, CheckoutComponents, UIKit Integration, card 4000 0000 0000 0002:

- Decline, then swipe the error screen away: the Debug App shows its Failure result with `primerCheckoutPresenterDidFailWithError`. Before this change nothing happened.
- Swipe away from the payment method list: the Debug App shows the dismissed alert.
- Both screens enabled, decline without swiping: unchanged, the SDK error screen stays with Retry.

# Tests

`PrimerCheckoutPresenterTests`, 8 new cases: failure route, success route, selection route, no navigator, double delivery guard for results and for dismissal, navigator cleanup. 16/16 passing.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge
