### PR TITLE
fix: Deliver checkout completion when the SDK result screen is disabled (ORC-8312)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/FlowScreenFactory.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/FlowScreenFactory.swift
@@ -124,7 +124,7 @@ struct FlowScreenFactory: LogReporter {
       // required for the completion to fire when the merchant disables the SDK screen.
       Color.clear.onAppear {
         logger.debug(message: "[CheckoutComponents] Success screen disabled - auto-dismissing")
-        onCompletion?(.success(result))
+        Task { @MainActor in onCompletion?(.success(result)) }
       }
     }
   }
@@ -143,7 +143,7 @@ struct FlowScreenFactory: LogReporter {
     } else {
       Color.clear.onAppear {
         logger.debug(message: "[CheckoutComponents] Error screen disabled - auto-dismissing")
-        onCompletion?(.failure(error))
+        Task { @MainActor in onCompletion?(.failure(error)) }
       }
     }
   }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/FlowScreenFactory.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/FlowScreenFactory.swift
@@ -120,11 +120,11 @@ struct FlowScreenFactory: LogReporter {
         }
       }
     } else {
-      EmptyView().onAppear {
+      // `EmptyView` never enters the hierarchy, so its `onAppear` never runs. A rendered view is
+      // required for the completion to fire when the merchant disables the SDK screen.
+      Color.clear.onAppear {
         logger.debug(message: "[CheckoutComponents] Success screen disabled - auto-dismissing")
-        Task { @MainActor in
-          onCompletion?(scope.currentState)
-        }
+        onCompletion?(.success(result))
       }
     }
   }
@@ -141,11 +141,9 @@ struct FlowScreenFactory: LogReporter {
         onChooseOtherPaymentMethods: showOtherMethodsAction
       )
     } else {
-      EmptyView().onAppear {
+      Color.clear.onAppear {
         logger.debug(message: "[CheckoutComponents] Error screen disabled - auto-dismissing")
-        Task { @MainActor in
-          onCompletion?(scope.currentState)
-        }
+        onCompletion?(.failure(error))
       }
     }
   }

--- a/Tests/Primer/CheckoutComponents/FlowScreenFactoryCompletionTests.swift
+++ b/Tests/Primer/CheckoutComponents/FlowScreenFactoryCompletionTests.swift
@@ -1,0 +1,129 @@
+//
+//  FlowScreenFactoryCompletionTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import SwiftUI
+import UIKit
+import XCTest
+@_spi(PrimerInternal) @testable import PrimerFoundation
+@_spi(PrimerInternal) @testable import PrimerCore
+
+/// When the merchant disables the SDK success or error screen, the terminal state must still reach
+/// `onCompletion`. The disabled branch renders no SDK UI, so the completion has to fire from a view
+/// that actually enters the hierarchy.
+@available(iOS 15.0, *)
+@MainActor
+final class FlowScreenFactoryCompletionTests: XCTestCase {
+
+  private final class Recorder {
+    var states: [PrimerCheckoutState] = []
+  }
+
+  override func setUp() async throws {
+    try await super.setUp()
+    await ContainerTestHelpers.resetSharedContainer()
+  }
+
+  override func tearDown() async throws {
+    await ContainerTestHelpers.resetSharedContainer()
+    try await super.tearDown()
+  }
+
+  // MARK: - Error screen
+
+  func test_failureState_errorScreenDisabled_callsCompletionOnceWithFailure() async {
+    let recorder = render(.failure(PrimerError.unknown()), successScreen: true, errorScreen: false)
+
+    XCTAssertEqual(recorder.states.count, 1)
+    guard case .failure = recorder.states.first else {
+      return XCTFail("Expected .failure, got \(String(describing: recorder.states.first))")
+    }
+  }
+
+  func test_failureState_errorScreenEnabled_doesNotCallCompletion() async {
+    let recorder = render(.failure(PrimerError.unknown()), successScreen: true, errorScreen: true)
+
+    XCTAssertTrue(recorder.states.isEmpty)
+  }
+
+  // MARK: - Success screen
+
+  func test_successState_successScreenDisabled_callsCompletionOnceWithSuccess() async {
+    let result = PaymentResult(paymentId: TestData.PaymentIds.success, status: .success, paymentMethodType: nil)
+    let recorder = render(.success(result), successScreen: false, errorScreen: true)
+
+    XCTAssertEqual(recorder.states.count, 1)
+    guard case let .success(received) = recorder.states.first else {
+      return XCTFail("Expected .success, got \(String(describing: recorder.states.first))")
+    }
+    XCTAssertEqual(received.paymentId, result.paymentId)
+  }
+
+  // MARK: - Harness sanity
+
+  /// Guards the harness itself: if appearance callbacks never fire in this host, the positive tests
+  /// above cannot be trusted.
+  func test_harness_deliversAppearanceCallbacks() {
+    let recorder = Recorder()
+    let view = Color.clear.onAppear { recorder.states.append(.dismissed) }
+    let controller = UIHostingController(rootView: view)
+    let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+    window.rootViewController = controller
+    window.makeKeyAndVisible()
+    controller.view.layoutIfNeeded()
+    let deadline = Date().addingTimeInterval(1)
+    while recorder.states.isEmpty, Date() < deadline {
+      RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+    }
+    window.isHidden = true
+    window.rootViewController = nil
+    XCTAssertEqual(recorder.states.count, 1)
+  }
+
+  // MARK: - Helpers
+
+  /// Hosts the factory's view for `state` in a key window and spins the run loop until the
+  /// completion fires or the timeout passes, so appearance callbacks have a chance to run.
+  private func render(
+    _ state: CheckoutNavigationState,
+    successScreen: Bool,
+    errorScreen: Bool,
+    timeout: TimeInterval = 1
+  ) -> Recorder {
+    let settings = PrimerSettings(
+      uiOptions: PrimerUIOptions(isSuccessScreenEnabled: successScreen, isErrorScreenEnabled: errorScreen)
+    )
+    let scope = DefaultCheckoutScope(
+      clientToken: TestData.Tokens.valid,
+      settings: settings,
+      navigator: CheckoutNavigator(coordinator: CheckoutCoordinator())
+    )
+    let recorder = Recorder()
+    let factory = FlowScreenFactory(
+      scope: scope,
+      theme: PrimerCheckoutTheme(),
+      onCompletion: { recorder.states.append($0) },
+      isInlineFlow: false
+    )
+
+    let controller = UIHostingController(rootView: factory.view(for: state))
+    let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+    window.rootViewController = controller
+    window.makeKeyAndVisible()
+    controller.view.layoutIfNeeded()
+
+    let deadline = Date().addingTimeInterval(timeout)
+    while recorder.states.isEmpty, Date() < deadline {
+      RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+    }
+    // One extra tick so a second, unexpected delivery would be caught by the count assertions.
+    RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+    window.isHidden = true
+    window.rootViewController = nil
+    return recorder
+  }
+}

--- a/Tests/Primer/CheckoutComponents/FlowScreenFactoryCompletionTests.swift
+++ b/Tests/Primer/CheckoutComponents/FlowScreenFactoryCompletionTests.swift
@@ -35,7 +35,7 @@ final class FlowScreenFactoryCompletionTests: XCTestCase {
   // MARK: - Error screen
 
   func test_failureState_errorScreenDisabled_callsCompletionOnceWithFailure() async {
-    let recorder = render(.failure(PrimerError.unknown()), successScreen: true, errorScreen: false)
+    let recorder = await render(.failure(PrimerError.unknown()), successScreen: true, errorScreen: false)
 
     XCTAssertEqual(recorder.states.count, 1)
     guard case .failure = recorder.states.first else {
@@ -44,7 +44,7 @@ final class FlowScreenFactoryCompletionTests: XCTestCase {
   }
 
   func test_failureState_errorScreenEnabled_doesNotCallCompletion() async {
-    let recorder = render(.failure(PrimerError.unknown()), successScreen: true, errorScreen: true)
+    let recorder = await render(.failure(PrimerError.unknown()), successScreen: true, errorScreen: true)
 
     XCTAssertTrue(recorder.states.isEmpty)
   }
@@ -53,7 +53,7 @@ final class FlowScreenFactoryCompletionTests: XCTestCase {
 
   func test_successState_successScreenDisabled_callsCompletionOnceWithSuccess() async {
     let result = PaymentResult(paymentId: TestData.PaymentIds.success, status: .success, paymentMethodType: nil)
-    let recorder = render(.success(result), successScreen: false, errorScreen: true)
+    let recorder = await render(.success(result), successScreen: false, errorScreen: true)
 
     XCTAssertEqual(recorder.states.count, 1)
     guard case let .success(received) = recorder.states.first else {
@@ -85,14 +85,15 @@ final class FlowScreenFactoryCompletionTests: XCTestCase {
 
   // MARK: - Helpers
 
-  /// Hosts the factory's view for `state` in a key window and spins the run loop until the
-  /// completion fires or the timeout passes, so appearance callbacks have a chance to run.
+  /// Hosts the factory's view for `state` in a key window and suspends until the completion fires
+  /// or the timeout passes. Suspending (rather than spinning the run loop) lets both the appearance
+  /// callback and the main-actor hop it schedules run.
   private func render(
     _ state: CheckoutNavigationState,
     successScreen: Bool,
     errorScreen: Bool,
     timeout: TimeInterval = 1
-  ) -> Recorder {
+  ) async -> Recorder {
     let settings = PrimerSettings(
       uiOptions: PrimerUIOptions(isSuccessScreenEnabled: successScreen, isErrorScreenEnabled: errorScreen)
     )
@@ -117,10 +118,10 @@ final class FlowScreenFactoryCompletionTests: XCTestCase {
 
     let deadline = Date().addingTimeInterval(timeout)
     while recorder.states.isEmpty, Date() < deadline {
-      RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+      try? await Task.sleep(nanoseconds: 20_000_000)
     }
     // One extra tick so a second, unexpected delivery would be caught by the count assertions.
-    RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    try? await Task.sleep(nanoseconds: 50_000_000)
 
     window.isHidden = true
     window.rootViewController = nil


### PR DESCRIPTION
# Description

ORC-8312

With `isErrorScreenEnabled` or `isSuccessScreenEnabled` set to `false`, the terminal state was handed to `EmptyView().onAppear`. `EmptyView` never enters the view hierarchy, so its `onAppear` never runs. The sheet stayed blank and the merchant received no completion, neither through `PrimerCheckout(onCompletion:)` nor through `PrimerCheckoutPresenterDelegate`. Jackpot.com reported this on 2026-09-02 as the second blocker for their own decline messaging.

`FlowScreenFactory` now renders `Color.clear` in the disabled branches and fires `onCompletion` from its `onAppear`. The state is taken straight from the navigation switch, so success delivers `.success(result)` and failure delivers `.failure(error)`.

No public API changes.

# Manual Testing

Debug App, iPhone 17 Pro simulator, CheckoutComponents, UIKit Integration, Disable Error Screen on, card 4000 0000 0000 0002:

- Decline: the sheet dismisses on its own and the Debug App shows its Failure result. Before this change the sheet stayed blank.
- Disable Error Screen off: unchanged, the SDK error screen shows with Retry.

The success path could not be checked in Sandbox today, every card payment fails after the 3DS resume. It is covered by the unit test below.

# Tests

`FlowScreenFactoryCompletionTests`, new: failure with the error screen disabled delivers one `.failure`; failure with the screen enabled delivers nothing; success with the success screen disabled delivers one `.success`; a harness sanity check. 4/4 passing.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge
