### PR TITLE
fix(components): repaint payment method tiles on a colour-scheme change (ORC-8363)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/CheckoutComponentsPaymentMethodsBridge.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Bridge/CheckoutComponentsPaymentMethodsBridge.swift
@@ -77,7 +77,9 @@ final class CheckoutComponentsPaymentMethodsBridge: GetPaymentMethodsInteractor,
         textColor: textColor,
         borderColor: borderColor,
         borderWidth: borderWidth,
-        cornerRadius: cornerRadius
+        cornerRadius: cornerRadius,
+        logoVariants: primerMethod.baseLogoImage,
+        borderWidthVariants: displayButton?.borderWidth
       )
     }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Data/Mappers/PaymentMethodMapper.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Data/Mappers/PaymentMethodMapper.swift
@@ -27,7 +27,7 @@ final class PaymentMethodMapperImpl: PaymentMethodMapper {
     let formattedSurcharge = formatSurcharge(
       internalMethod.surcharge, hasUnknownSurcharge: internalMethod.hasUnknownSurcharge)
 
-    return CheckoutPaymentMethod(
+    var method = CheckoutPaymentMethod(
       id: internalMethod.id,
       type: internalMethod.type,
       name: internalMethod.name,
@@ -42,6 +42,9 @@ final class PaymentMethodMapperImpl: PaymentMethodMapper {
       borderWidth: internalMethod.borderWidth,
       cornerRadius: internalMethod.cornerRadius
     )
+    method.logoVariants = internalMethod.logoVariants
+    method.borderWidthVariants = internalMethod.borderWidthVariants
+    return method
   }
 
   func mapToPublic(_ internalMethods: [InternalPaymentMethod]) -> [CheckoutPaymentMethod] {

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Data/Repositories/HeadlessRepositoryImpl.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Data/Repositories/HeadlessRepositoryImpl.swift
@@ -131,7 +131,9 @@ final class HeadlessRepositoryImpl: @preconcurrency HeadlessRepository, LogRepor
         textColor: displayButton?.textColor?.uiColor,
         borderColor: displayButton?.borderColor?.uiColor,
         borderWidth: displayButton?.borderWidth?.resolvedValue,
-        cornerRadius: displayButton?.cornerRadius.map(CGFloat.init)
+        cornerRadius: displayButton?.cornerRadius.map(CGFloat.init),
+        logoVariants: primerMethod.baseLogoImage,
+        borderWidthVariants: displayButton?.borderWidth
       )
     }
 

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Models/InternalPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Domain/Models/InternalPaymentMethod.swift
@@ -26,6 +26,8 @@ struct InternalPaymentMethod: Equatable {
   let borderColor: UIColor?
   let borderWidth: CGFloat?
   let cornerRadius: CGFloat?
+  let logoVariants: PrimerTheme.BaseImage?
+  let borderWidthVariants: PrimerTheme.BaseBorderWidth?
 
   init(
     id: String,
@@ -44,7 +46,9 @@ struct InternalPaymentMethod: Equatable {
     textColor: UIColor? = nil,
     borderColor: UIColor? = nil,
     borderWidth: CGFloat? = nil,
-    cornerRadius: CGFloat? = nil
+    cornerRadius: CGFloat? = nil,
+    logoVariants: PrimerTheme.BaseImage? = nil,
+    borderWidthVariants: PrimerTheme.BaseBorderWidth? = nil
   ) {
     self.id = id
     self.type = type
@@ -63,6 +67,8 @@ struct InternalPaymentMethod: Equatable {
     self.borderColor = borderColor
     self.borderWidth = borderWidth
     self.cornerRadius = cornerRadius
+    self.logoVariants = logoVariants
+    self.borderWidthVariants = borderWidthVariants
   }
 
   // Manual conformance: `UIImage`/`UIColor` fields block automatic synthesis. All
@@ -78,5 +84,7 @@ struct InternalPaymentMethod: Equatable {
       && lhs.buttonText == rhs.buttonText && lhs.textColor == rhs.textColor
       && lhs.borderColor == rhs.borderColor && lhs.borderWidth == rhs.borderWidth
       && lhs.cornerRadius == rhs.cornerRadius
+      && lhs.logoVariants === rhs.logoVariants
+      && lhs.borderWidthVariants === rhs.borderWidthVariants
   }
 }

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Presentation/Components/PaymentMethodButton.swift
@@ -14,6 +14,9 @@ struct PaymentMethodButton: View {
   let onSelect: () -> Void
 
   @Environment(\.designTokens) private var tokens
+  @Environment(\.colorScheme) private var colorScheme
+
+  private var isDark: Bool { colorScheme == .dark }
 
   var body: some View {
     let radius = method.cornerRadius ?? PrimerRadius.medium(tokens: tokens)
@@ -56,7 +59,9 @@ struct PaymentMethodButton: View {
     var green: CGFloat = 0
     var blue: CGFloat = 0
     var alpha: CGFloat = 0
-    bg.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+    // a dynamic colour resolves against UITraitCollection.current here, not this view's scheme
+    bg.resolvedColor(with: UITraitCollection(userInterfaceStyle: isDark ? .dark : .light))
+      .getRed(&red, green: &green, blue: &blue, alpha: &alpha)
     let luminance = 0.299 * red + 0.587 * green + 0.114 * blue
     return alpha > 0.1 && luminance < 0.95
   }
@@ -70,7 +75,7 @@ struct PaymentMethodButton: View {
   }
 
   private func borderWidth(for method: CheckoutPaymentMethod) -> CGFloat {
-    if let width = method.borderWidth, width > 0 {
+    if let width = method.borderWidthVariants?.resolvedValue(isDark: isDark) ?? method.borderWidth, width > 0 {
       return width
     }
     guard !hasVisibleBackground else { return 0 }
@@ -80,7 +85,8 @@ struct PaymentMethodButton: View {
   @ViewBuilder
   private var icon: some View {
     let image =
-      method.icon ?? PrimerPaymentMethodType(rawValue: method.type)?.defaultImageName.image
+      method.logoVariants?.image(isDark: isDark) ?? method.icon
+      ?? PrimerPaymentMethodType(rawValue: method.type)?.defaultImageName.image
     if let image {
       Image(uiImage: image)
         .resizable()

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodSelectionScope.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerPaymentMethodSelectionScope.swift
@@ -185,6 +185,10 @@ public struct CheckoutPaymentMethod: Equatable, Identifiable {
   /// Custom corner radius for the payment method button.
   public let cornerRadius: CGFloat?
 
+  // Not public: the prebuilt tile picks the scheme variant at render time, while `icon` and `borderWidth` stay the public snapshot.
+  var logoVariants: PrimerTheme.BaseImage?
+  var borderWidthVariants: PrimerTheme.BaseBorderWidth?
+
   public init(
     id: String,
     type: String,

--- a/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethod.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/PrimerPaymentMethod.swift
@@ -38,13 +38,7 @@ final class PrimerPaymentMethod: Codable, LogReporter {
     }()
 
     var logo: UIImage? {
-        guard let baseLogoImage else { return nil }
-        let isDarkModeEnabled = UIScreen.isDarkModeEnabled
-        return (
-            (isDarkModeEnabled ? baseLogoImage.dark : baseLogoImage.colored) ??
-                (isDarkModeEnabled ? baseLogoImage.colored : baseLogoImage.light) ??
-                (isDarkModeEnabled ? baseLogoImage.light : baseLogoImage.dark)
-        )
+        baseLogoImage?.image(isDark: UIScreen.isDarkModeEnabled)
     }
 
     var invertedLogo: UIImage? {

--- a/Sources/PrimerSDK/Classes/Data Models/Theme/PrimerTheme+Images.swift
+++ b/Sources/PrimerSDK/Classes/Data Models/Theme/PrimerTheme+Images.swift
@@ -24,6 +24,10 @@ extension PrimerTheme {
                 return nil
             }
         }
+
+        func image(isDark: Bool) -> UIImage? {
+            schemeVariant(isDark: isDark, colored: colored, light: light, dark: dark)
+        }
     }
 
     public final class BaseColoredURLs: Codable {
@@ -75,11 +79,13 @@ extension PrimerTheme {
         var darkHex: String?
         var lightHex: String?
 
-        /// Convert to UIColor based on current appearance mode
+        /// Resolves per trait collection, so a colour-scheme change repaints it wherever it is drawn.
         var uiColor: UIColor? {
-            let isDarkMode = UIScreen.isDarkModeEnabled
-            let hexString = isDarkMode ? (darkHex ?? coloredHex ?? lightHex) : (coloredHex ?? lightHex ?? darkHex)
-            return hexString?.hexToUIColor()
+            // a malformed hex keeps the old one-shot resolution rather than leaking the other scheme's colour
+            guard let light = hex(isDark: false)?.hexToUIColor(), let dark = hex(isDark: true)?.hexToUIColor() else {
+                return hex(isDark: UIScreen.isDarkModeEnabled)?.hexToUIColor()
+            }
+            return UIColor { $0.userInterfaceStyle == .dark ? dark : light }
         }
 
         // swiftlint:disable:next nesting
@@ -117,6 +123,10 @@ extension PrimerTheme {
             try? container.encode(darkHex, forKey: .darkHex)
             try? container.encode(lightHex, forKey: .lightHex)
         }
+
+        func hex(isDark: Bool) -> String? {
+            schemeVariant(isDark: isDark, colored: coloredHex, light: lightHex, dark: darkHex)
+        }
     }
 
     public final class BaseBorderWidth: Codable {
@@ -134,8 +144,7 @@ extension PrimerTheme {
 
         /// Resolve to a CGFloat based on current appearance mode
         var resolvedValue: CGFloat? {
-            let isDarkMode = UIScreen.isDarkModeEnabled
-            return isDarkMode ? (dark ?? colored ?? light) : (colored ?? light ?? dark)
+            resolvedValue(isDark: UIScreen.isDarkModeEnabled)
         }
 
         init?(
@@ -161,10 +170,18 @@ extension PrimerTheme {
             try? container.encode(light, forKey: .light)
             try? container.encode(dark, forKey: .dark)
         }
+
+        func resolvedValue(isDark: Bool) -> CGFloat? {
+            schemeVariant(isDark: isDark, colored: colored, light: light, dark: dark)
+        }
     }
 }
 
 // MARK: - Helper Extensions
+
+private func schemeVariant<T>(isDark: Bool, colored: T?, light: T?, dark: T?) -> T? {
+    isDark ? (dark ?? colored ?? light) : (colored ?? light ?? dark)
+}
 
 extension String {
     /// Convert hex string to UIColor

--- a/Tests/Primer/CheckoutComponents/Bridge/CheckoutComponentsPaymentMethodsBridgeTests.swift
+++ b/Tests/Primer/CheckoutComponents/Bridge/CheckoutComponentsPaymentMethodsBridgeTests.swift
@@ -5,6 +5,7 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 @testable import PrimerSDK
+import UIKit
 import XCTest
 @_spi(PrimerInternal) @testable import PrimerFoundation
 @_spi(PrimerInternal) @testable import PrimerCore
@@ -15,10 +16,14 @@ final class CheckoutComponentsPaymentMethodsBridgeTests: XCTestCase {
     private var mockConfigurationService: MockConfigurationService!
     private var sut: CheckoutComponentsPaymentMethodsBridge!
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         mockConfigurationService = MockConfigurationService()
         sut = CheckoutComponentsPaymentMethodsBridge(configurationService: mockConfigurationService)
+        // the bridge drops unregistered types, so the class must not depend on which tests ran before it
+        await CardPaymentMethod.register()
+        await PayPalPaymentMethod.register()
+        await ApplePayPaymentMethod.register()
     }
 
     override func tearDown() {
@@ -117,6 +122,26 @@ final class CheckoutComponentsPaymentMethodsBridgeTests: XCTestCase {
         XCTAssertEqual(paypal.id, "PAYPAL")
         XCTAssertEqual(paypal.type, "PAYPAL")
         XCTAssertEqual(paypal.name, "PayPal")
+    }
+
+    func test_execute_carriesLogoAndBorderWidthVariants() async throws {
+        // Given
+        let logo = PrimerTheme.BaseImage(colored: UIImage(), light: nil, dark: UIImage())
+        let width = PrimerTheme.BaseBorderWidth(colored: 1, light: 1, dark: 2)
+        let method = createPaymentMethod(type: "PAYMENT_CARD", name: "Card")
+        method.baseLogoImage = logo
+        method.displayMetadata = PrimerPaymentMethod.DisplayMetadata(
+            button: .init(
+                iconUrl: nil, backgroundColor: nil, cornerRadius: nil,
+                borderWidth: width, borderColor: nil, text: nil, textColor: nil))
+        mockConfigurationService.apiConfiguration = createConfiguration(paymentMethods: [method])
+
+        // When
+        let result = try await sut.execute()
+
+        // Then
+        XCTAssertTrue(result.first?.logoVariants === logo)
+        XCTAssertTrue(result.first?.borderWidthVariants === width)
     }
 
     // MARK: - Required Input Elements

--- a/Tests/Primer/CheckoutComponents/Data/HeadlessRepository/HeadlessRepositoryGetPaymentMethodsTests.swift
+++ b/Tests/Primer/CheckoutComponents/Data/HeadlessRepository/HeadlessRepositoryGetPaymentMethodsTests.swift
@@ -5,6 +5,7 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 @testable import PrimerSDK
+import UIKit
 import XCTest
 @_spi(PrimerInternal) @testable import PrimerFoundation
 @_spi(PrimerInternal) @testable import PrimerCore
@@ -73,6 +74,41 @@ final class GetPaymentMethodsTests: XCTestCase {
         XCTAssertEqual(methods.first?.name, "Card")
         XCTAssertEqual(methods.first?.configId, "config-123")
         XCTAssertEqual(methods.first?.surcharge, 100)
+    }
+
+    func testGetPaymentMethods_CarriesLogoAndBorderWidthVariants() async throws {
+        let logo = PrimerTheme.BaseImage(colored: UIImage(), light: nil, dark: UIImage())
+        let width = PrimerTheme.BaseBorderWidth(colored: 1, light: 1, dark: 2)
+        let paymentMethod = PrimerPaymentMethod(
+            id: "payment-card-id",
+            implementationType: .nativeSdk,
+            type: "PAYMENT_CARD",
+            name: "Card",
+            processorConfigId: "config-123",
+            surcharge: nil,
+            options: nil,
+            displayMetadata: PrimerPaymentMethod.DisplayMetadata(
+                button: .init(
+                    iconUrl: nil, backgroundColor: nil, cornerRadius: nil,
+                    borderWidth: width, borderColor: nil, text: nil, textColor: nil))
+        )
+        paymentMethod.baseLogoImage = logo
+        mockConfigurationService.apiConfiguration = PrimerAPIConfiguration(
+            coreUrl: "https://api.primer.io",
+            pciUrl: "https://pci.primer.io",
+            binDataUrl: "https://bin.primer.io",
+            assetsUrl: "https://assets.primer.io",
+            clientSession: nil,
+            paymentMethods: [paymentMethod],
+            primerAccountId: "account-123",
+            keys: nil,
+            checkoutModules: nil
+        )
+
+        let methods = try await repository.getPaymentMethods()
+
+        XCTAssertTrue(methods.first?.logoVariants === logo)
+        XCTAssertTrue(methods.first?.borderWidthVariants === width)
     }
 
     func testGetPaymentMethods_WithMultiplePaymentMethods_ReturnsAll() async throws {

--- a/Tests/Primer/CheckoutComponents/Domain/InternalPaymentMethodTests.swift
+++ b/Tests/Primer/CheckoutComponents/Domain/InternalPaymentMethodTests.swift
@@ -37,6 +37,8 @@ final class InternalPaymentMethodTests: XCTestCase {
         XCTAssertNil(method.borderColor)
         XCTAssertNil(method.borderWidth)
         XCTAssertNil(method.cornerRadius)
+        XCTAssertNil(method.logoVariants)
+        XCTAssertNil(method.borderWidthVariants)
     }
 
     func test_init_withAllParams_setsAllProperties() {
@@ -135,6 +137,39 @@ final class InternalPaymentMethodTests: XCTestCase {
         let method2 = InternalPaymentMethod(id: "pm-1", type: "CARD", name: "Card", networkSurcharges: ["VISA": 50])
 
         XCTAssertNotEqual(method1, method2)
+    }
+
+    func test_equality_differentLogoVariants_areNotEqual() {
+        let method1 = InternalPaymentMethod(
+            id: "pm-1", type: "CARD", name: "Card",
+            logoVariants: PrimerTheme.BaseImage(colored: UIImage(), light: nil, dark: nil))
+        let method2 = InternalPaymentMethod(
+            id: "pm-1", type: "CARD", name: "Card",
+            logoVariants: PrimerTheme.BaseImage(colored: UIImage(), light: nil, dark: nil))
+
+        XCTAssertNotEqual(method1, method2)
+    }
+
+    func test_equality_differentBorderWidthVariants_areNotEqual() {
+        let method1 = InternalPaymentMethod(
+            id: "pm-1", type: "CARD", name: "Card",
+            borderWidthVariants: PrimerTheme.BaseBorderWidth(colored: 1, light: 1, dark: 2))
+        let method2 = InternalPaymentMethod(
+            id: "pm-1", type: "CARD", name: "Card",
+            borderWidthVariants: PrimerTheme.BaseBorderWidth(colored: 1, light: 1, dark: 2))
+
+        XCTAssertNotEqual(method1, method2)
+    }
+
+    func test_equality_sameVariantObjects_areEqual() {
+        let logo = PrimerTheme.BaseImage(colored: UIImage(), light: nil, dark: nil)
+        let width = PrimerTheme.BaseBorderWidth(colored: 1, light: 1, dark: 2)
+        let method1 = InternalPaymentMethod(
+            id: "pm-1", type: "CARD", name: "Card", logoVariants: logo, borderWidthVariants: width)
+        let method2 = InternalPaymentMethod(
+            id: "pm-1", type: "CARD", name: "Card", logoVariants: logo, borderWidthVariants: width)
+
+        XCTAssertEqual(method1, method2)
     }
 
     func test_equality_differentStyling_areNotEqual() {

--- a/Tests/Primer/CheckoutComponents/Mappers/PaymentMethodMapperTests.swift
+++ b/Tests/Primer/CheckoutComponents/Mappers/PaymentMethodMapperTests.swift
@@ -5,6 +5,7 @@
 //  Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 @testable import PrimerSDK
+import UIKit
 import XCTest
 @_spi(PrimerInternal) @testable import PrimerFoundation
 @_spi(PrimerInternal) @testable import PrimerCore
@@ -35,6 +36,25 @@ final class PaymentMethodMapperTests: XCTestCase {
             surcharge: surcharge,
             hasUnknownSurcharge: hasUnknownSurcharge
         )
+    }
+
+    // MARK: - Scheme Variants
+
+    func test_mapToPublic_carriesLogoAndBorderWidthVariants() {
+        // Given
+        let mapper = createMapper()
+        let logo = PrimerTheme.BaseImage(colored: UIImage(), light: nil, dark: nil)
+        let width = PrimerTheme.BaseBorderWidth(colored: 1, light: 1, dark: 2)
+        let internalMethod = InternalPaymentMethod(
+            id: "pm-1", type: "PAYMENT_CARD", name: "Card",
+            logoVariants: logo, borderWidthVariants: width)
+
+        // When
+        let result = mapper.mapToPublic(internalMethod)
+
+        // Then
+        XCTAssertTrue(result.logoVariants === logo)
+        XCTAssertTrue(result.borderWidthVariants === width)
     }
 
     // MARK: - Surcharge Formatting Tests

--- a/Tests/Primer/Data Models/PrimerThemeImagesTests.swift
+++ b/Tests/Primer/Data Models/PrimerThemeImagesTests.swift
@@ -1,0 +1,123 @@
+//
+//  PrimerThemeImagesTests.swift
+//
+//  Copyright © 2026 Primer API Ltd. All rights reserved. 
+//  Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+@testable import PrimerSDK
+import UIKit
+import XCTest
+
+final class PrimerThemeImagesTests: XCTestCase {
+
+    private let light = UITraitCollection(userInterfaceStyle: .light)
+    private let dark = UITraitCollection(userInterfaceStyle: .dark)
+
+    override func tearDown() {
+        Primer.shared.configure(settings: PrimerSettings())
+        super.tearDown()
+    }
+
+    // MARK: - BaseColors
+
+    func test_uiColor_resolvedInEachTraitCollection_returnsThatSchemesColour() {
+        // Given
+        let colors = PrimerTheme.BaseColors(coloredHex: "#FFFFFF", lightHex: nil, darkHex: "#000000")!
+
+        // When
+        let color = colors.uiColor!
+
+        // Then
+        XCTAssertEqual(color.resolvedColor(with: light).whiteComponent, 1, accuracy: 0.001)
+        XCTAssertEqual(color.resolvedColor(with: dark).whiteComponent, 0, accuracy: 0.001)
+    }
+
+    func test_uiColor_withOnlyAColoredHex_isTheSameInBothSchemes() {
+        // Given
+        let colors = PrimerTheme.BaseColors(coloredHex: "#FF0000", lightHex: nil, darkHex: nil)!
+
+        // When
+        let color = colors.uiColor!
+
+        // Then
+        XCTAssertEqual(color.resolvedColor(with: light), UIColor(red: 1, green: 0, blue: 0, alpha: 1))
+        XCTAssertEqual(color.resolvedColor(with: dark), UIColor(red: 1, green: 0, blue: 0, alpha: 1))
+    }
+
+    func test_uiColor_withoutAnyHex_isNil() {
+        // Given
+        let colors = PrimerTheme.BaseColors(coloredHex: nil, lightHex: nil, darkHex: nil)!
+
+        // When / Then
+        XCTAssertNil(colors.uiColor)
+    }
+
+    func test_uiColor_withAMalformedHex_keepsTheOneShotResolutionForTheForcedAppearance() throws {
+        // Given
+        let colors = PrimerTheme.BaseColors(coloredHex: "#FFFFFF", lightHex: nil, darkHex: "#FFF")!
+
+        // When / Then
+        Primer.shared.configure(settings: PrimerSettings(uiOptions: PrimerUIOptions(appearanceMode: .dark)))
+        XCTAssertNil(colors.uiColor)
+
+        Primer.shared.configure(settings: PrimerSettings(uiOptions: PrimerUIOptions(appearanceMode: .light)))
+        let color = try XCTUnwrap(colors.uiColor)
+        XCTAssertEqual(color.resolvedColor(with: dark).whiteComponent, 1, accuracy: 0.001)
+    }
+
+    func test_hex_isDark_prefersDarkThenColoredThenLight() {
+        XCTAssertEqual(PrimerTheme.BaseColors(coloredHex: "#111111", lightHex: "#222222", darkHex: "#333333")!.hex(isDark: true), "#333333")
+        XCTAssertEqual(PrimerTheme.BaseColors(coloredHex: "#111111", lightHex: "#222222", darkHex: nil)!.hex(isDark: true), "#111111")
+        XCTAssertEqual(PrimerTheme.BaseColors(coloredHex: nil, lightHex: "#222222", darkHex: nil)!.hex(isDark: true), "#222222")
+    }
+
+    func test_hex_isLight_prefersColoredThenLightThenDark() {
+        XCTAssertEqual(PrimerTheme.BaseColors(coloredHex: "#111111", lightHex: "#222222", darkHex: "#333333")!.hex(isDark: false), "#111111")
+        XCTAssertEqual(PrimerTheme.BaseColors(coloredHex: nil, lightHex: "#222222", darkHex: "#333333")!.hex(isDark: false), "#222222")
+        XCTAssertEqual(PrimerTheme.BaseColors(coloredHex: nil, lightHex: nil, darkHex: "#333333")!.hex(isDark: false), "#333333")
+    }
+
+    // MARK: - BaseBorderWidth
+
+    func test_resolvedValue_isDark_prefersDarkThenColoredThenLight() {
+        XCTAssertEqual(PrimerTheme.BaseBorderWidth(colored: 1, light: 2, dark: 3)!.resolvedValue(isDark: true), 3)
+        XCTAssertEqual(PrimerTheme.BaseBorderWidth(colored: 1, light: 2, dark: nil)!.resolvedValue(isDark: true), 1)
+        XCTAssertEqual(PrimerTheme.BaseBorderWidth(colored: nil, light: 2, dark: nil)!.resolvedValue(isDark: true), 2)
+    }
+
+    func test_resolvedValue_isLight_prefersColoredThenLightThenDark() {
+        XCTAssertEqual(PrimerTheme.BaseBorderWidth(colored: 1, light: 2, dark: 3)!.resolvedValue(isDark: false), 1)
+        XCTAssertEqual(PrimerTheme.BaseBorderWidth(colored: nil, light: 2, dark: 3)!.resolvedValue(isDark: false), 2)
+        XCTAssertEqual(PrimerTheme.BaseBorderWidth(colored: nil, light: nil, dark: 3)!.resolvedValue(isDark: false), 3)
+    }
+
+    // MARK: - BaseImage
+
+    func test_image_isDark_prefersDarkThenColoredThenLight() {
+        let colored = UIImage(systemName: "paintbrush")!
+        let lightImage = UIImage(systemName: "sun.max")!
+        let darkImage = UIImage(systemName: "sun.min")!
+
+        XCTAssertEqual(PrimerTheme.BaseImage(colored: colored, light: lightImage, dark: darkImage)!.image(isDark: true), darkImage)
+        XCTAssertEqual(PrimerTheme.BaseImage(colored: colored, light: lightImage, dark: nil)!.image(isDark: true), colored)
+        XCTAssertEqual(PrimerTheme.BaseImage(colored: nil, light: lightImage, dark: nil)!.image(isDark: true), lightImage)
+    }
+
+    func test_image_isLight_prefersColoredThenLightThenDark() {
+        let colored = UIImage(systemName: "paintbrush")!
+        let lightImage = UIImage(systemName: "sun.max")!
+        let darkImage = UIImage(systemName: "sun.min")!
+
+        XCTAssertEqual(PrimerTheme.BaseImage(colored: colored, light: lightImage, dark: darkImage)!.image(isDark: false), colored)
+        XCTAssertEqual(PrimerTheme.BaseImage(colored: nil, light: lightImage, dark: darkImage)!.image(isDark: false), lightImage)
+        XCTAssertEqual(PrimerTheme.BaseImage(colored: nil, light: nil, dark: darkImage)!.image(isDark: false), darkImage)
+    }
+}
+
+private extension UIColor {
+    var whiteComponent: CGFloat {
+        var white: CGFloat = 0
+        getWhite(&white, alpha: nil)
+        return white
+    }
+}


### PR DESCRIPTION
# Description

ORC-8363

Open the checkout in dark mode and switch the phone to light while the sheet is open. The payment method tiles kept their dark background, border, border width and logo while the labels switched. Same the other way round.

The tile colours came out of `BaseColors.uiColor` as a fixed colour for whichever scheme was active when the list loaded, and the list is built once. `uiColor` now returns a dynamic colour that resolves against the trait collection it is drawn in, so `Color(uiColor)` repaints on a scheme change with no call-site change. Border width and logo cannot be dynamic values, so the metadata variant objects now travel with the payment method (internal fields; the public `icon` and `borderWidth` snapshot stay as they were) and `PaymentMethodButton` picks the variant from the environment colour scheme, the same source the design tokens use.

A merchant who forces light or dark through `appearanceMode` is unaffected. The sheet already pins its traits (`overrideUserInterfaceStyle` on the bridge controller, `preferredColorScheme` in `PrimerCheckout`), so trait-based resolution lands on the forced scheme.

No breaking changes. The public surface of `CheckoutPaymentMethod` is unchanged.

# Other Notes

- Drop-in is untouched. `PrimerPaymentMethod.logo` now goes through `BaseImage.image(isDark:)` with the same fallback order; `invertedLogo` and `UIScreen.isDarkModeEnabled` are as before.
- `hasVisibleBackground` resolves the colour for the current scheme before reading its components. `getRed` on a dynamic colour would otherwise use `UITraitCollection.current`.
- A malformed hex in the metadata keeps the old one-shot resolution for that colour instead of leaking the other scheme's value. Valid metadata is what gets the dynamic colour.
- Merchants rendering their own tile through the `PrimerPaymentMethods` `method` slot get the dynamic colours for free, but `icon` is still the load-time snapshot. A scheme-aware image accessor would be a public API addition, left for a follow-up.
- Origin: listed in the ORC-8178 findings on 2026-08-20. #1884 fixed the bridged input fields only, which had a different cause.
- `CheckoutComponentsPaymentMethodsBridgeTests` now registers the three payment method types it uses in `setUp`. Before, the class only passed when earlier test classes had filled the registry, and crashed with an index-out-of-range when run on its own.

# Manual Testing

Debug App, SPM target, Checkout Components, default checkout demo. Reproduced on the pre-fix build first, then verified on the fix; all four scenarios pass.

1. Simulator in dark, open the sheet, let the list render.
2. Cmd+Shift+A to light without leaving the sheet. Tiles repaint background, border and logo.
3. Repeat starting from light.
4. `appearanceMode` forced to `.light`, then `.dark`: tiles ignore the device switch.

Unit tests: `PrimerThemeImagesTests` (new), `InternalPaymentMethodTests`, `CheckoutComponentsPaymentMethodsBridgeTests`, `HeadlessRepositoryGetPaymentMethodsTests`, `PaymentMethodMapperTests`; `PrimerPaymentMethodTests` still covers `logo`.

# Contributor Checklist

- [ ]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [x]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge

# Other Stuff

- You can find out more about our automation checks [here](https://primerio.notion.site/iOS-Automation-Checks-198a1eb0e8994d999fb696d5902d97bb)
- Find out more about conventional commits [here](https://primerio.notion.site/Conventional-Commits-6ecfd6a0269a4db2af76d9f0537936b3)
