### PR TITLE
fix(components): drop the duplicate inputText colour helper

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/UI/Design/CheckoutColors.swift
@@ -133,8 +133,4 @@ enum CheckoutColors {
   static func onBrand(tokens: DesignTokens?, isEnabled: Bool = true) -> Color {
     isEnabled ? .white : (tokens?.primerColorTextDisabled ?? Color(.tertiaryLabel))
   }
-
-  static func inputText(tokens: DesignTokens?) -> Color {
-    tokens?.primerColorTextOutlinedDefault ?? .primary
-  }
 }


### PR DESCRIPTION
# Description

`CheckoutColors` declares `inputText(tokens:)` twice, so the branch does not compile.

Neither PR did this. #1877 added the helper and merged with one copy. #1878 was stacked on #1877, so its branch carried the helper too, and once #1877 had been squash-merged its commits no longer matched anything here, so the squash of #1878 was computed against an older base and applied the addition a second time. `ov/fix/ORC-8179-label-on-brand` itself has exactly one copy.

Deleting the second one. The file is byte-identical to #1878's branch afterwards.

# Other Notes

Worth switching the rest of the theming stack to merge commits rather than squashes. Every remaining PR sits on the one below it, so the same thing can happen again, and this time it landed with no conflict to warn anyone.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [x]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [x]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable
