### PR TITLE
refactor(components): make the raw palette colours internal (ORC-8396)

### DIFF
--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Internal/Tokens/DesignTokensManager.swift
@@ -37,7 +37,7 @@ final class DesignTokensManager: ObservableObject {
     tokens = loadedTokens
   }
 
-  /// Injected before references resolve, so tokens aliasing a palette entry or the brand font follow the override.
+  /// Injected before references resolve, so tokens aliasing the brand colour or the brand font follow the override.
   private func tokenValueOverrides(colors: ColorOverrides?) -> [String: Any] {
     var overrides: [String: Any] = [:]
     if let brandFont = themeOverrides?.typography?.brand {
@@ -49,27 +49,11 @@ final class DesignTokensManager: ObservableObject {
         overrides["primerTypographyBrand"] = brandFont
       }
     }
-    guard let colors else { return overrides }
-    let pairs: [(String, Color?)] = [
-      ("primerColorBrand", colors.primerColorBrand),
-      ("primerColorGray000", colors.primerColorGray000),
-      ("primerColorGray100", colors.primerColorGray100),
-      ("primerColorGray200", colors.primerColorGray200),
-      ("primerColorGray300", colors.primerColorGray300),
-      ("primerColorGray400", colors.primerColorGray400),
-      ("primerColorGray500", colors.primerColorGray500),
-      ("primerColorGray600", colors.primerColorGray600),
-      ("primerColorGray900", colors.primerColorGray900),
-      ("primerColorGreen500", colors.primerColorGreen500),
-      ("primerColorRed100", colors.primerColorRed100),
-      ("primerColorRed500", colors.primerColorRed500),
-      ("primerColorRed900", colors.primerColorRed900),
-      ("primerColorBlue500", colors.primerColorBlue500),
-      ("primerColorBlue900", colors.primerColorBlue900),
-    ]
-    return pairs.reduce(into: overrides) { result, pair in
-      if let color = pair.1, let components = Self.colorComponents(color) { result[pair.0] = components }
+    guard let brand = colors?.primerColorBrand, let components = Self.colorComponents(brand) else {
+      return overrides
     }
+    overrides["primerColorBrand"] = components
+    return overrides
   }
 
   /// Previews and tests call this with no overrides so they resolve what production resolves.
@@ -158,32 +142,14 @@ final class DesignTokensManager: ObservableObject {
   }
 
   private func applyColorOverrides(to tokens: DesignTokens, from colors: ColorOverrides) {
-    applyBrandAndGrayColorOverrides(to: tokens, from: colors)
+    if let value = colors.primerColorBrand { tokens.primerColorBrand = value }
     applySemanticColorOverrides(to: tokens, from: colors)
     applyTextColorOverrides(to: tokens, from: colors)
     applyBorderColorOverrides(to: tokens, from: colors)
     applyIconAndOtherColorOverrides(to: tokens, from: colors)
   }
 
-  private func applyBrandAndGrayColorOverrides(to tokens: DesignTokens, from colors: ColorOverrides) {
-    if let value = colors.primerColorBrand { tokens.primerColorBrand = value }
-    if let value = colors.primerColorGray000 { tokens.primerColorGray000 = value }
-    if let value = colors.primerColorGray100 { tokens.primerColorGray100 = value }
-    if let value = colors.primerColorGray200 { tokens.primerColorGray200 = value }
-    if let value = colors.primerColorGray300 { tokens.primerColorGray300 = value }
-    if let value = colors.primerColorGray400 { tokens.primerColorGray400 = value }
-    if let value = colors.primerColorGray500 { tokens.primerColorGray500 = value }
-    if let value = colors.primerColorGray600 { tokens.primerColorGray600 = value }
-    if let value = colors.primerColorGray900 { tokens.primerColorGray900 = value }
-  }
-
   private func applySemanticColorOverrides(to tokens: DesignTokens, from colors: ColorOverrides) {
-    if let value = colors.primerColorGreen500 { tokens.primerColorGreen500 = value }
-    if let value = colors.primerColorRed100 { tokens.primerColorRed100 = value }
-    if let value = colors.primerColorRed500 { tokens.primerColorRed500 = value }
-    if let value = colors.primerColorRed900 { tokens.primerColorRed900 = value }
-    if let value = colors.primerColorBlue500 { tokens.primerColorBlue500 = value }
-    if let value = colors.primerColorBlue900 { tokens.primerColorBlue900 = value }
     if let value = colors.primerColorBackgroundPrimary {
       tokens.primerColorBackgroundPrimary = value
       // the input fill aliases the sheet, so it follows unless the merchant names it too

--- a/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
+++ b/Sources/PrimerSDK/Classes/CheckoutComponents/Scope/PrimerCheckoutTheme.swift
@@ -70,29 +70,6 @@ public struct ColorOverrides: Equatable {
 
   public let primerColorBrand: Color?
 
-  // MARK: Grays (matching internal DesignTokens)
-
-  public let primerColorGray000: Color?
-  public let primerColorGray100: Color?
-  public let primerColorGray200: Color?
-  public let primerColorGray300: Color?
-  public let primerColorGray400: Color?
-  public let primerColorGray500: Color?
-  public let primerColorGray600: Color?
-  public let primerColorGray900: Color?
-
-  // MARK: Semantic Colors (matching internal DesignTokens)
-
-  /// Success color (internal: primerColorGreen500)
-  public let primerColorGreen500: Color?
-  /// Error colors (internal: primerColorRed100, primerColorRed500, primerColorRed900)
-  public let primerColorRed100: Color?
-  public let primerColorRed500: Color?
-  public let primerColorRed900: Color?
-  /// Info/link colors (internal: primerColorBlue500, primerColorBlue900)
-  public let primerColorBlue500: Color?
-  public let primerColorBlue900: Color?
-
   // MARK: Semantic UI Colors (matching internal DesignTokens)
 
   public let primerColorBackgroundPrimary: Color?
@@ -148,20 +125,6 @@ public struct ColorOverrides: Equatable {
 
   public init(
     primerColorBrand: Color? = nil,
-    primerColorGray000: Color? = nil,
-    primerColorGray100: Color? = nil,
-    primerColorGray200: Color? = nil,
-    primerColorGray300: Color? = nil,
-    primerColorGray400: Color? = nil,
-    primerColorGray500: Color? = nil,
-    primerColorGray600: Color? = nil,
-    primerColorGray900: Color? = nil,
-    primerColorGreen500: Color? = nil,
-    primerColorRed100: Color? = nil,
-    primerColorRed500: Color? = nil,
-    primerColorRed900: Color? = nil,
-    primerColorBlue500: Color? = nil,
-    primerColorBlue900: Color? = nil,
     primerColorBackgroundPrimary: Color? = nil,
     primerColorBackgroundSecondary: Color? = nil,
     primerColorBackgroundOutlinedDefault: Color? = nil,
@@ -202,20 +165,6 @@ public struct ColorOverrides: Equatable {
     primerColorLoader: Color? = nil
   ) {
     self.primerColorBrand = primerColorBrand
-    self.primerColorGray000 = primerColorGray000
-    self.primerColorGray100 = primerColorGray100
-    self.primerColorGray200 = primerColorGray200
-    self.primerColorGray300 = primerColorGray300
-    self.primerColorGray400 = primerColorGray400
-    self.primerColorGray500 = primerColorGray500
-    self.primerColorGray600 = primerColorGray600
-    self.primerColorGray900 = primerColorGray900
-    self.primerColorGreen500 = primerColorGreen500
-    self.primerColorRed100 = primerColorRed100
-    self.primerColorRed500 = primerColorRed500
-    self.primerColorRed900 = primerColorRed900
-    self.primerColorBlue500 = primerColorBlue500
-    self.primerColorBlue900 = primerColorBlue900
     self.primerColorBackgroundPrimary = primerColorBackgroundPrimary
     self.primerColorBackgroundSecondary = primerColorBackgroundSecondary
     self.primerColorBackgroundOutlinedDefault = primerColorBackgroundOutlinedDefault
@@ -506,20 +455,6 @@ extension ColorOverrides {
     guard let base else { return self }
     return ColorOverrides(
       primerColorBrand: primerColorBrand ?? base.primerColorBrand,
-      primerColorGray000: primerColorGray000 ?? base.primerColorGray000,
-      primerColorGray100: primerColorGray100 ?? base.primerColorGray100,
-      primerColorGray200: primerColorGray200 ?? base.primerColorGray200,
-      primerColorGray300: primerColorGray300 ?? base.primerColorGray300,
-      primerColorGray400: primerColorGray400 ?? base.primerColorGray400,
-      primerColorGray500: primerColorGray500 ?? base.primerColorGray500,
-      primerColorGray600: primerColorGray600 ?? base.primerColorGray600,
-      primerColorGray900: primerColorGray900 ?? base.primerColorGray900,
-      primerColorGreen500: primerColorGreen500 ?? base.primerColorGreen500,
-      primerColorRed100: primerColorRed100 ?? base.primerColorRed100,
-      primerColorRed500: primerColorRed500 ?? base.primerColorRed500,
-      primerColorRed900: primerColorRed900 ?? base.primerColorRed900,
-      primerColorBlue500: primerColorBlue500 ?? base.primerColorBlue500,
-      primerColorBlue900: primerColorBlue900 ?? base.primerColorBlue900,
       primerColorBackgroundPrimary: primerColorBackgroundPrimary ?? base.primerColorBackgroundPrimary,
       primerColorBackgroundSecondary: primerColorBackgroundSecondary ?? base.primerColorBackgroundSecondary,
       primerColorBackgroundOutlinedDefault: primerColorBackgroundOutlinedDefault ?? base.primerColorBackgroundOutlinedDefault,

--- a/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
+++ b/Tests/Primer/CheckoutComponents/Tokens/DesignTokensManagerTests.swift
@@ -121,51 +121,10 @@ final class DesignTokensManagerTests: XCTestCase {
         XCTAssertEqual(tokens.primerColorBrand, customBrand)
     }
 
-    func test_applyTheme_grayColorOverrides_appliedToTokens() async throws {
-        // Given
-        let customGray = Color.gray
-        let theme = PrimerCheckoutTheme(
-            colors: ColorOverrides(
-                primerColorGray000: customGray,
-                primerColorGray100: customGray,
-                primerColorGray200: customGray,
-                primerColorGray300: customGray,
-                primerColorGray400: customGray,
-                primerColorGray500: customGray,
-                primerColorGray600: customGray,
-                primerColorGray900: customGray
-            )
-        )
-        sut.applyTheme(theme)
-
-        // When
-        try await sut.fetchTokens(for: .light)
-
-        // Then
-        let tokens = try XCTUnwrap(sut.tokens)
-        XCTAssertEqual(tokens.primerColorGray000, customGray)
-        XCTAssertEqual(tokens.primerColorGray100, customGray)
-        XCTAssertEqual(tokens.primerColorGray200, customGray)
-        XCTAssertEqual(tokens.primerColorGray300, customGray)
-        XCTAssertEqual(tokens.primerColorGray400, customGray)
-        XCTAssertEqual(tokens.primerColorGray500, customGray)
-        XCTAssertEqual(tokens.primerColorGray600, customGray)
-        XCTAssertEqual(tokens.primerColorGray900, customGray)
-    }
-
     func test_applyTheme_semanticColorOverrides_appliedToTokens() async throws {
         // Given
-        let customGreen = Color.green
-        let customRed = Color.red
-        let customBlue = Color.blue
         let theme = PrimerCheckoutTheme(
             colors: ColorOverrides(
-                primerColorGreen500: customGreen,
-                primerColorRed100: customRed,
-                primerColorRed500: customRed,
-                primerColorRed900: customRed,
-                primerColorBlue500: customBlue,
-                primerColorBlue900: customBlue,
                 primerColorBackgroundPrimary: .white
             )
         )
@@ -176,12 +135,6 @@ final class DesignTokensManagerTests: XCTestCase {
 
         // Then
         let tokens = try XCTUnwrap(sut.tokens)
-        XCTAssertEqual(tokens.primerColorGreen500, customGreen)
-        XCTAssertEqual(tokens.primerColorRed100, customRed)
-        XCTAssertEqual(tokens.primerColorRed500, customRed)
-        XCTAssertEqual(tokens.primerColorRed900, customRed)
-        XCTAssertEqual(tokens.primerColorBlue500, customBlue)
-        XCTAssertEqual(tokens.primerColorBlue900, customBlue)
         XCTAssertEqual(tokens.primerColorBackgroundPrimary, .white)
     }
 
@@ -885,35 +838,35 @@ final class DesignTokensManagerTests: XCTestCase {
         }
     }
 
-    // MARK: - Palette Override Cascade
+    // MARK: - Brand Override Cascade
 
-    func test_fetchTokens_paletteOverride_cascadesIntoTokensThatAliasIt() async throws {
-        // Given border.outlined.default aliases gray.300 in the token JSON
+    func test_fetchTokens_brandOverride_cascadesIntoTokensThatAliasIt() async throws {
+        // Given border.outlined.selected aliases color.brand in the token JSON
         let baseline = try await tokens(for: .light)
-        let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedDefault)
+        let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedSelected)
 
         // Components chosen to survive the getRed round-trip exactly.
         let override = Color(red: 0.25, green: 0.5, blue: 0.75)
-        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: override)))
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorBrand: override)))
 
         // When
         try await sut.fetchTokens(for: .light)
 
         // Then the border holds the overridden value, not merely a different one.
         let themed = try XCTUnwrap(sut.tokens)
-        XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
+        XCTAssertNotEqual(themed.primerColorBorderOutlinedSelected, unthemedBorder)
         XCTAssertEqual(
-            themed.primerColorBorderOutlinedDefault,
+            themed.primerColorBorderOutlinedSelected,
             Color(red: 0.25, green: 0.5, blue: 0.75, opacity: 1))
     }
 
-    func test_fetchTokens_semanticOverride_winsOverPaletteOverride() async throws {
-        // Given both the palette entry and the token that aliases it are overridden
+    func test_fetchTokens_aliasOverride_winsOverBrandOverride() async throws {
+        // Given both the brand colour and the token that aliases it are overridden
         sut.applyTheme(
             PrimerCheckoutTheme(
                 colors: ColorOverrides(
-                    primerColorGray300: .pink,
-                    primerColorBorderOutlinedDefault: .green
+                    primerColorBrand: .pink,
+                    primerColorBorderOutlinedSelected: .green
                 )
             )
         )
@@ -923,11 +876,11 @@ final class DesignTokensManagerTests: XCTestCase {
 
         // Then
         let tokens = try XCTUnwrap(sut.tokens)
-        XCTAssertEqual(tokens.primerColorBorderOutlinedDefault, .green)
-        XCTAssertEqual(tokens.primerColorGray300, .pink)
+        XCTAssertEqual(tokens.primerColorBorderOutlinedSelected, .green)
+        XCTAssertEqual(tokens.primerColorBrand, .pink)
     }
 
-    func test_fetchTokens_noOverrides_paletteInjectionIsANoOp() async throws {
+    func test_fetchTokens_noOverrides_brandInjectionIsANoOp() async throws {
         // Given
         let withoutTheme = try await tokens(for: .light)
 
@@ -937,27 +890,27 @@ final class DesignTokensManagerTests: XCTestCase {
 
         // Then
         let withEmptyTheme = try XCTUnwrap(sut.tokens)
-        XCTAssertEqual(withEmptyTheme.primerColorBorderOutlinedDefault, withoutTheme.primerColorBorderOutlinedDefault)
+        XCTAssertEqual(withEmptyTheme.primerColorBorderOutlinedSelected, withoutTheme.primerColorBorderOutlinedSelected)
         XCTAssertEqual(withEmptyTheme.primerColorBackgroundPrimary, withoutTheme.primerColorBackgroundPrimary)
-        XCTAssertEqual(withEmptyTheme.primerColorGray300, withoutTheme.primerColorGray300)
+        XCTAssertEqual(withEmptyTheme.primerColorBrand, withoutTheme.primerColorBrand)
     }
 
-    func test_fetchTokens_paletteOverride_cascadesInDarkMode() async throws {
+    func test_fetchTokens_brandOverride_cascadesInDarkMode() async throws {
         // Given
         let baseline = try await tokens(for: .dark)
-        let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedDefault)
+        let unthemedBorder = try XCTUnwrap(baseline.primerColorBorderOutlinedSelected)
 
         let override = Color(red: 0.25, green: 0.5, blue: 0.75)
-        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorGray300: override)))
+        sut.applyTheme(PrimerCheckoutTheme(colors: ColorOverrides(primerColorBrand: override)))
 
         // When
         try await sut.fetchTokens(for: .dark)
 
         // Then
         let themed = try XCTUnwrap(sut.tokens)
-        XCTAssertNotEqual(themed.primerColorBorderOutlinedDefault, unthemedBorder)
+        XCTAssertNotEqual(themed.primerColorBorderOutlinedSelected, unthemedBorder)
         XCTAssertEqual(
-            themed.primerColorBorderOutlinedDefault,
+            themed.primerColorBorderOutlinedSelected,
             Color(red: 0.25, green: 0.5, blue: 0.75, opacity: 1))
     }
 


### PR DESCRIPTION
# Description

[ORC-8396](https://primerapi.atlassian.net/browse/ORC-8396)

The theme mixed two kinds of colour: ones named after their job (`primerColorBorderOutlinedDefault`) and ones named after the paint (`primerColorGray300`). A merchant setting the second kind has no way to know what it moves, and we were free to change it in any release without that counting as breaking.

This removes the 14 palette colours from `ColorOverrides`: the eight greys, `primerColorGreen500`, the three reds and the two blues. They stay in the token file and are still what the purposeful colours resolve from, so nothing looks different.

`primerColorBrand` stays, because it says what it is for. It is still injected before references resolve, so `borderOutlinedSelected`, `focus` and `loader` follow it.

Breaking: a merchant setting any of those 14 no longer compiles. They set the purposeful colour instead, which is what the other SDKs are moving to in the same ticket.

# Other Notes

Four tests covered the injection cascade using `gray300`. Rather than delete them they now use `primerColorBrand`, so the mechanism stays covered. Two tests that only set greys and asserted they took have gone.

Web is deliberately not part of this ticket. Its purposeful tokens are defined as the palette (`background.primary` is `var(--primer-color-gray-000)`), so the palette has to stay in the stylesheet and any merchant CSS can reach it.

# Manual Testing

None needed, no visual change.

# Contributor Checklist

- [x]  All status checks have passed prior to code review
- [x]  I have added unit tests to a reasonable level of coverage where suitable
- [ ]  I have added UI tests to new user flows, if applicable
- [ ]  I have manually tested newly added UX
- [ ]  I have open a documentation PR, if applicable

# Reviewer Checklist

- [ ]  I have verified that a suitable set of automated tests has been added
- [ ]  I have verified that the title prefix aligns to the code changes + whether a release is expected after merging the PR
- [ ]  I have verified the documentation PR aligns with this PR, if applicable

# Before Merging

- [ ]  If introducing a breaking change, I have communicated it internally
- [ ]  Any related documentation PRs are ready to merge


[ORC-8396]: https://primerapi.atlassian.net/browse/ORC-8396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ