### PR TITLE
fix: Reject manual payment handling before the checkout starts (ORC-8313)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Data/Repositories/HeadlessRepositoryImpl.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Data/Repositories/HeadlessRepositoryImpl.swift
@@ -18,9 +18,6 @@ final class HeadlessRepositoryImpl: @preconcurrency HeadlessRepository, LogRepor
 
   private var paymentMethods: [InternalPaymentMethod] = []
 
-  // MARK: - Settings Integration
-
-  private var settings: PrimerSettings?
   private var configurationService: ConfigurationService?
 
   // MARK: - Co-Badged Cards Support
@@ -85,20 +82,6 @@ final class HeadlessRepositoryImpl: @preconcurrency HeadlessRepository, LogRepor
     self.configurationServiceFactory = configurationServiceFactory
     self.rawDataManagerFactory = rawDataManagerFactory
     self.vaultManagerFactory = vaultManagerFactory
-  }
-
-  private func injectSettings() async {
-    guard settings == nil else { return }
-
-    do {
-      guard let container = await DIContainer.current else {
-        return
-      }
-
-      settings = try await container.resolve(PrimerSettings.self)
-    } catch {
-      logger.error(message: "Failed to resolve dependency: \(error)")
-    }
   }
 
   private func injectConfigurationService() async {
@@ -289,9 +272,8 @@ final class HeadlessRepositoryImpl: @preconcurrency HeadlessRepository, LogRepor
           return
         }
 
-        Task {
-          await self.submitPaymentWithHandlingMode(rawDataManager: rawDataManager)
-        }
+        // Triggers async payment processing and the delegate callbacks.
+        Task { @MainActor in rawDataManager.submit() }
       }
     } else {
       timeoutTask.cancel()
@@ -301,19 +283,6 @@ final class HeadlessRepositoryImpl: @preconcurrency HeadlessRepository, LogRepor
         validationErrors: validationErrors
       )
     }
-  }
-
-  @MainActor
-  private func submitPaymentWithHandlingMode(rawDataManager: RawDataManagerProtocol) async {
-    await injectSettings()
-    let paymentHandlingMode = settings?.paymentHandling ?? .auto
-
-    if paymentHandlingMode == .manual {
-      logger.warn(message: "[Card] Manual payment handling not yet supported in CheckoutComponents - proceeding with auto mode")
-    }
-
-    // This will trigger async payment processing and delegate callbacks
-    rawDataManager.submit()
   }
 
   private func handleValidationFailure(

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Scope/DefaultCheckoutScope.swift
@@ -214,6 +214,16 @@ final class DefaultCheckoutScope: CheckoutScopeInternal, ObservableObject, LogRe
     }
 
     do {
+      // The shared core answers the manual-mode decision on the merchant's behalf, so a manual
+      // session would tokenize and then wait on a payment nobody creates. Reject it up front.
+      guard settings.paymentHandling != .manual else {
+        throw PrimerError.invalidValue(
+          key: "paymentHandling",
+          value: settings.paymentHandling.rawValue,
+          reason: "Checkout Components supports automatic payment handling only"
+        )
+      }
+
       if isInitScreenEnabled {
         try await Task.sleep(nanoseconds: 500_000_000)
       }

--- a/Tests/Primer/CheckoutComponents/DefaultCheckoutScopePaymentHandlingTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultCheckoutScopePaymentHandlingTests.swift
@@ -18,10 +18,16 @@ final class DefaultCheckoutScopePaymentHandlingTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
         await ContainerTestHelpers.resetSharedContainer()
-        await DIContainer.setContainer(try await ContainerTestHelpers.createTestContainer())
+        // A configuration with one payment method lets the auto path reach `.ready`.
+        SDKSessionHelper.setUp()
+        let container = try await ContainerTestHelpers.createTestContainer(
+            apiConfiguration: PrimerAPIConfigurationModule.apiConfiguration
+        )
+        await DIContainer.setContainer(container)
     }
 
     override func tearDown() async throws {
+        SDKSessionHelper.tearDown()
         await ContainerTestHelpers.resetSharedContainer()
         try await super.tearDown()
     }
@@ -39,14 +45,13 @@ final class DefaultCheckoutScopePaymentHandlingTests: XCTestCase {
         XCTAssertEqual(sut.navigationState, .failure(error))
     }
 
-    func test_init_autoPaymentHandling_doesNotRejectSettings() async throws {
+    func test_init_autoPaymentHandling_reachesReady() async throws {
         let sut = makeSut(paymentHandling: .auto)
 
         let state = await settledState(of: sut)
 
-        XCTAssertNotEqual(state, .initializing)
-        if case let .failure(error) = state {
-            XCTAssertNotEqual(error.errorId, "invalid-value")
+        guard case .ready = state else {
+            return XCTFail("Expected .ready, got \(state)")
         }
     }
 

--- a/Tests/Primer/CheckoutComponents/DefaultCheckoutScopePaymentHandlingTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultCheckoutScopePaymentHandlingTests.swift
@@ -44,6 +44,7 @@ final class DefaultCheckoutScopePaymentHandlingTests: XCTestCase {
 
         let state = await settledState(of: sut)
 
+        XCTAssertNotEqual(state, .initializing)
         if case let .failure(error) = state {
             XCTAssertNotEqual(error.errorId, "invalid-value")
         }
@@ -60,14 +61,21 @@ final class DefaultCheckoutScopePaymentHandlingTests: XCTestCase {
         )
     }
 
-    /// Drains the state stream until the scope leaves `.initializing`, bounded so a broken init
-    /// cannot hang the suite.
+    /// Drains the state stream until the scope leaves `.initializing`. A stream that never emits
+    /// would suspend forever, so the drain races a five second timer and the loser is cancelled.
     private func settledState(of scope: DefaultCheckoutScope) async -> PrimerCheckoutState {
-        let deadline = Date().addingTimeInterval(5)
-        for await state in scope.state {
-            if case .initializing = state, Date() < deadline { continue }
-            return state
+        await withTaskGroup(of: PrimerCheckoutState.self) { group in
+            group.addTask { @MainActor in
+                for await state in scope.state where state != .initializing { return state }
+                return scope.currentState
+            }
+            group.addTask { @MainActor in
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                return scope.currentState
+            }
+            let first = await group.next() ?? scope.currentState
+            group.cancelAll()
+            return first
         }
-        return scope.currentState
     }
 }

--- a/Tests/Primer/CheckoutComponents/DefaultCheckoutScopePaymentHandlingTests.swift
+++ b/Tests/Primer/CheckoutComponents/DefaultCheckoutScopePaymentHandlingTests.swift
@@ -1,0 +1,73 @@
+//
+//  DefaultCheckoutScopePaymentHandlingTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import XCTest
+@_spi(PrimerInternal) @testable import PrimerFoundation
+@_spi(PrimerInternal) @testable import PrimerCore
+
+/// Checkout Components creates the payment itself. A session started with `.manual` must fail
+/// before any payment attempt instead of hanging on the processing screen.
+@available(iOS 15.0, *)
+@MainActor
+final class DefaultCheckoutScopePaymentHandlingTests: XCTestCase {
+
+    override func setUp() async throws {
+        try await super.setUp()
+        await ContainerTestHelpers.resetSharedContainer()
+        await DIContainer.setContainer(try await ContainerTestHelpers.createTestContainer())
+    }
+
+    override func tearDown() async throws {
+        await ContainerTestHelpers.resetSharedContainer()
+        try await super.tearDown()
+    }
+
+    func test_init_manualPaymentHandling_failsWithInvalidValue() async throws {
+        let sut = makeSut(paymentHandling: .manual)
+
+        let state = await settledState(of: sut)
+
+        guard case let .failure(error) = state else {
+            return XCTFail("Expected .failure, got \(state)")
+        }
+        XCTAssertEqual(error.errorId, "invalid-value")
+        XCTAssertTrue(error.errorDescription?.contains("paymentHandling") == true)
+        XCTAssertEqual(sut.navigationState, .failure(error))
+    }
+
+    func test_init_autoPaymentHandling_doesNotRejectSettings() async throws {
+        let sut = makeSut(paymentHandling: .auto)
+
+        let state = await settledState(of: sut)
+
+        if case let .failure(error) = state {
+            XCTAssertNotEqual(error.errorId, "invalid-value")
+        }
+    }
+
+    private func makeSut(paymentHandling: PrimerPaymentHandling) -> DefaultCheckoutScope {
+        DefaultCheckoutScope(
+            clientToken: TestData.Tokens.valid,
+            settings: PrimerSettings(
+                paymentHandling: paymentHandling,
+                uiOptions: PrimerUIOptions(isInitScreenEnabled: false)
+            ),
+            navigator: CheckoutNavigator(coordinator: CheckoutCoordinator())
+        )
+    }
+
+    /// Drains the state stream until the scope leaves `.initializing`, bounded so a broken init
+    /// cannot hang the suite.
+    private func settledState(of scope: DefaultCheckoutScope) async -> PrimerCheckoutState {
+        let deadline = Date().addingTimeInterval(5)
+        for await state in scope.state {
+            if case .initializing = state, Date() < deadline { continue }
+            return state
+        }
+        return scope.currentState
+    }
+}

--- a/Tests/Primer/CheckoutComponents/Klarna/KlarnaPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/Klarna/KlarnaPaymentMethodTests.swift
@@ -242,7 +242,7 @@ final class KlarnaPaymentMethodTests: XCTestCase {
 
         let navigator = CheckoutNavigator(coordinator: CheckoutCoordinator())
         let settings = PrimerSettings(
-            paymentHandling: .manual,
+            paymentHandling: .auto,
             paymentMethodOptions: PrimerPaymentMethodOptions()
         )
         let checkoutScope = DefaultCheckoutScope(

--- a/Tests/Primer/CheckoutComponents/TestSupport/ContainerTestHelpers.swift
+++ b/Tests/Primer/CheckoutComponents/TestSupport/ContainerTestHelpers.swift
@@ -50,7 +50,7 @@ enum ContainerTestHelpers {
     static func createMockCheckoutScope() async -> DefaultCheckoutScope {
         let navigator = CheckoutNavigator(coordinator: CheckoutCoordinator())
         let settings = PrimerSettings(
-            paymentHandling: .manual,
+            paymentHandling: .auto,
             paymentMethodOptions: PrimerPaymentMethodOptions()
         )
         return DefaultCheckoutScope(
@@ -73,7 +73,7 @@ enum ContainerTestHelpers {
 
         let navigator = CheckoutNavigator(coordinator: CheckoutCoordinator())
         let settings = PrimerSettings(
-            paymentHandling: .manual,
+            paymentHandling: .auto,
             paymentMethodOptions: PrimerPaymentMethodOptions(),
             uiOptions: PrimerUIOptions(isInitScreenEnabled: false)
         )
@@ -111,7 +111,7 @@ enum ContainerTestHelpers {
 
         let navigator = CheckoutNavigator(coordinator: CheckoutCoordinator())
         let settings = PrimerSettings(
-            paymentHandling: .manual,
+            paymentHandling: .auto,
             paymentMethodOptions: PrimerPaymentMethodOptions(),
             uiOptions: PrimerUIOptions(isInitScreenEnabled: false)
         )


### PR DESCRIPTION
# Description

ORC-8313

With `PrimerSettings(paymentHandling: .manual)` a card payment in Checkout Components tokenized and then sat on the processing spinner. After sixty seconds it failed with a generic timeout. Jackpot.com reported this on 2026-09-02 as their third question and described it as a crash.

Checkout Components reuses the shared core payment flow. In manual mode `RawDataManager.submit()` asks the merchant for a decision through `PrimerDelegateProxy`. For the `.checkoutComponents` integration type the proxy answers `PrimerResumeDecision.succeed()` on the merchant's behalf. No payment is created, the auto-only completion never fires, and the repository's continuation only exits through the timeout.

This PR makes the limitation explicit and immediate:

- `DefaultCheckoutScope` rejects `.manual` when it loads, before any payment method shows, with `PrimerError.invalidValue(key: "paymentHandling", ...)`. The error travels the normal failure path, so the SDK error screen, `PrimerCheckoutPresenterDelegate` and the SwiftUI `onCompletion` all see it.
- `HeadlessRepositoryImpl` loses the warning that claimed the SDK proceeds in auto mode. It never did, `RawDataManager` reads the setting on its own. The now unused `settings` injection goes with it.
- The CC test helpers built their scopes with `.manual` for no reason. They now use `.auto`, the mode they exercised all along.

Real manual payment handling stays out of scope. The public handler shape has to match Android first.

Merchant docs: public-docs MR `bn/ios-cc-auto-payment-handling-only` updates the settings reference, the UIKit guide (its example used `.manual`), the payment result pages, troubleshooting, and the iOS tab of the migration guide.

# Manual Testing

Debug App, iPhone 17 Pro simulator, Checkout flow = Manual, CheckoutComponents, UIKit Integration:

- The error screen appears at once with `[invalid-value] Invalid value 'MANUAL' for key 'paymentHandling'`. No spinner, no sixty second wait.
- Checkout flow = Auto: unchanged, the payment method list loads.

Known limitation kept from today: the error screen for init-time failures still shows Retry, which has no payment to retry. Same as the existing `missingPrimerConfiguration` path.

# Tests

`DefaultCheckoutScopePaymentHandlingTests`, new: `.manual` settles in `.failure` with `errorId` `invalid-value` and mirrors it into the navigation state; `.auto` reaches `.ready`. Full `UnitTestsTestPlan` run: 3037 tests, 0 failures.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [x]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

