### PR TITLE
test(components): stop the unit-test bundle crashing and hanging in CI (ORC-8364)

### DIFF
--- a/Tests/Primer/CheckoutComponents/ApplePay/DefaultApplePayScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/ApplePay/DefaultApplePayScopeTests.swift
@@ -463,15 +463,19 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
 
     func test_performPayment_whenApplePayRequestFactoryThrows_resetsLoading() async throws {
         // Given
-        let sut = createScope(applePayRequestFactory: {
+        var sut: DefaultApplePayScope!
+        var wasLoadingWhenFactoryRan = false
+        sut = createScope(applePayRequestFactory: {
+            wasLoadingWhenFactoryRan = sut.structuredState.isLoading
             throw PrimerError.invalidClientSessionValue(name: "order.countryCode")
         })
 
         // When
         sut.submit()
 
-        // Then — the payment Task resets loading before it finishes
+        // Then — loading is set while the Task runs and reset before it finishes
         try await XCTUnwrap(sut.paymentTask).value
+        XCTAssertTrue(wasLoadingWhenFactoryRan)
         XCTAssertFalse(sut.structuredState.isLoading)
     }
 
@@ -489,8 +493,9 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — the payment Task resets loading before it finishes
+        // Then — the Task ran (it reached the client-session step) and reset loading before it finished
         try await XCTUnwrap(sut.paymentTask).value
+        XCTAssertEqual(mockClientSessionActions.selectPaymentMethodCalls.count, 1)
         XCTAssertFalse(sut.structuredState.isLoading)
     }
 
@@ -528,8 +533,9 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — the payment Task resets loading before it finishes
+        // Then — the Task ran (it reached the client-session step) and reset loading before it finished
         try await XCTUnwrap(sut.paymentTask).value
+        XCTAssertEqual(mockClientSessionActions.selectPaymentMethodCalls.count, 1)
         XCTAssertFalse(sut.structuredState.isLoading)
     }
 
@@ -545,8 +551,9 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — the payment Task resets loading before it finishes
+        // Then — the Task ran (it reached the client-session step) and reset loading before it finished
         try await XCTUnwrap(sut.paymentTask).value
+        XCTAssertEqual(mockClientSessionActions.selectPaymentMethodCalls.count, 1)
         XCTAssertFalse(sut.structuredState.isLoading)
     }
 
@@ -581,7 +588,10 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
             presentWasCalled = true
             return .success(())
         }
-        let sut = createScope(applePayRequestFactory: {
+        var sut: DefaultApplePayScope!
+        var wasLoadingWhenFactoryRan = false
+        sut = createScope(applePayRequestFactory: {
+            wasLoadingWhenFactoryRan = sut.structuredState.isLoading
             throw TestError.unknown
         })
 
@@ -590,6 +600,7 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
 
         // Then — the factory throws before presentation, so present is never reached
         try await XCTUnwrap(sut.paymentTask).value
+        XCTAssertTrue(wasLoadingWhenFactoryRan)
         XCTAssertFalse(presentWasCalled)
         XCTAssertFalse(sut.structuredState.isLoading)
     }

--- a/Tests/Primer/CheckoutComponents/ApplePay/DefaultApplePayScopeTests.swift
+++ b/Tests/Primer/CheckoutComponents/ApplePay/DefaultApplePayScopeTests.swift
@@ -470,11 +470,8 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — payment Task sets loading true, then resets it when the factory throws
-        try await withTimeout(2.0) { [self] in
-            while !sut.structuredState.isLoading { await Task.yield() }
-            while sut.structuredState.isLoading { await Task.yield() }
-        }
+        // Then — the payment Task resets loading before it finishes
+        try await XCTUnwrap(sut.paymentTask).value
         XCTAssertFalse(sut.structuredState.isLoading)
     }
 
@@ -492,11 +489,8 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — payment Task sets loading true, then resets it on the cancelled error
-        try await withTimeout(2.0) { [self] in
-            while !sut.structuredState.isLoading { await Task.yield() }
-            while sut.structuredState.isLoading { await Task.yield() }
-        }
+        // Then — the payment Task resets loading before it finishes
+        try await XCTUnwrap(sut.paymentTask).value
         XCTAssertFalse(sut.structuredState.isLoading)
     }
 
@@ -514,10 +508,8 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — wait until the payment Task records the selectPaymentMethod call
-        try await withTimeout(2.0) { [self] in
-            while mockClientSessionActions.selectPaymentMethodCalls.isEmpty { await Task.yield() }
-        }
+        // Then — the payment Task records the selectPaymentMethod call before it finishes
+        try await XCTUnwrap(sut.paymentTask).value
         XCTAssertEqual(mockClientSessionActions.selectPaymentMethodCalls.count, 1)
         XCTAssertEqual(
             mockClientSessionActions.selectPaymentMethodCalls.first?.type,
@@ -536,11 +528,8 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — payment Task sets loading true, then resets it when selectPaymentMethod throws
-        try await withTimeout(2.0) { [self] in
-            while !sut.structuredState.isLoading { await Task.yield() }
-            while sut.structuredState.isLoading { await Task.yield() }
-        }
+        // Then — the payment Task resets loading before it finishes
+        try await XCTUnwrap(sut.paymentTask).value
         XCTAssertFalse(sut.structuredState.isLoading)
     }
 
@@ -556,11 +545,8 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — payment Task sets loading true, then resets it on the wrapped error
-        try await withTimeout(2.0) { [self] in
-            while !sut.structuredState.isLoading { await Task.yield() }
-            while sut.structuredState.isLoading { await Task.yield() }
-        }
+        // Then — the payment Task resets loading before it finishes
+        try await XCTUnwrap(sut.paymentTask).value
         XCTAssertFalse(sut.structuredState.isLoading)
     }
 
@@ -580,11 +566,8 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — wait until the payment Task invokes the presentation manager and resets loading
-        try await withTimeout(2.0) { [self] in
-            while !presentWasCalled { await Task.yield() }
-            while sut.structuredState.isLoading { await Task.yield() }
-        }
+        // Then — the payment Task invokes the presentation manager and resets loading before it finishes
+        try await XCTUnwrap(sut.paymentTask).value
         XCTAssertTrue(presentWasCalled)
         XCTAssertFalse(sut.structuredState.isLoading)
     }
@@ -605,12 +588,8 @@ final class DefaultApplePayScopeFactoryTests: XCTestCase {
         // When
         sut.submit()
 
-        // Then — the factory throws before presentation; once the loading cycle completes
-        // the Task has finished and present was never reached
-        try await withTimeout(2.0) { [self] in
-            while !sut.structuredState.isLoading { await Task.yield() }
-            while sut.structuredState.isLoading { await Task.yield() }
-        }
+        // Then — the factory throws before presentation, so present is never reached
+        try await XCTUnwrap(sut.paymentTask).value
         XCTAssertFalse(presentWasCalled)
         XCTAssertFalse(sut.structuredState.isLoading)
     }

--- a/Tests/Primer/CheckoutComponents/Mocks/MockClientSessionActionsModule.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockClientSessionActionsModule.swift
@@ -12,16 +12,29 @@ import Foundation
 @available(iOS 15.0, *)
 final class MockClientSessionActionsModule: ClientSessionActionsProtocol {
 
-    var selectPaymentMethodError: Error?
-    var unselectPaymentMethodError: Error?
-    var dispatchActionsError: Error?
-
-    // Production callers fire these methods from concurrent tasks, so the recorded calls are
-    // guarded; an unguarded array here corrupts the heap and crashes the test runner.
+    // Production code calls this from concurrent tasks; unguarded state here corrupts the heap and crashes the runner.
     private let lock = NSLock()
+    private var _selectPaymentMethodError: Error?
+    private var _unselectPaymentMethodError: Error?
+    private var _dispatchActionsError: Error?
     private var _selectPaymentMethodCalls: [(type: String, network: String?)] = []
     private var _unselectPaymentMethodCallCount = 0
     private var _dispatchActionsCalls: [[ClientSession.Action]] = []
+
+    var selectPaymentMethodError: Error? {
+        get { synchronized { _selectPaymentMethodError } }
+        set { synchronized { _selectPaymentMethodError = newValue } }
+    }
+
+    var unselectPaymentMethodError: Error? {
+        get { synchronized { _unselectPaymentMethodError } }
+        set { synchronized { _unselectPaymentMethodError = newValue } }
+    }
+
+    var dispatchActionsError: Error? {
+        get { synchronized { _dispatchActionsError } }
+        set { synchronized { _dispatchActionsError = newValue } }
+    }
 
     var selectPaymentMethodCalls: [(type: String, network: String?)] {
         synchronized { _selectPaymentMethodCalls }
@@ -48,10 +61,10 @@ final class MockClientSessionActionsModule: ClientSessionActionsProtocol {
             _selectPaymentMethodCalls = []
             _unselectPaymentMethodCallCount = 0
             _dispatchActionsCalls = []
+            _selectPaymentMethodError = nil
+            _unselectPaymentMethodError = nil
+            _dispatchActionsError = nil
         }
-        selectPaymentMethodError = nil
-        unselectPaymentMethodError = nil
-        dispatchActionsError = nil
     }
 
     func selectPaymentMethodIfNeeded(_ paymentMethodType: String, cardNetwork: String?) async throws {

--- a/Tests/Primer/CheckoutComponents/Mocks/MockClientSessionActionsModule.swift
+++ b/Tests/Primer/CheckoutComponents/Mocks/MockClientSessionActionsModule.swift
@@ -16,9 +16,24 @@ final class MockClientSessionActionsModule: ClientSessionActionsProtocol {
     var unselectPaymentMethodError: Error?
     var dispatchActionsError: Error?
 
-    private(set) var selectPaymentMethodCalls: [(type: String, network: String?)] = []
-    private(set) var unselectPaymentMethodCallCount = 0
-    private(set) var dispatchActionsCalls: [[ClientSession.Action]] = []
+    // Production callers fire these methods from concurrent tasks, so the recorded calls are
+    // guarded; an unguarded array here corrupts the heap and crashes the test runner.
+    private let lock = NSLock()
+    private var _selectPaymentMethodCalls: [(type: String, network: String?)] = []
+    private var _unselectPaymentMethodCallCount = 0
+    private var _dispatchActionsCalls: [[ClientSession.Action]] = []
+
+    var selectPaymentMethodCalls: [(type: String, network: String?)] {
+        synchronized { _selectPaymentMethodCalls }
+    }
+
+    var unselectPaymentMethodCallCount: Int {
+        synchronized { _unselectPaymentMethodCallCount }
+    }
+
+    var dispatchActionsCalls: [[ClientSession.Action]] {
+        synchronized { _dispatchActionsCalls }
+    }
 
     var lastSelectPaymentMethodCall: (type: String, network: String?)? {
         selectPaymentMethodCalls.last
@@ -29,32 +44,40 @@ final class MockClientSessionActionsModule: ClientSessionActionsProtocol {
     }
 
     func reset() {
-        selectPaymentMethodCalls = []
-        unselectPaymentMethodCallCount = 0
-        dispatchActionsCalls = []
+        synchronized {
+            _selectPaymentMethodCalls = []
+            _unselectPaymentMethodCallCount = 0
+            _dispatchActionsCalls = []
+        }
         selectPaymentMethodError = nil
         unselectPaymentMethodError = nil
         dispatchActionsError = nil
     }
 
     func selectPaymentMethodIfNeeded(_ paymentMethodType: String, cardNetwork: String?) async throws {
-        selectPaymentMethodCalls.append((paymentMethodType, cardNetwork))
+        synchronized { _selectPaymentMethodCalls.append((paymentMethodType, cardNetwork)) }
         if let selectPaymentMethodError {
             throw selectPaymentMethodError
         }
     }
 
     func unselectPaymentMethodIfNeeded() async throws {
-        unselectPaymentMethodCallCount += 1
+        synchronized { _unselectPaymentMethodCallCount += 1 }
         if let unselectPaymentMethodError {
             throw unselectPaymentMethodError
         }
     }
 
     func dispatch(actions: [ClientSession.Action]) async throws {
-        dispatchActionsCalls.append(actions)
+        synchronized { _dispatchActionsCalls.append(actions) }
         if let dispatchActionsError {
             throw dispatchActionsError
         }
+    }
+
+    private func synchronized<T>(_ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body()
     }
 }


### PR DESCRIPTION
# Description

ORC-8364

The PrimerSDKTests bundle has been going red on CI with no failing test in the log: the test process crashed or a test hung until the 2-minute allowance, xcodebuild restarted the bundle, and the remaining suites printed green followed by `** TEST FAILED **`. Two test-only causes, both reproduced locally.

- `MockClientSessionActionsModule` recorded calls into plain arrays. `HeadlessRepositoryImpl.selectCardNetwork` and `DefaultApplePayScope.performPayment` append to it from concurrent tasks, so when a test triggers several calls in a row the appends race, the heap gets corrupted and the runner traps in malloc. The mock now guards its recorded calls with a lock.
- Seven `DefaultApplePayScopeFactoryTests` waited for `isLoading` to go true and then false by polling with `Task.yield()`. When the payment fails fast, both flips happen before the first loop looks, so it spins forever, and since `Task.yield()` ignores cancellation the 2 s `withTimeout` cannot end the group. The tests now await `sut.paymentTask` directly; every reset of `isLoading` happens inside that task before it finishes.

No production code changes. Not a release.

# Other Notes

Two related items are left for their own tickets: the first-value race in `DefaultCheckoutScopeBehaviorTests` (`navigationStateStream`), and a production race in `Analytics.Service.sync` that can resend already-sent events under concurrent recording.

# Manual Testing

Locally on the iPhone 17 Pro simulator (iOS 26.2), `PrimerSDKTests` scheme:

- Before: running `DefaultApplePayScopeTests`, `DefaultApplePayScopeFactoryTests` and `SelectCardNetworkTests` together crashed on the first attempt (EXC_BREAKPOINT in the malloc freelist, crashing task inside `append` in the mock). A full-bundle run hung in `test_performPayment_whenRequestFactoryThrows_doesNotCallPresentationManager` until the allowance killed it.
- After: 5 runs of those classes and 3 runs of the full bundle, all green (3078 passed each time).

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge
